### PR TITLE
Decouple I18n\View\Helper\AbstractTranslatorHelper from ext\intl

### DIFF
--- a/library/Zend/Form/Exception/ExtensionNotLoadedException.php
+++ b/library/Zend/Form/Exception/ExtensionNotLoadedException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form\Exception;
+
+class ExtensionNotLoadedException extends DomainException
+{}

--- a/library/Zend/Form/View/Helper/FormDateTimeSelect.php
+++ b/library/Zend/Form/View/Helper/FormDateTimeSelect.php
@@ -23,7 +23,17 @@ class FormDateTimeSelect extends FormDateSelectHelper
      *
      * @var int
      */
-    protected $timeType = IntlDateFormatter::LONG;
+    protected $timeType;
+
+    /**
+     * @throws Exception\ExtensionsNotLoadedException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->timeType = IntlDateFormatter::LONG;
+    }
 
     /**
      * Invoke helper as function

--- a/library/Zend/Form/View/Helper/FormMonthSelect.php
+++ b/library/Zend/Form/View/Helper/FormMonthSelect.php
@@ -30,7 +30,7 @@ class FormMonthSelect extends AbstractHelper
      *
      * @var int
      */
-    protected $dateType = IntlDateFormatter::LONG;
+    protected $dateType;
 
     /**
      * Pattern to use for Date rendering
@@ -45,6 +45,21 @@ class FormMonthSelect extends AbstractHelper
      * @var string
      */
     protected $locale;
+
+    /**
+     * @throws Exception\ExtensionsNotLoadedException if ext/intl is not present
+     */
+    public function __construct()
+    {
+        if (!extension_loaded('intl')) {
+            throw new Exception\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+
+        $this->dateType = IntlDateFormatter::LONG;
+    }
 
     /**
      * Invoke helper as function

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -12,6 +12,7 @@ namespace Zend\I18n\Validator;
 use Locale;
 use IntlDateFormatter;
 use Traversable;
+use Zend\I18n\Exception as I18nException;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
 
@@ -38,12 +39,12 @@ class DateTime extends AbstractValidator
     /**
      * @var int
      */
-    protected $dateType = IntlDateFormatter::NONE;
+    protected $dateType;
 
     /**
      * @var int
      */
-    protected $timeType = IntlDateFormatter::NONE;
+    protected $timeType;
 
     /**
      * Optional timezone
@@ -60,7 +61,7 @@ class DateTime extends AbstractValidator
     /**
      * @var int
      */
-    protected $calendar = IntlDateFormatter::GREGORIAN;
+    protected $calendar;
 
     /**
      * @var IntlDateFormatter
@@ -80,9 +81,21 @@ class DateTime extends AbstractValidator
      * Constructor for the Date validator
      *
      * @param array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
      */
     public function __construct($options = array())
     {
+        if (!extension_loaded('intl')) {
+            throw new I18nException\ExtensionNotLoadedException(sprintf(
+                '%s component requires the intl PHP extension',
+                __NAMESPACE__
+            ));
+        }
+
+        $this->dateType = IntlDateFormatter::NONE;
+        $this->timeType = IntlDateFormatter::NONE;
+        $this->calendar = IntlDateFormatter::GREGORIAN;
+
         parent::__construct($options);
 
         if (null === $this->locale) {

--- a/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -9,7 +9,6 @@
 
 namespace Zend\I18n\View\Helper;
 
-use Zend\I18n\Exception;
 use Zend\I18n\Translator\Translator;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\View\Helper\AbstractHelper;
@@ -30,19 +29,6 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
      * @var string
      */
     protected $translatorTextDomain = 'default';
-
-    /**
-     * @throws Exception\ExtensionsNotLoadedException if ext/intl is not present
-     */
-    public function __construct()
-    {
-        if (!extension_loaded('intl')) {
-            throw new Exception\ExtensionNotLoadedException(sprintf(
-                '%s component requires the intl PHP extension',
-                __NAMESPACE__
-            ));
-        }
-    }
 
     /**
      * Whether translator should be used


### PR DESCRIPTION
https://github.com/zendframework/zf2/blob/release-2.2.0rc1/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php#L34-L45

is too wide and involves also

https://github.com/zendframework/zf2/blob/release-2.2.0rc1/library/Zend/Form/View/Helper/AbstractHelper.php#L13

which has nothing to do with `ext\intl` apart for `FormMonthSelect` and its descendants

Without this fix, no `Form\View\Helper` can be used if `ext\intl` is missing.

I had to put some attribute initialization into constructors to avoid unmanagable fatal errors.
