### PR TITLE
ensure the wrapElements option in Zend\Form\Form::prepareElement

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -188,6 +188,29 @@ class Form extends Fieldset implements FormInterface
     }
 
     /**
+     * Ensures state is ready for use. Here, we append the name of the fieldsets to every elements in order to avoid
+     * name clashes if the same fieldset is used multiple times
+     *
+     * @param  FormInterface $form
+     * @return mixed|void
+     */
+    public function prepareElement(FormInterface $form)
+    {
+        $name = $this->getName();
+
+        foreach ($this->byName as $elementOrFieldset) {
+            if ($form->wrapElements()) {
+                $elementOrFieldset->setName($name . '[' . $elementOrFieldset->getName() . ']');
+            }
+
+            // Recursively prepare elements
+            if ($elementOrFieldset instanceof ElementPrepareAwareInterface) {
+                $elementOrFieldset->prepareElement($form);
+            }
+        }
+    }
+
+    /**
      * Set data to validate and/or populate elements
      *
      * Typically, also passes data on to the composed input filter.

--- a/tests/ZendTest/Form/FormElementManagerFactoryTest.php
+++ b/tests/ZendTest/Form/FormElementManagerFactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Form;
+
+use ArrayObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Service\FormElementManagerFactory;
+use Zend\Mvc\Service\DiFactory;
+use Zend\Mvc\Service\DiAbstractServiceFactoryFactory;
+use Zend\Mvc\Service\DiServiceInitializerFactory;
+
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Mvc\Exception;
+use Zend\Form\FormElementManager;
+
+class FormElementManagerFactoryTest extends TestCase
+{
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
+    /**
+     * @var \Zend\Mvc\Controller\ControllerManager
+     */
+    protected $loader;
+
+    public function setUp()
+    {
+        $formElementManagerFactory = new FormElementManagerFactory();
+        $config = new ArrayObject(array('di' => array()));
+        $services = $this->services = new ServiceManager();
+        $services->setService('Zend\ServiceManager\ServiceLocatorInterface', $services);
+        $services->setFactory('FormElementManager', $formElementManagerFactory);
+        $services->setService('Config', $config);
+        $services->setFactory('Di', new DiFactory());
+        $services->setFactory('DiAbstractServiceFactory', new DiAbstractServiceFactoryFactory());
+        $services->setFactory('DiServiceInitializer', new DiServiceInitializerFactory());
+
+        $this->manager = $services->get('FormElementManager');
+
+        $this->standaloneManager = new FormElementManager();
+    }
+
+    public function testWillInstantiateFormFromInvokable()
+    {
+        $form = $this->manager->get('form');
+        $this->assertInstanceof('Zend\Form\Form', $form);
+    }
+
+    public function testWillInstantiateFormFromDiAbstractFactory()
+    {
+        //without DiAbstractFactory
+        $this->assertFalse($this->standaloneManager->has('ZendTest\Form\TestAsset\CustomForm'));
+        //with DiAbstractFactory
+        $this->assertTrue($this->manager->has('ZendTest\Form\TestAsset\CustomForm'));
+        $form = $this->manager->get('ZendTest\Form\TestAsset\CustomForm');
+        $this->assertInstanceof('ZendTest\Form\TestAsset\CustomForm', $form);
+    }
+
+    public function testNoWrapFieldName()
+    {
+        $form = $this->manager->get('ZendTest\Form\TestAsset\CustomForm');
+        $this->assertFalse($form->wrapElements(), 'ensure wrapElements option');
+        $this->assertTrue($form->has('email'), 'ensure the form has email element');
+        $emailElement = $form->get('email');
+        $this->assertEquals('email', $emailElement->getName());
+    }
+}

--- a/tests/ZendTest/Form/FormElementManagerFactoryTest.php
+++ b/tests/ZendTest/Form/FormElementManagerFactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Mvc
  */
 
 namespace ZendTest\Form;

--- a/tests/ZendTest/Form/TestAsset/CustomForm.php
+++ b/tests/ZendTest/Form/TestAsset/CustomForm.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form\TestAsset;

--- a/tests/ZendTest/Form/TestAsset/CustomForm.php
+++ b/tests/ZendTest/Form/TestAsset/CustomForm.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Form;
+use Zend\Form\Element;
+use Zend\Validator;
+use Zend\Stdlib\Hydrator\ClassMethods as ClassMethodsHydrator;
+
+class CustomForm extends Form
+{
+    public function __construct()
+    {
+        parent::__construct('test_form');
+
+        $this->setAttribute('method', 'post')
+             ->setHydrator(new ClassMethodsHydrator());
+
+        $field1 = new Element('name', array('label' => 'Name'));
+        $field1->setAttribute('type', 'text');
+        $this->add($field1);
+
+        $field2 = new Element('email', array('label' => 'Email'));
+        $field2->setAttribute('type', 'text');
+        $this->add($field2);
+
+        $this->add(array(
+            'name' => 'submit',
+            'attributes' => array(
+                'type' => 'submit'
+            )
+        ));
+    }
+
+    public function getInputFilterSpecification()
+    {
+        return array(
+            'name' => array(
+                'required' => true,
+                'filters'  => array(
+                    array('name' => 'Zend\Filter\StringTrim'),
+                ),
+            ),
+            'email' => array(
+                'required' => true,
+                'filters'  => array(
+                    array('name' => 'Zend\Filter\StringTrim'),
+                ),
+                'validators' => array(
+                    new Validator\EmailAddress(),
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Check the wrapElements option to avoid a violation of field name,
even if a client calls Zend\Form\Form::prepareElement without checking.
