### PR TITLE
Remove cache and log abstract factories from MVC

### DIFF
--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -86,9 +86,7 @@ class ServiceListenerFactory implements FactoryInterface
             'Zend\View\Resolver\ResolverInterface'   => 'ViewResolver',
         ),
         'abstract_factories' => array(
-            'Zend\Cache\Service\StorageCacheAbstractServiceFactory',
             'Zend\Form\FormAbstractServiceFactory',
-            'Zend\Log\LoggerAbstractServiceFactory',
         ),
     );
 


### PR DESCRIPTION
As @ocramius pointed out in IRC, adding the Logger and Cache abstract factories to the MVC in effect added new dependencies, which was leading to some breakage of other modules and applications.

I've removed them here, in favor of adding those in the skeleton application; see zendframework/ZendSkeletonApplication#183 for that.
