### PR TITLE
Segregated interfaces for Translator dependency of Validator component

### DIFF
--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc;
+
+use Zend\I18n\Translator\Translator as I18nTranslator;
+use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
+
+class Translator extends I18nTranslator implements ValidatorTranslatorInterface
+{
+}

--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace Zend\Mvc;
+namespace Zend\Mvc\I18n;
 
 use Zend\I18n\Translator\Translator as I18nTranslator;
 use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;

--- a/library/Zend/Mvc/I18n/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/I18n/TranslatorServiceFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\I18n;
+
+use Zend\I18n\Translator\TranslatorServiceFactory as I18nTranslatorServiceFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Overrides the translator factory from the i18n component in order to
+ * replace it with the bridge class from this namespace.
+ */
+class TranslatorServiceFactory extends I18nTranslatorServiceFactory
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        // Configure the translator
+        $config     = $serviceLocator->get('Config');
+        $trConfig   = isset($config['translator']) ? $config['translator'] : array();
+        $translator = Translator::factory($trConfig);
+        return $translator;
+    }
+}

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -63,6 +63,7 @@ class ServiceListenerFactory implements FactoryInterface
             'Router'                         => 'Zend\Mvc\Service\RouterFactory',
             'RoutePluginManager'             => 'Zend\Mvc\Service\RoutePluginManagerFactory',
             'SerializerAdapterManager'       => 'Zend\Mvc\Service\SerializerAdapterPluginManagerFactory',
+            'Translator'                     => 'Zend\Mvc\I18n\TranslatorServiceFactory',
             'ValidatorManager'               => 'Zend\Mvc\Service\ValidatorManagerFactory',
             'ViewHelperManager'              => 'Zend\Mvc\Service\ViewHelperManagerFactory',
             'ViewFeedRenderer'               => 'Zend\Mvc\Service\ViewFeedRendererFactory',

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -63,7 +63,7 @@ class ServiceListenerFactory implements FactoryInterface
             'Router'                         => 'Zend\Mvc\Service\RouterFactory',
             'RoutePluginManager'             => 'Zend\Mvc\Service\RoutePluginManagerFactory',
             'SerializerAdapterManager'       => 'Zend\Mvc\Service\SerializerAdapterPluginManagerFactory',
-            'Translator'                     => 'Zend\Mvc\I18n\TranslatorServiceFactory',
+            'Translator'                     => 'Zend\Mvc\Service\TranslatorServiceFactory',
             'ValidatorManager'               => 'Zend\Mvc\Service\ValidatorManagerFactory',
             'ViewHelperManager'              => 'Zend\Mvc\Service\ViewHelperManagerFactory',
             'ViewFeedRenderer'               => 'Zend\Mvc\Service\ViewFeedRendererFactory',

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -7,9 +7,10 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace Zend\Mvc\I18n;
+namespace Zend\Mvc\Service;
 
 use Zend\I18n\Translator\TranslatorServiceFactory as I18nTranslatorServiceFactory;
+use Zend\Mvc\I18n\Translator;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**

--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -10,13 +10,10 @@
 namespace Zend\Validator;
 
 use Traversable;
-use Zend\I18n\Translator\Translator;
-use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Validator\Exception\InvalidArgumentException;
 
 abstract class AbstractValidator implements
-    TranslatorAwareInterface,
+    Translator\TranslatorAwareInterface,
     ValidatorInterface
 {
     /**
@@ -28,7 +25,7 @@ abstract class AbstractValidator implements
 
     /**
      * Default translation object for all validate objects
-     * @var Translator
+     * @var Translator\TranslatorInterface
      */
     protected static $defaultTranslator;
 
@@ -49,7 +46,7 @@ abstract class AbstractValidator implements
         'messages'             => array(), // Array of validation failure messages
         'messageTemplates'     => array(), // Array of validation failure message templates
         'messageVariables'     => array(), // Array of additional variables available for validation failure messages
-        'translator'           => null,    // Translation object to used -> Zend\I18n\Translator\Translator
+        'translator'           => null,    // Translation object to used -> Translator\TranslatorInterface
         'translatorTextDomain' => null,    // Translation text domain
         'translatorEnabled'    => true,    // Is translation enabled?
         'valueObscured'        => false,   // Flag indicating whether or not value should be obfuscated
@@ -103,7 +100,7 @@ abstract class AbstractValidator implements
             return $this->options[$option];
         }
 
-        throw new InvalidArgumentException("Invalid option '$option'");
+        throw new Exception\InvalidArgumentException("Invalid option '$option'");
     }
 
     /**
@@ -212,7 +209,7 @@ abstract class AbstractValidator implements
         }
 
         if (!isset($this->abstractOptions['messageTemplates'][$messageKey])) {
-            throw new InvalidArgumentException("No message template exists for key '$messageKey'");
+            throw new Exception\InvalidArgumentException("No message template exists for key '$messageKey'");
         }
 
         $this->abstractOptions['messageTemplates'][$messageKey] = $messageString;
@@ -268,7 +265,7 @@ abstract class AbstractValidator implements
             return $result;
         }
 
-        throw new InvalidArgumentException("No property exists by the name '$property'");
+        throw new Exception\InvalidArgumentException("No property exists by the name '$property'");
     }
 
     /**
@@ -395,12 +392,12 @@ abstract class AbstractValidator implements
     /**
      * Set translation object
      *
-     * @param  Translator|null $translator
+     * @param  Translator\TranslatorInterface|null $translator
      * @param  string          $textDomain (optional)
      * @return AbstractValidator
      * @throws Exception\InvalidArgumentException
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(Translator\TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->abstractOptions['translator'] = $translator;
         if (null !== $textDomain) {
@@ -412,7 +409,7 @@ abstract class AbstractValidator implements
     /**
      * Return translation object
      *
-     * @return Translator|null
+     * @return Translator\TranslatorInterface|null
      */
     public function getTranslator()
     {
@@ -466,13 +463,13 @@ abstract class AbstractValidator implements
     /**
      * Set default translation object for all validate objects
      *
-     * @param  Translator|null $translator
+     * @param  Translator\TranslatorInterface|null $translator
      * @param  string          $textDomain (optional)
      * @return void
      * @throws Exception\InvalidArgumentException
      */
     public static function setDefaultTranslator(
-        Translator $translator = null, $textDomain = null
+        Translator\TranslatorInterface $translator = null, $textDomain = null
     )
     {
         static::$defaultTranslator = $translator;
@@ -484,7 +481,7 @@ abstract class AbstractValidator implements
     /**
      * Get default translation object for all validate objects
      *
-     * @return Translator|null
+     * @return Translator\TranslatorInterface|null
      */
     public static function getDefaultTranslator()
     {

--- a/library/Zend/Validator/Translator/TranslatorAwareInterface.php
+++ b/library/Zend/Validator/Translator/TranslatorAwareInterface.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *;
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Validator\Translator;
+
+interface TranslatorAwareInterface
+{
+    /**
+     * Sets translator to use in helper
+     *
+     * @param  TranslatorInterface $translator  [optional] translator.
+     *             Default is null, which sets no translator.
+     * @param  string $textDomain  [optional] text domain
+     *             Default is null, which skips setTranslatorTextDomain
+     * @return self
+     */
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null);
+
+    /**
+     * Returns translator used in object
+     *
+     * @return TranslatorInterface|null
+     */
+    public function getTranslator();
+
+    /**
+     * Checks if the object has a translator
+     *
+     * @return bool
+     */
+    public function hasTranslator();
+
+    /**
+     * Sets whether translator is enabled and should be used
+     *
+     * @param  bool $enabled [optional] whether translator should be used.
+     *                  Default is true.
+     * @return self
+     */
+    public function setTranslatorEnabled($enabled = true);
+
+    /**
+     * Returns whether translator is enabled and should be used
+     *
+     * @return bool
+     */
+    public function isTranslatorEnabled();
+
+    /**
+     * Set translation text domain
+     *
+     * @param  string $textDomain
+     * @return TranslatorAwareInterface
+     */
+    public function setTranslatorTextDomain($textDomain = 'default');
+
+    /**
+     * Return the translation text domain
+     *
+     * @return string
+     */
+    public function getTranslatorTextDomain();
+}

--- a/library/Zend/Validator/Translator/TranslatorInterface.php
+++ b/library/Zend/Validator/Translator/TranslatorInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Validator\Translator;
+
+interface TranslatorInterface
+{
+    /**
+     * @param  string $message 
+     * @param  string $textDomain 
+     * @param  string $locale 
+     * @return string
+     */
+    public function translate($message, $textDomain = 'default', $locale = null);
+}

--- a/library/Zend/Validator/Translator/TranslatorInterface.php
+++ b/library/Zend/Validator/Translator/TranslatorInterface.php
@@ -12,9 +12,9 @@ namespace Zend\Validator\Translator;
 interface TranslatorInterface
 {
     /**
-     * @param  string $message 
-     * @param  string $textDomain 
-     * @param  string $locale 
+     * @param  string $message
+     * @param  string $textDomain
+     * @param  string $locale
      * @return string
      */
     public function translate($message, $textDomain = 'default', $locale = null);

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Validator;
 
-use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
 
@@ -135,7 +134,7 @@ class ValidatorPluginManager extends AbstractPluginManager
      */
     public function injectTranslator($validator)
     {
-        if ($validator instanceof TranslatorAwareInterface) {
+        if ($validator instanceof Translator\TranslatorAwareInterface) {
             $locator = $this->getServiceLocator();
             if ($locator && $locator->has('translator')) {
                 $validator->setTranslator($locator->get('translator'));

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -14,16 +14,18 @@
     "target-dir": "Zend/Validator",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-i18n": "self.version",
-        "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-stdlib": "self.version"
     },
     "require-dev": {
-        "zendframework/zend-math": "self.version"
+        "zendframework/zend-i18n": "self.version",
+        "zendframework/zend-math": "self.version",
+        "zendframework/zend-servicemanager": "self.version"
     },
     "suggest": {
         "zendframework/zend-db": "Zend\\Db component",
-        "zendframework/zend-math": "Zend\\Math component"
+        "zendframework/zend-i18n": "self.version",
+        "zendframework/zend-math": "Zend\\Math component",
+        "zendframework/zend-servicemanager": "self.version"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -23,9 +23,9 @@
     },
     "suggest": {
         "zendframework/zend-db": "Zend\\Db component",
-        "zendframework/zend-i18n": "self.version",
+        "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
         "zendframework/zend-math": "Zend\\Math component",
-        "zendframework/zend-servicemanager": "self.version"
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains"
     },
     "extra": {
         "branch-alias": {

--- a/tests/ZendTest/Validator/AbstractTest.php
+++ b/tests/ZendTest/Validator/AbstractTest.php
@@ -11,7 +11,6 @@
 namespace ZendTest\Validator;
 
 use ReflectionMethod;
-use Zend\I18n\Translator\Translator;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\EmailAddress;
 use Zend\Validator\Hostname;
@@ -53,7 +52,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testTranslatorNullByDefault();
         set_error_handler(array($this, 'errorHandlerIgnore'));
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         restore_error_handler();
         $this->validator->setTranslator($translator);
         $this->assertSame($translator, $this->validator->getTranslator());
@@ -79,7 +78,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $loader->translations = array(
             'fooMessage' => 'This is the translated message for %value%',
         );
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('default', $loader);
         $translator->addTranslationFile('default', null);
 
@@ -97,7 +96,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $loader->translations = array(
             '%value% was passed' => 'This is the translated message for %value%',
         );
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('default', $loader);
         $translator->addTranslationFile('default', null);
 
@@ -147,7 +146,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testTranslatorEnabledPerDefault()
     {
         set_error_handler(array($this, 'errorHandlerIgnore'));
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         $this->validator->setTranslator($translator);
         $this->assertTrue($this->validator->isTranslatorEnabled());
     }
@@ -158,7 +157,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $loader->translations = array(
             '%value% was passed' => 'This is the translated message for %value%',
         );
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('default', $loader);
         $translator->addTranslationFile('default', null);
         $this->validator->setTranslator($translator);
@@ -202,7 +201,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorMethods()
     {
-        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock = $this->getMock('ZendTest\Validator\TestAsset\Translator');
         $this->validator->setTranslator($translatorMock, 'foo');
 
         $this->assertEquals($translatorMock, $this->validator->getTranslator());
@@ -222,7 +221,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->validator->hasTranslator());
 
-        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock = $this->getMock('ZendTest\Validator\TestAsset\Translator');
         AbstractValidator::setDefaultTranslator($translatorMock, 'foo');
 
         $this->assertEquals($translatorMock, AbstractValidator::getDefaultTranslator());

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -10,7 +10,6 @@
 
 namespace ZendTest\Validator;
 
-use Zend\I18n\Translator\Translator;
 use Zend\Validator\EmailAddress;
 use Zend\Validator\Hostname;
 
@@ -396,7 +395,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         );
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = $translations;
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('test', $loader);
         $translator->addTranslationFile('test', null);
 

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -10,7 +10,6 @@
 
 namespace ZendTest\Validator;
 
-use Zend\I18n\Translator\Translator;
 use Zend\Validator\Hostname;
 
 /**
@@ -266,7 +265,7 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
         );
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = $translations;
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('default', $loader);
         $translator->addTranslationFile('default', null);
         $this->validator->setTranslator($translator);

--- a/tests/ZendTest/Validator/StaticValidatorTest.php
+++ b/tests/ZendTest/Validator/StaticValidatorTest.php
@@ -10,7 +10,6 @@
 
 namespace ZendTest\Validator;
 
-use Zend\I18n\Translator;
 use Zend\Validator\AbstractValidator;
 use Zend\I18n\Validator\Alpha;
 use Zend\Validator\Between;
@@ -70,7 +69,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testCanSetGlobalDefaultTranslator()
     {
-        $translator = new Translator\Translator();
+        $translator = new TestAsset\Translator();
         AbstractValidator::setDefaultTranslator($translator);
         $this->assertSame($translator, AbstractValidator::getDefaultTranslator());
     }
@@ -84,7 +83,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
     public function testLocalTranslatorPreferredOverGlobalTranslator()
     {
         $this->testCanSetGlobalDefaultTranslator();
-        $translator = new Translator\Translator();
+        $translator = new TestAsset\Translator();
         $this->validator->setTranslator($translator);
         $this->assertNotSame(AbstractValidator::getDefaultTranslator(), $this->validator->getTranslator());
     }
@@ -99,7 +98,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
         $loader->translations = array(
             Alpha::INVALID => 'This is the translated message for %value%',
         );
-        $translator = new Translator\Translator();
+        $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('default', $loader);
         $translator->addTranslationFile('default', null);
 
@@ -123,7 +122,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetGetDefaultTranslator()
     {
-        $translator = new Translator\Translator();
+        $translator = new TestAsset\Translator();
         AbstractValidator::setDefaultTranslator($translator);
         $this->assertSame($translator, AbstractValidator::getDefaultTranslator());
     }

--- a/tests/ZendTest/Validator/TestAsset/Translator.php
+++ b/tests/ZendTest/Validator/TestAsset/Translator.php
@@ -5,20 +5,13 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Validator
  */
 
 namespace ZendTest\Validator\TestAsset;
 
-use Zend\I18n\Translator as I18nTranslator;
+use Zend\I18n\Translator\Translator as I18nTranslator;
+use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
 
-class ArrayTranslator implements I18nTranslator\Loader\FileLoaderInterface
+class Translator extends I18nTranslator implements ValidatorTranslatorInterface
 {
-    public $translations;
-
-    public function load($filename, $locale)
-    {
-        $textDomain =  new I18nTranslator\TextDomain($this->translations);
-        return $textDomain;
-    }
 }

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -10,7 +10,6 @@
 
 namespace ZendTest\Validator;
 
-use Zend\I18n\Translator\Translator;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Between;
 use Zend\Validator\NotEmpty;
@@ -142,7 +141,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
 
     public function testSetGetDefaultTranslator()
     {
-        $translator = new Translator();
+        $translator = new TestAsset\Translator();
         AbstractValidator::setDefaultTranslator($translator);
         $this->assertSame($translator, AbstractValidator::getDefaultTranslator());
     }

--- a/tests/ZendTest/Validator/ValidatorPluginManagerTest.php
+++ b/tests/ZendTest/Validator/ValidatorPluginManagerTest.php
@@ -27,7 +27,7 @@ class ValidatorPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testAllowsInjectingTranslator()
     {
-        $translator = $this->getMock("Zend\I18n\Translator\Translator");
+        $translator = $this->getMock('ZendTest\Validator\TestAsset\Translator');
 
         $slContents = array(array('translator', $translator));
         $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');


### PR DESCRIPTION
This PR introduces segregated interfaces for the Translator dependency inside the Validator component.

This allows us to remove the hard dependency on the i18n component, and allows usage of the Validator with other translator systems via interface implementation.

A bridge is provided in the `Zend\Mvc\I18n` subcomponent; additionally, the MVC uses a translator factory that consumes that bridge to ensure the translator service works with all components.
