### PR TITLE
Remove Version dependency from Feed component

### DIFF
--- a/library/Zend/Feed/PubSubHubbub/Publisher.php
+++ b/library/Zend/Feed/PubSubHubbub/Publisher.php
@@ -13,7 +13,6 @@ use Traversable;
 use Zend\Http\Request as HttpRequest;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Uri;
-use Zend\Version\Version;
 
 class Publisher
 {

--- a/library/Zend/Feed/PubSubHubbub/Subscriber.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber.php
@@ -15,7 +15,6 @@ use Traversable;
 use Zend\Http\Request as HttpRequest;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Uri;
-use Zend\Version\Version;
 
 class Subscriber
 {

--- a/library/Zend/Feed/PubSubHubbub/Version.php
+++ b/library/Zend/Feed/PubSubHubbub/Version.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\PubSubHubbub;
+
+abstract class Version
+{
+    const VERSION = '2';
+}

--- a/library/Zend/Feed/Writer/Renderer/Feed/AbstractAtom.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/AbstractAtom.php
@@ -14,7 +14,7 @@ use DOMDocument;
 use DOMElement;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
-use Zend\Version\Version;
+use Zend\Feed\Writer\Version;
 
 /**
 */

--- a/library/Zend/Feed/Writer/Renderer/Feed/Atom/AbstractAtom.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Atom/AbstractAtom.php
@@ -13,7 +13,7 @@ use Datetime;
 use DOMDocument;
 use DOMElement;
 use Zend\Feed;
-use Zend\Version\Version;
+use Zend\Feed\Writer\Version;
 
 class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
 {

--- a/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -14,8 +14,8 @@ use DOMDocument;
 use DOMElement;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
+use Zend\Feed\Writer\Version;
 use Zend\Uri;
-use Zend\Version\Version;
 
 /**
 */

--- a/library/Zend/Feed/Writer/Version.php
+++ b/library/Zend/Feed/Writer/Version.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Writer;
+
+abstract class Version
+{
+    const VERSION = '2';
+}

--- a/library/Zend/Feed/composer.json
+++ b/library/Zend/Feed/composer.json
@@ -17,8 +17,7 @@
         "zendframework/zend-escaper": "self.version",
         "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-servicemanager": "self.version",
-        "zendframework/zend-uri": "self.version",
-        "zendframework/zend-version": "self.version"
+        "zendframework/zend-uri": "self.version"
     },
     "suggest": {
         "zendframework/zend-validator": "Zend\\Validator component"

--- a/tests/ZendTest/Feed/Writer/FeedTest.php
+++ b/tests/ZendTest/Feed/Writer/FeedTest.php
@@ -13,7 +13,7 @@ namespace ZendTest\Feed\Writer;
 use DateTime;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Feed;
-use Zend\Version\Version;
+use Zend\Feed\Writer\Version;
 
 /**
  * @category   Zend

--- a/tests/ZendTest/Feed/Writer/Renderer/Feed/RssTest.php
+++ b/tests/ZendTest/Feed/Writer/Renderer/Feed/RssTest.php
@@ -13,6 +13,7 @@ namespace ZendTest\Feed\Writer\Renderer\Feed;
 use DateTime;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
+use Zend\Feed\Writer\Version;
 use Zend\Feed\Reader;
 
 /**
@@ -179,7 +180,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         $rssFeed->render();
         $feed = Reader\Reader::importString($rssFeed->saveXml());
         $this->assertEquals(
-            'Zend_Feed_Writer ' . \Zend\Version\Version::VERSION . ' (http://framework.zend.com)', $feed->getGenerator());
+            'Zend_Feed_Writer ' . Version::VERSION . ' (http://framework.zend.com)', $feed->getGenerator());
     }
 
     public function testFeedLanguageHasBeenSet()


### PR DESCRIPTION
This pull request removes the Version dependency from the Feed component by adding the following:
- `Zend\Feed\Writer\Version` for denoting the feed writer version
- `Zend\Feed\PubSubHubbub\Version` for denoting the PuSH version
