### PR TITLE
Ensure that DateTimeFormatter doesn't format an empty string

### DIFF
--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -71,7 +71,9 @@ class DateTimeFormatter extends AbstractFilter
      */
     protected function normalizeDateTime($value)
     {
-        if (is_int($value)) {
+        if (empty($value)) {
+            return $value;
+        } elseif (is_int($value)) {
             $dateTime = new DateTime('@' . $value);
         } elseif (!$value instanceof DateTime) {
             $dateTime = new DateTime($value);

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -33,6 +33,15 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         date_default_timezone_set($this->defaultTimezone);
     }
 
+    public function testFormatterDoesNotFormatAnEmptyString()
+    {
+        date_default_timezone_set('UTC');
+
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter('');
+        $this->assertEquals('', $result);
+    }
+
     public function testDateTimeFormatted()
     {
         date_default_timezone_set('UTC');


### PR DESCRIPTION
This fixes #4393 and maintains BC.
