### PR TITLE
Make ServiceManager dependency optional in Feed component

### DIFF
--- a/library/Zend/Feed/Reader/ExtensionManager.php
+++ b/library/Zend/Feed/Reader/ExtensionManager.php
@@ -17,7 +17,7 @@ use Zend\ServiceManager\AbstractPluginManager;
  * Validation checks that we have an Extension\AbstractEntry or
  * Extension\AbstractFeed.
  */
-class ExtensionManager extends AbstractPluginManager
+class ExtensionManager extends AbstractPluginManager implements ExtensionManagerInterface
 {
     /**
      * Default set of extension classes

--- a/library/Zend/Feed/Reader/ExtensionManager.php
+++ b/library/Zend/Feed/Reader/ExtensionManager.php
@@ -9,68 +9,72 @@
 
 namespace Zend\Feed\Reader;
 
-use Zend\ServiceManager\AbstractPluginManager;
-
 /**
- * Plugin manager implementation for feed reader extensions
+ * Default implementation of ExtensionManagerInterface
  *
- * Validation checks that we have an Extension\AbstractEntry or
- * Extension\AbstractFeed.
+ * Decorator of ExtensionPluginManager.
  */
-class ExtensionManager extends AbstractPluginManager implements ExtensionManagerInterface
+class ExtensionManager implements ExtensionManagerInterface
 {
-    /**
-     * Default set of extension classes
-     *
-     * @var array
-     */
-    protected $invokableClasses = array(
-        'atomentry'            => 'Zend\Feed\Reader\Extension\Atom\Entry',
-        'atomfeed'             => 'Zend\Feed\Reader\Extension\Atom\Feed',
-        'contententry'         => 'Zend\Feed\Reader\Extension\Content\Entry',
-        'creativecommonsentry' => 'Zend\Feed\Reader\Extension\CreativeCommons\Entry',
-        'creativecommonsfeed'  => 'Zend\Feed\Reader\Extension\CreativeCommons\Feed',
-        'dublincoreentry'      => 'Zend\Feed\Reader\Extension\DublinCore\Entry',
-        'dublincorefeed'       => 'Zend\Feed\Reader\Extension\DublinCore\Feed',
-        'podcastentry'         => 'Zend\Feed\Reader\Extension\Podcast\Entry',
-        'podcastfeed'          => 'Zend\Feed\Reader\Extension\Podcast\Feed',
-        'slashentry'           => 'Zend\Feed\Reader\Extension\Slash\Entry',
-        'syndicationfeed'      => 'Zend\Feed\Reader\Extension\Syndication\Feed',
-        'threadentry'          => 'Zend\Feed\Reader\Extension\Thread\Entry',
-        'wellformedwebentry'   => 'Zend\Feed\Reader\Extension\WellFormedWeb\Entry',
-    );
+    protected $pluginManager;
 
     /**
-     * Do not share instances
+     * Constructor
      *
-     * @var bool
+     * Seeds the extension manager with a plugin manager; if none provided,
+     * creates an instance.
+     *
+     * @param  null|ExtensionPluginManager $pluginManager
      */
-    protected $shareByDefault = false;
-
-    /**
-     * Validate the plugin
-     *
-     * Checks that the extension loaded is of a valid type.
-     *
-     * @param  mixed $plugin
-     * @return void
-     * @throws Exception\InvalidArgumentException if invalid
-     */
-    public function validatePlugin($plugin)
+    public function __construct(ExtensionPluginManager $pluginManager = null)
     {
-        if ($plugin instanceof Extension\AbstractEntry
-            || $plugin instanceof Extension\AbstractFeed
-        ) {
-            // we're okay
-            return;
+        if (null === $pluginManager) {
+            $pluginManager = new ExtensionPluginManager();
         }
+        $this->pluginManager = $pluginManager;
+    }
 
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
-            . 'or %s\Extension\AbstractEntry',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            __NAMESPACE__,
-            __NAMESPACE__
-        ));
+    /**
+     * Method overloading
+     *
+     * Proxy to composed ExtensionPluginManager instance.
+     *
+     * @param  string $method
+     * @param  array $args
+     * @return mixed
+     * @throws Exception\BadMethodCallException
+     */
+    public function __call($method, $args)
+    {
+        if (!method_exists($this->pluginManager, $method)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                'Method by name of %s does not exist in %s',
+                $method,
+                __CLASS__
+            ));
+        }
+        return call_user_func_array(array($this->pluginManager, $method), $args);
+    }
+
+    /**
+     * Get the named extension
+     *
+     * @param  string $name
+     * @return Extension\AbstractEntry|Extension\AbstractFeed
+     */
+    public function get($name)
+    {
+        return $this->pluginManager->get($name);
+    }
+
+    /**
+     * Do we have the named extension?
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function has($name)
+    {
+        return $this->pluginManager->has($name);
     }
 }

--- a/library/Zend/Feed/Reader/ExtensionManagerInterface.php
+++ b/library/Zend/Feed/Reader/ExtensionManagerInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader;
+
+interface ExtensionManagerInterface
+{
+    /**
+     * Do we have the extension?
+     *
+     * @param  string $extension
+     * @return bool
+     */
+    public function has($extension);
+
+    /**
+     * Retrieve the extension
+     *
+     * @param  string $extension
+     * @return mixed
+     */
+    public function get($extension);
+}

--- a/library/Zend/Feed/Reader/ExtensionPluginManager.php
+++ b/library/Zend/Feed/Reader/ExtensionPluginManager.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader;
+
+use Zend\ServiceManager\AbstractPluginManager;
+
+/**
+ * Plugin manager implementation for feed reader extensions based on the
+ * AbstractPluginManager.
+ *
+ * Validation checks that we have an Extension\AbstractEntry or
+ * Extension\AbstractFeed.
+ */
+class ExtensionPluginManager extends AbstractPluginManager
+{
+    /**
+     * Default set of extension classes
+     *
+     * @var array
+     */
+    protected $invokableClasses = array(
+        'atomentry'            => 'Zend\Feed\Reader\Extension\Atom\Entry',
+        'atomfeed'             => 'Zend\Feed\Reader\Extension\Atom\Feed',
+        'contententry'         => 'Zend\Feed\Reader\Extension\Content\Entry',
+        'creativecommonsentry' => 'Zend\Feed\Reader\Extension\CreativeCommons\Entry',
+        'creativecommonsfeed'  => 'Zend\Feed\Reader\Extension\CreativeCommons\Feed',
+        'dublincoreentry'      => 'Zend\Feed\Reader\Extension\DublinCore\Entry',
+        'dublincorefeed'       => 'Zend\Feed\Reader\Extension\DublinCore\Feed',
+        'podcastentry'         => 'Zend\Feed\Reader\Extension\Podcast\Entry',
+        'podcastfeed'          => 'Zend\Feed\Reader\Extension\Podcast\Feed',
+        'slashentry'           => 'Zend\Feed\Reader\Extension\Slash\Entry',
+        'syndicationfeed'      => 'Zend\Feed\Reader\Extension\Syndication\Feed',
+        'threadentry'          => 'Zend\Feed\Reader\Extension\Thread\Entry',
+        'wellformedwebentry'   => 'Zend\Feed\Reader\Extension\WellFormedWeb\Entry',
+    );
+
+    /**
+     * Do not share instances
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Validate the plugin
+     *
+     * Checks that the extension loaded is of a valid type.
+     *
+     * @param  mixed $plugin
+     * @return void
+     * @throws Exception\InvalidArgumentException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        if ($plugin instanceof Extension\AbstractEntry
+            || $plugin instanceof Extension\AbstractFeed
+        ) {
+            // we're okay
+            return;
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
+            . 'or %s\Extension\AbstractEntry',
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+            __NAMESPACE__,
+            __NAMESPACE__
+        ));
+    }
+}

--- a/library/Zend/Feed/Reader/Reader.php
+++ b/library/Zend/Feed/Reader/Reader.php
@@ -494,9 +494,9 @@ class Reader
     /**
      * Set plugin manager for use with Extensions
      *
-     * @param ExtensionManager $extensionManager
+     * @param ExtensionManagerInterface $extensionManager
      */
-    public static function setExtensionManager(ExtensionManager $extensionManager)
+    public static function setExtensionManager(ExtensionManagerInterface $extensionManager)
     {
         static::$extensionManager = $extensionManager;
     }
@@ -504,7 +504,7 @@ class Reader
     /**
      * Get plugin manager for use with Extensions
      *
-     * @return ExtensionManager
+     * @return ExtensionManagerInterface
      */
     public static function getExtensionManager()
     {

--- a/library/Zend/Feed/Writer/ExtensionManager.php
+++ b/library/Zend/Feed/Writer/ExtensionManager.php
@@ -9,72 +9,72 @@
 
 namespace Zend\Feed\Writer;
 
-use Zend\ServiceManager\AbstractPluginManager;
-
 /**
- * Plugin manager implementation for feed writer extensions
+ * Default implementation of ExtensionManagerInterface
  *
- * Validation checks that we have an Entry, Feed, or Extension\AbstractRenderer.
+ * Decorator of ExtensionPluginManager.
  */
-class ExtensionManager extends AbstractPluginManager implements ExtensionManagerInterface
+class ExtensionManager implements ExtensionManagerInterface
 {
-    /**
-     * Default set of extension classes
-     *
-     * @var array
-     */
-    protected $invokableClasses = array(
-        'atomrendererfeed'           => 'Zend\Feed\Writer\Extension\Atom\Renderer\Feed',
-        'contentrendererentry'       => 'Zend\Feed\Writer\Extension\Content\Renderer\Entry',
-        'dublincorerendererentry'    => 'Zend\Feed\Writer\Extension\DublinCore\Renderer\Entry',
-        'dublincorerendererfeed'     => 'Zend\Feed\Writer\Extension\DublinCore\Renderer\Feed',
-        'itunesentry'                => 'Zend\Feed\Writer\Extension\ITunes\Entry',
-        'itunesfeed'                 => 'Zend\Feed\Writer\Extension\ITunes\Feed',
-        'itunesrendererentry'        => 'Zend\Feed\Writer\Extension\ITunes\Renderer\Entry',
-        'itunesrendererfeed'         => 'Zend\Feed\Writer\Extension\ITunes\Renderer\Feed',
-        'slashrendererentry'         => 'Zend\Feed\Writer\Extension\Slash\Renderer\Entry',
-        'threadingrendererentry'     => 'Zend\Feed\Writer\Extension\Threading\Renderer\Entry',
-        'wellformedwebrendererentry' => 'Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry',
-    );
+    protected $pluginManager;
 
     /**
-     * Do not share instances
+     * Constructor
      *
-     * @var bool
+     * Seeds the extension manager with a plugin manager; if none provided,
+     * creates an instance.
+     *
+     * @param  null|ExtensionPluginManager $pluginManager
      */
-    protected $shareByDefault = false;
-
-    /**
-     * Validate the plugin
-     *
-     * Checks that the extension loaded is of a valid type.
-     *
-     * @param  mixed $plugin
-     * @return void
-     * @throws Exception\InvalidArgumentException if invalid
-     */
-    public function validatePlugin($plugin)
+    public function __construct(ExtensionPluginManager $pluginManager = null)
     {
-        if ($plugin instanceof Extension\AbstractRenderer) {
-            // we're okay
-            return;
+        if (null === $pluginManager) {
+            $pluginManager = new ExtensionPluginManager();
         }
+        $this->pluginManager = $pluginManager;
+    }
 
-        if ('Feed' == substr(get_class($plugin), -4)) {
-            // we're okay
-            return;
+    /**
+     * Method overloading
+     *
+     * Proxy to composed ExtensionPluginManager instance.
+     *
+     * @param  string $method
+     * @param  array $args
+     * @return mixed
+     * @throws Exception\BadMethodCallException
+     */
+    public function __call($method, $args)
+    {
+        if (!method_exists($this->pluginManager, $method)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                'Method by name of %s does not exist in %s',
+                $method,
+                __CLASS__
+            ));
         }
+        return call_user_func_array(array($this->pluginManager, $method), $args);
+    }
 
-        if ('Entry' == substr(get_class($plugin), -5)) {
-            // we're okay
-            return;
-        }
+    /**
+     * Get the named extension
+     *
+     * @param  string $name
+     * @return Extension\AbstractEntry|Extension\AbstractFeed
+     */
+    public function get($name)
+    {
+        return $this->pluginManager->get($name);
+    }
 
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must implement %s\Extension\RendererInterface '
-            . 'or the classname must end in "Feed" or "Entry"',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            __NAMESPACE__
-        ));
+    /**
+     * Do we have the named extension?
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function has($name)
+    {
+        return $this->pluginManager->has($name);
     }
 }

--- a/library/Zend/Feed/Writer/ExtensionManager.php
+++ b/library/Zend/Feed/Writer/ExtensionManager.php
@@ -16,7 +16,7 @@ use Zend\ServiceManager\AbstractPluginManager;
  *
  * Validation checks that we have an Entry, Feed, or Extension\AbstractRenderer.
  */
-class ExtensionManager extends AbstractPluginManager
+class ExtensionManager extends AbstractPluginManager implements ExtensionManagerInterface
 {
     /**
      * Default set of extension classes

--- a/library/Zend/Feed/Writer/ExtensionManagerInterface.php
+++ b/library/Zend/Feed/Writer/ExtensionManagerInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Writer;
+
+interface ExtensionManagerInterface
+{
+    /**
+     * Do we have the extension?
+     *
+     * @param  string $extension
+     * @return bool
+     */
+    public function has($extension);
+
+    /**
+     * Retrieve the extension
+     *
+     * @param  string $extension
+     * @return mixed
+     */
+    public function get($extension);
+}

--- a/library/Zend/Feed/Writer/ExtensionPluginManager.php
+++ b/library/Zend/Feed/Writer/ExtensionPluginManager.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Writer;
+
+use Zend\ServiceManager\AbstractPluginManager;
+
+/**
+ * Plugin manager implementation for feed writer extensions
+ *
+ * Validation checks that we have an Entry, Feed, or Extension\AbstractRenderer.
+ */
+class ExtensionPluginManager extends AbstractPluginManager
+{
+    /**
+     * Default set of extension classes
+     *
+     * @var array
+     */
+    protected $invokableClasses = array(
+        'atomrendererfeed'           => 'Zend\Feed\Writer\Extension\Atom\Renderer\Feed',
+        'contentrendererentry'       => 'Zend\Feed\Writer\Extension\Content\Renderer\Entry',
+        'dublincorerendererentry'    => 'Zend\Feed\Writer\Extension\DublinCore\Renderer\Entry',
+        'dublincorerendererfeed'     => 'Zend\Feed\Writer\Extension\DublinCore\Renderer\Feed',
+        'itunesentry'                => 'Zend\Feed\Writer\Extension\ITunes\Entry',
+        'itunesfeed'                 => 'Zend\Feed\Writer\Extension\ITunes\Feed',
+        'itunesrendererentry'        => 'Zend\Feed\Writer\Extension\ITunes\Renderer\Entry',
+        'itunesrendererfeed'         => 'Zend\Feed\Writer\Extension\ITunes\Renderer\Feed',
+        'slashrendererentry'         => 'Zend\Feed\Writer\Extension\Slash\Renderer\Entry',
+        'threadingrendererentry'     => 'Zend\Feed\Writer\Extension\Threading\Renderer\Entry',
+        'wellformedwebrendererentry' => 'Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry',
+    );
+
+    /**
+     * Do not share instances
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Validate the plugin
+     *
+     * Checks that the extension loaded is of a valid type.
+     *
+     * @param  mixed $plugin
+     * @return void
+     * @throws Exception\InvalidArgumentException if invalid
+     */
+    public function validatePlugin($plugin)
+    {
+        if ($plugin instanceof Extension\AbstractRenderer) {
+            // we're okay
+            return;
+        }
+
+        if ('Feed' == substr(get_class($plugin), -4)) {
+            // we're okay
+            return;
+        }
+
+        if ('Entry' == substr(get_class($plugin), -5)) {
+            // we're okay
+            return;
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Plugin of type %s is invalid; must implement %s\Extension\RendererInterface '
+            . 'or the classname must end in "Feed" or "Entry"',
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+            __NAMESPACE__
+        ));
+    }
+}

--- a/library/Zend/Feed/Writer/Writer.php
+++ b/library/Zend/Feed/Writer/Writer.php
@@ -41,7 +41,7 @@ class Writer
     const TYPE_RSS_ANY          = 'rss';
 
     /**
-     * @var ExtensionManager
+     * @var ExtensionManagerInterface
      */
     protected static $extensionManager = null;
 
@@ -62,9 +62,9 @@ class Writer
     /**
      * Set plugin loader for use with Extensions
      *
-     * @param ExtensionManager
+     * @param ExtensionManagerInterface
      */
-    public static function setExtensionManager(ExtensionManager $extensionManager)
+    public static function setExtensionManager(ExtensionManagerInterface $extensionManager)
     {
         static::$extensionManager = $extensionManager;
     }
@@ -72,7 +72,7 @@ class Writer
     /**
      * Get plugin manager for use with Extensions
      *
-     * @return ExtensionManager
+     * @return ExtensionManagerInterface
      */
     public static function getExtensionManager()
     {

--- a/library/Zend/Feed/composer.json
+++ b/library/Zend/Feed/composer.json
@@ -16,11 +16,11 @@
         "php": ">=5.3.3",
         "zendframework/zend-escaper": "self.version",
         "zendframework/zend-stdlib": "self.version",
-        "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-uri": "self.version",
         "zendframework/zend-version": "self.version"
     },
     "suggest": {
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for default/recommended ExtensionManager implementations",
         "zendframework/zend-validator": "Zend\\Validator component"
     },
     "extra": {


### PR DESCRIPTION
This PR makes the ServiceManager dependency in the Feed component optional.
- Creates `Zend\Feed\Reader\ExtensionManagerInterface`, defining required capabilities for an extension manager; `ExtensionManager` implements this interface now.
- Creates `Zend\Feed\Writer\ExtensionManagerInterface`, defining required capabilities for an extension manager; `ExtensionManager` implements this interface now.

If desired, you can substitute your own implementations using:

``` php
Reader::setExtensionManager($customImplementation);
Writer::setExtensionManager($customImplementation);
```
