### PR TITLE
Add coveralls support and fix a few testing bugs related to coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+src_dir: library
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_install:
 script:
  - ant travis -keep-going
 
+after_script:
+  - php vendor/bin/coveralls
+
 notifications:
   irc: "irc.freenode.org#zftalk.dev"
   email: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 ### Welcome to the *Zend Framework 2.2* Release!
 
-Master: [![Build Status](https://secure.travis-ci.org/zendframework/zf2.png?branch=master)](http://travis-ci.org/zendframework/zf2)
-Develop: [![Build Status](https://secure.travis-ci.org/zendframework/zf2.png?branch=develop)](http://travis-ci.org/zendframework/zf2)
+Master:
+[![Build Status](https://secure.travis-ci.org/zendframework/zf2.png?branch=master)](http://travis-ci.org/zendframework/zf2)
+[![Coverage Status](https://coveralls.io/repos/zendframework/zf2/badge.png?branch=master)](https://coveralls.io/r/zendframework/zf2)
+Develop:
+[![Build Status](https://secure.travis-ci.org/zendframework/zf2.png?branch=develop)](http://travis-ci.org/zendframework/zf2)
+[![Coverage Status](https://coveralls.io/repos/zendframework/zf2/badge.png?branch=develop)](https://coveralls.io/r/zendframework/zf2)
 
 ## RELEASE INFORMATION
 

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="ZF2" default="build">
-    <target name="travis" depends="tests-parallel,show-test-results" />
+    <target name="travis" depends="tests-parallel,merge-clover,show-test-results" />
 
     <target name="clean" description="Cleanup build artifacts">
         <delete dir="${basedir}/build"/>
@@ -9,6 +9,8 @@
     <target name="prepare" depends="clean" description="Prepare for build">
         <mkdir dir="${basedir}/build/test-results"/>
         <mkdir dir="${basedir}/build/cs-results"/>
+        <mkdir dir="${basedir}/build/coverage"/>
+        <mkdir dir="${basedir}/build/logs"/>
     </target>
 
     <target name="get-cs-fixer" depends="clean" description="Get coding standards fixer">
@@ -30,6 +32,19 @@
             </exec>
         </sequential>
     </target>
+
+    <target name="merge-clover" description="Merges the individual clover reports of each component into a single clover.xml">
+        <sequential>
+            <exec executable="vendor/bin/phpcov.php" failonerror="true">
+                <arg value="--merge" />
+                <arg value="--clover" />
+                <arg value="${basedir}/build/logs/clover.xml" />
+                <arg value="--whitelist" />
+                <arg value="${basedir}/library" />
+                <arg value="${basedir}/build/coverage" />
+            </exec>
+        </sequential>
+    </target>  
 
     <target
         name="tests-parallel"
@@ -118,6 +133,8 @@
             >
                 <arg value="-c" />
                 <arg value="${basedir}/tests/phpunit.xml.dist" />
+                <arg value="--coverage-php" />
+                <arg value="${basedir}/build/coverage/coverage-@{component}.cov" />
                 <arg value="${basedir}/tests/ZendTest/@{component}" />
             </exec>
         </sequential>

--- a/build.xml
+++ b/build.xml
@@ -35,7 +35,10 @@
 
     <target name="merge-clover" description="Merges the individual clover reports of each component into a single clover.xml">
         <sequential>
-            <exec executable="vendor/bin/phpcov.php" failonerror="true">
+            <exec executable="php" failonerror="true">
+                <arg value="-d" />
+                <arg value="memory_limit=-1" />
+                <arg value="vendor/bin/phpcov.php" />
                 <arg value="--merge" />
                 <arg value="--clover" />
                 <arg value="${basedir}/build/logs/clover.xml" />

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,27 @@
     ],
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "sebastianbergmann/phpcov",
+                "version": "1.1.0",
+                "dist": {
+                    "url": "https://github.com/sebastianbergmann/phpcov/archive/1.1.0.zip",
+                    "type": "zip"
+                },
+                "source": {
+                    "url": "https://github.com/sebastianbergmann/phpcov.git",
+                    "type": "git",
+                    "reference": "1.1.0"
+                },
+                "bin": [
+                    "phpcov.php"
+                ]
+            }
+        }
+    ],
     "require": {
         "php": ">=5.3.3"
     },
@@ -16,7 +37,9 @@
         "ircmaxell/random-lib": "dev-master",
         "ircmaxell/security-lib": "dev-master",
         "ocramius/proxy-manager": "0.3.*",
-        "phpunit/PHPUnit": "3.7.*"
+        "phpunit/PHPUnit": "3.7.*",
+        "satooshi/php-coveralls": "dev-master",
+        "sebastianbergmann/phpcov": "1.1.0"
     },
     "suggest": {
         "ext-intl": "ext/intl for i18n features (included in default builds of PHP)",

--- a/tests/ZendTest/Http/Header/AcceptTest.php
+++ b/tests/ZendTest/Http/Header/AcceptTest.php
@@ -282,7 +282,7 @@ class AcceptTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group 3739
-     * @covers Accept::matchAcceptParams()
+     * @covers Zend\Http\Header\AbstractAccept::matchAcceptParams()
      */
     public function testParamRangesWithDecimals()
     {
@@ -293,8 +293,8 @@ class AcceptTest extends \PHPUnit_Framework_TestCase
     /**
      * @group 3740
      * @dataProvider provideParamRanges
-     * @covers Accept::matchAcceptParams()
-     * @covers Accept::getParametersFromFieldValuePart()
+     * @covers Zend\Http\Header\AbstractAccept::matchAcceptParams()
+     * @covers Zend\Http\Header\AbstractAccept::getParametersFromFieldValuePart()
      */
     public function testParamRangesSupportDevStage($range, $input, $success)
     {

--- a/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ControllerManagerTest.php
@@ -62,8 +62,8 @@ class ControllerManagerTest extends TestCase
     }
 
     /**
-     * @covers ControllerManager::has
-     * @covers ControllerManager::get
+     * @covers Zend\ServiceManager\ServiceManager::has
+     * @covers Zend\ServiceManager\AbstractPluginManager::get
      */
     public function testDoNotUsePeeringServiceManagers()
     {

--- a/tests/ZendTest/Validator/File/IsCompressedTest.php
+++ b/tests/ZendTest/Validator/File/IsCompressedTest.php
@@ -33,6 +33,11 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
             return __DIR__ . '/_files/magic.lte.5.3.10.mime';
         }
 
+        // Ubuntu has backported the changes in 12.04 to PHP 5.3.10.
+        if (strpos(PHP_VERSION, 'ubuntu') !== false && version_compare(PHP_VERSION, '5.3.10', '>=')) {
+            return __DIR__ . '/_files/magic.lte.5.3.10.mime';
+        }
+
         return __DIR__ . '/_files/magic.mime';
     }
 

--- a/tests/ZendTest/Validator/File/IsImageTest.php
+++ b/tests/ZendTest/Validator/File/IsImageTest.php
@@ -31,6 +31,11 @@ class IsImageTest extends \PHPUnit_Framework_TestCase
             return __DIR__ . '/_files/magic.lte.5.3.10.mime';
         }
 
+        // Ubuntu has backported the changes in 12.04 to PHP 5.3.10.
+        if (strpos(PHP_VERSION, 'ubuntu') !== false && version_compare(PHP_VERSION, '5.3.10', '>=')) {
+            return __DIR__ . '/_files/magic.lte.5.3.10.mime';
+        }
+
         return __DIR__ . '/_files/magic.mime';
     }
 


### PR DESCRIPTION
This PR adds coveralls support (https://coveralls.io/) to ZF2. This tool integrates nicely with both GitHub and Travis, and allows us to keep track of our code coverage.

In the same run I fixed a few broken `@covers` annotations and a bug which prevented complete testing on Ubuntu 12.04 (see comments in the diff).

Coveralls status can be found at https://coveralls.io/r/zendframework/zf2
