### PR TITLE
Allow DateTimeFormatter to format zero.

### DIFF
--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -71,7 +71,7 @@ class DateTimeFormatter extends AbstractFilter
      */
     protected function normalizeDateTime($value)
     {
-        if (empty($value)) {
+        if ($value === '' || $value === null) {
             return $value;
         } elseif (is_int($value)) {
             $dateTime = new DateTime('@' . $value);

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -42,6 +42,22 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $result);
     }
 
+    public function testFormatterDoesNotFormatNull()
+    {
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter(null);
+        $this->assertEquals(null, $result);
+    }
+
+    public function testFormatterFormatsZero()
+    {
+        date_default_timezone_set('UTC');
+
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter(0);
+        $this->assertEquals('1970-01-01T00:00:00+0000', $result);
+    }
+
     public function testDateTimeFormatted()
     {
         date_default_timezone_set('UTC');


### PR DESCRIPTION
This addresses the note raised in issue #4393 after merge that zero is a
valid UNIX timestamp.
