### PR TITLE
Ability to get an element with creation options from the FormElementManager

### DIFF
--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -123,4 +123,62 @@ class FormElementManager extends AbstractPluginManager
             (is_object($plugin) ? get_class($plugin) : gettype($plugin))
         ));
     }
+
+    /**
+     * Retrieve a service from the manager by name
+     *
+     * Allows passing an array of options to use when creating the instance.
+     * createFromInvokable() will use these and pass them to the instance
+     * constructor if not null and a non-empty array.
+     *
+     * @param  string $name
+     * @param  string|array $options
+     * @param  bool $usePeeringServiceManagers
+     * @return object
+     */
+    public function get($name, $options = array(), $usePeeringServiceManagers = true)
+    {
+        if (is_string($options)) {
+            $options = array('name' => $options);
+        }
+        return parent::get($name, $options, $usePeeringServiceManagers);
+    }
+
+    /**
+     * Attempt to create an instance via an invokable class
+     *
+     * Overrides parent implementation by passing $creationOptions to the
+     * constructor, if non-null.
+     *
+     * @param  string $canonicalName
+     * @param  string $requestedName
+     * @return null|\stdClass
+     * @throws Exception\ServiceNotCreatedException If resolved class does not exist
+     */
+    protected function createFromInvokable($canonicalName, $requestedName)
+    {
+        $invokable = $this->invokableClasses[$canonicalName];
+
+        if (null === $this->creationOptions
+            || (is_array($this->creationOptions) && empty($this->creationOptions))
+        ) {
+            $instance = new $invokable();
+        } else {
+            if (isset($this->creationOptions['name'])) {
+                $name = $this->creationOptions['name'];
+            } else {
+                $name = $requestedName;
+            }
+
+            if (isset($this->creationOptions['options'])) {
+                $options = $this->creationOptions['options'];
+            } else {
+                $options = $this->creationOptions;
+            }
+
+            $instance = new $invokable($name, $options);
+        }
+
+        return $instance;
+    }
 }

--- a/tests/ZendTest/Form/FormElementManagerTest.php
+++ b/tests/ZendTest/Form/FormElementManagerTest.php
@@ -67,4 +67,46 @@ class FormElementManagerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Form\Exception\InvalidElementException');
         $this->manager->get('test');
     }
+
+    public function testStringCreationOptions()
+    {
+        $args = 'foo';
+        $element = $this->manager->get('element', $args);
+        $this->assertEquals('foo', $element->getName(), 'The argument is string');
+    }
+
+    public function testArrayCreationOptions()
+    {
+        $args = array(
+            'name' => 'foo',
+            'options' => array(
+                'label' => 'bar'
+            ),
+        );
+        $element = $this->manager->get('element', $args);
+        $this->assertEquals('foo', $element->getName(), 'Specified name in array[name]');
+        $this->assertEquals('bar', $element->getLabel(), 'Specified options in array[options]');
+    }
+
+    public function testOptionsCreationOptions()
+    {
+        $args = array(
+            'label' => 'bar'
+        );
+        $element = $this->manager->get('element', $args);
+        $this->assertEquals('element', $element->getName(), 'Invokable CNAME');
+        $this->assertEquals('bar', $element->getLabel(), 'Specified options in array');
+    }
+
+    public function testArrayOptionsCreationOptions()
+    {
+        $args = array(
+            'options' => array(
+                'label' => 'bar'
+            ),
+        );
+        $element = $this->manager->get('element', $args);
+        $this->assertEquals('element', $element->getName(), 'Invokable CNAME');
+        $this->assertEquals('bar', $element->getLabel(), 'Specified options in array[options]');
+    }
 }


### PR DESCRIPTION
Now we can get an element from the FormElementManager with only name.

``` php
$element = $FormElementManager->get('element', 'foo');
echo $element->getName();// foo
```

 It is inconvenient not to have the 2nd parameter, 'options'.
