### PR TITLE
Optimize MutableCreationOptionsInterface capability

### DIFF
--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -29,6 +29,14 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function setup()
     {
         $this->serviceManager = new ServiceManager;
+        $this->pluginManager = new FooPluginManager(new Config(array(
+            'factories' => array(
+                'Foo' => 'ZendTest\ServiceManager\TestAsset\FooFactory'
+            ),
+            'shared' => array(
+                'Foo' => false
+            )
+        )));
     }
 
     public function testSetMultipleCreationOptions()
@@ -60,5 +68,19 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFactory', $value['foo']);
         $this->assertEquals(array('key2' => 'value2'), $value['foo']->getCreationOptions());
+    }
+
+    public function testAbstractFactoryWithMutableCreationOptions()
+    {
+        $creationOptions = array('key1' => 'value1');
+        $mock = 'ZendTest\ServiceManager\TestAsset\AbstractFactoryWithMutableCreationOptions';
+        $abstractFactory = $this->getMock($mock, array('setCreationOptions'));
+        $abstractFactory->expects($this->once())
+                ->method('setCreationOptions')
+                ->with($creationOptions);
+
+        $this->pluginManager->addAbstractFactory($abstractFactory);
+        $instance = $this->pluginManager->get('classnoexists', $creationOptions);
+        $this->assertTrue(is_object($instance));
     }
 }

--- a/tests/ZendTest/ServiceManager/TestAsset/AbstractFactoryWithMutableCreationOptions.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/AbstractFactoryWithMutableCreationOptions.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\MutableCreationOptionsInterface;
+/**
+ * implements multiple interface mock
+ *
+ */
+class AbstractFactoryWithMutableCreationOptions implements
+    AbstractFactoryInterface,
+    MutableCreationOptionsInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return true;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return new \StdClass;
+    }
+
+    public function setCreationOptions(array $options)
+    {
+        $this->options = $options;
+    }
+}


### PR DESCRIPTION
This enables Not only the factories but also the abstract factories implementing MutableCreationOptionsInterface to be able to get creation options.
