### PR TITLE
add 'sizes' to itemKeys in HeadLinkHelper

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -25,7 +25,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      *
      * @var array
      */
-    protected $itemKeys = array('charset', 'href', 'hreflang', 'id', 'media', 'rel', 'rev', 'type', 'title', 'extras');
+    protected $itemKeys = array('charset', 'href', 'hreflang', 'id', 'media', 'rel', 'rev', 'sizes', 'type', 'title', 'extras');
 
     /**
      * @var string registry key


### PR DESCRIPTION
Specifies the size of the linked resource. Only for rel="icon". This is new for HTML5
