### PR TITLE
Optimize MutableCreationOptionsInterface capability

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -202,10 +202,6 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         }
 
         if ($factory instanceof FactoryInterface) {
-            if ($hasCreationOptions && $factory instanceof MutableCreationOptionsInterface) {
-                $factory->setCreationOptions($this->creationOptions);
-            }
-
             $instance = $this->createServiceViaCallback(array($factory, 'createService'), $canonicalName, $requestedName);
         } elseif (is_callable($factory)) {
             $instance = $this->createServiceViaCallback($factory, $canonicalName, $requestedName);
@@ -216,5 +212,32 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         }
 
         return $instance;
+    }
+
+    /**
+     * Create service via callback
+     *
+     * @param  callable $callable
+     * @param  string   $cName
+     * @param  string   $rName
+     * @throws Exception\ServiceNotCreatedException
+     * @throws Exception\ServiceNotFoundException
+     * @throws Exception\CircularDependencyFoundException
+     * @return object
+     */
+    protected function createServiceViaCallback($callable, $cName, $rName)
+    {
+        if (is_object($callable)) {
+            $factory = $callable;
+        } elseif (is_array($callable)) {
+            $factory = reset($callable);
+        }
+
+        if (isset($factory) && ($factory instanceof MutableCreationOptionsInterface)
+            && is_array($this->creationOptions) && !empty($this->creationOptions)){
+            $factory->setCreationOptions($this->creationOptions);
+        }
+
+        return parent::createServiceViaCallback($callable, $cName, $rName);
     }
 }

--- a/tests/ZendTest/ServiceManager/TestAsset/AbstractFactoryWithMutableCreationOptions.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/AbstractFactoryWithMutableCreationOptions.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\MutableCreationOptionsInterface;
+/**
+ * implements multiple interface mock
+ *
+ */
+class AbstractFactoryWithMutableCreationOptions implements
+    AbstractFactoryInterface,
+    MutableCreationOptionsInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return true;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return new \StdClass;
+    }
+
+    public function setCreationOptions(array $options)
+    {
+        $this->options = $options;
+    }
+}

--- a/tests/ZendTest/ServiceManager/TestAsset/CallableWithMutableCreationOptions.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/CallableWithMutableCreationOptions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\MutableCreationOptionsInterface;
+/**
+ * implements multiple interface invokable object mock
+ *
+ */
+class CallableWithMutableCreationOptions implements MutableCreationOptionsInterface
+{
+    public function setCreationOptions(array $options)
+    {
+        $this->options = $options;
+    }
+
+    public function __invoke(ServiceLocatorInterface $serviceLocator, $cName, $rName)
+    {
+        return new \StdClass;
+    }
+}


### PR DESCRIPTION
This enables Not only the factories but also the abstract factories implementing MutableCreationOptionsInterface to be able to get creation options.
