### PR TITLE
Fix BC break in HTTP client resetParameters signature

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -461,8 +461,13 @@ class Client implements Stdlib\DispatchableInterface
      * @param  bool   $clearAuth     Also clear http authentication? (defaults to true)
      * @return Client
      */
-    public function resetParameters($clearCookies = false, $clearAuth = true)
+    public function resetParameters($clearCookies = false /*, $clearAuth = true */)
     {
+        $clearAuth = true;
+        if (func_num_args() > 1) {
+            $clearAuth = func_get_arg(1);
+        }
+
         $uri = $this->getUri();
 
         $this->streamName      = null;


### PR DESCRIPTION
See zendframework/ZendOAuth#11 for an example of the consequences of the change.

This PR simply comments out the parameter (by using a comment, we indicate it's expected), and uses `func_num_args()` and `func_get_arg()` to sniff for it.
