### PR TITLE
FormRow: enable partial rendering

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -123,6 +123,15 @@ class FormRow extends AbstractHelper
         $inputErrorClass = $this->getInputErrorClass();
         $elementErrors   = $elementErrorsHelper->render($element);
 
+        if (isset($label) && '' !== $label) {
+            // Translate the label
+            if (null !== ($translator = $this->getTranslator())) {
+                $label = $translator->translate(
+                    $label, $this->getTranslatorTextDomain()
+                );
+            }
+        }
+
         // Does this element have errors ?
         if (!empty($elementErrors) && !empty($inputErrorClass)) {
             $classAttributes = ($element->hasAttribute('class') ? $element->getAttribute('class') . ' ' : '');
@@ -134,6 +143,7 @@ class FormRow extends AbstractHelper
         if ($this->partial) {
             $vars = array(
                 'element'           => $element,
+                'label'             => $label,
                 'labelAttributes'   => $this->labelAttributes,
                 'labelPosition'     => $this->labelPosition,
                 'renderErrors'      => $this->renderErrors,
@@ -145,13 +155,6 @@ class FormRow extends AbstractHelper
         $elementString = $elementHelper->render($element);
 
         if (isset($label) && '' !== $label) {
-            // Translate the label
-            if (null !== ($translator = $this->getTranslator())) {
-                $label = $translator->translate(
-                    $label, $this->getTranslatorTextDomain()
-                );
-            }
-
             $label = $escapeHtmlHelper($label);
             $labelAttributes = $element->getLabelAttributes();
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -73,11 +73,6 @@ class FormRow extends AbstractHelper
     protected $partial;
 
     /**
-     * @var array
-     */
-    protected $partialVars = array();
-
-    /**
      * Invoke helper as functor
      *
      * Proxies to {@link render()}.
@@ -87,7 +82,7 @@ class FormRow extends AbstractHelper
      * @param  bool                  $renderErrors
      * @return string|FormRow
      */
-    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null)
+    public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null, $partial = null)
     {
         if (!$element) {
             return $this;
@@ -101,6 +96,10 @@ class FormRow extends AbstractHelper
 
         if ($renderErrors !== null) {
             $this->setRenderErrors($renderErrors);
+        }
+
+        if ($partial !== null) {
+            $this->setPartial($partial);
         }
 
         return $this->render($element);
@@ -130,6 +129,17 @@ class FormRow extends AbstractHelper
             $classAttributes = $classAttributes . $inputErrorClass;
 
             $element->setAttribute('class', $classAttributes);
+        }
+
+        if ($this->partial) {
+            $vars = array(
+                'element'           => $element,
+                'labelAttributes'   => $this->labelAttributes,
+                'labelPosition'     => $this->labelPosition,
+                'renderErrors'      => $this->renderErrors,
+            );
+
+            return $this->view->render($this->partial, $vars);
         }
 
         $elementString = $elementHelper->render($element);
@@ -171,19 +181,6 @@ class FormRow extends AbstractHelper
                     $label = '<span>' . $label . '</span>';
                 }
 
-                if ($this->partial) {
-                    $vars = array(
-                        'element'       => $elementString,
-                        'label'         => $label,
-                        'labelOpen'     => $labelOpen,
-                        'labelClose'    => $labelClose,
-                        'labelPosition' => $this->labelPosition,
-                        'errors'        => $elementErrors,
-                        'renderErrors'  => $this->renderErrors
-                    );
-                    return $this->view->render($this->partial, array_merge($vars, $this->partialVars));
-                }
-
                 switch ($this->labelPosition) {
                     case self::LABEL_PREPEND:
                         $markup = $labelOpen . $label . $elementString . $labelClose;
@@ -199,15 +196,6 @@ class FormRow extends AbstractHelper
                 $markup .= $elementErrors;
             }
         } else {
-            if ($this->partial) {
-                $vars = array(
-                    'element'       => $elementString,
-                    'errors'        => $elementErrors,
-                    'renderErrors'  => $this->renderErrors
-                );
-                return $this->view->render($this->partial, array_merge($vars, $this->partialVars));
-            }
-
             if ($this->renderErrors) {
                 $markup = $elementString . $elementErrors;
             } else {
@@ -316,6 +304,28 @@ class FormRow extends AbstractHelper
     public function getRenderErrors()
     {
         return $this->renderErrors;
+    }
+
+    /**
+     * Set a partial view script to use for rendering the row
+     *
+     * @param null|string $partial
+     * @return FormRow
+     */
+    public function setPartial($partial)
+    {
+        $this->partial = $partial;
+        return $this;
+    }
+
+    /**
+     * Retrive current partial
+     *
+     * @return null|string
+     */
+    public function getPartial()
+    {
+        return $this->partial;
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -349,4 +349,18 @@ class FormRowTest extends TestCase
         $markup = $this->helper->render($element);
         $this->assertRegexp('#^<input name="foo" id="bar" type="text" value=""\/?><label for="bar">Baz</label>$#', $markup);
     }
+
+    public function testUsePartialView()
+    {
+        $element = new Element('fooname');
+        $element->setLabel('foolabel');
+        $partial = 'formrow-partial.phtml';
+
+        $this->renderer->resolver()->addPath(__DIR__ . '/_templates');
+        $markup = $this->helper->__invoke($element, null, null, $partial);
+        $this->assertContains('fooname', $markup);
+        $this->assertContains('foolabel', $markup);
+
+        $this->assertSame($partial, $this->helper->getPartial());
+    }
 }

--- a/tests/ZendTest/Form/View/Helper/_templates/formrow-partial.phtml
+++ b/tests/ZendTest/Form/View/Helper/_templates/formrow-partial.phtml
@@ -1,0 +1,3 @@
+<?php
+echo $element->getName();
+echo $element->getLabel();


### PR DESCRIPTION
Issue https://github.com/zendframework/zf2/issues/4405

This is what I think @davidwindell intended to do, a way to use custom partial in the form row helper.

If you're thinking about why using a partial within a helper instead of directly call the partial helper in a view, I think that this is a way to easy override a lot of views leaving the `$this->formRow($element);` code in them.

The view has every helper it heeds to render whatever you want, so we can call the `return $this->view->[...]` immediately, instead of after some logic.
