### PR TITLE
Remove URI dependency and make HTTP dependency optional in Feed

### DIFF
--- a/library/Zend/Feed/PubSubHubbub/Publisher.php
+++ b/library/Zend/Feed/PubSubHubbub/Publisher.php
@@ -10,9 +10,9 @@
 namespace Zend\Feed\PubSubHubbub;
 
 use Traversable;
+use Zend\Feed\Uri;
 use Zend\Http\Request as HttpRequest;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Uri;
 use Zend\Version\Version;
 
 class Publisher
@@ -101,7 +101,7 @@ class Publisher
      */
     public function addHubUrl($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 . ' of "' . $url . '" must be a non-empty string and a valid'
                 . 'URL');
@@ -160,7 +160,7 @@ class Publisher
      */
     public function addUpdatedTopicUrl($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 . ' of "' . $url . '" must be a non-empty string and a valid'
                 . 'URL');
@@ -220,7 +220,7 @@ class Publisher
      */
     public function notifyHub($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 . ' of "' . $url . '" must be a non-empty string and a valid'
                 . 'URL');

--- a/library/Zend/Feed/PubSubHubbub/Subscriber.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber.php
@@ -12,9 +12,9 @@ namespace Zend\Feed\PubSubHubbub;
 use DateInterval;
 use DateTime;
 use Traversable;
+use Zend\Feed\Uri;
 use Zend\Http\Request as HttpRequest;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Uri;
 use Zend\Version\Version;
 
 class Subscriber
@@ -194,7 +194,7 @@ class Subscriber
      */
     public function setTopicUrl($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 .' of "' . $url . '" must be a non-empty string and a valid'
                 .' URL');
@@ -257,7 +257,7 @@ class Subscriber
      */
     public function setCallbackUrl($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 . ' of "' . $url . '" must be a non-empty string and a valid'
                 . ' URL');
@@ -327,7 +327,7 @@ class Subscriber
      */
     public function addHubUrl($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 . ' of "' . $url . '" must be a non-empty string and a valid'
                 . ' URL');
@@ -387,7 +387,7 @@ class Subscriber
      */
     public function addAuthentication($url, array $authentication)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter "url"'
                 . ' of "' . $url . '" must be a non-empty string and a valid'
                 . ' URL');

--- a/library/Zend/Feed/PubSubHubbub/Subscriber/Callback.php
+++ b/library/Zend/Feed/PubSubHubbub/Subscriber/Callback.php
@@ -11,7 +11,7 @@ namespace Zend\Feed\PubSubHubbub\Subscriber;
 
 use Zend\Feed\PubSubHubbub;
 use Zend\Feed\PubSubHubbub\Exception;
-use Zend\Uri;
+use Zend\Feed\Uri;
 
 class Callback extends PubSubHubbub\AbstractCallback
 {
@@ -161,7 +161,7 @@ class Callback extends PubSubHubbub\AbstractCallback
         ) {
             return false;
         }
-        if (!Uri\UriFactory::factory($httpGetData['hub_topic'])->isValid()) {
+        if (!Uri::factory($httpGetData['hub_topic'])->isValid()) {
             return false;
         }
 

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -16,7 +16,7 @@ use stdClass;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
-use Zend\Uri;
+use Zend\Feed\Uri;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -548,10 +548,10 @@ class Entry extends Extension\AbstractEntry
      */
     protected function absolutiseUri($link)
     {
-        if (!Uri\UriFactory::factory($link)->isAbsolute()) {
+        if (!Uri::factory($link)->isAbsolute()) {
             if ($this->getBaseUrl() !== null) {
                 $link = $this->getBaseUrl() . $link;
-                if (!Uri\UriFactory::factory($link)->isValid()) {
+                if (!Uri::factory($link)->isValid()) {
                     $link = null;
                 }
             }

--- a/library/Zend/Feed/Reader/Extension/Atom/Feed.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Feed.php
@@ -14,7 +14,7 @@ use DOMElement;
 use Zend\Feed\Reader;
 use Zend\Feed\Reader\Collection;
 use Zend\Feed\Reader\Extension;
-use Zend\Uri;
+use Zend\Feed\Uri;
 
 class Feed extends Extension\AbstractFeed
 {
@@ -482,10 +482,10 @@ class Feed extends Extension\AbstractFeed
      */
     protected function absolutiseUri($link)
     {
-        if (!Uri\UriFactory::factory($link)->isAbsolute()) {
+        if (!Uri::factory($link)->isAbsolute()) {
             if ($this->getBaseUrl() !== null) {
                 $link = $this->getBaseUrl() . $link;
-                if (!Uri\UriFactory::factory($link)->isValid()) {
+                if (!Uri::factory($link)->isValid()) {
                     $link = null;
                 }
             }

--- a/library/Zend/Feed/Reader/FeedSet.php
+++ b/library/Zend/Feed/Reader/FeedSet.php
@@ -11,7 +11,7 @@ namespace Zend\Feed\Reader;
 
 use ArrayObject;
 use DOMNodeList;
-use Zend\Uri;
+use Zend\Feed\Uri;
 
 /**
 */
@@ -67,17 +67,17 @@ class FeedSet extends ArrayObject
      */
     protected function absolutiseUri($link, $uri = null)
     {
-        $linkUri = Uri\UriFactory::factory($link);
+        $linkUri = Uri::factory($link);
         if (!$linkUri->isAbsolute() or !$linkUri->isValid()) {
             if ($uri !== null) {
-                $uri = Uri\UriFactory::factory($uri);
+                $uri = Uri::factory($uri);
 
                 if ($link[0] !== '/') {
                     $link = $uri->getPath() . '/' . $link;
                 }
 
                 $link = $uri->getScheme() . '://' . $uri->getHost() . '/' . $this->canonicalizePath($link);
-                if (!Uri\UriFactory::factory($link)->isValid()) {
+                if (!Uri::factory($link)->isValid()) {
                     $link = null;
                 }
             }

--- a/library/Zend/Feed/Reader/Http/ClientInterface.php
+++ b/library/Zend/Feed/Reader/Http/ClientInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+interface ClientInterface
+{
+    /**
+     * Make a GET request to a given URI
+     *
+     * @param  string $uri
+     * @return ResponseInterface
+     */
+    public function get($uri);
+}

--- a/library/Zend/Feed/Reader/Http/ResponseInterface.php
+++ b/library/Zend/Feed/Reader/Http/ResponseInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader\Http;
+
+interface ResponseInterface
+{
+    /**
+     * Retrieve the response body
+     *
+     * @return string
+     */
+    public function getBody();
+
+    /**
+     * Retrieve the HTTP response status code
+     *
+     * @return int
+     */
+    public function getStatusCode();
+}

--- a/library/Zend/Feed/Uri.php
+++ b/library/Zend/Feed/Uri.php
@@ -66,7 +66,7 @@ class Uri
     );
 
     /**
-     * @param  string $uri 
+     * @param  string $uri
      */
     public function __construct($uri)
     {
@@ -90,8 +90,8 @@ class Uri
      * Create an instance
      *
      * Useful for chained validations
-     * 
-     * @param  string $uri 
+     *
+     * @param  string $uri
      * @return self
      */
     public static function factory($uri)
@@ -101,7 +101,7 @@ class Uri
 
     /**
      * Retrieve the host
-     * 
+     *
      * @return string
      */
     public function getHost()
@@ -111,7 +111,7 @@ class Uri
 
     /**
      * Retrieve the URI path
-     * 
+     *
      * @return string
      */
     public function getPath()
@@ -121,7 +121,7 @@ class Uri
 
     /**
      * Retrieve the scheme
-     * 
+     *
      * @return string
      */
     public function getScheme()
@@ -130,8 +130,8 @@ class Uri
     }
 
     /**
-     * Is the URI valid? 
-     * 
+     * Is the URI valid?
+     *
      * @return bool
      */
     public function isValid()
@@ -174,7 +174,7 @@ class Uri
 
     /**
      * Is the URI absolute?
-     * 
+     *
      * @return bool
      */
     public function isAbsolute()

--- a/library/Zend/Feed/Uri.php
+++ b/library/Zend/Feed/Uri.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed;
+
+class Uri
+{
+    /**
+     * @var string
+     */
+    protected $fragment;
+
+    /**
+     * @var string
+     */
+    protected $host;
+
+    /**
+     * @var string
+     */
+    protected $pass;
+
+    /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var int
+     */
+    protected $port;
+
+    /**
+     * @var string
+     */
+    protected $query;
+
+    /**
+     * @var string
+     */
+    protected $scheme;
+
+    /**
+     * @var string
+     */
+    protected $user;
+
+    /**
+     * @var bool
+     */
+    protected $valid;
+
+    /**
+     * Valid schemes
+     */
+    protected $validSchemes = array(
+        'http',
+        'https',
+        'file',
+    );
+
+    /**
+     * @param  string $uri 
+     */
+    public function __construct($uri)
+    {
+        $parsed = parse_url($uri);
+        if (false === $parsed) {
+            $this->valid = false;
+            return;
+        }
+
+        $this->scheme   = isset($parsed['scheme'])   ? $parsed['scheme']   : null;
+        $this->host     = isset($parsed['host'])     ? $parsed['host']     : null;
+        $this->port     = isset($parsed['port'])     ? $parsed['port']     : null;
+        $this->user     = isset($parsed['user'])     ? $parsed['user']     : null;
+        $this->pass     = isset($parsed['pass'])     ? $parsed['pass']     : null;
+        $this->path     = isset($parsed['path'])     ? $parsed['path']     : null;
+        $this->query    = isset($parsed['query'])    ? $parsed['query']    : null;
+        $this->fragment = isset($parsed['fragment']) ? $parsed['fragment'] : null;
+    }
+
+    /**
+     * Create an instance
+     *
+     * Useful for chained validations
+     * 
+     * @param  string $uri 
+     * @return self
+     */
+    public static function factory($uri)
+    {
+        return new static($uri);
+    }
+
+    /**
+     * Retrieve the host
+     * 
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Retrieve the URI path
+     * 
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Retrieve the scheme
+     * 
+     * @return string
+     */
+    public function getScheme()
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * Is the URI valid? 
+     * 
+     * @return bool
+     */
+    public function isValid()
+    {
+        if (false === $this->valid) {
+            return false;
+        }
+
+        if ($this->scheme && !in_array($this->scheme, $this->validSchemes)) {
+            return false;
+        }
+
+        if ($this->host) {
+            if ($this->path && substr($this->path, 0, 1) != '/') {
+                return false;
+            }
+            return true;
+        }
+
+        // no host, but user and/or port... what?
+        if ($this->user || $this->port) {
+            return false;
+        }
+
+        if ($this->path) {
+            // Check path-only (no host) URI
+            if (substr($this->path, 0, 2) == '//') {
+                return false;
+            }
+            return true;
+        }
+
+        if (! ($this->query || $this->fragment)) {
+            // No host, path, query or fragment - this is not a valid URI
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Is the URI absolute?
+     * 
+     * @return bool
+     */
+    public function isAbsolute()
+    {
+        return ($this->scheme !== null);
+    }
+}

--- a/library/Zend/Feed/Writer/AbstractFeed.php
+++ b/library/Zend/Feed/Writer/AbstractFeed.php
@@ -10,7 +10,7 @@
 namespace Zend\Feed\Writer;
 
 use DateTime;
-use Zend\Uri;
+use Zend\Feed\Uri;
 use Zend\Validator;
 
 class AbstractFeed
@@ -77,7 +77,7 @@ class AbstractFeed
         }
         if (isset($author['uri'])) {
             if (empty($author['uri']) || !is_string($author['uri']) ||
-                !Uri\UriFactory::factory($author['uri'])->isValid()
+                !Uri::factory($author['uri'])->isValid()
             ) {
                 throw new Exception\InvalidArgumentException(
                     'Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
@@ -229,7 +229,7 @@ class AbstractFeed
                 $generator['version'] = $data['version'];
             }
             if (isset($data['uri'])) {
-                if (empty($data['uri']) || !is_string($data['uri']) || !Uri\UriFactory::factory($data['uri'])->isValid()) {
+                if (empty($data['uri']) || !is_string($data['uri']) || !Uri::factory($data['uri'])->isValid()) {
                     throw new Exception\InvalidArgumentException('Invalid parameter: "uri" must be a non-empty string and a valid URI/IRI');
                 }
                 $generator['uri'] = $data['uri'];
@@ -246,7 +246,7 @@ class AbstractFeed
                 $generator['version'] = $version;
             }
             if (isset($uri)) {
-                if (empty($uri) || !is_string($uri) || !Uri\UriFactory::factory($uri)->isValid()) {
+                if (empty($uri) || !is_string($uri) || !Uri::factory($uri)->isValid()) {
                     throw new Exception\InvalidArgumentException('Invalid parameter: "uri" must be a non-empty string and a valid URI/IRI');
                 }
                 $generator['uri'] = $uri;
@@ -266,7 +266,7 @@ class AbstractFeed
      */
     public function setId($id)
     {
-        if ((empty($id) || !is_string($id) || !Uri\UriFactory::factory($id)->isValid())
+        if ((empty($id) || !is_string($id) || !Uri::factory($id)->isValid())
             && !preg_match("#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#", $id)
             && !$this->_validateTagUri($id)
         ) {
@@ -322,7 +322,7 @@ class AbstractFeed
     public function setImage(array $data)
     {
         if (empty($data['uri']) || !is_string($data['uri'])
-            || !Uri\UriFactory::factory($data['uri'])->isValid()
+            || !Uri::factory($data['uri'])->isValid()
         ) {
             throw new Exception\InvalidArgumentException('Invalid parameter: parameter \'uri\''
             . ' must be a non-empty string and valid URI/IRI');
@@ -358,7 +358,7 @@ class AbstractFeed
      */
     public function setLink($link)
     {
-        if (empty($link) || !is_string($link) || !Uri\UriFactory::factory($link)->isValid()) {
+        if (empty($link) || !is_string($link) || !Uri::factory($link)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: parameter must be a non-empty string and valid URI/IRI');
         }
         $this->data['link'] = $link;
@@ -376,7 +376,7 @@ class AbstractFeed
      */
     public function setFeedLink($link, $type)
     {
-        if (empty($link) || !is_string($link) || !Uri\UriFactory::factory($link)->isValid()) {
+        if (empty($link) || !is_string($link) || !Uri::factory($link)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: "link"" must be a non-empty string and valid URI/IRI');
         }
         if (!in_array(strtolower($type), array('rss', 'rdf', 'atom'))) {
@@ -430,7 +430,7 @@ class AbstractFeed
      */
     public function setBaseUrl($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: "url" array value'
             . ' must be a non-empty string and valid URI/IRI');
         }
@@ -448,7 +448,7 @@ class AbstractFeed
      */
     public function addHub($url)
     {
-        if (empty($url) || !is_string($url) || !Uri\UriFactory::factory($url)->isValid()) {
+        if (empty($url) || !is_string($url) || !Uri::factory($url)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: "url" array value'
             . ' must be a non-empty string and valid URI/IRI');
         }
@@ -492,7 +492,7 @@ class AbstractFeed
         if (isset($category['scheme'])) {
             if (empty($category['scheme'])
                 || !is_string($category['scheme'])
-                || !Uri\UriFactory::factory($category['scheme'])->isValid()
+                || !Uri::factory($category['scheme'])->isValid()
             ) {
                 throw new Exception\InvalidArgumentException('The Atom scheme or RSS domain of'
                 . ' a category must be a valid URI');

--- a/library/Zend/Feed/Writer/Deleted.php
+++ b/library/Zend/Feed/Writer/Deleted.php
@@ -10,7 +10,7 @@
 namespace Zend\Feed\Writer;
 
 use DateTime;
-use Zend\Uri;
+use Zend\Feed\Uri;
 
 /**
 */
@@ -191,7 +191,7 @@ class Deleted
         if (isset($by['uri'])) {
             if (empty($by['uri'])
                 || !is_string($by['uri'])
-                || !Uri\UriFactory::factory($by['uri'])->isValid()
+                || !Uri::factory($by['uri'])->isValid()
             ) {
                 throw new Exception\InvalidArgumentException('Invalid parameter: "uri" array value must'
                  . ' be a non-empty string and valid URI/IRI');

--- a/library/Zend/Feed/Writer/Entry.php
+++ b/library/Zend/Feed/Writer/Entry.php
@@ -10,8 +10,8 @@
 namespace Zend\Feed\Writer;
 
 use DateTime;
+use Zend\Feed\Uri;
 use Zend\Feed\Writer\Exception;
-use Zend\Uri;
 
 /**
 */
@@ -82,7 +82,7 @@ class Entry
         }
         if (isset($author['uri'])) {
             if (empty($author['uri']) || !is_string($author['uri']) ||
-                !Uri\UriFactory::factory($author['uri'])->isValid()
+                !Uri::factory($author['uri'])->isValid()
             ) {
                 throw new Exception\InvalidArgumentException(
                     'Invalid parameter: "uri" array value must be a non-empty string and valid URI/IRI');
@@ -259,7 +259,7 @@ class Entry
      */
     public function setLink($link)
     {
-        if (empty($link) || !is_string($link) || !Uri\UriFactory::factory($link)->isValid()) {
+        if (empty($link) || !is_string($link) || !Uri::factory($link)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: parameter must be a non-empty string and valid URI/IRI');
         }
         $this->data['link'] = $link;
@@ -293,7 +293,7 @@ class Entry
      */
     public function setCommentLink($link)
     {
-        if (empty($link) || !is_string($link) || !Uri\UriFactory::factory($link)->isValid()) {
+        if (empty($link) || !is_string($link) || !Uri::factory($link)->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: "link" must be a non-empty string and valid URI/IRI');
         }
         $this->data['commentLink'] = $link;
@@ -310,7 +310,7 @@ class Entry
      */
     public function setCommentFeedLink(array $link)
     {
-        if (!isset($link['uri']) || !is_string($link['uri']) || !Uri\UriFactory::factory($link['uri'])->isValid()) {
+        if (!isset($link['uri']) || !is_string($link['uri']) || !Uri::factory($link['uri'])->isValid()) {
             throw new Exception\InvalidArgumentException('Invalid parameter: "link" must be a non-empty string and valid URI/IRI');
         }
         if (!isset($link['type']) || !in_array($link['type'], array('atom', 'rss', 'rdf'))) {
@@ -547,7 +547,7 @@ class Entry
         if (isset($category['scheme'])) {
             if (empty($category['scheme'])
                 || !is_string($category['scheme'])
-                || !Uri\UriFactory::factory($category['scheme'])->isValid()
+                || !Uri::factory($category['scheme'])->isValid()
             ) {
                 throw new Exception\InvalidArgumentException('The Atom scheme or RSS domain of'
                 . ' a category must be a valid URI');
@@ -604,7 +604,7 @@ class Entry
         if (!isset($enclosure['uri'])) {
             throw new Exception\InvalidArgumentException('Enclosure "uri" is not set');
         }
-        if (!Uri\UriFactory::factory($enclosure['uri'])->isValid()) {
+        if (!Uri::factory($enclosure['uri'])->isValid()) {
             throw new Exception\InvalidArgumentException('Enclosure "uri" is not a valid URI/IRI');
         }
         $this->data['enclosure'] = $enclosure;

--- a/library/Zend/Feed/Writer/Extension/ITunes/Feed.php
+++ b/library/Zend/Feed/Writer/Extension/ITunes/Feed.php
@@ -9,8 +9,8 @@
 
 namespace Zend\Feed\Writer\Extension\ITunes;
 
+use Zend\Feed\Uri;
 use Zend\Feed\Writer;
-use Zend\Uri;
 use Zend\Stdlib\StringUtils;
 use Zend\Stdlib\StringWrapper\StringWrapperInterface;
 
@@ -171,7 +171,7 @@ class Feed
      */
     public function setItunesImage($value)
     {
-        if (!Uri\UriFactory::factory($value)->isValid()) {
+        if (!Uri::factory($value)->isValid()) {
             throw new Writer\Exception\InvalidArgumentException('invalid parameter: "image" may only'
             . ' be a valid URI/IRI');
         }
@@ -254,7 +254,7 @@ class Feed
      */
     public function setItunesNewFeedUrl($value)
     {
-        if (!Uri\UriFactory::factory($value)->isValid()) {
+        if (!Uri::factory($value)->isValid()) {
             throw new Writer\Exception\InvalidArgumentException('invalid parameter: "newFeedUrl" may only'
             . ' be a valid URI/IRI');
         }

--- a/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
@@ -12,9 +12,9 @@ namespace Zend\Feed\Writer\Renderer\Entry;
 use DateTime;
 use DOMDocument;
 use DOMElement;
+use Zend\Feed\Uri;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
-use Zend\Uri;
 use Zend\Validator;
 
 class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterface
@@ -267,7 +267,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
             $this->getDataContainer()->setId(
                 $this->getDataContainer()->getLink());
         }
-        if (!Uri\UriFactory::factory($this->getDataContainer()->getId())->isValid()
+        if (!Uri::factory($this->getDataContainer()->getId())->isValid()
             && !preg_match(
                 "#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#",
                 $this->getDataContainer()->getId())

--- a/library/Zend/Feed/Writer/Renderer/Entry/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Rss.php
@@ -12,9 +12,9 @@ namespace Zend\Feed\Writer\Renderer\Entry;
 use DateTime;
 use DOMDocument;
 use DOMElement;
+use Zend\Feed\Uri;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
-use Zend\Uri;
 
 /**
 */
@@ -279,7 +279,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $text = $dom->createTextNode($this->getDataContainer()->getId());
         $id->appendChild($text);
-        if (!Uri\UriFactory::factory($this->getDataContainer()->getId())->isValid()) {
+        if (!Uri::factory($this->getDataContainer()->getId())->isValid()) {
             $id->setAttribute('isPermaLink', 'false');
         }
     }

--- a/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -12,9 +12,9 @@ namespace Zend\Feed\Writer\Renderer\Feed;
 use DateTime;
 use DOMDocument;
 use DOMElement;
+use Zend\Feed\Uri;
 use Zend\Feed\Writer;
 use Zend\Feed\Writer\Renderer;
-use Zend\Uri;
 use Zend\Version\Version;
 
 /**
@@ -239,7 +239,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         $root->appendChild($link);
         $text = $dom->createTextNode($value);
         $link->appendChild($text);
-        if (!Uri\UriFactory::factory($value)->isValid()) {
+        if (!Uri::factory($value)->isValid()) {
             $link->setAttribute('isPermaLink', 'false');
         }
     }
@@ -317,7 +317,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
 
         if (empty($image['link']) || !is_string($image['link'])
-            || !Uri\UriFactory::factory($image['link'])->isValid()
+            || !Uri::factory($image['link'])->isValid()
         ) {
             $message = 'Invalid parameter: parameter \'link\''
             . ' must be a non-empty string and valid URI/IRI';

--- a/library/Zend/Feed/composer.json
+++ b/library/Zend/Feed/composer.json
@@ -17,9 +17,11 @@
         "zendframework/zend-escaper": "self.version",
         "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-validator": "self.version"
         "zendframework/zend-version": "self.version"
     },
     "suggest": {
+        "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\Reader",
         "zendframework/zend-validator": "Zend\\Validator component"
     },
     "extra": {

--- a/library/Zend/Feed/composer.json
+++ b/library/Zend/Feed/composer.json
@@ -17,7 +17,6 @@
         "zendframework/zend-escaper": "self.version",
         "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-servicemanager": "self.version",
-        "zendframework/zend-uri": "self.version",
         "zendframework/zend-version": "self.version"
     },
     "suggest": {

--- a/tests/ZendTest/Feed/Reader/ReaderTest.php
+++ b/tests/ZendTest/Feed/Reader/ReaderTest.php
@@ -277,6 +277,30 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         //$this->assertEquals('info:', $feed->getTitle());
     }
 
+    public function testImportRemoteFeedMethodPerformsAsExpected()
+    {
+        $uri = 'http://example.com/feeds/reader.xml';
+        $feedContents = file_get_contents($this->feedSamplePath . '/Reader/rss20.xml');
+        $response = $this->getMock('Zend\Feed\Reader\Http\ResponseInterface', array('getStatusCode', 'getBody'));
+        $response->expects($this->once())
+            ->method('getStatusCode')
+            ->will($this->returnValue(200));
+        $response->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue($feedContents));
+
+        $client = $this->getMock('Zend\Feed\Reader\Http\ClientInterface', array('get'));
+        $client->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo($uri))
+            ->will($this->returnValue($response));
+
+        $feed = Reader\Reader::importRemoteFeed($uri, $client);
+        $this->assertInstanceOf('Zend\Feed\Reader\Feed\FeedInterface', $feed);
+        $type = Reader\Reader::detectType($feed);
+        $this->assertEquals(Reader\Reader::TYPE_RSS_20, $type);
+    }
+
     protected function _getTempDirectory()
     {
         $tmpdir = array();


### PR DESCRIPTION
This PR removes the dependency on `Zend\Uri`, and makes the dependency on `Zend\Http` optional in `Zend\Feed`.

`Zend\Feed` was using a small subset of the functionality of `Zend\Uri`, primarily related to ensuring we have a valid URI and/or absolute URI. This subset was ported into a component-specific implementation.

`Zend\Http` was already optional, as it was only being used by the `import()` method of `Zend\Feed\Reader\Reader`, and the `PubSubHubbub` (PuSH) subcomponent. `import()`, while it uses a variety of functionality from the `Http` component, is an optional path for consuming feeds. A new method, `importRemoteFeed()` was added, which accepts a string URI, and an HTTP client -- however, in this case, it is a component-specific client interface that is being typed. This allows bridging alternate HTTP client implementations for the purpose of using the Reader component.

Usage is:

``` php
$feed = Reader::importRemoteFeed('http://example.com/feeds/reader.xml', $client);
```

The client interface looks like this:

``` php
namespace Zend\Feed\Reader\Http;
interface ClientInterface
{
    public function get($uri); // should return a ResponseInterface instance
}
```

and the response interface is as follows:

``` php
namespace Zend\Feed\Reader\Http;
interface ResponseInterface
{
    public function getStatusCode();
    public function getBody();
}
```

A simple example using Guzzle might look like:

``` php
use Guzzle\Http\Client;
use Guzzle\Http\Message\Response;
use Zend\Feed\Reader\Http\ClientInterface;
use Zend\Feed\Reader\Http\ResponseInterface;
use Zend\Feed\Reader\Reader;

class GuzzleResponse implements ResponseInterface
{
    protected $response;

    public function __construct(Response $response)
    {
        $this->response = $response;
    }

    public function getStatusCode()
    {
        return $this->response->getStatusCode();
    }

    public function getBody()
    {
        return $this->response->getBody(true);
    }
}

class GuzzleClient
{
    protected $guzzle;

    public function __construct(Client $guzzle)
    {
        $this->guzzle = $guzzle;
    }

    public function get($uri)
    {
        $request  = $this->guzzle->get($uri);
        $response = $request->send();
        return new GuzzleResponse($response);
    }
}

$client = new GuzzleClient(new Client());
$feed   = Reader::importRemoteFeed('http://example.org/feed/reader.xml', $client);
```
