### PR TITLE
sync svn r24702 - support application/x-zip in Validator\File\IsCompressed

### DIFF
--- a/library/Zend/Validator/File/IsCompressed.php
+++ b/library/Zend/Validator/File/IsCompressed.php
@@ -71,6 +71,7 @@ class IsCompressed extends MimeType
             'application/x-stuffit',
             'application/x-tar',
             'application/zip',
+            'application/x-zip',
             'application/zoo',
             'multipart/x-gzip',
         );

--- a/tests/ZendTest/Validator/File/IsCompressedTest.php
+++ b/tests/ZendTest/Validator/File/IsCompressedTest.php
@@ -42,17 +42,25 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
     public function basicBehaviorDataProvider()
     {
         $testFile = __DIR__ . '/_files/test.zip';
+
+        // Sometimes mime_content_type() gives application/zip and sometimes 
+        // application/x-zip ...
+        $expectedMimeType = mime_content_type(__DIR__ . '/_files/test.zip');
+        if (!in_array($expectedMimeType, array('application/zip', 'application/x-zip'))) {
+            $this->markTestSkipped('mime_content_type exhibits buggy behavior on this system!');
+        }
+
         $fileUpload = array(
             'tmp_name' => $testFile, 'name' => basename($testFile),
-            'size' => 200, 'error' => 0, 'type' => 'application/zip'
+            'size' => 200, 'error' => 0, 'type' => $expectedMimeType
         );
         return array(
             //    Options, isValid Param, Expected value
             array(null,                                          $fileUpload, true),
             array('zip',                                         $fileUpload, true),
             array('test/notype',                                 $fileUpload, false),
-            array('application/zip, application/x-tar',          $fileUpload, true),
-            array(array('application/zip', 'application/x-tar'), $fileUpload, true),
+            array('application/x-zip, application/zip, application/x-tar', $fileUpload, true),
+            array(array('application/x-zip', 'application/zip', 'application/x-tar'), $fileUpload, true),
             array(array('zip', 'tar'),                           $fileUpload, true),
             array(array('tar', 'arj'),                           $fileUpload, false),
         );


### PR DESCRIPTION
This is a sync of svn r24702.
for support application/x-zip 

@see (commit-log)
https://bitbucket.org/sasezaki/mirror-zf1-standard-trunk-libraray-validate-dir/commits/deab989ef3728529ff4f0f35aba7ca6498643523
https://bitbucket.org/sasezaki/mirror-zf1-standard-trunk-tests-validate-dir/commits/c11495d2a6d3f191694820f9a9b6b7938a062fa8

original commit is using mime_content_type() function (yeah, it is deprecated) , so should be attention before merge this.
