### PR TITLE
set self::HOST_DNS_OR_IPV4_OR_IPV6_OR_REGNAME as default value of  $allowed parameter

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -125,7 +125,7 @@ class Http extends Uri
      * @param  int $allowed
      * @return bool
      */
-    public static function validateHost($host, $allowed = self::HOST_DNS_OR_IPV4_OR_IPV6)
+    public static function validateHost($host, $allowed = self::HOST_DNS_OR_IPV4_OR_IPV6_OR_REGNAME)
     {
         return parent::validateHost($host, $allowed);
     }


### PR DESCRIPTION
in Zend\Uri\Http::validateHost based on $validHostTypes property.
