### PR TITLE
[WIP] Di compatibility (#4434)

### DIFF
--- a/library/Zend/Di/Definition/ArrayDefinition.php
+++ b/library/Zend/Di/Definition/ArrayDefinition.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Di\Definition;
 
+use Zend\Di\Definition\Builder\InjectionMethod;
 /**
  * Class definitions based on a given array
  */
@@ -27,6 +28,15 @@ class ArrayDefinition implements DefinitionInterface
         foreach ($dataArray as $class => $value) {
             // force lower names
             $dataArray[$class] = array_change_key_case($dataArray[$class], CASE_LOWER);
+        }
+        foreach ($dataArray as $class => $definition) {
+            if (isset($definition['methods']) && is_array($definition['methods'])) {
+                foreach ($definition['methods'] as $type => $requirement) {
+                    if (!is_int($requirement)) {
+                        $dataArray[$class]['methods'][$type] = InjectionMethod::detectMethodRequirement($requirement);
+                    }
+                }
+            }
         }
         $this->dataArray = $dataArray;
     }

--- a/library/Zend/Di/Definition/Builder/InjectionMethod.php
+++ b/library/Zend/Di/Definition/Builder/InjectionMethod.php
@@ -111,6 +111,9 @@ class InjectionMethod
                 case "instantiator":
                     return Di::METHOD_IS_INSTANTIATOR;
                     break;
+                case "eager":
+                    return Di::METHOD_IS_EAGER;
+                    break;
             }
         }
         return 0;

--- a/library/Zend/Di/Definition/Builder/InjectionMethod.php
+++ b/library/Zend/Di/Definition/Builder/InjectionMethod.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Di\Definition\Builder;
 
+use Zend\Di\Di;
+
 /**
  * Definitions for an injection endpoint method
  */
@@ -52,10 +54,42 @@ class InjectionMethod
      */
     public function addParameter($name, $class = null, $isRequired = null, $default = null)
     {
+        if (is_bool($isRequired)) {
+            $methodRequirementType = $isRequired ? Di::METHOD_IS_REQUIRED : Di::METHOD_IS_OPTIONAL;
+        }
+
+        if (null === $isRequired) {
+            $methodRequirementType = Di::METHOD_IS_REQUIRED;
+        }
+
+        if (is_int($isRequired)) {
+            $methodRequirementType = $isRequired;
+        }
+
+        if (is_string($isRequired)) {
+            switch (strtolower($isRequired)) {
+                case "require":
+                case "required":
+                    $methodRequirementType = Di::METHOD_IS_REQUIRED;
+                    break;
+                case "aware":
+                    $methodRequirementType = Di::METHOD_IS_AWARE;
+                    break;
+                case "optional":
+                    $methodRequirementType = Di::METHOD_IS_OPTIONAL;
+                    break;
+                case "constructor":
+                    $methodRequirementType = Di::MEHTOD_IS_CONSTRUCTOR;
+                    break;
+                case "instantiator":
+                    $methodRequirementType = Di::METHOD_IS_INSTANTIATOR;
+                    break;
+            }
+        }
         $this->parameters[] = array(
             $name,
             $class,
-            ($isRequired == null) ? true : false,
+            $methodRequirementType,
             $default,
         );
 

--- a/library/Zend/Di/Definition/Builder/InjectionMethod.php
+++ b/library/Zend/Di/Definition/Builder/InjectionMethod.php
@@ -54,42 +54,10 @@ class InjectionMethod
      */
     public function addParameter($name, $class = null, $isRequired = null, $default = null)
     {
-        if (is_bool($isRequired)) {
-            $methodRequirementType = $isRequired ? Di::METHOD_IS_REQUIRED : Di::METHOD_IS_OPTIONAL;
-        }
-
-        if (null === $isRequired) {
-            $methodRequirementType = Di::METHOD_IS_REQUIRED;
-        }
-
-        if (is_int($isRequired)) {
-            $methodRequirementType = $isRequired;
-        }
-
-        if (is_string($isRequired)) {
-            switch (strtolower($isRequired)) {
-                case "require":
-                case "required":
-                    $methodRequirementType = Di::METHOD_IS_REQUIRED;
-                    break;
-                case "aware":
-                    $methodRequirementType = Di::METHOD_IS_AWARE;
-                    break;
-                case "optional":
-                    $methodRequirementType = Di::METHOD_IS_OPTIONAL;
-                    break;
-                case "constructor":
-                    $methodRequirementType = Di::MEHTOD_IS_CONSTRUCTOR;
-                    break;
-                case "instantiator":
-                    $methodRequirementType = Di::METHOD_IS_INSTANTIATOR;
-                    break;
-            }
-        }
         $this->parameters[] = array(
             $name,
             $class,
-            $methodRequirementType,
+            self::detectMethodRequirement($isRequired),
             $default,
         );
 

--- a/library/Zend/Di/Definition/Builder/InjectionMethod.php
+++ b/library/Zend/Di/Definition/Builder/InjectionMethod.php
@@ -103,4 +103,48 @@ class InjectionMethod
     {
         return $this->parameters;
     }
+
+    /**
+     *
+     * @param mixed $requirement
+     * @return int
+     */
+    public static function detectMethodRequirement($requirement)
+    {
+        if (is_bool($requirement)) {
+            return $requirement ? Di::METHOD_IS_REQUIRED : Di::METHOD_IS_OPTIONAL;
+        }
+
+        if (null === $requirement) {
+            //This is mismatch to ClassDefinition::addMethod is it ok ? is optional?
+            return Di::METHOD_IS_REQUIRED;
+        }
+
+        if (is_int($requirement)) {
+            return $requirement;
+        }
+
+        if (is_string($requirement)) {
+            switch (strtolower($requirement)) {
+                default:
+                case "require":
+                case "required":
+                    return Di::METHOD_IS_REQUIRED;
+                    break;
+                case "aware":
+                    return Di::METHOD_IS_AWARE;
+                    break;
+                case "optional":
+                    return Di::METHOD_IS_OPTIONAL;
+                    break;
+                case "constructor":
+                    return Di::MEHTOD_IS_CONSTRUCTOR;
+                    break;
+                case "instantiator":
+                    return Di::METHOD_IS_INSTANTIATOR;
+                    break;
+            }
+        }
+        return 0;
+    }
 }

--- a/library/Zend/Di/Definition/ClassDefinition.php
+++ b/library/Zend/Di/Definition/ClassDefinition.php
@@ -10,6 +10,8 @@
 namespace Zend\Di\Definition;
 
 use Zend\Di\Di;
+use Zend\Di\Definition\Builder\InjectionMethod;
+
 /**
  * Class definitions for a single class
  */
@@ -77,40 +79,13 @@ class ClassDefinition implements DefinitionInterface, PartialMarker
      */
     public function addMethod($method, $isRequired = null)
     {
-        if ($isRequired === null) {
+       if ($isRequired === null) {
             if ($method === '__construct') {
                 $methodRequirementType = Di::METHOD_IS_CONSTRUCTOR;
             }
             $methodRequirementType = Di::METHOD_IS_OPTIONAL;
-        }
-
-        if (is_bool($isRequired)) {
-            $methodRequirementType = $isRequired ? Di::METHOD_IS_REQUIRED : Di::METHOD_IS_OPTIONAL;
-        }
-
-        if (is_int($isRequired)) {
-            $methodRequirementType = $isRequired;
-        }
-
-        if (is_string($isRequired)) {
-            switch (strtolower($isRequired)) {
-                case "require":
-                case "required":
-                    $methodRequirementType = Di::METHOD_IS_REQUIRED;
-                    break;
-                case "aware":
-                    $methodRequirementType = Di::METHOD_IS_AWARE;
-                    break;
-                case "optional":
-                    $methodRequirementType = Di::METHOD_IS_OPTIONAL;
-                    break;
-                case "constructor":
-                    $methodRequirementType = Di::MEHTOD_IS_CONSTRUCTOR;
-                    break;
-                case "instantiator":
-                    $methodRequirementType = Di::METHOD_IS_INSTANTIATOR;
-                    break;
-            }
+        } else {
+            $methodRequirementType = InjectionMethod::detectMethodRequirement($isRequired);
         }
 
         $this->methods[$method] = $methodRequirementType;

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -12,7 +12,7 @@ namespace Zend\Di\Definition;
 use Zend\Code\Annotation\AnnotationCollection;
 use Zend\Code\Reflection;
 use Zend\Di\Definition\Annotation;
-
+use Zend\Di\Di;
 /**
  * Class definitions based on runtime reflection
  */
@@ -248,7 +248,7 @@ class RuntimeDefinition implements DefinitionInterface
         }
 
         if ($rClass->hasMethod('__construct')) {
-            $def['methods']['__construct'] = true; // required
+            $def['methods']['__construct'] = Di::METHOD_IS_CONSTRUCTOR; // required
             $this->processParams($def, $rClass, $rClass->getMethod('__construct'));
         }
 
@@ -266,7 +266,8 @@ class RuntimeDefinition implements DefinitionInterface
                 if (($annotations instanceof AnnotationCollection)
                     && $annotations->hasAnnotation('Zend\Di\Definition\Annotation\Inject')) {
 
-                    $def['methods'][$methodName] = true;
+                    // use '@inject' and search for parameters
+                    $def['methods'][$methodName] = Di::METHOD_IS_EAGER;
                     $this->processParams($def, $rClass, $rMethod);
                     continue;
                 }
@@ -278,7 +279,7 @@ class RuntimeDefinition implements DefinitionInterface
             foreach ($methodPatterns as $methodInjectorPattern) {
                 preg_match($methodInjectorPattern, $methodName, $matches);
                 if ($matches) {
-                    $def['methods'][$methodName] = false; // check ot see if this is required?
+                    $def['methods'][$methodName] = Di::METHOD_IS_OPTIONAL; // check ot see if this is required?
                     $this->processParams($def, $rClass, $rMethod);
                     continue 2;
                 }
@@ -304,7 +305,7 @@ class RuntimeDefinition implements DefinitionInterface
                             // constructor not allowed in interfaces
                             continue;
                         }
-                        $def['methods'][$rMethod->getName()] = true;
+                        $def['methods'][$rMethod->getName()] = Di::METHOD_IS_AWARE;
                         $this->processParams($def, $rClass, $rMethod);
                     }
                     continue 2;

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -755,6 +755,8 @@ class Di implements DependencyInjectionInterface
                     }
                 } catch (Exception\RuntimeException $e) {
                     if ($methodRequirementType & self::RESOLVE_STRICT) {
+                        //finally ( be aware to do at the end of flow)
+                        array_pop($this->currentDependencies);
                         // if this item was marked strict,
                         // plus it cannot be resolve, and no value exist, bail out
                         throw new Exception\MissingPropertyException(sprintf(
@@ -764,6 +766,8 @@ class Di implements DependencyInjectionInterface
                         $e->getCode(),
                         $e);
                     } else {
+                        //finally ( be aware to do at the end of flow)
+                        array_pop($this->currentDependencies);
                         return false;
                     }
                 }

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -92,6 +92,12 @@ class Di implements DependencyInjectionInterface
     const METHOD_IS_REQUIRED = 3;
 
     /**
+     *
+     * resolve mode RESOLVE_EAGER
+     */
+    const METHOD_IS_EAGER = 1;
+
+    /**
      * Constructor
      *
      * @param null|DefinitionList  $definitions

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -196,9 +196,6 @@ class Form extends Fieldset implements FormInterface
      */
     public function prepareElement(FormInterface $form)
     {
-        if ($form !== $this) {
-            return;
-        }
         $name = $this->getName();
 
         foreach ($this->byName as $elementOrFieldset) {

--- a/library/Zend/Mvc/Service/FormElementManagerFactory.php
+++ b/library/Zend/Mvc/Service/FormElementManagerFactory.php
@@ -25,6 +25,8 @@ class FormElementManagerFactory extends AbstractPluginManagerFactory
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $plugins = parent::createService($serviceLocator);
+        $plugins->addPeeringServiceManager($serviceLocator);
+        $plugins->setRetrieveFromPeeringManagerFirst(true);
         return $plugins;
     }
 }

--- a/library/Zend/Mvc/Service/FormElementManagerFactory.php
+++ b/library/Zend/Mvc/Service/FormElementManagerFactory.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Mvc\Service;
 
-use Zend\Form\Form;
 use Zend\Form\FormElementManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -26,16 +25,6 @@ class FormElementManagerFactory extends AbstractPluginManagerFactory
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $plugins = parent::createService($serviceLocator);
-        if ($serviceLocator->has('Di')) {
-            $di = $serviceLocator->get('Di');
-            $im = $di->instanceManager();
-            if (!$im->getTypePreferences('Zend\Form\FormInterface')) {
-                $form = new Form;
-                $im->setTypePreference('Zend\Form\FormInterface', array($form));
-            }
-            $plugins->addPeeringServiceManager($serviceLocator);
-            $plugins->setRetrieveFromPeeringManagerFirst(true);
-        }
         return $plugins;
     }
 }

--- a/tests/ZendTest/Di/DiCompatibilityTest.php
+++ b/tests/ZendTest/Di/DiCompatibilityTest.php
@@ -22,7 +22,7 @@ class DiCompatibilityTest extends \PHPUnit_Framework_TestCase
     /**
      *
      * @dataProvider providesSimpleClasses
-     * @param type $class
+     * @param string $class
      */
     public function testDiSimple($class)
     {
@@ -39,7 +39,7 @@ class DiCompatibilityTest extends \PHPUnit_Framework_TestCase
     /**
      * provides known classes invokable without parameters
      *
-     * @return string
+     * @return array
      */
     public function providesSimpleClasses()
     {

--- a/tests/ZendTest/Di/DiCompatibilityTest.php
+++ b/tests/ZendTest/Di/DiCompatibilityTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Di
+ */
+
+namespace ZendTest\Di;
+
+use Zend\Di\Di;
+use Zend\Di\DefinitionList;
+use Zend\Di\InstanceManager;
+use Zend\Di\Config;
+use Zend\Di\Definition;
+
+use Zend\Form\Form;
+
+class DiCompatibilityTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     *
+     * @dataProvider providesSimpleClasses
+     * @param type $class
+     */
+    public function testDiSimple($class)
+    {
+        $di = new Di();
+
+        $bareObject = new $class;
+
+        $diObject = $di->get($class);
+
+        $this->assertInstanceOf($class, $bareObject, 'Test instantiate simple');
+        $this->assertInstanceOf($class, $diObject, 'Test $di->get');
+    }
+
+    /**
+     * provides known classes invokable without parameters
+     *
+     * @return string
+     */
+    public function providesSimpleClasses()
+    {
+        return array(
+            array('Zend\Di\Di'),
+            array('Zend\EventManager\EventManager'),
+            array('Zend\Filter\Null'),
+            array('Zend\Form\Form'),
+            array('Zend\Stdlib\SplStack'),
+            array('Zend\View\Model\ViewModel'),
+        );
+    }
+}

--- a/tests/ZendTest/Di/DiCompatibilityTest.php
+++ b/tests/ZendTest/Di/DiCompatibilityTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Di
  */
 
 namespace ZendTest\Di;

--- a/tests/ZendTest/Di/DiTest.php
+++ b/tests/ZendTest/Di/DiTest.php
@@ -456,7 +456,13 @@ class DiTest extends \PHPUnit_Framework_TestCase
      */
     public function testNewInstanceWillUsePreferredClassForInterfaceHints()
     {
-        $di = new Di();
+        $definitionList = new DefinitionList(array(
+            $classdef = new Definition\ClassDefinition('ZendTest\Di\TestAsset\PreferredImplClasses\C'),
+            new Definition\RuntimeDefinition()
+        ));
+        $classdef->addMethod('setA', Di::METHOD_IS_EAGER);
+        $di = new Di($definitionList);
+
         $di->instanceManager()->addTypePreference(
             'ZendTest\Di\TestAsset\PreferredImplClasses\A',
             'ZendTest\Di\TestAsset\PreferredImplClasses\BofA'
@@ -467,6 +473,35 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZendTest\Di\TestAsset\PreferredImplClasses\BofA', $a);
         $d = $di->get('ZendTest\Di\TestAsset\PreferredImplClasses\D');
         $this->assertSame($a, $d->a);
+    }
+
+    public function testMatchPreferredClassWithAwareInterface()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->addTypePreference(
+            'ZendTest\Di\TestAsset\PreferredImplClasses\A',
+            'ZendTest\Di\TestAsset\PreferredImplClasses\BofA'
+        );
+
+        $e = $di->get('ZendTest\Di\TestAsset\PreferredImplClasses\E');
+        $this->assertInstanceOf('ZendTest\Di\TestAsset\PreferredImplClasses\BofA', $e->a);
+    }
+
+    public function testWillNotUsePreferredClassForInterfaceHints()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->addTypePreference(
+            'ZendTest\Di\TestAsset\PreferredImplClasses\A',
+            'ZendTest\Di\TestAsset\PreferredImplClasses\BofA'
+        );
+
+        $c = $di->get('ZendTest\Di\TestAsset\PreferredImplClasses\C');
+        $a = $c->a;
+        $this->assertNull($a);
+        $d = $di->get('ZendTest\Di\TestAsset\PreferredImplClasses\D');
+        $this->assertNull($d->a);
     }
 
     public function testInjectionInstancesCanBeInjectedMultipleTimes()

--- a/tests/ZendTest/Di/TestAsset/PreferredImplClasses/AAwareInterface.php
+++ b/tests/ZendTest/Di/TestAsset/PreferredImplClasses/AAwareInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset\PreferredImplClasses;
+
+interface AAwareInterface
+{
+    public function foo(A $a);
+}

--- a/tests/ZendTest/Di/TestAsset/PreferredImplClasses/E.php
+++ b/tests/ZendTest/Di/TestAsset/PreferredImplClasses/E.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset\PreferredImplClasses;
+
+class E implements AAwareInterface
+{
+    public $a = null;
+    public function foo(A $a)
+    {
+        $this->a = $a;
+    }
+}


### PR DESCRIPTION
Relative to #4434
Now we cannot get some instances from the di even if the zf2's simple classes. This PR is a hotfix for it.
And this also enhances the capability to manage dependencies explicitly. But it has a minor BC break. If we should keep BC strictly, remove a5f1362 , b0d918e
## Overview
### METHOD_IS_REQUIRED:

> Resolve dependencies
>  by specified params and TypePreference and name as Class.
> Missing parameter and raise exception
- constructor
- instantiator
- set method option METHOD_IS_REQUIRED or (required => true) explicitly
### METHOD_IS_EAGER:

> Resolve dependencies
>  by specified params and TypePreference and name as Class.
> Missing parameter and give up resolving
- AwareInterface's setter
- set method option METHOD_IS_EAGER explicitly
### METHOD_IS_OPTIONAL:

> Resolve dependencies only by specified params
- setter injection

---
- [x] Add issue reproduce test
- [x] Initial implementation
- [ ] Collect feedback
- [ ] Test coverage
