### PR TITLE
fixed signature of loadConstraintReferences #4438

### DIFF
--- a/library/Zend/Db/Metadata/Source/MysqlMetadata.php
+++ b/library/Zend/Db/Metadata/Source/MysqlMetadata.php
@@ -373,13 +373,9 @@ class MysqlMetadata extends AbstractSource
         $this->data['constraint_keys'][$schema] = $data;
     }
 
-    protected function loadConstraintReferences($schema)
+    protected function loadConstraintReferences($table, $schema)
     {
-        if (isset($this->data['constraint_references'][$schema])) {
-            return;
-        }
-
-        $this->prepareDataHierarchy('constraint_references', $schema);
+        parent::loadConstraintReferences($table, $schema);
 
         $p = $this->adapter->getPlatform();
 


### PR DESCRIPTION
Fixes #4438 

Now MysqlMetadata::loadConstraintReferences() signature matches the signature of AbstractSource::loadConstraintReferences().

Only a syntatic fix, so no test provided.
