### PR TITLE
PHP Warning:  call_user_func() expects…when Weakref enabled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "doctrine/annotations": "Doctrine Annotations >=1.0 for annotation features",
         "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable",
         "ocramius/proxy-manager": "ProxyManager to handle lazy initialization of services",
-        "pecl-weakref": "Implementation of weak references for Zend\\Stdlib\\CallbackHandler",
         "zendframework/zendpdf": "ZendPdf for creating PDF representations of barcodes",
         "zendframework/zendservice-recaptcha": "ZendService\\ReCaptcha for rendering ReCaptchas in Zend\\Captcha and/or Zend\\Form"
     },

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -462,10 +462,6 @@ class EventManager implements EventManagerInterface
 
         foreach ($listeners as $listener) {
             $listenerCallback = $listener->getCallback();
-            if (!$listenerCallback) {
-                $this->detach($listener);
-                continue;
-            }
 
             // Trigger the listener's callback, and push its result onto the
             // response collection

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -13,7 +13,6 @@
     },
     "target-dir": "Zend/Stdlib",
     "suggest": {
-        "pecl-weakref": "Implementation of weak references for Stdlib\\CallbackHandler",
         "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
     },
     "require": {

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -546,22 +546,6 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($responses->stopped());
     }
 
-    public function testWeakRefsAreHonoredWhenTriggering()
-    {
-        if (!class_exists('WeakRef', false)) {
-            $this->markTestSkipped('Requires pecl/weakref');
-        }
-
-        $functor = new TestAsset\Functor;
-        $this->events->attach('test', $functor);
-
-        unset($functor);
-
-        $result = $this->events->trigger('test', $this, array());
-        $message = $result->last();
-        $this->assertNull($message);
-    }
-
     public function testDuplicateIdentifiersAreNotRegistered()
     {
         $events = new EventManager(array(__CLASS__, get_class($this)));


### PR DESCRIPTION
PHP Warning:  call_user_func() expects…when Weakref enabled

Hi.

When opening the ZendSkeletonApplication, it gave me a bunch of warnings and an error:

```
 PHP Warning:  call_user_func() expects parameter 1 to be a valid callback, first array member is not a valid class name or object in /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php on line 472
 PHP Stack trace:
 PHP   1. {main}() /test/public/index.php:0
 PHP   2. Zend\\Mvc\\Application::init($configuration = *uninitialized*) /test/public/index.php:12
 PHP   3. Zend\\ModuleManager\\ModuleManager->loadModules() /test/vendor/zendframework/zendframework/library/Zend/Mvc/Application.php:238
 PHP   4. Zend\\EventManager\\EventManager->trigger($event = *uninitialized*, $target = *uninitialized*, $argv = *uninitialized*, $callback = *uninitialized*) /test/vendor/zendframework/zendframework/library/Zend/ModuleManager/ModuleManager.php:100
 PHP   5. Zend\\EventManager\\EventManager->triggerListeners($event = *uninitialized*, $e = *uninitialized*, $callback = *uninitialized*) /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:207
 PHP   6. call_user_func(*uninitialized*, *uninitialized*) /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:472

 PHP Warning:  call_user_func() expects parameter 1 to be a valid callback, first array member is not a valid class name or object in /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php on line 472
 PHP Stack trace:
 PHP   1. {main}() /test/public/index.php:0
 PHP   2. Zend\\Mvc\\Application::init($configuration = *uninitialized*) /test/public/index.php:12
 PHP   3. Zend\\ModuleManager\\ModuleManager->loadModules() /test/vendor/zendframework/zendframework/library/Zend/Mvc/Application.php:238
 PHP   4. Zend\\EventManager\\EventManager->trigger($event = *uninitialized*, $target = *uninitialized*, $argv = *uninitialized*, $callback = *uninitialized*) /test/vendor/zendframework/zendframework/library/Zend/ModuleManager/ModuleManager.php:100
 PHP   5. Zend\\EventManager\\EventManager->triggerListeners($event = *uninitialized*, $e = *uninitialized*, $callback = *uninitialized*) /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:207
 PHP   6. call_user_func(*uninitialized*, *uninitialized*) /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php:472

 PHP Fatal error:  Uncaught exception 'Zend\\ModuleManager\\Exception\\RuntimeException' with message 'Module (Application) could not be initialized.' in /test/vendor/zendframework/zendframework/library/Zend/ModuleManager/ModuleManager.php:140
 Stack trace:
 #0 /test/vendor/zendframework/zendframework/library/Zend/ModuleManager/ModuleManager.php(81): Zend\\ModuleManager\\ModuleManager->loadModule('Application')
 #1 [internal function]: Zend\\ModuleManager\\ModuleManager->onLoadModules(Object(Zend\\ModuleManager\\ModuleEvent))
 #2 /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php(472): call_user_func(Array, Object(Zend\\ModuleManager\\ModuleEvent))
 #3 /test/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php(207): Zend\\EventManager\\EventManager->triggerListeners('loadModules', Object(Zend\\ModuleManager\\ModuleEvent), NULL)
 #4 /test/vendor/zendframework/zendframework/library/Zend/ModuleManager/ModuleManager.php(100): Zend\\EventManager\\EventManager->trigger('loadModules', Object(Zend\\ModuleManager\\ModuleManager), Object(Zend\\ModuleManager\\ModuleEvent))
 #5 /test/vendor/zendframework/zendframework/library/Zend/Mvc/Application.php(238): Zend\\ModuleManager\\ModuleManager->loadModules()
 #6 /test/public/index.php(12): Zend\\Mvc\\Application::init(Array)
 #7 {main}
   thrown in /test/vendor/zendframework/zendframework/library/Zend/ModuleManager/ModuleManager.php on line 140
```

　
I installed Weakref from source:

```
 wget http://pecl.php.net/get/Weakref-0.2.2.tgz
 tar xzvf Weakref-0.2.2.tgz
 cd Weakref-0.2.2
 /usr/local/php/bin/phpize
 ./configure --with-php-config=/usr/local/php/bin/php-config
 make
 make install

 // phpinfo() output -> Weak References support Version: 0.0.1-alpha
```

　
I'm using:

```
 Zend Framework version 2.1.5

 PHP 5.4.14 (cli) (built: Apr 30 2013 20:11:38)
 Copyright (c) 1997-2013 The PHP Group
 Zend Engine v2.4.0, Copyright (c) 1998-2013 Zend Technologies
      with XCache v3.0.1, Copyright (c) 2005-2013, by mOo
      with Xdebug v2.2.2, Copyright (c) 2002-2013, by Derick Rethans
      with XCache Cacher v3.0.1, Copyright (c) 2005-2013, by mOo
      with XCache Coverager v3.0.1, Copyright (c) 2005-2013, by mOo
```

　
Please advise.
