### PR TITLE
Issues found by hphp static analysis

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/MemcachedResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcachedResourceManager.php
@@ -282,14 +282,14 @@ class MemcachedResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $constValue = $this->normalizeLibOptionKey($key);
+        $this->normalizeLibOptionKey($key);
         $resource   = & $this->resources[$id];
 
         if ($resource instanceof MemcachedResource) {
-            return $resource->getOption($constValue);
+            return $resource->getOption($key);
         }
 
-        return isset($resource['lib_options'][$constValue]) ? $resource['lib_options'][$constValue] : null;
+        return isset($resource['lib_options'][$key]) ? $resource['lib_options'][$key] : null;
     }
 
     /**

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -329,14 +329,14 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $constValue = $this->normalizeLibOptionKey($key);
+        $this->normalizeLibOptionKey($key);
         $resource   = & $this->resources[$id];
 
         if ($resource instanceof RedisResource) {
-            return $resource->getOption($constValue);
+            return $resource->getOption($key);
         }
 
-        return isset($resource['lib_options'][$constValue]) ? $resource['lib_options'][$constValue] : null;
+        return isset($resource['lib_options'][$key]) ? $resource['lib_options'][$key] : null;
     }
 
     /**

--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -171,11 +171,11 @@ class DocBlockGenerator extends AbstractGenerator
         if (is_array($tag)) {
             $tag = new DockBlockTag($tag);
         } elseif (!$tag instanceof DockBlockTag) {
-            throw new Exception\InvalidArgumentException(
+            throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects either an array of method options or an instance of %s\DocBlock\Tag',
                 __METHOD__,
                 __NAMESPACE__
-            );
+            ));
         }
 
         $this->tags[] = $tag;

--- a/library/Zend/Code/Scanner/Util.php
+++ b/library/Zend/Code/Scanner/Util.php
@@ -26,9 +26,12 @@ class Util
      * @return void
      * @throws Exception\InvalidArgumentException
      */
-    public static function resolveImports(&$value, $key = null, stdClass $data)
+    public static function resolveImports(&$value, $key = null, stdClass $data = null)
     {
-        if (!property_exists($data, 'uses') || !property_exists($data, 'namespace')) {
+        if (!is_object($data)
+            || !property_exists($data, 'uses')
+            || !property_exists($data, 'namespace')
+        ) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects a data object containing "uses" and "namespace" properties; on or both missing',
                 __METHOD__

--- a/library/Zend/Feed/Reader/Extension/CreativeCommons/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/CreativeCommons/Entry.php
@@ -53,9 +53,7 @@ class Entry extends Extension\AbstractEntry
 
             $licenses = array_unique($licenses);
         } else {
-            $cc = new Feed(
-                $this->domDocument, $this->data['type'], $this->xpath
-            );
+            $cc = new Feed();
             $licenses = $cc->getLicenses();
         }
 

--- a/library/Zend/Mail/Storage/Folder/Maildir.php
+++ b/library/Zend/Mail/Storage/Folder/Maildir.php
@@ -193,7 +193,7 @@ class Maildir extends Storage\Maildir implements FolderInterface
                 throw new Exception\RuntimeException("{$this->currentFolder} is not selectable", 0, $e);
             }
             // seems like file has vanished; rebuilding folder tree - but it's still an exception
-            $this->_buildFolderTree($this->rootdir);
+            $this->_buildFolderTree();
             throw new Exception\RuntimeException('seems like the maildir has vanished, I\'ve rebuild the ' .
                                                          'folder tree, search for an other folder and try again', 0, $e);
         }

--- a/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php
@@ -162,7 +162,7 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
         $banner = $this->getConsoleBanner($console, $mm);
 
         // Get application usage information
-        $usage = $this->getConsoleUsage($console, $scriptName, $mm, $router);
+        $usage = $this->getConsoleUsage($console, $scriptName, $mm);
 
         // Inject the text into view
         $result  = $banner ? rtrim($banner, "\r\n")        : '';

--- a/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
@@ -193,7 +193,7 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
         $model->setTemplate($this->getNotFoundTemplate());
 
         // If displaying reasons, inject the reason
-        $this->injectNotFoundReason($model, $e);
+        $this->injectNotFoundReason($model);
 
         // If displaying exceptions, inject
         $this->injectException($model, $e);

--- a/library/Zend/Serializer/Adapter/PythonPickle.php
+++ b/library/Zend/Serializer/Adapter/PythonPickle.php
@@ -421,7 +421,9 @@ class PythonPickle extends AbstractAdapter
         $this->memorize($value);
 
         foreach ($value as $k => $v) {
-            $this->pickle .= $this->write($k) . $this->write($v) . self::OP_SETITEM;
+            $this->write($k);
+            $this->write($v);
+            $this->pickle .= self::OP_SETITEM;
         }
     }
 
@@ -441,7 +443,8 @@ class PythonPickle extends AbstractAdapter
         $this->memorize($value);
 
         foreach ($value as $v) {
-            $this->pickle .= $this->write($v) . self::OP_APPEND;
+            $this->write($v);
+            $this->pickle .= self::OP_APPEND;
         }
     }
 

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -40,10 +40,10 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
     {
         $this->serviceLocator = $serviceLocator;
         if ($requestedName) {
-            return $this->get($requestedName, array(), true);
+            return $this->get($requestedName, array());
         }
 
-        return $this->get($serviceName, array(), true);
+        return $this->get($serviceName, array());
     }
 
     /**

--- a/library/Zend/ServiceManager/Di/DiServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiServiceFactory.php
@@ -81,7 +81,7 @@ class DiServiceFactory extends Di implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
-        return $this->get($this->name, $this->parameters, true);
+        return $this->get($this->name, $this->parameters);
     }
 
     /**

--- a/library/Zend/Validator/File/ExcludeMimeType.php
+++ b/library/Zend/Validator/File/ExcludeMimeType.php
@@ -87,7 +87,7 @@ class ExcludeMimeType extends MimeType
 
         if (empty($this->type)) {
             $this->error(self::NOT_DETECTED);
-            false;
+            return false;
         }
 
         $mimetype = $this->getMimeType(true);


### PR DESCRIPTION
I think I weeded out most of the false positives, but there may be a few still in there. For the TooManyArgument error it doesn't know about func_get_args(), so that is the most common false positive.

```
--------------------------------
File       : library/Zend/Feed/Reader/Extension/CreativeCommons/Entry.php:56
Reason     : BadConstructorCall
Snippet    : new Zend\Feed\Reader\Extension\CreativeCommons\Feed($this->domDocument, $this->data['type'], $this->xpath)
Line       : $cc = new Feed(
--------------------------------
File       : library/Zend/Code/Scanner/Util.php:29
Reason     : RequiredAfterOptionalParam
Snippet    : $key = null
Line       : public static function resolveImports(&$value, $key = null, stdClass $data)
--------------------------------
File       : library/Zend/Mvc/View/Console/RouteNotFoundStrategy.php:165
Reason     : TooManyArgument
Snippet    : $this->getConsoleUsage($console, $scriptName, $mm, $router)
Line       : $usage = $this->getConsoleUsage($console, $scriptName, $mm, $router);
--------------------------------
File       : library/Zend/Mail/Storage/Folder/Maildir.php:196
Reason     : TooManyArgument
Snippet    : $this->_buildFolderTree($this->rootdir)
Line       : $this->_buildFolderTree($this->rootdir);
--------------------------------
File       : library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php:196
Reason     : TooManyArgument
Snippet    : $this->injectNotFoundReason($model, $e)
Line       : $this->injectNotFoundReason($model, $e);
--------------------------------
File       : library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php:43
Reason     : TooManyArgument
Snippet    : $this->get($requestedName, array(), true)
Line       : return $this->get($requestedName, array(), true);
--------------------------------
File       : library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php:46
Reason     : TooManyArgument
Snippet    : $this->get($serviceName, array(), true)
Line       : return $this->get($serviceName, array(), true);
--------------------------------
File       : library/Zend/ServiceManager/Di/DiServiceFactory.php:84
Reason     : TooManyArgument
Snippet    : $this->get($this->name, $this->parameters, true)
Line       : return $this->get($this->name, $this->parameters, true);
--------------------------------
File       : library/Zend/Code/Generator/DocBlockGenerator.php:174
Reason     : BadArgumentType
Snippet    : parameter 3 of __construct() requires Object - exception, called with String
Line       : throw new Exception\InvalidArgumentException(
--------------------------------
File       : library/Zend/Validator/File/ExcludeMimeType.php:90
Reason     : StatementHasNoEffect
Snippet    : false;
Line       : false;
--------------------------------
File       : library/Zend/Cache/Storage/Adapter/RedisResourceManager.php:332
Reason     : UseVoidReturn
Snippet    : $this->normalizeLibOptionKey($key)
Line       : $constValue = $this->normalizeLibOptionKey($key);
--------------------------------
File       : library/Zend/Serializer/Adapter/PythonPickle.php:424
Reason     : UseVoidReturn
Snippet    : $this->write($k)
Line       : $this->pickle .= $this->write($k) . $this->write($v) . self::OP_SETITEM;
--------------------------------
File       : library/Zend/Serializer/Adapter/PythonPickle.php:424
Reason     : UseVoidReturn
Snippet    : $this->write($v)
Line       : $this->pickle .= $this->write($k) . $this->write($v) . self::OP_SETITEM;
--------------------------------
File       : library/Zend/Serializer/Adapter/PythonPickle.php:444
Reason     : UseVoidReturn
Snippet    : $this->write($v)
Line       : $this->pickle .= $this->write($v) . self::OP_APPEND;
--------------------------------
File       : library/Zend/Cache/Storage/Adapter/MemcachedResourceManager.php:285
Reason     : UseVoidReturn
Snippet    : $this->normalizeLibOptionKey($key)
Line       : $constValue = $this->normalizeLibOptionKey($key);
--------------------------------
File       : library/Zend/Mvc/Controller/AbstractRestfulController.php:316
Reason     : UseVoidReturn
Snippet    : $this->deleteList()
Line       : $return = $this->deleteList();
--------------------------------
File       : library/Zend/Mvc/Controller/AbstractRestfulController.php:354
Reason     : UseVoidReturn
Snippet    : $this->patch($id, $data)
Line       : $return = $this->patch($id, $data);
--------------------------------
File       : library/Zend/Mvc/Controller/AbstractRestfulController.php:363
Reason     : UseVoidReturn
Snippet    : $this->patchList($data)
Line       : $return = $this->patchList($data);
--------------------------------
File       : library/Zend/Mvc/Controller/AbstractRestfulController.php:387
Reason     : UseVoidReturn
Snippet    : $this->replaceList($data)
Line       : $return = $this->replaceList($data);
```
