### PR TITLE
Fix iterating over empty result set with buffering enabled

### DIFF
--- a/library/Zend/Db/ResultSet/AbstractResultSet.php
+++ b/library/Zend/Db/ResultSet/AbstractResultSet.php
@@ -18,7 +18,6 @@ use Zend\Db\Adapter\Driver\ResultInterface;
 
 abstract class AbstractResultSet implements Iterator, ResultSetInterface
 {
-
     /**
      * if -1, datasource is already buffered
      * if -2, implicitly disabling buffering in ResultSet
@@ -47,7 +46,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
     /**
      * @var int
      */
-    protected $position = 0;
+    protected $position = -1;
 
     /**
      * Set the data source for the result set
@@ -211,7 +210,6 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             $key = key($this->dataSource);
             return ($key !== null);
         }
-
     }
 
     /**
@@ -221,7 +219,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      */
     public function rewind()
     {
-        if (!is_array($this->buffer)) {
+        if (!is_array($this->buffer) || $this->position === -1) {
             if ($this->dataSource instanceof Iterator) {
                 $this->dataSource->rewind();
             } else {

--- a/library/Zend/Db/ResultSet/AbstractResultSet.php
+++ b/library/Zend/Db/ResultSet/AbstractResultSet.php
@@ -57,6 +57,11 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      */
     public function initialize($dataSource)
     {
+        // reset buffering
+        if (is_array($this->buffer)) {
+            $this->buffer = array();
+        }
+
         if ($dataSource instanceof ResultInterface) {
             $this->count = $dataSource->count();
             $this->fieldCount = $dataSource->getFieldCount();
@@ -64,7 +69,9 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             if ($dataSource->isBuffered()) {
                 $this->buffer = -1;
             }
-            $this->dataSource->rewind();
+            if (is_array($this->buffer)) {
+                $this->dataSource->rewind();
+            }
             return $this;
         }
 
@@ -97,6 +104,9 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             throw new Exception\RuntimeException('Buffering must be enabled before iteration is started');
         } elseif ($this->buffer === null) {
             $this->buffer = array();
+            if ($this->dataSource instanceof ResultInterface) {
+                $this->dataSource->rewind();
+            }
         }
         return $this;
     }

--- a/library/Zend/Db/ResultSet/AbstractResultSet.php
+++ b/library/Zend/Db/ResultSet/AbstractResultSet.php
@@ -46,7 +46,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
     /**
      * @var int
      */
-    protected $position = -1;
+    protected $position = 0;
 
     /**
      * Set the data source for the result set
@@ -64,6 +64,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             if ($dataSource->isBuffered()) {
                 $this->buffer = -1;
             }
+            $this->dataSource->rewind();
             return $this;
         }
 
@@ -219,7 +220,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      */
     public function rewind()
     {
-        if (!is_array($this->buffer) || $this->position === -1) {
+        if (!is_array($this->buffer)) {
             if ($this->dataSource instanceof Iterator) {
                 $this->dataSource->rewind();
             } else {


### PR DESCRIPTION
In case we using result set with buffering dataSource rewind method should be called at least once before resultSet rewind call, to ensure dataSource valid() would work as expected.

Simple test case:

``` php
$adapter = new \Zend\Db\Adapter\Adapter(...);

$hydrator = new Zend\Stdlib\Hydrator\ArraySerializable();
$resultSet = new \Zend\Db\ResultSet\HydratingResultSet($hydrator);
// any empty table for test
$table = new \Zend\Db\TableGateway\TableGateway('test', $adapter, null, $resultSet);

$test = $table->select();
$test->buffer();
foreach ($test as $item) {
    var_dump($item);
}
```

If no data in result set (ie empty result) when Iterator rewind calls (\Zend\Db\ResultSet\AbstractResultSet::rewind) and buffer is enabled, then dataSource rewind never be called and in this case iteration loop started and first item will be false (at least for Adapter/Pdo/Result). But expected behavior is iteration not started for empty result set.

``` php
    public function rewind()
    {
        if (!is_array($this->buffer)) {
            if ($this->dataSource instanceof Iterator) {
                $this->dataSource->rewind();
            } else {
                reset($this->dataSource);
            }
        }
        $this->position = 0;
    }
```

So, we introduce result set position default state is -1, to ensure first iteration calls dataSource rewind at least one even buffer is enabled
`if (!is_array($this->buffer) || $this->position === -1) {`
BTW if buffering is disabled we call rewind on dataSource for every iteration as before
