### PR TITLE
Form InputFilterSpecification: incorrect propagation

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -718,8 +718,8 @@ class Form extends Fieldset implements FormInterface
         $formFactory  = $this->getFormFactory();
         $inputFactory = $formFactory->getInputFilterFactory();
 
-        if ($this instanceof InputFilterProviderInterface) {
-            foreach ($this->getInputFilterSpecification() as $name => $spec) {
+        if ($fieldset === $this && $fieldset instanceof InputFilterProviderInterface) {
+            foreach ($fieldset->getInputFilterSpecification() as $name => $spec) {
                 $input = $inputFactory->createInput($spec);
                 $inputFilter->add($input, $name);
             }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -183,6 +183,15 @@ class FormTest extends TestCase
         $this->assertTrue($fooInput->isRequired());
     }
 
+    public function testInputProviderInterfaceAddsInputFiltersOnlyForSelf()
+    {
+        $form = new TestAsset\InputFilterProviderWithFieldset();
+
+        $inputFilter = $form->getInputFilter();
+        $fieldsetInputFilter = $inputFilter->get('basic_fieldset');
+        $this->assertFalse($fieldsetInputFilter->has('foo'));
+    }
+
     public function testCallingIsValidRaisesExceptionIfNoDataSet()
     {
         $this->setExpectedException('Zend\Form\Exception\DomainException');

--- a/tests/ZendTest/Form/TestAsset/InputFilterProviderWithFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/InputFilterProviderWithFieldset.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Form;
+use Zend\InputFilter\InputFilterProviderInterface;
+
+class InputFilterProviderWithFieldset extends Form implements InputFilterProviderInterface
+{
+    public function __construct($name = null, $options = array())
+    {
+        parent::__construct($name, $options);
+
+        $this->add(array(
+            'name' => 'foo',
+            'options' => array(
+                'label' => 'Foo'
+            ),
+        ));
+
+        $this->add(new BasicFieldset());
+    }
+
+    public function getInputFilterSpecification()
+    {
+        return array(
+            'foo' => array(
+                'required' => true,
+            )
+        );
+    }
+}


### PR DESCRIPTION
When a Form implements `InputFilterProviderInterface` and has fieldsets, form specification is propagated to fieldsets, and so the form can't never validate.

This is because `$this` reference was used everytime `attachInputFilterDefaults` calls itself.
