### PR TITLE
Zend\Authentication\Result custom result codes not possible

### DIFF
--- a/library/Zend/Authentication/Result.php
+++ b/library/Zend/Authentication/Result.php
@@ -73,15 +73,7 @@ class Result
      */
     public function __construct($code, $identity, array $messages = array())
     {
-        $code = (int) $code;
-
-        if ($code < self::FAILURE_UNCATEGORIZED) {
-            $code = self::FAILURE;
-        } elseif ($code > self::SUCCESS) {
-            $code = self::SUCCESS;
-        }
-
-        $this->code     = $code;
+        $this->code     = (int) $code;
         $this->identity = $identity;
         $this->messages = $messages;
     }

--- a/library/Zend/Authentication/Result.php
+++ b/library/Zend/Authentication/Result.php
@@ -78,7 +78,7 @@ class Result
         if ($code < self::FAILURE_UNCATEGORIZED) {
             $code = self::FAILURE;
         } elseif ($code > self::SUCCESS) {
-            $code = 1;
+            $code = self::SUCCESS;
         }
 
         $this->code     = $code;


### PR DESCRIPTION
What's the point of this in the Result constructor:

```
    if ($code < self::FAILURE_UNCATEGORIZED) {
        $code = self::FAILURE;
    } elseif ($code > self::SUCCESS ) {
        $code = 1;
    }
```

It pretty much nullifies the usefulness of any classes that extend result using custom codes without making a custom constructor, and seems to be there for no discernible reason.
