### PR TITLE
Oci8 Driver generating "Fetch out of sequence warning"

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Oci8/Result.php
+++ b/library/Zend/Db/Adapter/Driver/Oci8/Result.php
@@ -145,14 +145,11 @@ class Result implements \Iterator, ResultInterface
      */
     protected function loadData()
     {
-        $this->currentComplete = false;
-        $this->currentData = null;
-
+        $this->currentComplete = true;
         $this->currentData = oci_fetch_assoc($this->resource);
 
         if ($this->currentData !== false) {
             $this->position++;
-            $this->currentComplete = true;
             return true;
         }
         return false;
@@ -192,7 +189,7 @@ class Result implements \Iterator, ResultInterface
     public function valid()
     {
         if ($this->currentComplete) {
-            return true;
+            return ($this->currentData !== false);
         }
 
         return $this->loadData();


### PR DESCRIPTION
`Zend\Db\Adapter\Driver\Oci8\Result` line 151 is generating a `oci_fetch_assoc(): ORA-01002: fetch out of sequence` warning for any larger queries. Limiting the results to less than 50 stops the warning appearing but anything larger it appears.

Suppressing warnings with `@oci_fetch_assoc` get's rid of the warning and returns results as expected but obviously this isn't fixing the issue.

The warning is usually generated when a fetch is performed after a commit.
