### PR TITLE
Add ConstantScanner to Zend\Code\Scanner

### DIFF
--- a/library/Zend/Code/Scanner/ClassScanner.php
+++ b/library/Zend/Code/Scanner/ClassScanner.php
@@ -276,7 +276,7 @@ class ClassScanner implements ScannerInterface
                 continue;
             }
 
-            $return[] = $info['name'];
+            $return[] = $this->getConstant($info['name']);
         }
 
         return $return;

--- a/library/Zend/Code/Scanner/ClassScanner.php
+++ b/library/Zend/Code/Scanner/ClassScanner.php
@@ -122,6 +122,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return documentation comment
+     *
      * @return null|string
      */
     public function getDocComment()
@@ -132,6 +134,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return documentation block
+     *
      * @return false|DocBlockScanner
      */
     public function getDocBlock()
@@ -144,6 +148,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return a name of class
+     *
      * @return null|string
      */
     public function getName()
@@ -153,6 +159,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return short name of class
+     *
      * @return null|string
      */
     public function getShortName()
@@ -162,6 +170,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return number of first line
+     *
      * @return int|null
      */
     public function getLineStart()
@@ -171,6 +181,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return number of last line
+     *
      * @return int|null
      */
     public function getLineEnd()
@@ -180,6 +192,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class is final
+     *
      * @return bool
      */
     public function isFinal()
@@ -189,6 +203,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class is instantiable
+     *
      * @return bool
      */
     public function isInstantiable()
@@ -198,6 +214,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class is an abstract class
+     *
      * @return bool
      */
     public function isAbstract()
@@ -207,6 +225,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class is an interface
+     *
      * @return bool
      */
     public function isInterface()
@@ -216,6 +236,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class has parent
+     *
      * @return bool
      */
     public function hasParentClass()
@@ -225,6 +247,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return a name of parent class
+     *
      * @return null|string
      */
     public function getParentClass()
@@ -234,6 +258,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return a list of interface names
+     *
      * @return array
      */
     public function getInterfaces()
@@ -243,7 +269,7 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
-     * Returns a list of constant names
+     * Return a list of constant names
      *
      * @return array
      */
@@ -264,7 +290,9 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
-     * @return array
+     * Return a list of constants
+     *
+     * @return ConstantScanner[]
      */
     public function getConstants()
     {
@@ -282,6 +310,13 @@ class ClassScanner implements ScannerInterface
         return $return;
     }
 
+    /**
+     * Return a single constant by given name or index of info
+     *
+     * @param  string|int $constantNameOrInfoIndex
+     * @throws Exception\InvalidArgumentException
+     * @return bool|ConstantScanner
+     */
     public function getConstant($constantNameOrInfoIndex)
     {
         $this->scan();
@@ -318,7 +353,26 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
-     * Returns a list of property names
+     * Verify if class has constant
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function hasConstant($name)
+    {
+        $this->scan();
+
+        foreach ($this->infos as $info) {
+            if ($info['type'] === 'constant' && $info['name'] === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return a list of property names
      *
      * @return array
      */
@@ -339,9 +393,9 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
-     * Returns a list of properties
+     * Return a list of properties
      *
-     * @return array
+     * @return PropertyScanner
      */
     public function getProperties()
     {
@@ -359,6 +413,13 @@ class ClassScanner implements ScannerInterface
         return $return;
     }
 
+    /**
+     * Return a single property by given name or index of info
+     *
+     * @param  string|int $propertyNameOrInfoIndex
+     * @throws Exception\InvalidArgumentException
+     * @return bool|PropertyScanner
+     */
     public function getProperty($propertyNameOrInfoIndex)
     {
         $this->scan();
@@ -395,6 +456,27 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class has property
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function hasProperty($name)
+    {
+        $this->scan();
+
+        foreach ($this->infos as $info) {
+            if ($info['type'] === 'property' && $info['name'] === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return a list of method names
+     *
      * @return array
      */
     public function getMethodNames()
@@ -414,6 +496,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return a list of methods
+     *
      * @return MethodScanner[]
      */
     public function getMethods()
@@ -433,6 +517,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Return a single method by given name or index of info
+     *
      * @param  string|int $methodNameOrInfoIndex
      * @throws Exception\InvalidArgumentException
      * @return MethodScanner
@@ -473,6 +559,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Verify if class has method by given name
+     *
      * @param  string $name
      * @return bool
      */
@@ -500,6 +588,8 @@ class ClassScanner implements ScannerInterface
     }
 
     /**
+     * Scan tokens
+     *
      * @return void
      * @throws Exception\RuntimeException
      */

--- a/library/Zend/Code/Scanner/ClassScanner.php
+++ b/library/Zend/Code/Scanner/ClassScanner.php
@@ -292,10 +292,16 @@ class ClassScanner implements ScannerInterface
     /**
      * Return a list of constants
      *
-     * @return ConstantScanner[]
+     * @param  bool $namesOnly Set false to return instances of ConstantScanner
+     * @return array|ConstantScanner[]
      */
-    public function getConstants()
+    public function getConstants($namesOnly = true)
     {
+        if (true === $namesOnly) {
+            trigger_error('Use method getConstantNames() instead', E_USER_DEPRECATED);
+            return $this->getConstantNames();
+        }
+
         $this->scan();
 
         $return = array();

--- a/library/Zend/Code/Scanner/ConstantScanner.php
+++ b/library/Zend/Code/Scanner/ConstantScanner.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Code\Scanner;
+
+use Zend\Code\Annotation;
+use Zend\Code\Exception;
+use Zend\Code\NameInformation;
+
+class ConstantScanner implements ScannerInterface
+{
+    /**
+     * @var bool
+     */
+    protected $isScanned = false;
+
+    /**
+     * @var array
+     */
+    protected $tokens;
+
+    /**
+     * @var NameInformation
+     */
+    protected $nameInformation;
+
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @var ClassScanner
+     */
+    protected $scannerClass;
+
+    /**
+     * @var int
+     */
+    protected $lineStart;
+
+    /**
+     * @var string
+     */
+    protected $docComment;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Constructor
+     *
+     * @param array $constantTokens
+     * @param NameInformation $nameInformation
+     */
+    public function __construct(array $constantTokens, NameInformation $nameInformation = null)
+    {
+        $this->tokens = $constantTokens;
+        $this->nameInformation = $nameInformation;
+    }
+
+    /**
+     * @param string $class
+     */
+    public function setClass($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * @param ClassScanner $scannerClass
+     */
+    public function setScannerClass(ClassScanner $scannerClass)
+    {
+        $this->scannerClass = $scannerClass;
+    }
+
+    /**
+     * @return ClassScanner
+     */
+    public function getClassScanner()
+    {
+        return $this->scannerClass;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        $this->scan();
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        $this->scan();
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocComment()
+    {
+        $this->scan();
+        return $this->docComment;
+    }
+
+    /**
+     * @param Annotation\AnnotationManager $annotationManager
+     * @return AnnotationScanner
+     */
+    public function getAnnotations(Annotation\AnnotationManager $annotationManager)
+    {
+        if (($docComment = $this->getDocComment()) == '') {
+            return false;
+        }
+
+        return new AnnotationScanner($annotationManager, $docComment, $this->nameInformation);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        $this->scan();
+        return var_export($this, true);
+    }
+
+    /**
+     * Scan tokens
+     *
+     * @throws Exception\RuntimeException
+     */
+    protected function scan()
+    {
+        if ($this->isScanned) {
+            return;
+        }
+
+        if (!$this->tokens) {
+            throw new Exception\RuntimeException('No tokens were provided');
+        }
+
+        /**
+         * Variables & Setup
+         */
+        $tokens = &$this->tokens;
+
+        reset($tokens);
+
+        SCANNER_TOP:
+
+        $token = current($tokens);
+
+        if (!is_string($token)) {
+            list($tokenType, $tokenContent, $tokenLine) = $token;
+
+            switch ($tokenType) {
+                case T_DOC_COMMENT:
+                    if ($this->docComment === null && $this->name === null) {
+                        $this->docComment = $tokenContent;
+                    }
+                    goto SCANNER_CONTINUE;
+
+                case T_STRING:
+                    $string = (is_string($token)) ? $token : $tokenContent;
+
+                    if (null === $this->name) {
+                        $this->name = $string;
+                    } else {
+                        if ('self' == strtolower($string)) {
+                            list($tokenNextType, $tokenNextContent, $tokenNextLine) = next($tokens);
+
+                            if ('::' == $tokenNextContent) {
+                                list($tokenNextType, $tokenNextContent, $tokenNextLine) = next($tokens);
+
+                                if ($this->getClassScanner()->getConstant($tokenNextContent)) {
+                                    $this->value = $this->getClassScanner()->getConstant($tokenNextContent)->getValue();
+                                }
+                            }
+                        }
+                    }
+
+                    goto SCANNER_CONTINUE;
+
+                case T_CONSTANT_ENCAPSED_STRING:
+                case T_DNUMBER:
+                case T_LNUMBER:
+                    $string = (is_string($token)) ? $token : $tokenContent;
+
+                    if (substr($string, 0, 1) === '"' || substr($string, 0, 1) === "'") {
+                        $this->value = substr($string, 1, -1); // Remove quotes
+                    } else {
+                        $this->value = $string;
+                    }
+                    goto SCANNER_CONTINUE;
+
+                default:
+                    goto SCANNER_CONTINUE;
+            }
+        }
+
+        SCANNER_CONTINUE:
+
+        if (next($this->tokens) === false) {
+            goto SCANNER_END;
+        }
+        goto SCANNER_TOP;
+
+        SCANNER_END:
+
+        $this->isScanned = true;
+    }
+}

--- a/library/Zend/Code/Scanner/DerivedClassScanner.php
+++ b/library/Zend/Code/Scanner/DerivedClassScanner.php
@@ -153,16 +153,100 @@ class DerivedClassScanner extends ClassScanner
     }
 
     /**
+     * Return a list of constant names
+     *
      * @return array
      */
-    public function getConstants()
+    public function getConstantNames()
     {
-        $constants = $this->classScanner->getConstants();
+        $constants = $this->classScanner->getConstantNames();
         foreach ($this->parentClassScanners as $pClassScanner) {
-            $constants = array_merge($constants, $pClassScanner->getConstants());
+            $constants = array_merge($constants, $pClassScanner->getConstantNames());
         }
 
         return $constants;
+    }
+
+    /**
+     * Return a list of constants
+     *
+     * @param  bool $namesOnly Set false to return instances of ConstantScanner
+     * @return array|ConstantScanner[]
+     */
+    public function getConstants($namesOnly = true)
+    {
+        if (true === $namesOnly) {
+            trigger_error('Use method getConstantNames() instead', E_USER_DEPRECATED);
+            return $this->getConstantNames();
+        }
+
+        $constants = $this->classScanner->getConstants();
+        foreach ($this->parentClassScanners as $pClassScanner) {
+            $constants = array_merge($constants, $pClassScanner->getConstants($namesOnly));
+        }
+
+        return $constants;
+    }
+
+    /**
+     * Return a single constant by given name or index of info
+     *
+     * @param  string|int $constantNameOrInfoIndex
+     * @throws Exception\InvalidArgumentException
+     * @return bool|ConstantScanner
+     */
+    public function getConstant($constantNameOrInfoIndex)
+    {
+        if ($this->classScanner->hasConstant($constantNameOrInfoIndex)) {
+            return $this->classScanner->getConstant($constantNameOrInfoIndex);
+        }
+
+        foreach ($this->parentClassScanners as $pClassScanner) {
+            if ($pClassScanner->hasConstant($constantNameOrInfoIndex)) {
+                return $pClassScanner->getConstant($constantNameOrInfoIndex);
+            }
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Constant %s not found in %s',
+            $constantNameOrInfoIndex,
+            $this->classScanner->getName()
+        ));
+    }
+
+    /**
+     * Verify if class or parent class has constant
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function hasConstant($name)
+    {
+        if ($this->classScanner->hasConstant($name)) {
+            return true;
+        }
+        foreach ($this->parentClassScanners as $pClassScanner) {
+            if ($pClassScanner->hasConstant($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return a list of property names
+     *
+     * @return array
+     */
+    public function getPropertyNames()
+    {
+        $properties = $this->classScanner->getPropertyNames();
+        foreach ($this->parentClassScanners as $pClassScanner) {
+            $properties = array_merge($properties, $pClassScanner->getPropertyNames());
+        }
+
+        return $properties;
     }
 
     /**
@@ -177,6 +261,52 @@ class DerivedClassScanner extends ClassScanner
         }
 
         return $properties;
+    }
+
+    /**
+     * Return a single property by given name or index of info
+     *
+     * @param  string|int $propertyNameOrInfoIndex
+     * @throws Exception\InvalidArgumentException
+     * @return bool|PropertyScanner
+     */
+    public function getProperty($propertyNameOrInfoIndex)
+    {
+        if ($this->classScanner->hasProperty($propertyNameOrInfoIndex)) {
+            return $this->classScanner->getProperty($propertyNameOrInfoIndex);
+        }
+
+        foreach ($this->parentClassScanners as $pClassScanner) {
+            if ($pClassScanner->hasProperty($propertyNameOrInfoIndex)) {
+                return $pClassScanner->getProperty($propertyNameOrInfoIndex);
+            }
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Property %s not found in %s',
+            $propertyNameOrInfoIndex,
+            $this->classScanner->getName()
+        ));
+    }
+
+    /**
+     * Verify if class or parent class has property
+     *
+     * @param  string $name
+     * @return bool
+     */
+    public function hasProperty($name)
+    {
+        if ($this->classScanner->hasProperty($name)) {
+            return true;
+        }
+        foreach ($this->parentClassScanners as $pClassScanner) {
+            if ($pClassScanner->hasProperty($name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -230,6 +360,8 @@ class DerivedClassScanner extends ClassScanner
     }
 
     /**
+     * Verify if class or parent class has method by given name
+     *
      * @param  string $name
      * @return bool
      */

--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -100,7 +100,7 @@ class ClassScannerTest extends TestCase
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
         $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
         $this->assertEquals(11, $class->getLineStart());
-        $this->assertEquals(31, $class->getLineEnd());
+        $this->assertEquals(36, $class->getLineEnd());
 
         $file    = new FileScanner(__DIR__ . '/../TestAsset/BarClass.php');
         $class   = $file->getClass('ZendTest\Code\TestAsset\BarClass');

--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -52,6 +52,7 @@ class ClassScannerTest extends TestCase
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
         $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
         $this->assertInternalType('array', $class->getConstantNames());
+        $this->assertContains('FOO', $class->getConstantNames());
     }
 
     public function testClassScannerHasProperties()
@@ -68,14 +69,47 @@ class ClassScannerTest extends TestCase
         $this->assertContains('fooBarBaz', $class->getMethodNames());
     }
 
-    public function testClassScannerReturnsConstantsWithConstantScanners()
+    public function testGetConstantsReturnsConstantNames()
     {
         $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
         $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
-        $constants = $class->getConstants();
+        $this->assertContains('foo', $class->getConstants());
+    }
+
+    public function testGetConstantsReturnsInstancesOfConstantScanner()
+    {
+        $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
+        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $constants = $class->getConstants(false);
         foreach ($constants as $constant) {
             $this->assertInstanceOf('Zend\Code\Scanner\ConstantScanner', $constant);
         }
+    }
+
+    public function testHasConstant()
+    {
+        $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
+        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $this->assertTrue($class->hasConstant('FOO'));
+        $this->assertFalse($class->hasConstant('foo'));
+    }
+
+    public function testHasProperty()
+    {
+        $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
+        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $this->assertTrue($class->hasProperty('foo'));
+        $this->assertFalse($class->hasProperty('FOO'));
+        $this->assertTrue($class->hasProperty('bar'));
+    }
+
+    public function testHasMethod()
+    {
+        $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
+        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $this->assertTrue($class->hasMethod('fooBarBaz'));
+        $this->assertFalse($class->hasMethod('FooBarBaz'));
+        $this->assertFalse($class->hasMethod('bar'));
     }
 
     public function testClassScannerReturnsMethodsWithMethodScanners()

--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -51,7 +51,7 @@ class ClassScannerTest extends TestCase
     {
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
         $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
-        $this->assertInternalType('array', $class->getConstants());
+        $this->assertInternalType('array', $class->getConstantNames());
     }
 
     public function testClassScannerHasProperties()
@@ -66,6 +66,16 @@ class ClassScannerTest extends TestCase
         $file  = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
         $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
         $this->assertContains('fooBarBaz', $class->getMethodNames());
+    }
+
+    public function testClassScannerReturnsConstantsWithConstantScanners()
+    {
+        $file    = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
+        $class   = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+        $constants = $class->getConstants();
+        foreach ($constants as $constant) {
+            $this->assertInstanceOf('Zend\Code\Scanner\ConstantScanner', $constant);
+        }
     }
 
     public function testClassScannerReturnsMethodsWithMethodScanners()

--- a/tests/ZendTest/Code/Scanner/ConstantScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ConstantScannerTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Code
+ */
+
+namespace ZendTest\Code\Scanner;
+
+use Zend\Code\Scanner\FileScanner;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ConstantScannerTest extends TestCase
+{
+    public function testConstantScannerHasConstantInformation()
+    {
+        $file = new FileScanner(__DIR__ . '/../TestAsset/FooClass.php');
+        $class = $file->getClass('ZendTest\Code\TestAsset\FooClass');
+
+        $constant = $class->getConstant('BAR');
+        $this->assertEquals('BAR', $constant->getName());
+        $this->assertEquals(5, $constant->getValue());
+
+        $constant = $class->getConstant('FOO');
+        $this->assertEquals('FOO', $constant->getName());
+        $this->assertEquals(5, $constant->getValue());
+
+        $constant = $class->getConstant('BAZ');
+        $this->assertEquals('BAZ', $constant->getName());
+        $this->assertEquals('baz', $constant->getValue());
+        $this->assertNotNull('Some comment', $constant->getDocComment());
+    }
+}

--- a/tests/ZendTest/Code/TestAsset/FooClass.php
+++ b/tests/ZendTest/Code/TestAsset/FooClass.php
@@ -13,6 +13,11 @@ abstract class FooClass implements \ArrayAccess, E\Blarg, Local\SubClass
     const BAR = 5;
     const FOO = self::BAR;
 
+    /**
+     * Constant comment
+     */
+    const BAZ = 'baz';
+
     protected static $bar = 'value';
     public $foo = 'value2';
 


### PR DESCRIPTION
Fix bug introduced in #4457 and add some new features.
- Can parse constants of type float, number or string
- Can parse constants with docblock on previous line
- Can parse constants with self:: reference
- Added has\* methods for constant and property
- Updated docblocks

There is one BC break. Method getConstants() don't return constant names now, but return instance of ConstantScanner.
