### PR TITLE
sync ZF1 svn r24807 - ZF-12128: File Upload validator should display file na...

### DIFF
--- a/library/Zend/Validator/File/Upload.php
+++ b/library/Zend/Validator/File/Upload.php
@@ -163,40 +163,40 @@ class Upload extends AbstractValidator
             switch ($content['error']) {
                 case 0:
                     if (!is_uploaded_file($content['tmp_name'])) {
-                        $this->throwError($file, self::ATTACK);
+                        $this->throwError($content, self::ATTACK);
                     }
                     break;
 
                 case 1:
-                    $this->throwError($file, self::INI_SIZE);
+                    $this->throwError($content, self::INI_SIZE);
                     break;
 
                 case 2:
-                    $this->throwError($file, self::FORM_SIZE);
+                    $this->throwError($content, self::FORM_SIZE);
                     break;
 
                 case 3:
-                    $this->throwError($file, self::PARTIAL);
+                    $this->throwError($content, self::PARTIAL);
                     break;
 
                 case 4:
-                    $this->throwError($file, self::NO_FILE);
+                    $this->throwError($content, self::NO_FILE);
                     break;
 
                 case 6:
-                    $this->throwError($file, self::NO_TMP_DIR);
+                    $this->throwError($content, self::NO_TMP_DIR);
                     break;
 
                 case 7:
-                    $this->throwError($file, self::CANT_WRITE);
+                    $this->throwError($content, self::CANT_WRITE);
                     break;
 
                 case 8:
-                    $this->throwError($file, self::EXTENSION);
+                    $this->throwError($content, self::EXTENSION);
                     break;
 
                 default:
-                    $this->throwError($file, self::UNKNOWN);
+                    $this->throwError($content, self::UNKNOWN);
                     break;
             }
         }

--- a/tests/ZendTest/Validator/File/UploadTest.php
+++ b/tests/ZendTest/Validator/File/UploadTest.php
@@ -249,4 +249,30 @@ class UploadTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileUploadErrorFileNotFound', $validator->getMessages()));
         $this->assertContains("nofile.mo'", current($validator->getMessages()));
     }
+
+    /**
+     * @group ZF-12128
+     */
+    public function testErrorMessage()
+    {
+        $_FILES = array(
+            'foo' => array(
+                'name'     => 'bar',
+                'type'     => 'text',
+                'size'     => 100,
+                'tmp_name' => 'tmp_bar',
+                'error'    => 7,
+            )
+        );
+
+        $validator = new File\Upload;
+        $validator->isValid('foo');
+
+        $this->assertEquals(
+            array(
+                'fileUploadErrorCantWrite' => "File 'bar' can't be written",
+            ),
+            $validator->getMessages()
+        );
+    }
 }


### PR DESCRIPTION
...me instead of field name in error

@see
http://framework.zend.com/issues/browse/ZF-12128

https://bitbucket.org/sasezaki/mirror-zf1-standard-trunk-libraray-validate-dir/commits/413ed37ec4979a16474321b5141b4ec94277c366 (svn diff )
https://bitbucket.org/sasezaki/mirror-zf1-standard-trunk-tests-validate-dir/commits/0080e1eb920330792fe2246a59540cc0429d703a (svn diff )
