### PR TITLE
swap order of the arguments in credentialValidationCallback

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CallbackCheckAdapter.php
@@ -96,7 +96,7 @@ class CallbackCheckAdapter extends AbstractAdapter
     protected function authenticateValidateResult($resultIdentity)
     {
         try {
-            $callbackResult = call_user_func($this->credentialValidationCallback, $resultIdentity[$this->credentialColumn], $this->credential);
+            $callbackResult = call_user_func($this->credentialValidationCallback, $this->credential, $resultIdentity[$this->credentialColumn]);
         } catch (\Exception $e) {
             $this->authenticateResultInfo['code']       = AuthenticationResult::FAILURE_UNCATEGORIZED;
             $this->authenticateResultInfo['messages'][] = $e->getMessage();


### PR DESCRIPTION
I would suggest swapping the order of the parameters in CallbackCheckAdapter::authenticateValidateResult to match the Zend\Crypt\Password\PasswordInterface::verify(credential, hash)
