### PR TITLE
fixed Cache\StorageFactory::factory()

### DIFF
--- a/library/Zend/Cache/StorageFactory.php
+++ b/library/Zend/Cache/StorageFactory.php
@@ -54,16 +54,16 @@ abstract class StorageFactory
             throw new Exception\InvalidArgumentException('Missing "adapter"');
         }
         $adapterName    = $cfg['adapter'];
-        $adapterOptions = null;
+        $adapterOptions = array();
         if (is_array($cfg['adapter'])) {
             if (!isset($cfg['adapter']['name'])) {
                 throw new Exception\InvalidArgumentException('Missing "adapter.name"');
             }
 
             $adapterName    = $cfg['adapter']['name'];
-            $adapterOptions = isset($cfg['adapter']['options']) ? $cfg['adapter']['options'] : null;
+            $adapterOptions = isset($cfg['adapter']['options']) ? $cfg['adapter']['options'] : array();
         }
-        if ($adapterOptions && isset($cfg['options'])) {
+        if (isset($cfg['options'])) {
             $adapterOptions = array_merge($adapterOptions, $cfg['options']);
         }
 

--- a/tests/ZendTest/Cache/StorageFactoryTest.php
+++ b/tests/ZendTest/Cache/StorageFactoryTest.php
@@ -89,6 +89,22 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $cache);
     }
 
+    /**
+     * @group 4445
+     */
+    public function testFactoryWithAdapterAsStringAndOptions()
+    {
+        $cache = Cache\StorageFactory::factory(array(
+            'adapter' => 'Memory',
+            'options' => array(
+                'namespace' => 'test'
+            ),
+        ));
+
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $cache);
+        $this->assertSame('test', $cache->getOptions()->getNamespace());
+    }
+
     public function testFactoryAdapterAsArray()
     {
         $cache = Cache\StorageFactory::factory(array(


### PR DESCRIPTION
Fixes #4445

`Cache\StorageFactory::factory()`: Allow to pass adapter as string with an options array
