### PR TITLE
Add a test to check FormElementManager has ServiceLocator in Mvc #3923

### DIFF
--- a/tests/ZendTest/Mvc/Service/FormElementManagerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/FormElementManagerFactoryTest.php
@@ -70,4 +70,11 @@ class FormElementManagerFactoryTest extends TestCase
         $form = $formElementManager->get('ZendTest\Mvc\Service\TestAsset\CustomForm');
         $this->assertInstanceof('ZendTest\Mvc\Service\TestAsset\CustomForm', $form);
     }
+
+    public function testAccordingToServiceLocatorAwareInterface()
+    {
+        $formElementManager = $this->services->get('FormElementManager');
+        $serviceLocator = $formElementManager->getServiceLocator();
+        $this->assertInstanceof('Zend\ServiceManager\ServiceLocatorInterface', $serviceLocator);
+    }
 }


### PR DESCRIPTION
Relative to #3923

In case instances made in AbstractPluginManager implement ServiceLocatorAwareInterface, these have AbstractPluginManager as ServiceLocator.
Is it designed behavior?

This test indicates that we can get the Application's ServiceLocator from  AbstractPluginManager::getServiceLocator in the Mvc scope.

notes:
https://github.com/zendframework/zf2/issues/4464#issuecomment-17797941
