### PR TITLE
Set Default Translator to Abstract Validator not working #4485

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -19,11 +19,12 @@ use Zend\I18n\Exception;
 use Zend\I18n\Translator\Loader\FileLoaderInterface;
 use Zend\I18n\Translator\Loader\RemoteLoaderInterface;
 use Zend\Stdlib\ArrayUtils;
+use Zend\Validator\Translator\TranslatorInterface;
 
 /**
  * Translator.
  */
-class Translator
+class Translator implements TranslatorInterface
 {
     /**
      * Event fired when the translation for a message is missing.


### PR DESCRIPTION
I did the change in the \Zend\I18n\Translator\Translator class and now the translator implements the \Zend\Validator\Translator\TranslatorInterface.

So it could be set now as de Default Translator for the validators.
