### PR TITLE
Nonvalid literal value for the boolean type, PDO

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
@@ -264,7 +264,11 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
         $parameters = $this->parameterContainer->getNamedArray();
         foreach ($parameters as $name => &$value) {
-            $type = \PDO::PARAM_STR;
+            if (is_bool($value)) {
+                $type = \PDO::PARAM_BOOL;
+            } else {
+                $type = \PDO::PARAM_STR;
+            }
             if ($this->parameterContainer->offsetHasErrata($name)) {
                 switch ($this->parameterContainer->offsetGetErrata($name)) {
                     case ParameterContainer::TYPE_INTEGER:
@@ -275,9 +279,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
                         break;
                     case ParameterContainer::TYPE_LOB:
                         $type = \PDO::PARAM_LOB;
-                        break;
-                    case (is_bool($value)):
-                        $type = \PDO::PARAM_BOOL;
                         break;
                 }
             }


### PR DESCRIPTION
SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type boolean: ""' error has been fixed
