### PR TITLE
Add build.xml to .gitattributes/export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 .gitignore export-ignore
 .travis.yml export-ignore
 .php_cs export-ignore
+build.xml export-ignore


### PR DESCRIPTION
Like other testing files, `build.xml` is useless for public distribution
