### PR TITLE
Class methods hydrator skips getters with optional parameters

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Filter/OptionalParametersFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/OptionalParametersFilter.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link           http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright      Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license        http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Stdlib\Hydrator\Filter;
+
+use InvalidArgumentException;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionParameter;
+
+/**
+ * Filter that includes methods which have no parameters or only optional parameters
+ */
+class OptionalParametersFilter implements FilterInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function filter($property)
+    {
+        try {
+            $reflectionMethod = new ReflectionMethod($property);
+        } catch (ReflectionException $exception) {
+            throw new InvalidArgumentException(sprintf('Method %s doesn\'t exist', $property));
+        }
+
+        $mandatoryParameters = array_filter(
+            $reflectionMethod->getParameters(),
+            function (ReflectionParameter $parameter) {
+                return ! $parameter->isOptional();
+            }
+        );
+
+        return empty($mandatoryParameters);
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Filter/OptionalParametersFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/OptionalParametersFilter.php
@@ -19,10 +19,23 @@ use ReflectionParameter;
 class OptionalParametersFilter implements FilterInterface
 {
     /**
+     * Map of methods already analyzed
+     * by {@see \Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter::filter()},
+     * cached for performance reasons
+     *
+     * @var bool[]
+     */
+    private static $propertiesCache = array();
+
+    /**
      * {@inheritDoc}
      */
     public function filter($property)
     {
+        if (isset(self::$propertiesCache[$property])) {
+            return self::$propertiesCache[$property];
+        }
+
         try {
             $reflectionMethod = new ReflectionMethod($property);
         } catch (ReflectionException $exception) {
@@ -36,6 +49,6 @@ class OptionalParametersFilter implements FilterInterface
             }
         );
 
-        return empty($mandatoryParameters);
+        return self::$propertiesCache[$property] = empty($mandatoryParameters);
     }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/ClassMethodsTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/ClassMethodsTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator;
+
+use Zend\Stdlib\Hydrator\ClassMethods;
+use ZendTest\Stdlib\TestAsset\ClassMethodsOptionalParameters;
+
+/**
+ * Unit tests for {@see \Zend\Stdlib\Hydrator\ClassMethods}
+ *
+ * @covers \Zend\Stdlib\Hydrator\ClassMethods
+ * @group Zend_Stdlib
+ */
+class ClassMethodsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ClassMethods
+     */
+    protected $hydrator;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->hydrator = new ClassMethods();
+    }
+
+    /**
+     * Verifies that extraction can happen even when a getter has parameters if those are all optional
+     */
+    public function testCanExtractFromMethodsWithOptionalParameters()
+    {
+        $this->assertSame(array('foo' => 'bar'), $this->hydrator->extract(new ClassMethodsOptionalParameters()));
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/Filter/OptionalParametersFilterTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Filter/OptionalParametersFilterTest.php
@@ -15,6 +15,7 @@ use Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter;
  * Unit tests for {@see \Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter}
  *
  * @covers \Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter
+ * @group Zend_Stdlib
  */
 class OptionalParametersFilterTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ZendTest/Stdlib/Hydrator/Filter/OptionalParametersFilterTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Filter/OptionalParametersFilterTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\Filter;
+
+use Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter;
+
+/**
+ * Unit tests for {@see \Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter}
+ *
+ * @covers \Zend\Stdlib\Hydrator\Filter\OptionalParametersFilter
+ */
+class OptionalParametersFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var OptionalParametersFilter
+     */
+    protected $filter;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->filter = new OptionalParametersFilter();
+    }
+
+    /**
+     * Verifies a list of methods against expected results
+     *
+     * @param string $method
+     * @param bool   $expectedResult
+     *
+     * @dataProvider methodProvider
+     */
+    public function testMethods($method, $expectedResult)
+    {
+        $this->assertSame($expectedResult, $this->filter->filter($method));
+    }
+
+    public function testTriggersExceptionOnUnknownMethod()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->filter->filter(__CLASS__ . '::' . 'nonExistingMethod');
+    }
+
+    /**
+     * Provides a list of methods to be checked against the filter
+     *
+     * @return array
+     */
+    public function methodProvider()
+    {
+        return array(
+            array(__CLASS__ . '::' . 'methodWithoutParameters', true),
+            array(__CLASS__ . '::' . 'methodWithSingleMandatoryParameter', false),
+            array(__CLASS__ . '::' . 'methodWithSingleOptionalParameter', true),
+            array(__CLASS__ . '::' . 'methodWithMultipleMandatoryParameters', false),
+            array(__CLASS__ . '::' . 'methodWithMultipleOptionalParameters', true),
+        );
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithoutParameters()
+    {
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithSingleMandatoryParameter($parameter)
+    {
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithSingleOptionalParameter($parameter = null)
+    {
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithMultipleMandatoryParameters($parameter, $otherParameter)
+    {
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithMultipleOptionalParameters($parameter = null, $otherParameter = null)
+    {
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/Filter/OptionalParametersFilterTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Filter/OptionalParametersFilterTest.php
@@ -45,6 +45,22 @@ class OptionalParametersFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedResult, $this->filter->filter($method));
     }
 
+    /**
+     * Verifies a list of methods against expected results over subsequent calls, checking
+     * that the filter behaves consistently regardless of cache optimizations
+     *
+     * @param string $method
+     * @param bool   $expectedResult
+     *
+     * @dataProvider methodProvider
+     */
+    public function testMethodsOnSubsequentCalls($method, $expectedResult)
+    {
+        for ($i = 0; $i < 5; $i += 1) {
+            $this->assertSame($expectedResult, $this->filter->filter($method));
+        }
+    }
+
     public function testTriggersExceptionOnUnknownMethod()
     {
         $this->setExpectedException('InvalidArgumentException');

--- a/tests/ZendTest/Stdlib/TestAsset/ClassMethodsOptionalParameters.php
+++ b/tests/ZendTest/Stdlib/TestAsset/ClassMethodsOptionalParameters.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+/**
+ * Test asset to check how optional parameters of are treated methods
+ */
+class ClassMethodsOptionalParameters
+{
+    /**
+     * @var string
+     */
+    public $foo = 'bar';
+
+    /**
+     * @param mixed $optional
+     *
+     * @return string
+     */
+    public function getFoo($optional = null)
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param string $foo
+     * @param mixed  $optional
+     */
+    public function setFoo($foo, $optional = null)
+    {
+        $this->foo = (string) $foo;
+    }
+}


### PR DESCRIPTION
Currently, `Zend\Stdlib\Hydrator\ClassMethods` skips getters like `getFoo($bar = null)` as they have `>0` parameters.

This hotfix allows to call those methods as long as all parameters are optional.
