### PR TITLE
Fix name of LoggerAbstractServiceFactory test

### DIFF
--- a/tests/ZendTest/Log/LoggerAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Log/LoggerAbstractServiceFactoryTest.php
@@ -19,7 +19,7 @@ use Zend\Mvc\Service\ServiceManagerConfig;
  * @subpackage UnitTests
  * @group      Zend_Log
  */
-class LoggerAbstractServiceFactoryTeset extends \PHPUnit_Framework_TestCase
+class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Zend\ServiceManager\ServiceLocatorInterface


### PR DESCRIPTION
While browsing through the change log - an activity I especially enjoy when it comes to ZF2 change logs - I realised that the test accompanying the `Zend\Log\LoggerAbstractServiceFactory` is inadequately named.

I guess it should be `LoggerAbstractServiceFactoryTest` instead of `LoggerAbstractServiceFactoryTeset`.
