### PR TITLE
Add service definition for DateTimeFormatter (related to #3632)

### DIFF
--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -39,6 +39,7 @@ class FilterPluginManager extends AbstractPluginManager
         'compresssnappy'            => 'Zend\Filter\Compress\Snappy',
         'compresstar'               => 'Zend\Filter\Compress\Tar',
         'compresszip'               => 'Zend\Filter\Compress\Zip',
+        'datetimeformatter'         => 'Zend\Filter\DateTimeFormatter',
         'decompress'                => 'Zend\Filter\Decompress',
         'decrypt'                   => 'Zend\Filter\Decrypt',
         'digits'                    => 'Zend\Filter\Digits',


### PR DESCRIPTION
When attempting to add a `DateTimeFormatter` filter to the filter chain of an input like this

``` php
$this->add(array(
    'name' => 'release_date',
    'filters' => array(
        array(
            'name'  => 'DateTimeFormatter',
        ),
    ),
));
```

a `ServiceNotFoundException` is thrown because the `FilterPluginManager` is unaware of a factory.
