### PR TITLE
introduce compatible support for JsonSerializable

### DIFF
--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -12,6 +12,7 @@ namespace Zend\Json;
 use Iterator;
 use IteratorAggregate;
 use ReflectionClass;
+use JsonSerializable;
 use Zend\Json\Exception\InvalidArgumentException;
 use Zend\Json\Exception\RecursionException;
 

--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -12,7 +12,6 @@ namespace Zend\Json;
 use Iterator;
 use IteratorAggregate;
 use ReflectionClass;
-use JsonSerializable;
 use Zend\Json\Exception\InvalidArgumentException;
 use Zend\Json\Exception\RecursionException;
 
@@ -67,7 +66,7 @@ class Encoder
     {
         $encoder = new static(($cycleCheck) ? true : false, $options);
 
-        if ($value instanceof JsonSerializable) {
+        if ($value instanceof \JsonSerializable) {
             $value = $value->JsonSerialize();
         }
 

--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -66,6 +66,10 @@ class Encoder
     {
         $encoder = new static(($cycleCheck) ? true : false, $options);
 
+        if ($value instanceof JsonSerializable) {
+            $value = $value->JsonSerialize();
+        }
+
         return $encoder->_encodeValue($value);
     }
 

--- a/library/Zend/Json/JsonSerializable.php
+++ b/library/Zend/Json/JsonSerializable.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Json;
+
+/**
+ * Compatible interface for >=PHP 5.4 or over.
+ * @see http://php.net/jsonserializable.jsonserialize.php
+ */
+interface JsonSerializable
+{
+    public function jsonSerialize();
+}

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -1054,4 +1054,3 @@ class JsonSerializableImpl implements \JsonSerializable
         return array(__FUNCTION__);
     }
 }
-

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -12,6 +12,10 @@ namespace ZendTest\Json;
 
 use Zend\Json;
 
+if (!version_compare(PHP_VERSION, '5.4.0', 'gt')) {
+    class_alias('Zend\Json\JsonSerializable', 'JsonSerializable');
+}
+
 /**
  * @category   Zend
  * @package    Zend_JSON
@@ -921,6 +925,17 @@ EOB;
         $this->assertEquals('test', $object->_empty_);
     }
 
+    /**
+     * Test JsonSerializable implements (PHP's json support it since 5.4.0)
+     *
+     * @see http://php.net/jsonserializable.jsonserialize.php
+     */
+    public function testJsonSerializable()
+    {
+        $encoded = Json\Encoder::encode(new JsonSerializableImpl);
+        $this->assertEquals('["jsonSerialize"]', $encoded);
+    }
+
 }
 
 /**
@@ -1031,3 +1046,12 @@ class ToJSONWithExpr
         return Json\Json::encode($data, false, array('enableJsonExprFinder' => true));
     }
 }
+
+class JsonSerializableImpl implements \JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return array(__FUNCTION__);
+    }
+}
+


### PR DESCRIPTION
For PHP 5.3.x environment, 
this is enhancement for Json Component for JsonSerializable compatiblity.

@see http://php.net/jsonserializable.jsonserialize.php

NOTES : now implementation needs before using

```
class_alias('Zend\Json\JsonSerializable', 'JsonSerializable');
```

so, if this proposal is acceptable, needs to write it documentation.
