### PR TITLE
[DateTimeFormatter] Format DateTime values correctly

### DIFF
--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -74,11 +74,11 @@ class DateTimeFormatter extends AbstractFilter
         if ($value === '' || $value === null) {
             return $value;
         } elseif (is_int($value)) {
-            $dateTime = new DateTime('@' . $value);
+            $value = new DateTime('@' . $value);
         } elseif (!$value instanceof DateTime) {
-            $dateTime = new DateTime($value);
+            $value = new DateTime($value);
         }
 
-        return $dateTime->format($this->format);
+        return $value->format($this->format);
     }
 }

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -101,6 +101,15 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('2013-02-01T17:30:01+0000', $result);
     }
 
+    public function testAcceptDateTimeValue()
+    {
+        date_default_timezone_set('UTC');
+
+        $filter = new DateTimeFormatter();
+        $result = $filter->filter(new DateTime('2012-01-01'));
+        $this->assertEquals('2012-01-01T00:00:00+0000', $result);
+    }
+
     public function testInvalidArgumentExceptionThrownOnInvalidInput()
     {
         $this->setExpectedException('Zend\Filter\Exception\InvalidArgumentException');


### PR DESCRIPTION
Fixes error;

```
Notice: Undefined variable: dateTime in ...zendframework\library\Zend\Filter\DateTimeFormatter.php on line 82

Fatal error: Call to a member function format() on a non-object in ...zendframework\library\Zend\Filter\DateTimeFormatter.php on line 82
```
