### PR TITLE
blackhole cache storage adapter

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/BlackHole.php
+++ b/library/Zend/Cache/Storage/Adapter/BlackHole.php
@@ -10,10 +10,29 @@
 namespace Zend\Cache\Storage\Adapter;
 
 use stdClass;
+use Zend\Cache\Storage\AvailableSpaceCapableInterface;
 use Zend\Cache\Storage\Capabilities;
+use Zend\Cache\Storage\ClearByNamespaceInterface;
+use Zend\Cache\Storage\ClearByPrefixInterface;
+use Zend\Cache\Storage\ClearExpiredInterface;
+use Zend\Cache\Storage\FlushableInterface;
+use Zend\Cache\Storage\IterableInterface;
+use Zend\Cache\Storage\OptimizableInterface;
 use Zend\Cache\Storage\StorageInterface;
+use Zend\Cache\Storage\TaggableInterface;
+use Zend\Cache\Storage\TotalSpaceCapableInterface;
 
-class BlackHole implements StorageInterface
+class BlackHole implements
+    StorageInterface,
+    AvailableSpaceCapableInterface,
+    ClearByNamespaceInterface,
+    ClearByPrefixInterface,
+    ClearExpiredInterface,
+    FlushableInterface,
+    IterableInterface,
+    OptimizableInterface,        
+    TaggableInterface,
+    TotalSpaceCapableInterface
 {
     /**
      * Capabilities of this adapter
@@ -340,5 +359,144 @@ class BlackHole implements StorageInterface
             $this->capabilities     = new Capabilities($this, $this->capabilityMarker);
         }
         return $this->capabilities;
+    }
+
+    /* AvailableSpaceCapableInterface */
+
+    /**
+     * Get available space in bytes
+     *
+     * @return int|float
+     */
+    public function getAvailableSpace()
+    {
+        return 0;
+    }
+
+    /* ClearByNamespaceInterface */
+
+    /**
+     * Remove items of given namespace
+     *
+     * @param string $namespace
+     * @return bool
+     */
+    public function clearByNamespace($namespace)
+    {
+        return false;
+    }
+
+    /* ClearByPrefixInterface */
+
+    /**
+     * Remove items matching given prefix
+     *
+     * @param string $prefix
+     * @return bool
+     */
+    public function clearByPrefix($prefix)
+    {
+        return false;
+    }
+
+    /* ClearExpiredInterface */
+
+    /**
+     * Remove expired items
+     *
+     * @return bool
+     */
+    public function clearExpired()
+    {
+        return false;
+    }
+
+    /* FlushableInterface */
+
+    /**
+     * Flush the whole storage
+     *
+     * @return bool
+     */
+    public function flush()
+    {
+        return false;
+    }
+
+    /* IterableInterface */
+
+    /**
+     * Get the storage iterator
+     *
+     * @return KeyIterator
+     */
+    public function getIterator()
+    {
+        return new KeyListIterator($this, array());
+    }
+
+    /* OptimizableInterface */
+
+    /**
+     * Optimize the storage
+     *
+     * @return bool
+     */
+    public function optimize()
+    {
+        return false;
+    }
+
+    /* TaggableInterface */
+
+    /**
+     * Set tags to an item by given key.
+     * An empty array will remove all tags.
+     *
+     * @param string   $key
+     * @param string[] $tags
+     * @return bool
+     */
+    public function setTags($key, array $tags)
+    {
+        return false;
+    }
+
+    /**
+     * Get tags of an item by given key
+     *
+     * @param string $key
+     * @return string[]|FALSE
+     */
+    public function getTags($key)
+    {
+        return false;
+    }
+
+    /**
+     * Remove items matching given tags.
+     *
+     * If $disjunction only one of the given tags must match
+     * else all given tags must match.
+     *
+     * @param string[] $tags
+     * @param  bool  $disjunction
+     * @return bool
+     */
+    public function clearByTags(array $tags, $disjunction = false)
+    {
+        return false;
+    }
+
+    /* TotalSpaceCapableInterface */
+
+    /**
+     * Get total space in bytes
+     *
+     * @return int|float
+     */
+    public function getTotalSpace()
+    {
+        return 0;
     }
 }

--- a/library/Zend/Cache/Storage/Adapter/BlackHole.php
+++ b/library/Zend/Cache/Storage/Adapter/BlackHole.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Cache\Storage\Adapter;
+
+use stdClass;
+use Zend\Cache\Storage\Capabilities;
+use Zend\Cache\Storage\StorageInterface;
+
+class BlackHole implements StorageInterface
+{
+    /**
+     * Capabilities of this adapter
+     *
+     * @var null|Capabilities
+     */
+    protected $capabilities = null;
+
+    /**
+     * Marker to change capabilities
+     *
+     * @var null|object
+     */
+    protected $capabilityMarker;
+
+    /**
+     * options
+     *
+     * @var null|AdapterOptions
+     */
+    protected $options;
+
+    /**
+     * Constructor
+     *
+     * @param  null|array|Traversable|AdapterOptions $options
+     */
+    public function __construct($options = null)
+    {
+        if ($options) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * Set options.
+     *
+     * @param array|Traversable|Adapter\AdapterOptions $options
+     * @return StorageInterface Fluent interface
+     */
+    public function setOptions($options)
+    {
+        if ($this->options !== $options) {
+            if (!$options instanceof AdapterOptions) {
+                $options = new AdapterOptions($options);
+            }
+
+            if ($this->options) {
+                $this->options->setAdapter(null);
+            }
+            $options->setAdapter($this);
+            $this->options = $options;
+        }
+        return $this;
+    }
+
+    /**
+     * Get options
+     *
+     * @return Adapter\AdapterOptions
+     */
+    public function getOptions()
+    {
+        if (!$this->options) {
+            $this->setOptions(new AdapterOptions());
+        }
+        return $this->options;
+    }
+
+    /**
+     * Get an item.
+     *
+     * @param  string  $key
+     * @param  bool $success
+     * @param  mixed   $casToken
+     * @return mixed Data on success, null on failure
+     */
+    public function getItem($key, & $success = null, & $casToken = null)
+    {
+        $success = false;
+        return null;
+    }
+
+    /**
+     * Get multiple items.
+     *
+     * @param  array $keys
+     * @return array Associative array of keys and values
+     */
+    public function getItems(array $keys)
+    {
+        return array();
+    }
+
+    /**
+     * Test if an item exists.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function hasItem($key)
+    {
+        return false;
+    }
+
+    /**
+     * Test multiple items.
+     *
+     * @param  array $keys
+     * @return array Array of found keys
+     */
+    public function hasItems(array $keys)
+    {
+        return array();
+    }
+
+    /**
+     * Get metadata of an item.
+     *
+     * @param  string $key
+     * @return array|bool Metadata on success, false on failure
+     */
+    public function getMetadata($key)
+    {
+        return false;
+    }
+
+    /**
+     * Get multiple metadata
+     *
+     * @param  array $keys
+     * @return array Associative array of keys and metadata
+     */
+    public function getMetadatas(array $keys)
+    {
+        return array();
+    }
+
+    /**
+     * Store an item.
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function setItem($key, $value)
+    {
+        return false;
+    }
+
+    /**
+     * Store multiple items.
+     *
+     * @param  array $keyValuePairs
+     * @return array Array of not stored keys
+     */
+    public function setItems(array $keyValuePairs)
+    {
+        return array_keys($keyValuePairs);
+    }
+
+    /**
+     * Add an item.
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function addItem($key, $value)
+    {
+        return false;
+    }
+
+    /**
+     * Add multiple items.
+     *
+     * @param  array $keyValuePairs
+     * @return array Array of not stored keys
+     */
+    public function addItems(array $keyValuePairs)
+    {
+        return array_keys($keyValuePairs);
+    }
+
+    /**
+     * Replace an existing item.
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function replaceItem($key, $value)
+    {
+        return false;
+    }
+
+    /**
+     * Replace multiple existing items.
+     *
+     * @param  array $keyValuePairs
+     * @return array Array of not stored keys
+     */
+    public function replaceItems(array $keyValuePairs)
+    {
+        return array_keys($keyValuePairs);
+    }
+
+    /**
+     * Set an item only if token matches
+     *
+     * It uses the token received from getItem() to check if the item has
+     * changed before overwriting it.
+     *
+     * @param  mixed  $token
+     * @param  string $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function checkAndSetItem($token, $key, $value)
+    {
+        return false;
+    }
+
+    /**
+     * Reset lifetime of an item
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function touchItem($key)
+    {
+        return false;
+    }
+
+    /**
+     * Reset lifetime of multiple items.
+     *
+     * @param  array $keys
+     * @return array Array of not updated keys
+     */
+    public function touchItems(array $keys)
+    {
+        return $keys;
+    }
+
+    /**
+     * Remove an item.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function removeItem($key)
+    {
+        return false;
+    }
+
+    /**
+     * Remove multiple items.
+     *
+     * @param  array $keys
+     * @return array Array of not removed keys
+     */
+    public function removeItems(array $keys)
+    {
+        return $keys;
+    }
+
+    /**
+     * Increment an item.
+     *
+     * @param  string $key
+     * @param  int    $value
+     * @return int|bool The new value on success, false on failure
+     */
+    public function incrementItem($key, $value)
+    {
+        return false;
+    }
+
+    /**
+     * Increment multiple items.
+     *
+     * @param  array $keyValuePairs
+     * @return array Associative array of keys and new values
+     */
+    public function incrementItems(array $keyValuePairs)
+    {
+        return array();
+    }
+
+    /**
+     * Decrement an item.
+     *
+     * @param  string $key
+     * @param  int    $value
+     * @return int|bool The new value on success, false on failure
+     */
+    public function decrementItem($key, $value)
+    {
+        return false;
+    }
+
+    /**
+     * Decrement multiple items.
+     *
+     * @param  array $keyValuePairs
+     * @return array Associative array of keys and new values
+     */
+    public function decrementItems(array $keyValuePairs)
+    {
+        return array();
+    }
+
+    /**
+     * Capabilities of this storage
+     *
+     * @return Capabilities
+     */
+    public function getCapabilities()
+    {
+        if ($this->capabilities === null) {
+            // use default capabilities only
+            $this->capabilityMarker = new stdClass();
+            $this->capabilities     = new Capabilities($this, $this->capabilityMarker);
+        }
+        return $this->capabilities;
+    }
+}

--- a/library/Zend/Cache/Storage/AdapterPluginManager.php
+++ b/library/Zend/Cache/Storage/AdapterPluginManager.php
@@ -28,6 +28,7 @@ class AdapterPluginManager extends AbstractPluginManager
      */
     protected $invokableClasses = array(
         'apc'            => 'Zend\Cache\Storage\Adapter\Apc',
+        'blackhole'      => 'Zend\Cache\Storage\Adapter\BlackHole',
         'dba'            => 'Zend\Cache\Storage\Adapter\Dba',
         'filesystem'     => 'Zend\Cache\Storage\Adapter\Filesystem',
         'memcached'      => 'Zend\Cache\Storage\Adapter\Memcached',

--- a/library/Zend/Cache/StorageFactory.php
+++ b/library/Zend/Cache/StorageFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Cache;
 
 use Traversable;
+use Zend\EventManager\EventsCapableInterface;
 use Zend\Stdlib\ArrayUtils;
 
 abstract class StorageFactory
@@ -71,6 +72,14 @@ abstract class StorageFactory
 
         // add plugins
         if (isset($cfg['plugins'])) {
+            if (!$adapter instanceof EventsCapableInterface) {
+                throw new Exception\RuntimeException(sprintf(
+                    "The adapter '%s' doesn't implement '%s' and therefore can't handle plugins",
+                    get_class($adapter),
+                    'Zend\EventManager\EventsCapableInterface'
+                ));
+            }
+
             if (!is_array($cfg['plugins'])) {
                 throw new Exception\InvalidArgumentException(
                     'Plugins needs to be an array'

--- a/tests/ZendTest/Cache/Storage/Adapter/BlackHoleTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/BlackHoleTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Cache
+ */
+
+namespace ZendTest\Cache\Storage\Adapter;
+
+use Zend\Cache\Storage\Adapter\BlackHole;
+use Zend\Cache\StorageFactory;
+
+/**
+ * PHPUnit test case
+ */
+
+/**
+ * @category   Zend
+ * @package    Zend_Cache
+ * @subpackage UnitTests
+ * @group      Zend_Cache
+ */
+class BlackHoleAdapterTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * The storage adapter
+     *
+     * @var StorageInterface
+     */
+    protected $storage;
+
+    public function setUp()
+    {
+        $this->storage = StorageFactory::adapterFactory('BlackHole');
+    }
+
+    public function testGetOptions()
+    {
+        $options = $this->storage->getOptions();
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\AdapterOptions', $options);
+    }
+
+    public function testSetOptions()
+    {
+        $this->storage->setOptions(array('namespace' => 'test'));
+        $this->assertSame('test', $this->storage->getOptions()->getNamespace());
+    }
+
+    public function testGetCapabilities()
+    {
+        $capabilities = $this->storage->getCapabilities();
+        $this->assertInstanceOf('Zend\Cache\Storage\Capabilities', $capabilities);
+    }
+
+    public function testSingleStorageOperatios()
+    {
+        $this->assertFalse($this->storage->setItem('test', 1));
+        $this->assertFalse($this->storage->addItem('test', 1));
+        $this->assertFalse($this->storage->replaceItem('test', 1));
+        $this->assertFalse($this->storage->touchItem('test'));
+        $this->assertFalse($this->storage->incrementItem('test', 1));
+        $this->assertFalse($this->storage->decrementItem('test', 1));
+        $this->assertFalse($this->storage->hasItem('test'));
+        $this->assertNull($this->storage->getItem('test', $success));
+        $this->assertFalse($success);
+        $this->assertFalse($this->storage->getMetadata('test'));
+        $this->assertFalse($this->storage->removeItem('test'));
+    }
+
+    public function testMultiStorageOperatios()
+    {
+        $this->assertSame(array('test'), $this->storage->setItems(array('test' => 1)));
+        $this->assertSame(array('test'), $this->storage->addItems(array('test' => 1)));
+        $this->assertSame(array('test'), $this->storage->replaceItems(array('test' => 1)));
+        $this->assertSame(array('test'), $this->storage->touchItems(array('test')));
+        $this->assertSame(array(), $this->storage->incrementItems(array('test' => 1)));
+        $this->assertSame(array(), $this->storage->decrementItems(array('test' => 1)));
+        $this->assertSame(array(), $this->storage->hasItems(array('test')));
+        $this->assertSame(array(), $this->storage->getItems(array('test')));
+        $this->assertSame(array(), $this->storage->getMetadatas(array('test')));
+        $this->assertSame(array('test'), $this->storage->removeItems(array('test')));
+    }
+}

--- a/tests/ZendTest/Cache/Storage/Adapter/BlackHoleTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/BlackHoleTest.php
@@ -11,6 +11,15 @@
 namespace ZendTest\Cache\Storage\Adapter;
 
 use Zend\Cache\Storage\Adapter\BlackHole;
+use Zend\Cache\Storage\AvailableSpaceCapableInterface;
+use Zend\Cache\Storage\ClearByNamespaceInterface;
+use Zend\Cache\Storage\ClearByPrefixInterface;
+use Zend\Cache\Storage\ClearExpiredInterface;
+use Zend\Cache\Storage\FlushableInterface;
+use Zend\Cache\Storage\IterableInterface;
+use Zend\Cache\Storage\OptimizableInterface;
+use Zend\Cache\Storage\TaggableInterface;
+use Zend\Cache\Storage\TotalSpaceCapableInterface;
 use Zend\Cache\StorageFactory;
 
 /**
@@ -83,5 +92,64 @@ class BlackHoleAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array(), $this->storage->getItems(array('test')));
         $this->assertSame(array(), $this->storage->getMetadatas(array('test')));
         $this->assertSame(array('test'), $this->storage->removeItems(array('test')));
+    }
+
+    public function testAvailableSpaceCapableInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\AvailableSpaceCapableInterface', $this->storage);
+        $this->assertSame(0, $this->storage->getAvailableSpace());
+    }
+
+    public function testClearByNamespaceInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\ClearByNamespaceInterface', $this->storage);
+        $this->assertFalse($this->storage->clearByNamespace('test'));
+    }
+
+    public function testClearByPrefixInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\ClearByPrefixInterface', $this->storage);
+        $this->assertFalse($this->storage->clearByPrefix('test'));
+    }
+
+    public function testCleariExpiredInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\ClearExpiredInterface', $this->storage);
+        $this->assertFalse($this->storage->clearExpired());
+    }
+
+    public function testFlushableInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\FlushableInterface', $this->storage);
+        $this->assertFalse($this->storage->flush());
+    }
+
+    public function testIterableInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\IterableInterface', $this->storage);
+        $iterator = $this->storage->getIterator();
+        foreach ($iterator as $item) {
+            $this->fail('The iterator of the BlackHole adapter should be empty');
+        }
+    }
+
+    public function testOptimizableInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\OptimizableInterface', $this->storage);
+        $this->assertFalse($this->storage->optimize());
+    }
+
+    public function testTaggableInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\TaggableInterface', $this->storage);
+        $this->assertFalse($this->storage->setTags('test', array('tag1')));
+        $this->assertFalse($this->storage->getTags('test'));
+        $this->assertFalse($this->storage->clearByTags(array('tag1')));
+    }
+
+    public function testTotalSpaceCapableInterface()
+    {
+        $this->assertInstanceOf('Zend\Cache\Storage\TotalSpaceCapableInterface', $this->storage);
+        $this->assertSame(0, $this->storage->getTotalSpace());
     }
 }

--- a/tests/ZendTest/Cache/StorageFactoryTest.php
+++ b/tests/ZendTest/Cache/StorageFactoryTest.php
@@ -119,6 +119,16 @@ class StorageFactoryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFactoryInstantiateAdapterWithPluginsWithoutEventsCapableInterfaceThrowsException()
+    {
+        // The BlackHole adapter doesn't implement EventsCapableInterface
+        $this->setExpectedException('Zend\Cache\Exception\RuntimeException');
+        Cache\StorageFactory::factory(array(
+            'adapter' => 'blackhole',
+            'plugins' => array('Serializer'),
+        ));
+    }
+
     public function testFactoryWithPluginsAndOptionsArray()
     {
         $factory = array(


### PR DESCRIPTION
This PR implements a black hole storage adapter (like in #4196) but doesn't extends `AbstractAdapter` so there is no overhead and it implements all interfaces to make it possible as a replacement in all cases.

Because it doesn't extend `AbstractAdapter` it has no plugin system implemented and configuring plugins together with this adapter will result in an exception.
