### PR TITLE
Does not render label outside button

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Form\View\Helper;
 
+use Zend\Form\Element\Button;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 use Zend\Form\View\Helper\AbstractHelper;
@@ -80,6 +81,7 @@ class FormRow extends AbstractHelper
      * @param  null|ElementInterface $element
      * @param  null|string           $labelPosition
      * @param  bool                  $renderErrors
+     * @param  string|null           $partial
      * @return string|FormRow
      */
     public function __invoke(ElementInterface $element = null, $labelPosition = null, $renderErrors = null, $partial = null)
@@ -185,6 +187,11 @@ class FormRow extends AbstractHelper
 
                 if ($label !== '' && !$element->hasAttribute('id')) {
                     $label = '<span>' . $label . '</span>';
+                }
+
+                // Button element is a special case, because label is always rendered inside it
+                if ($element instanceof Button) {
+                    $labelOpen = $labelClose = $label = '';
                 }
 
                 switch ($this->labelPosition) {

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -363,4 +363,13 @@ class FormRowTest extends TestCase
 
         $this->assertSame($partial, $this->helper->getPartial());
     }
+
+    public function testAssertButtonElementDoesNotRenderLabelTwice()
+    {
+        $element = new Element\Button('button');
+        $element->setLabel('foo');
+
+        $markup = $this->helper->render($element);
+        $this->assertRegexp('#^<button type="button" name="button" value=""\/?>foo</button>$#', $markup);
+    }
 }


### PR DESCRIPTION
Currently, formRow renders button element like any other element (by appending or prepending label), but button is the only form element that does not follow this convention as label is always inside the tag.

Fixes https://github.com/zendframework/zf2/issues/3014#issuecomment-18180365
