### PR TITLE
CollectionInputFilter should respect the keys of collectionData

### DIFF
--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -145,7 +145,7 @@ class CollectionInputFilter extends InputFilter
      */
     public function setData($data)
     {
-        $this->collectionData = array_values($data);
+        $this->collectionData = $data;
     }
 
     /**
@@ -162,13 +162,16 @@ class CollectionInputFilter extends InputFilter
             return $valid;
         }
 
-        $inputCollection = array_fill(0, $this->getCount(), $this->validationGroup ?: array_keys($this->inputs));
+        if (count($this->collectionData) < $this->getCount()) {
+            $valid = false;
+        }
 
-        foreach ($inputCollection as $key => $inputs) {
-            $this->data = array();
-            if (isset($this->collectionData[$key])) {
-               $this->data = $this->collectionData[$key];
+        $inputs = $this->validationGroup ?: array_keys($this->inputs);
+        foreach ($this->collectionData as $key => $data) {
+            if (!is_array($data)) {
+                $data = array();
             }
+            $this->data = $data;
             $this->populate();
 
             if ($this->validateInputs($inputs)) {

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -163,6 +163,16 @@ class CollectionInputFilterTest extends TestCase
         $this->assertTrue($this->filter->isValid());
     }
 
+    public function testCanValidateValidDataWithNonConsecutiveKeys()
+    {
+        $collectionData = $this->getValidCollectionData();
+        $collectionData[2] = $collectionData[0];
+        unset($collectionData[0]);
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($collectionData);
+        $this->assertTrue($this->filter->isValid());
+    }
+
     public function testInvalidDataReturnsFalse()
     {
         $invalidCollectionData = array(


### PR DESCRIPTION
Currently the CollectionInputFilter assumes that collectionData has always consecutive array keys which can be wrong.

Two changes
- Iterating over collectionData instead of a composed inputCollection
- When there are less items in collectionData than `$this->count` is set to, just mark the collection as invalid, since it doesn't make sense to add them to invalidInputs when there is no corresponding set of data.
