### PR TITLE
Remove unknown invokables from FilterPluginManager

### DIFF
--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -55,8 +55,6 @@ class FilterPluginManager extends AbstractPluginManager
         'htmlentities'              => 'Zend\Filter\HtmlEntities',
         'inflector'                 => 'Zend\Filter\Inflector',
         'int'                       => 'Zend\Filter\Int',
-        'localizedtonormalized'     => 'Zend\Filter\LocalizedToNormalized',
-        'normalizedtolocalized'     => 'Zend\Filter\NormalizedToLocalized',
         'null'                      => 'Zend\Filter\Null',
         'numberformat'              => 'Zend\I18n\Filter\NumberFormat',
         'pregreplace'               => 'Zend\Filter\PregReplace',


### PR DESCRIPTION
The filters 
- `Zend\Filter\LocalizedToNormalized`
- `Zend\Filter\NormalizedToLocalized`

do not to exist, therefore it makes sense to remove them from the `invokableClasses` property of the `FilterPluginManager`.
