### PR TITLE
Allow skipping the md5() on the email address value in the Gravatar helper

### DIFF
--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -69,10 +69,10 @@ class Gravatar extends AbstractHtmlElement
      * @var array
      */
     protected $options = array(
-        'img_size'        => 80,
-        'default_img'     => self::DEFAULT_MM,
-        'rating'          => self::RATING_G,
-        'secure'          => null,
+        'img_size'    => 80,
+        'default_img' => self::DEFAULT_MM,
+        'rating'      => self::RATING_G,
+        'secure'      => null,
     );
 
     /**

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -62,10 +62,11 @@ class Gravatar extends AbstractHtmlElement
      * @var array
      */
     protected $options = array(
-        'img_size'    => 80,
-        'default_img' => self::DEFAULT_MM,
-        'rating'      => self::RATING_G,
-        'secure'      => null,
+        'img_size'        => 80,
+        'default_img'     => self::DEFAULT_MM,
+        'rating'          => self::RATING_G,
+        'secure'          => null,
+        'skip_email_hash' => false,
     );
 
     /**
@@ -135,7 +136,7 @@ class Gravatar extends AbstractHtmlElement
     protected function getAvatarUrl()
     {
         $src = $this->getGravatarUrl()
-            . '/'   . md5($this->getEmail())
+            . '/'   . ($this->getSkipEmailHash() ? $this->getEmail() : md5($this->getEmail()))
             . '?s=' . $this->getImgSize()
             . '&d=' . $this->getDefaultImg()
             . '&r=' . $this->getRating();
@@ -331,6 +332,33 @@ class Gravatar extends AbstractHtmlElement
 
         return $this->options['secure'];
     }
+
+    /**
+     * Skip email hashing
+     *
+     * This is useful if you are using a webservice that provides you the
+     * gravatar hash (md5sum) of users' email addresses, but not the actual
+     * email addresses themselves.
+     *
+     * @param  bool $flag
+     * @return Gravatar
+     */
+    public function setSkipEmailHash($flag)
+    {
+        $this->options['skip_email_hash'] = $flag;
+        return $this;
+    }
+
+    /**
+     * Returns if the helper should pass the email through md5() or not.
+     *
+     * @return boolean
+     */
+    public function getSkipEmailHash()
+    {
+        return $this->options['skip_email_hash'];
+    }
+
 
     /**
      * Set src attrib for image.

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -57,6 +57,13 @@ class Gravatar extends AbstractHtmlElement
     protected $email;
 
     /**
+     * True or false if the email address passed is already an MD5 hash
+     *
+     * @var bool
+     */
+    protected $emailIsHashed;
+
+    /**
      * Options
      *
      * @var array
@@ -66,7 +73,6 @@ class Gravatar extends AbstractHtmlElement
         'default_img'     => self::DEFAULT_MM,
         'rating'          => self::RATING_G,
         'secure'          => null,
-        'skip_email_hash' => false,
     );
 
     /**
@@ -136,7 +142,7 @@ class Gravatar extends AbstractHtmlElement
     protected function getAvatarUrl()
     {
         $src = $this->getGravatarUrl()
-            . '/'   . ($this->getSkipEmailHash() ? $this->getEmail() : md5($this->getEmail()))
+            . '/'   . ($this->emailIsHashed ? $this->getEmail() : md5($this->getEmail()))
             . '?s=' . $this->getImgSize()
             . '&d=' . $this->getDefaultImg()
             . '&r=' . $this->getRating();
@@ -232,6 +238,7 @@ class Gravatar extends AbstractHtmlElement
      */
     public function setEmail($email)
     {
+        $this->emailIsHashed = (bool) preg_match('/^[A-Za-z0-9]{32}$/', $email);
         $this->email = $email;
         return $this;
     }
@@ -332,33 +339,6 @@ class Gravatar extends AbstractHtmlElement
 
         return $this->options['secure'];
     }
-
-    /**
-     * Skip email hashing
-     *
-     * This is useful if you are using a webservice that provides you the
-     * gravatar hash (md5sum) of users' email addresses, but not the actual
-     * email addresses themselves.
-     *
-     * @param  bool $flag
-     * @return Gravatar
-     */
-    public function setSkipEmailHash($flag)
-    {
-        $this->options['skip_email_hash'] = $flag;
-        return $this;
-    }
-
-    /**
-     * Returns if the helper should pass the email through md5() or not.
-     *
-     * @return boolean
-     */
-    public function getSkipEmailHash()
-    {
-        return $this->options['skip_email_hash'];
-    }
-
 
     /**
      * Set src attrib for image.

--- a/tests/ZendTest/View/Helper/GravatarTest.php
+++ b/tests/ZendTest/View/Helper/GravatarTest.php
@@ -92,6 +92,7 @@ class GravatarTest extends TestCase
         $this->helper->setDefaultImg('monsterid')
                      ->setImgSize(150)
                      ->setSecure(true)
+                     ->setSkipEmailHash(true)
                      ->setEmail("example@example.com")
                      ->setAttribs($attribs)
                      ->setRating('pg');
@@ -101,6 +102,7 @@ class GravatarTest extends TestCase
         $this->assertEquals($attribs, $this->helper->getAttribs());
         $this->assertEquals(150, $this->helper->getImgSize());
         $this->assertTrue($this->helper->getSecure());
+        $this->assertTrue($this->helper->getSkipEmailHash());
     }
 
     public function tesSetDefaultImg()
@@ -185,6 +187,18 @@ class GravatarTest extends TestCase
         $this->assertRegExp(
             '#src="http://www.gravatar.com/avatar/[a-z0-9]{32}\?s=125&amp;d=wavatar&amp;r=pg"#',
             $this->helper->__invoke("example@example.com", array('rating' => 'pg', 'imgSize' => 125, 'defaultImg' => 'wavatar', 'secure' => false))->__toString()
+        );
+    }
+
+    public function testSkipEmailHashingOptionTogglesMd5Hashing()
+    {
+        $this->assertNotContains(
+            'b642b4217b34b1e8d3bd915fc65c4452',
+            $this->helper->__invoke('b642b4217b34b1e8d3bd915fc65c4452')->__toString()
+        );
+        $this->assertContains(
+            'b642b4217b34b1e8d3bd915fc65c4452',
+            $this->helper->__invoke('b642b4217b34b1e8d3bd915fc65c4452', array('skip_email_hash' => true))->__toString()
         );
     }
 

--- a/tests/ZendTest/View/Helper/GravatarTest.php
+++ b/tests/ZendTest/View/Helper/GravatarTest.php
@@ -92,7 +92,6 @@ class GravatarTest extends TestCase
         $this->helper->setDefaultImg('monsterid')
                      ->setImgSize(150)
                      ->setSecure(true)
-                     ->setSkipEmailHash(true)
                      ->setEmail("example@example.com")
                      ->setAttribs($attribs)
                      ->setRating('pg');
@@ -102,7 +101,6 @@ class GravatarTest extends TestCase
         $this->assertEquals($attribs, $this->helper->getAttribs());
         $this->assertEquals(150, $this->helper->getImgSize());
         $this->assertTrue($this->helper->getSecure());
-        $this->assertTrue($this->helper->getSkipEmailHash());
     }
 
     public function tesSetDefaultImg()
@@ -190,15 +188,15 @@ class GravatarTest extends TestCase
         );
     }
 
-    public function testSkipEmailHashingOptionTogglesMd5Hashing()
+    public function testPassingAnMd5HashSkipsMd5Hashing()
     {
         $this->assertNotContains(
-            'b642b4217b34b1e8d3bd915fc65c4452',
-            $this->helper->__invoke('b642b4217b34b1e8d3bd915fc65c4452')->__toString()
+            'test@test.com',
+            $this->helper->__invoke('test@test.com')->__toString()
         );
         $this->assertContains(
             'b642b4217b34b1e8d3bd915fc65c4452',
-            $this->helper->__invoke('b642b4217b34b1e8d3bd915fc65c4452', array('skip_email_hash' => true))->__toString()
+            $this->helper->__invoke('b642b4217b34b1e8d3bd915fc65c4452')->__toString()
         );
     }
 


### PR DESCRIPTION
This is useful for web services which pass the gravatar hash but not the
original email address of users.

Tests included. Should not pose any sort of BC break at all.
