### PR TITLE
Fix priority not handled in AggregateHydrator

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Aggregate/HydratorListener.php
+++ b/library/Zend/Stdlib/Hydrator/Aggregate/HydratorListener.php
@@ -37,10 +37,10 @@ class HydratorListener extends AbstractListenerAggregate
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
-        $this->listeners[] = $events->attach(HydrateEvent::EVENT_HYDRATE, array($this, 'onHydrate'));
-        $this->listeners[] = $events->attach(ExtractEvent::EVENT_EXTRACT, array($this, 'onExtract'));
+        $this->listeners[] = $events->attach(HydrateEvent::EVENT_HYDRATE, array($this, 'onHydrate'), $priority);
+        $this->listeners[] = $events->attach(ExtractEvent::EVENT_EXTRACT, array($this, 'onExtract'), $priority);
     }
 
     /**


### PR DESCRIPTION
The interface of the ListenerAggregateInterface is wrong (it does not take into account the "priority" parameter. Therefore the priority was not given to the listener aggregate, so priority given to add were ignored.

This PR fix that.
