### PR TITLE
Allow Zend\Form\Element\Checkbox to return real value instead of always a boolean

### DIFF
--- a/library/Zend/Form/Element/Checkbox.php
+++ b/library/Zend/Form/Element/Checkbox.php
@@ -195,7 +195,7 @@ class Checkbox extends Element implements InputProviderInterface
      */
     public function isChecked()
     {
-        return (bool) $this->value;
+        return $this->value === $this->getCheckedValue();
     }
 
     /**
@@ -206,7 +206,7 @@ class Checkbox extends Element implements InputProviderInterface
      */
     public function setChecked($value)
     {
-        $this->value = (bool) $value;
+        $this->value = $value ? $this->getCheckedValue() : $this->getUncheckedValue();
         return $this;
     }
 
@@ -218,11 +218,9 @@ class Checkbox extends Element implements InputProviderInterface
      */
     public function setValue($value)
     {
-        if (is_bool($value)) {
-            $this->value = $value;
-        } else {
-            $this->value = $value === $this->getCheckedValue();
-        }
+        // Cast to strings because POST data comes in string form
+        $checked = (string) $value === (string) $this->getCheckedValue();
+        $this->value = $checked ? $this->getCheckedValue() : $this->getUncheckedValue();
         return $this;
     }
 }

--- a/tests/ZendTest/Form/Element/CheckboxTest.php
+++ b/tests/ZendTest/Form/Element/CheckboxTest.php
@@ -73,6 +73,19 @@ class CheckboxTest extends TestCase
 
         $element->setAttribute('value', true);
         $this->assertEquals(true, $element->isChecked());
+
+        $element->setCheckedValue('string_value');
+        $element->setChecked(true);
+        $this->assertEquals($element->getCheckedValue(), $element->getValue());
+
+        $element->setChecked(false);
+        $this->assertEquals($element->getUncheckedValue(), $element->getValue());
+
+        $element->setAttribute('value', 'string_value');
+        $this->assertEquals(true, $element->isChecked());
+
+        $element->setAttribute('value', 'another_string');
+        $this->assertEquals(false, $element->isChecked());
     }
 
     public function testIntegerCheckedValue()


### PR DESCRIPTION
This PR will fix the way Zend's Checkbox element handles values. The Checkbox element allows us to set any value as checked/unchecked value via setCheckedValue() and setUncheckedValue(). The default value is (string) 1 for checked state. 

The bug is that currently Checkbox will not follow these values based on its check state. Instead Checkbox::getValue() always returns a boolean true/false. After this patch Checkbox will return the value of getUncheckedValue() when isChecked() return false and value of getCheckedValue() when isChecked() returns true.

I also updated the ZendTest\Form\Element\CheckboxTest::testSetAttributeValue() to cover these other use-cases.
