### PR TITLE
Fix for unmatched routes in navigation

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -197,7 +197,7 @@ class Mvc extends AbstractPage
             );
         }
 
-        if ($this->useRouteMatch()) {
+        if ($this->useRouteMatch() && $this->getRouteMatch()) {
             $rmParams = $this->getRouteMatch()->getParams();
 
             if (isset($rmParams[ModuleRouteListener::ORIGINAL_CONTROLLER])) {

--- a/tests/ZendTest/Navigation/Page/MvcTest.php
+++ b/tests/ZendTest/Navigation/Page/MvcTest.php
@@ -68,6 +68,19 @@ class MvcTest extends TestCase
         $this->assertEquals('/news/view', $page->getHref());
     }
 
+    public function testHrefRouteMatchEnabledWithoutRouteMatchObject()
+    {
+        $page = new Page\Mvc(array(
+            'label'      => 'foo',
+            'route' => 'test/route',
+            'use_route_match' => true
+        ));
+        $router = $this->getMock('\Zend\Mvc\Router\Http\TreeRouteStack');
+        $router->expects($this->once())->method('assemble')->will($this->returnValue('/test/route'));
+        $page->setRouter($router);
+        $this->assertEquals('/test/route', $page->getHref());
+    }
+
     public function testHrefGeneratedIsRouteAware()
     {
         $page = new Page\Mvc(array(


### PR DESCRIPTION
Zf 2.2 changed the navigation behaviour for the segment route from 2.1.5 it needs the route match to keep the old behavior only on error (404) pages the route is not matched and will throw and error on the getParams method as it is not an object.
