### PR TITLE
Fix to lastItemNumber in Paginator

### DIFF
--- a/library/Zend/Paginator/Paginator.php
+++ b/library/Zend/Paginator/Paginator.php
@@ -920,7 +920,7 @@ class Paginator implements Countable, IteratorAggregate
             $pages->itemCountPerPage = $this->getItemCountPerPage();
             $pages->totalItemCount   = $this->getTotalItemCount();
             $pages->firstItemNumber  = (($currentPageNumber - 1) * $this->getItemCountPerPage()) + 1;
-            $pages->lastItemNumber   = $pages->firstItemNumber + $pages->currentItemCount - 1;
+            $pages->lastItemNumber   = $pages->firstItemNumber + $pages->itemCountPerPage - 1;
         }
 
         return $pages;


### PR DESCRIPTION
This fixes the display of "1-5 of 12" for example, previously it was
using the total to calculate the "lastItemNumber" i.e "1-12 of 12".
