### PR TITLE
Introduce JsonSerializable polyfill and support in Zend\Json\Encoder

### DIFF
--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -11,6 +11,7 @@ namespace Zend\Json;
 
 use Iterator;
 use IteratorAggregate;
+use JsonSerializable;
 use ReflectionClass;
 use Zend\Json\Exception\InvalidArgumentException;
 use Zend\Json\Exception\RecursionException;
@@ -65,6 +66,10 @@ class Encoder
     public static function encode($value, $cycleCheck = false, $options = array())
     {
         $encoder = new static(($cycleCheck) ? true : false, $options);
+
+        if ($value instanceof JsonSerializable) {
+            $value = $value->jsonSerialize();
+        }
 
         return $encoder->_encodeValue($value);
     }

--- a/library/Zend/Stdlib/JsonSerializable.php
+++ b/library/Zend/Stdlib/JsonSerializable.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib;
+
+if (version_compare(PHP_VERSION, '5.4.0', 'lt')) {
+    class_alias(
+        'Zend\Stdlib\JsonSerializable\PhpLegacyCompatibility',
+        'JsonSerializable'
+    );
+}
+
+/**
+ * Polyfill for JsonSerializable
+ *
+ * JsonSerializable was introduced in PHP 5.4.0.
+ *
+ * @see http://php.net/manual/class.jsonserializable.php
+ */
+interface JsonSerializable extends \JsonSerializable
+{
+}

--- a/library/Zend/Stdlib/JsonSerializable/PhpLegacyCompatibility.php
+++ b/library/Zend/Stdlib/JsonSerializable/PhpLegacyCompatibility.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\JsonSerializable;
+
+/**
+ * Interface compatible with the built-in JsonSerializable interface
+ *
+ * JsonSerializable was introduced in PHP 5.4.0.
+ *
+ * @see http://php.net/manual/class.jsonserializable.php
+ */
+interface PhpLegacyCompatibility
+{
+    /**
+     * Returns data which can be serialized by json_encode().
+     *
+     * @return mixed
+     * @see    http://php.net/manual/jsonserializable.jsonserialize.php
+     */
+    public function jsonSerialize();
+}

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -463,7 +463,29 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"firstName":"John","lastName":"Doe","email":"john@doe.com"}', $result);
     }
 
-     /**
+    public function testJsonSerializableWithBuiltinImplementation()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', 'lt')) {
+            $this->markTestSkipped('JsonSerializable does not exist in PHP <5.4.0.');
+        }
+
+        $encoded = Json\Encoder::encode(
+            new TestAsset\JsonSerializableBuiltinImpl()
+        );
+
+        $this->assertEquals('["jsonSerialize"]', $encoded);
+    }
+
+    public function testJsonSerializableWithZFImplementation()
+    {
+        $encoded = Json\Encoder::encode(
+            new TestAsset\JsonSerializableZFImpl()
+        );
+
+        $this->assertEquals('["jsonSerialize"]', $encoded);
+    }
+
+    /**
      * test encoding array with Zend_JSON_Expr
      *
      * @group ZF-4946

--- a/tests/ZendTest/Json/TestAsset/JsonSerializableBuiltinImpl.php
+++ b/tests/ZendTest/Json/TestAsset/JsonSerializableBuiltinImpl.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Json
+ */
+
+namespace ZendTest\Json\TestAsset;
+
+use JsonSerializable;
+
+/**
+ * Implementation of the built-in JsonSerializable interface.
+ *
+ * This asset will not work in PHP <5.4.0.
+ */
+class JsonSerializableBuiltinImpl implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return array(__FUNCTION__);
+    }
+}

--- a/tests/ZendTest/Json/TestAsset/JsonSerializableZFImpl.php
+++ b/tests/ZendTest/Json/TestAsset/JsonSerializableZFImpl.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Json
+ */
+
+namespace ZendTest\Json\TestAsset;
+
+use Zend\Stdlib\JsonSerializable;
+
+class JsonSerializableZFImpl implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return array(__FUNCTION__);
+    }
+}


### PR DESCRIPTION
This is an alternative to https://github.com/zendframework/zf2/pull/4507

It introduces a polyfill into `Zend\Stdlib` which can be used by legacy PHP implementations. `Zend\Json\Encoder` then tests for the PHP built-in interface which will work even on PHP implementations where `\JsonSerializable` doesn't exist.
