### PR TITLE
Remove ZendTest from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Zend\\": "library/",
-            "ZendTest\\": "tests/"
+            "Zend\\": "library/"
         }
     },
     "bin": [

--- a/tests/_autoload.php
+++ b/tests/_autoload.php
@@ -3,17 +3,14 @@
  * Setup autoloading
  */
 
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    include_once __DIR__ . '/../vendor/autoload.php';
-} else {
-    // if composer autoloader is missing, explicitly add the ZF library path
-    require_once __DIR__ . '/../library/Zend/Loader/StandardAutoloader.php';
-    $loader = new Zend\Loader\StandardAutoloader(
-        array(
-             Zend\Loader\StandardAutoloader::LOAD_NS => array(
-                 'Zend'     => __DIR__ . '/../library/Zend',
-                 'ZendTest' => __DIR__ . '/ZendTest',
-             ),
-        ));
-    $loader->register();
+// if composer autoloader is missing, explicitly add the ZF library path
+require_once __DIR__ . '/../library/Zend/Loader/StandardAutoloader.php';
+$loader = new Zend\Loader\StandardAutoloader(
+    array(
+        Zend\Loader\StandardAutoloader::LOAD_NS => array(
+            'Zend'     => __DIR__ . '/../library/Zend',
+            'ZendTest' => __DIR__ . '/ZendTest',
+        ),
+    ));
+$loader->register();
 }


### PR DESCRIPTION
I have a script to deploy my application that install my application with composer, with the option --optimize-autoloader enabled. However, the dist package of ZF 2 does not include tests folder, so composer throw an exception as it tries to create the classmap from an unknown folder, which make the process fails.

The only solution is to add --prefer-source option so that the whole package with tests is loaded, but as we don't ship tests, it's better to remove this in the composer.json file.
