### PR TITLE
Allow referencing to LESS stylesheets using HeadLink

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -112,7 +112,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function __call($method, $args)
     {
-        if (preg_match('/^(?P<action>set|(ap|pre)pend|offsetSet)(?P<type>Stylesheet|Alternate|Prev|Next)$/', $method, $matches)) {
+        if (preg_match('/^(?P<action>set|(ap|pre)pend|offsetSet)(?P<type>Stylesheet|Alternate|Prev|Next|Less)$/', $method, $matches)) {
             $argc   = count($args);
             $action = $matches['action'];
             $type   = $matches['type'];
@@ -333,7 +333,29 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
      */
     public function createDataStylesheet(array $args)
     {
-        $rel                   = 'stylesheet';
+        return $this->createDataForStylesheet('stylesheet', $args);
+    }
+
+    /**
+     * Create item for LESS stylesheet link item
+     *
+     * @param  array $args
+     * @return stdClass|false Returns false if stylesheet is a duplicate
+     */
+    public function createDataLess(array $args)
+    {
+        return $this->createDataForStylesheet('stylesheet/less', $args);
+    }
+
+    /**
+     * Create item for stylesheet link item with a given rel.
+     *
+     * @param  string $rel
+     * @param  array $args
+     * @return stdClass|false Returns false if stylesheet is a duplicate
+     */
+    protected function createDataForStylesheet($rel, array $args)
+    {
         $type                  = 'text/css';
         $media                 = 'screen';
         $conditionalStylesheet = false;

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -419,9 +419,9 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
     public function testSetLess()
     {
-        $this->helper->appendLess('/foo/bar');
+        $this->helper->appendLess('/foo/bar.less');
         $test = $this->helper->toString();
-        $this->assertContains('href="/foo/bar"', $test);
+        $this->assertContains('href="/foo/bar.less"', $test);
         $this->assertContains('rel="stylesheet/less"', $test);
     }
 

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -417,6 +417,14 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $test);
     }
 
+    public function testSetLess()
+    {
+        $this->helper->appendLess('/foo/bar');
+        $test = $this->helper->toString();
+        $this->assertContains('href="/foo/bar"', $test);
+        $this->assertContains('rel="stylesheet/less"', $test);
+    }
+
     /**
      * @issue ZF-10345
      */


### PR DESCRIPTION
This PR adds the `appendLess`, `setLess`, etc .. methods to the HeadLink view helper. This can be used to reference to LESS stylesheets. They are defined identically to the way CSS files are referenced to, but have a rel of `stylesheet/less`.
