### PR TITLE
Fix crypt() return value check to match PHP documentation

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -97,7 +97,7 @@ class Bcrypt implements PasswordInterface
             }
         }
         $hash = crypt($password, $prefix . $this->cost . '$' . $salt64);
-        if (strlen($hash) <= 13) {
+        if (strlen($hash) < 13) {
             throw new Exception\RuntimeException('Error during the bcrypt generation');
         }
         return $hash;


### PR DESCRIPTION
"Returns the hashed string or a string that is shorter than 13 characters and is
guaranteed to differ from the salt on failure." -- [PHP documentation](http://php.net/function.crypt.php)

While I was in there, I didn't see a test case for a `crypt()` "failure", and it wasn't immediately obvious to me how to create a test for it if one is needed.
