### PR TITLE
Fix the controller plugin PostRedirectGet wrong redirection (in MVC)

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -93,14 +93,17 @@ class PostRedirectGet extends AbstractPlugin
      */
     protected function redirect($redirect, $redirectToUrl)
     {
-        $controller = $this->getController();
-        $params     = array();
+        $controller         = $this->getController();
+        $params             = array();
+        $options            = array();
+        $reuseMatchedParams = false;
 
         if (null === $redirect) {
             $routeMatch = $controller->getEvent()->getRouteMatch();
 
             $redirect = $routeMatch->getMatchedRouteName();
-            $params   = $routeMatch->getParams();
+            //null indicates to redirect for self.
+            $reuseMatchedParams = true;
         }
 
         if (method_exists($controller, 'getPluginManager')) {
@@ -119,7 +122,7 @@ class PostRedirectGet extends AbstractPlugin
         }
 
         if ($redirectToUrl === false) {
-            $response = $redirector->toRoute($redirect, $params);
+            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams);
             $response->setStatusCode(303);
             return $response;
         }


### PR DESCRIPTION
Using segment route with '**NAMESPACE**' and ':controller', the PRG plugin with no params redirects to the wrong url. 
Relative to the behavior of ModuleRouteListener.

relative: #2866
