### PR TITLE
[Navigation] Allow non-string permissions

### DIFF
--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -111,7 +111,7 @@ abstract class AbstractPage extends AbstractContainer
     /**
      * Permission associated with this page
      *
-     * @var string|null
+     * @var mixed|null
      */
     protected $permission;
 
@@ -710,7 +710,7 @@ abstract class AbstractPage extends AbstractContainer
     /**
      * Sets permission associated with this page
      *
-     * @param  string|null $permission  [optional] permission to associate
+     * @param  mixed|null $permission  [optional] permission to associate
      *                                  with this page. Default is null, which
      *                                  sets no permission.
      *
@@ -718,14 +718,14 @@ abstract class AbstractPage extends AbstractContainer
      */
     public function setPermission($permission = null)
     {
-        $this->permission = is_string($permission) ? $permission : null;
+        $this->permission = $permission;
         return $this;
     }
 
     /**
      * Returns permission associated with this page
      *
-     * @return string|null  permission or null
+     * @return mixed|null  permission or null
      */
     public function getPermission()
     {

--- a/tests/ZendTest/Navigation/Page/PageTest.php
+++ b/tests/ZendTest/Navigation/Page/PageTest.php
@@ -1157,4 +1157,39 @@ class PageTest extends \PHPUnit_Framework_TestCase
         ksort($toArray);
         $this->assertEquals($options, $toArray);
     }
+
+    public function testSetPermission()
+    {
+        $page = AbstractPage::factory(array(
+            'type'       => 'uri'
+        ));
+
+        $page->setPermission('my_permission');
+        $this->assertEquals('my_permission', $page->getPermission());
+    }
+
+    public function testSetArrayPermission()
+    {
+        $page = AbstractPage::factory(array(
+            'type'       => 'uri'
+        ));
+
+        $page->setPermission(array('my_permission', 'other_permission'));
+        $this->assertInternalType('array', $page->getPermission());
+        $this->assertCount(2, $page->getPermission());
+    }
+
+    public function testSetObjectPermission()
+    {
+        $page = AbstractPage::factory(array(
+            'type'       => 'uri'
+        ));
+
+        $permission = new \stdClass();
+        $permission->name = 'my_permission';
+
+        $page->setPermission($permission);
+        $this->assertInstanceOf('stdClass', $page->getPermission());
+        $this->assertEquals('my_permission', $page->getPermission()->name);
+    }
 }


### PR DESCRIPTION
This allows, for example, an array of permissions or permission objects to be attached to a page.
