### PR TITLE
Fix generating array with unsorted keys

### DIFF
--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -364,9 +364,18 @@ class ValueGenerator extends AbstractGenerator
                     /* @var $v ValueGenerator */
                     $v->setArrayDepth($this->arrayDepth + 1);
                     $partV = $v->generate();
-                    if ($n === $noKeyIndex) {
+                    $short = false;
+                    if (is_int($n)) {
+                        if ($n === $noKeyIndex) {
+                            $short = true;
+                            $noKeyIndex++;
+                        } else {
+                            $noKeyIndex = max($n + 1, $noKeyIndex);
+                        }
+                    }
+
+                    if ($short) {
                         $outputParts[] = $partV;
-                        $noKeyIndex++;
                     } else {
                         $outputParts[] = (is_int($n) ? $n : self::escape($n)) . ' => ' . $partV;
                     }

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -112,4 +112,29 @@ EOS;
         $generatedTargetSource = $valueGenerator->generate();
         $this->assertEquals($expectedSource, $generatedTargetSource);
     }
+
+    public function testPropertyDefaultValueCanHandleArrayWithUnsortedKeys()
+    {
+        $value = array(
+            1 => 'a',
+            0 => 'b',
+            'c',
+            7 => 'd',
+            3 => 'e'
+        );
+
+        $valueGenerator = new ValueGenerator();
+        $valueGenerator->setValue($value);
+$expectedSource = <<<EOS
+array(
+        1 => 'a',
+        0 => 'b',
+        'c',
+        7 => 'd',
+        3 => 'e'
+        )
+EOS;
+
+        $this->assertEquals($expectedSource, $valueGenerator->generate());
+    }
 }


### PR DESCRIPTION
For example array

``` php
$value = array(
    1 => 'a',
    0 => 'b',
    'c'
)
```

generating to 

``` php
array(
    1 => 'a',
    'b', // this value will be lost, because it will be rewrite by value 'c'
    2 => 'c'
)
```

this patch fix it, and do as expected

``` php
array(
    1 => 'a',
    0 => 'b',
    'c'
)
```
