### PR TITLE
[InputFilter][Hotfix] Missing check for allowEmpty()

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -236,6 +236,7 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
                 && '' === $this->data[$name]
                 && $input instanceof InputInterface
                 && !$input->isRequired()
+                && $input->allowEmpty()
             ) {
                 $this->validInputs[$name] = $input;
                 continue;

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -197,8 +197,8 @@ class Factory
                     break;
                 case 'required':
                     $input->setRequired($value);
-                    if (!isset($inputSpecification['allow_empty'])) {
-                        $input->setAllowEmpty(!$value);
+                    if (isset($inputSpecification['allow_empty'])) {
+                        $input->setAllowEmpty($inputSpecification['allow_empty']);
                     }
                     break;
                 case 'allow_empty':

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -142,6 +142,7 @@ class Input implements InputInterface, EmptyContextInterface
     public function setRequired($required)
     {
         $this->required = (bool) $required;
+        $this->setAllowEmpty(!$required);
         return $this;
     }
 

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -564,6 +564,22 @@ class BaseInputFilterTest extends TestCase
         $this->assertFalse($filter->isValid());
     }
 
+    public function testValidationMarksInputInvalidWhenNotRequiredAndAllowEmptyFlagIsFalse()
+    {
+        $filter = new InputFilter();
+
+        $foo   = new Input();
+        $foo->setRequired(false);
+        $foo->setAllowEmpty(false);
+
+        $filter->add($foo, 'foo');
+
+        $data = array('foo' => '');
+        $filter->setData($data);
+
+        $this->assertFalse($filter->isValid());
+    }
+
     public static function contextDataProvider()
     {
         return array(


### PR DESCRIPTION
The InputFilter was allowing empty strings to pass through when allowEmpty was set to true since the refactor.

Ping @weierophinney
