### PR TITLE
PR: forward plugin compatibility with ModuleRouteListner

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -15,6 +15,7 @@ use Zend\Mvc\Exception;
 use Zend\Mvc\InjectApplicationEventInterface;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\ModuleRouteListener;
 
 class Forward extends AbstractPlugin
 {
@@ -113,6 +114,16 @@ class Forward extends AbstractPlugin
     public function dispatch($name, array $params = null)
     {
         $event   = clone($this->getEvent());
+
+        if (is_array($params) && isset($params[ModuleRouteListener::MODULE_NAMESPACE])) {
+            $module = $params[ModuleRouteListener::MODULE_NAMESPACE];
+            if (strpos($name, $module) !== 0) {
+                if (!isset($params[ModuleRouteListener::ORIGINAL_CONTROLLER])) {
+                    $params[ModuleRouteListener::ORIGINAL_CONTROLLER] = $name;
+                }
+                $name = $module . '\\' . str_replace(' ', '', ucwords(str_replace('-', ' ', $name)));
+            }
+        }
 
         $controller = $this->controllers->get($name);
         if ($controller instanceof InjectApplicationEventInterface) {

--- a/tests/ZendTest/Mvc/Controller/TestAsset/ForwardFqController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/ForwardFqController.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+use Zend\Mvc\Controller\AbstractActionController;
+
+class ForwardFqController extends AbstractActionController
+{
+    public function testAction()
+    {
+        return array(
+            'content' => __METHOD__,
+            'params' => $this->getEvent()->getRouteMatch()->getParams(),
+        );
+    }
+
+    public function testMatchesAction()
+    {
+        $e = $this->getEvent();
+        return $e->getRouteMatch()->getParams();
+    }
+
+    public function notFoundAction()
+    {
+        return array(
+            'status' => 'not-found',
+            'params' => $this->params()->fromRoute(),
+        );
+    }
+}


### PR DESCRIPTION
Now,

``` php
// in the controller
$params = $this->params()->fromRoute();
$this->forward()->dispatch('foo', $params);
```

It raises an exception In some case, such as using '**NAMESPACE**' in the route.

```
Zend\ServiceManager\Exception\ServiceNotFoundException: 
Zend\Mvc\Controller\ControllerManager::get was unable to fetch or create an instance for foo
```

We expect the forwarder to be compatible with the Application's dispatch spec.
