### PR TITLE
Use Cypt\Utils::compareStrings() in Zend\Auth

### DIFF
--- a/library/Zend/Authentication/Adapter/Digest.php
+++ b/library/Zend/Authentication/Adapter/Digest.php
@@ -11,6 +11,7 @@ namespace Zend\Authentication\Adapter;
 
 use Zend\Authentication\Result as AuthenticationResult;
 use Zend\Stdlib\ErrorHandler;
+use Zend\Crypt\Utils as CryptUtils;
 
 class Digest extends AbstractAdapter
 {
@@ -178,7 +179,7 @@ class Digest extends AbstractAdapter
                 break;
             }
             if (substr($line, 0, $idLength) === $id) {
-                if ($this->_secureStringCompare(substr($line, -32), md5("$this->identity:$this->realm:$this->credential"))) {
+                if (CryptUtils::compareStrings(substr($line, -32), md5("$this->identity:$this->realm:$this->credential"))) {
                     $result['code'] = AuthenticationResult::SUCCESS;
                 } else {
                     $result['code'] = AuthenticationResult::FAILURE_CREDENTIAL_INVALID;
@@ -191,27 +192,5 @@ class Digest extends AbstractAdapter
         $result['code'] = AuthenticationResult::FAILURE_IDENTITY_NOT_FOUND;
         $result['messages'][] = "Username '$this->identity' and realm '$this->realm' combination not found";
         return new AuthenticationResult($result['code'], $result['identity'], $result['messages']);
-    }
-
-    /**
-     * Securely compare two strings for equality while avoided C level memcmp()
-     * optimisations capable of leaking timing information useful to an attacker
-     * attempting to iteratively guess the unknown string (e.g. password) being
-     * compared against.
-     *
-     * @param string $a
-     * @param string $b
-     * @return bool
-     */
-    protected function _secureStringCompare($a, $b)
-    {
-        if (strlen($a) !== strlen($b)) {
-            return false;
-        }
-        $result = 0;
-        for ($i = 0, $len = strlen($a); $i < $len; $i++) {
-            $result |= ord($a[$i]) ^ ord($b[$i]);
-        }
-        return $result == 0;
     }
 }

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -13,6 +13,7 @@ use Zend\Authentication;
 use Zend\Http\Request as HTTPRequest;
 use Zend\Http\Response as HTTPResponse;
 use Zend\Uri\UriFactory;
+use Zend\Crypt\Utils as CryptUtils;
 
 /**
  * HTTP Authentication Adapter
@@ -489,7 +490,7 @@ class Http implements AdapterInterface
 
         if (!$result instanceof Authentication\Result
             && !is_array($result)
-            && $this->_secureStringCompare($result, $creds[1])
+            && CryptUtils::compareStrings($result, $creds[1])
         ) {
             $identity = array('username' => $creds[0], 'realm' => $this->realm);
             return new Authentication\Result(Authentication\Result::SUCCESS, $identity);
@@ -582,7 +583,7 @@ class Http implements AdapterInterface
 
         // If our digest matches the client's let them in, otherwise return
         // a 401 code and exit to prevent access to the protected resource.
-        if ($this->_secureStringCompare($digest, $data['response'])) {
+        if (CryptUtils::compareStrings($digest, $data['response'])) {
             $identity = array('username' => $data['username'], 'realm' => $data['realm']);
             return new Authentication\Result(Authentication\Result::SUCCESS, $identity);
         }
@@ -797,27 +798,5 @@ class Http implements AdapterInterface
         $temp = null;
 
         return $data;
-    }
-
-    /**
-     * Securely compare two strings for equality while avoided C level memcmp()
-     * optimisations capable of leaking timing information useful to an attacker
-     * attempting to iteratively guess the unknown string (e.g. password) being
-     * compared against.
-     *
-     * @param string $a
-     * @param string $b
-     * @return bool
-     */
-    protected function _secureStringCompare($a, $b)
-    {
-        if (strlen($a) !== strlen($b)) {
-            return false;
-        }
-        $result = 0;
-        for ($i = 0, $len = strlen($a); $i < $len; $i++) {
-            $result |= ord($a[$i]) ^ ord($b[$i]);
-        }
-        return $result == 0;
     }
 }

--- a/library/Zend/Authentication/composer.json
+++ b/library/Zend/Authentication/composer.json
@@ -18,6 +18,7 @@
     },
     "suggest": {
         "zendframework/zend-db": "Zend\\Db component",
+        "zendframework/zend-crypt": "Zend\\Crypt component",
         "zendframework/zend-uri": "Zend\\Uri component",
         "zendframework/zend-session": "Zend\\Session component"
     },


### PR DESCRIPTION
- Replace the duplicate _secureStringCompare() methods from the Http
  and Digest Zend\Authentication adapters with
  Zend\Crypt\Utils::compareStrings().
- Update Zend\Authentication's composer.json to reflect the dependency
  on Zend\Crypt.
- This potentially reduces the risk of a possible Information Disclosure
  vulnerability, where the length of the target string could be
  discovered via a timing attack. At least in the Digest adapter, there
  was no security issue before this patch, as the string lengths for
  both strings are _always_ 32 character MD5 hashes, thus there is no
  unknown string length to disclose. I'm not 100% sure about the Http
  adapter.

Potential vulnerability was responsibly disclosed by @Freeaqingme.
