### PR TITLE
Zend\Form Should throw exception if try to get() an element that does not exist

### DIFF
--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -10,6 +10,7 @@
 namespace Zend\Form;
 
 use Traversable;
+use Zend\Form\Exception\InvalidElementException;
 use Zend\Stdlib\Hydrator;
 use Zend\Stdlib\Hydrator\HydratorAwareInterface;
 use Zend\Stdlib\Hydrator\HydratorInterface;
@@ -206,14 +207,13 @@ class Fieldset extends Element implements FieldsetInterface
     /**
      * Retrieve a named element or fieldset
      *
-     * @todo   Should this raise an exception if no entry is found?
      * @param  string $elementOrFieldset
      * @return ElementInterface
      */
     public function get($elementOrFieldset)
     {
         if (!$this->has($elementOrFieldset)) {
-            return null;
+            throw new InvalidElementException("No element by the name of [$elementOrFieldset] found in form.");
         }
         return $this->byName[$elementOrFieldset];
     }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -10,7 +10,6 @@
 namespace Zend\Form;
 
 use Traversable;
-use Zend\Form\Exception\InvalidElementException;
 use Zend\Stdlib\Hydrator;
 use Zend\Stdlib\Hydrator\HydratorAwareInterface;
 use Zend\Stdlib\Hydrator\HydratorInterface;
@@ -213,7 +212,10 @@ class Fieldset extends Element implements FieldsetInterface
     public function get($elementOrFieldset)
     {
         if (!$this->has($elementOrFieldset)) {
-            throw new InvalidElementException("No element by the name of [$elementOrFieldset] found in form.");
+            throw new Exception\InvalidElementException(sprintf(
+                "No element by the name of [%s] found in form",
+                $elementOrFieldset
+            ));
         }
         return $this->byName[$elementOrFieldset];
     }

--- a/tests/ZendTest/Form/FieldsetTest.php
+++ b/tests/ZendTest/Form/FieldsetTest.php
@@ -443,10 +443,12 @@ class FieldsetTest extends TestCase
         $this->assertEquals('bar', $option);
     }
 
-    public function testGetReturnsNull()
+    /**
+     * @expectedException Zend\Form\Exception\InvalidElementException
+     */
+    public function testShouldThrowExceptionWhenGetInvalidElement()
     {
-        $foo = $this->fieldset->get('foo');
-        $this->assertNull($foo);
+        $this->fieldset->get('doesnt_exist');
     }
 
     public function testBindValuesHasNoName()

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -166,6 +166,14 @@ class FormTest extends TestCase
         $this->assertSame($filter, $this->form->getInputFilter());
     }
 
+    /**
+     * @expectedException Zend\Form\Exception\InvalidElementException
+     */
+    public function testShouldThrowExceptionWhenGetInvalidElement()
+    {
+        $this->form->get('doesnt_exist');
+    }
+
     public function testDefaultNonRequiredInputFilterIsSet()
     {
         $this->form->add(new Element('foo'));


### PR DESCRIPTION
I'm one of your ZF1 certified engineers and this documentation is difficult to follow for me. In your 'getting started' guide, you did not call parent::__construct(). This made it so I can't even display my form.  I couldn't find the documentation to do a pull request for that part

If you do this in your view:
echo $this->formRow($form->get('field_that_doesnt_exist'));

Instead of a helpful message like "trying to get() a field that doesnt exist", the obscure error message I actually got was:
"Catchable fatal error: Object of class Zend\Form\View\Helper\FormRow could not be converted to string"

This pull request will throw an exception if you try to get() an element that does not exist.
