### PR TITLE
Fix issue with Redis Cache adapter whereby setOption was being called before connecting to Redis server

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -66,12 +66,12 @@ class RedisResourceManager
 
         $redis = new RedisResource();
 
+        $resource['resource'] = $redis;
+        $this->connect($resource);
+
         foreach ($resource['lib_options'] as $k => $v) {
             $redis->setOption($k, $v);
         }
-
-        $resource['resource'] = $redis;
-        $this->connect($resource);
 
         $info = $redis->info();
         $resource['version'] = $info['redis_version'];


### PR DESCRIPTION
You can't call setOption until you've connected to Redis. Not really sure why this is the case but this is how the phpredis extension behaves.

See issue #4576
