### PR TITLE
Hostname route ignore HTTP_HOST and give SERVER_NAME precedence

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -261,12 +261,29 @@ class Request extends HttpRequest
         // Set the host
         if ($this->getHeaders()->get('host')) {
             $host = $this->getHeaders()->get('host')->getFieldValue();
+
             // works for regname, IPv4 & IPv6
             if (preg_match('|\:(\d+)$|', $host, $matches)) {
                 $host = substr($host, 0, -1 * (strlen($matches[1]) + 1));
                 $port = (int) $matches[1];
             }
-        } elseif (isset($this->serverParams['SERVER_NAME'])) {
+
+            // set up a validator that check if the hostname is legal (not spoofed)
+            $hostnameValidator = new \Zend\Validator\Hostname(
+                array(
+                    'allow'=>\Zend\Validator\Hostname::ALLOW_ALL,
+                    'useIdnCheck'=>false,
+                    'useTldCheck'=>false
+                )
+            );
+            // If invalid. Reset the host & port
+            if (!$hostnameValidator->isValid($host)) {
+                $host = null;
+                $port = null;
+            }
+        }
+
+        if (!$host && isset($this->serverParams['SERVER_NAME'])) {
             $host = $this->serverParams['SERVER_NAME'];
             if (isset($this->serverParams['SERVER_PORT'])) {
                 $port = (int) $this->serverParams['SERVER_PORT'];

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -266,8 +266,7 @@ class Request extends HttpRequest
                 $host = substr($host, 0, -1 * (strlen($matches[1]) + 1));
                 $port = (int) $matches[1];
             }
-        }
-        elseif (isset($this->serverParams['SERVER_NAME'])) {
+        } elseif (isset($this->serverParams['SERVER_NAME'])) {
             $host = $this->serverParams['SERVER_NAME'];
             if (isset($this->serverParams['SERVER_PORT'])) {
                 $port = (int) $this->serverParams['SERVER_PORT'];

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -267,9 +267,8 @@ class Request extends HttpRequest
                 $port = (int) $matches[1];
             }
         }
-        // Do we need HTTP_POST????
-        elseif (isset($this->serverParams['HTTP_HOST']) || isset($this->serverParams['SERVER_NAME'])) {
-            $host = (isset($this->serverParams['HTTP_HOST'])) ? $this->serverParams['HTTP_HOST'] : $this->serverParams['SERVER_NAME'];
+        elseif (isset($this->serverParams['SERVER_NAME'])) {
+            $host = $this->serverParams['SERVER_NAME'];
             if (isset($this->serverParams['SERVER_PORT'])) {
                 $port = (int) $this->serverParams['SERVER_PORT'];
             }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -257,8 +257,18 @@ class Request extends HttpRequest
         // URI host & port
         $host = null;
         $port = null;
-        // Set the host. HTTP_HOST will take precedence over SERVER_NAME as it will reflect the requested URL (not necessarily the server name)
-        if (isset($this->serverParams['HTTP_HOST']) || isset($this->serverParams['SERVER_NAME'])) {
+
+        // Set the host
+        if ($this->getHeaders()->get('host')) {
+            $host = $this->getHeaders()->get('host')->getFieldValue();
+            // works for regname, IPv4 & IPv6
+            if (preg_match('|\:(\d+)$|', $host, $matches)) {
+                $host = substr($host, 0, -1 * (strlen($matches[1]) + 1));
+                $port = (int) $matches[1];
+            }
+        }
+        // Do we need HTTP_POST????
+        elseif (isset($this->serverParams['HTTP_HOST']) || isset($this->serverParams['SERVER_NAME'])) {
             $host = (isset($this->serverParams['HTTP_HOST'])) ? $this->serverParams['HTTP_HOST'] : $this->serverParams['SERVER_NAME'];
             if (isset($this->serverParams['SERVER_PORT'])) {
                 $port = (int) $this->serverParams['SERVER_PORT'];
@@ -272,13 +282,6 @@ class Request extends HttpRequest
                     // Unset the port so the default port can be used
                     $port = null;
                 }
-            }
-        } elseif ($this->getHeaders()->get('host')) {
-            $host = $this->getHeaders()->get('host')->getFieldValue();
-            // works for regname, IPv4 & IPv6
-            if (preg_match('|\:(\d+)$|', $host, $matches)) {
-                $host = substr($host, 0, -1 * (strlen($matches[1]) + 1));
-                $port = (int) $matches[1];
             }
         }
         $uri->setHost($host);

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -257,8 +257,9 @@ class Request extends HttpRequest
         // URI host & port
         $host = null;
         $port = null;
-        if (isset($this->serverParams['SERVER_NAME'])) {
-            $host = $this->serverParams['SERVER_NAME'];
+        // Set the host. HTTP_HOST will take precedence over SERVER_NAME as it will reflect the requested URL (not necessarily the server name)
+        if (isset($this->serverParams['HTTP_HOST']) || isset($this->serverParams['SERVER_NAME'])) {
+            $host = (isset($this->serverParams['HTTP_HOST'])) ? $this->serverParams['HTTP_HOST'] : $this->serverParams['SERVER_NAME'];
             if (isset($this->serverParams['SERVER_PORT'])) {
                 $port = (int) $this->serverParams['SERVER_PORT'];
             }

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -336,6 +336,16 @@ class RequestTest extends TestCase
             ),
             array(
                 array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'HTTP_HOST' => '<script>alert("Spoofed host");</script>',
+                    'REQUEST_URI' => 'http://test.example.com/news',
+                ),
+                'test.example.com',
+                '80',
+                '/news',
+            ),
+            array(
+                array(
                     'SERVER_NAME' => '[1:2:3:4:5:6::6]',
                     'SERVER_ADDR' => '1:2:3:4:5:6::6',
                     'SERVER_PORT' => '80',

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -326,6 +326,16 @@ class RequestTest extends TestCase
             ),
             array(
                 array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'HTTP_HOST' => 'requested.example.com',
+                    'REQUEST_URI' => 'http://test.example.com/news',
+                ),
+                'requested.example.com',
+                '80',
+                '/news',
+            ),
+            array(
+                array(
                     'SERVER_NAME' => '[1:2:3:4:5:6::6]',
                     'SERVER_ADDR' => '1:2:3:4:5:6::6',
                     'SERVER_PORT' => '80',


### PR DESCRIPTION
Web servers that are configured to accept more then one name for a virtual host, pass the following variables:

SERVER_NAME - the virtual host **primary** name
- In Apache -> **ServerName domain.com** (other names under ServerAlias )
- In Nginx, the first value of: **server_name  will-be-servername.com will-not-be-servername.com**

HTTP_HOST - the requested domain in the URL

As discussed with @DASPRiD, HTTP_HOST need to be checked first to verify what domain was asked by the client.

@weierophinney raised concern about the host header being spoofed. The Q is, even if so, do we have an alternative?

Extra info about the subject:
http://shiflett.org/blog/2006/mar/server-name-versus-http-host
