### PR TITLE
[BUG] Missing invokable fo Redis Cache Storage, problem with setting password

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/RedisOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisOptions.php
@@ -237,4 +237,27 @@ class RedisOptions extends AdapterOptions
     {
         return $this->getResourceManager()->getDatabase($this->getResourceId());
     }
+
+    /**
+     * Set resource password
+     *
+     * @param string $password Password
+     *
+     * @return RedisOptions
+     */
+    public function setPassword($password)
+    {
+        $this->getResourceManager()->setPassword($this->getResourceId(), $password);
+        return $this;
+    }
+
+    /**
+     * Get resource password
+     *
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->getResourceManager()->getPassword($this->getResourceId());
+    }
 }

--- a/library/Zend/Cache/Storage/AdapterPluginManager.php
+++ b/library/Zend/Cache/Storage/AdapterPluginManager.php
@@ -32,6 +32,7 @@ class AdapterPluginManager extends AbstractPluginManager
         'filesystem'     => 'Zend\Cache\Storage\Adapter\Filesystem',
         'memcached'      => 'Zend\Cache\Storage\Adapter\Memcached',
         'memory'         => 'Zend\Cache\Storage\Adapter\Memory',
+        'redis'          => 'Zend\Cache\Storage\Adapter\Redis',
         'session'        => 'Zend\Cache\Storage\Adapter\Session',
         'xcache'         => 'Zend\Cache\Storage\Adapter\XCache',
         'wincache'       => 'Zend\Cache\Storage\Adapter\WinCache',

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -261,4 +261,11 @@ class RedisTest extends CommonAdapterTest
         $this->assertEquals($database, $this->_options->getDatabase(), 'Database not set correctly using RedisOptions');
     }
 
+    public function testOptionsGetSetPassword()
+    {
+        $password = 'my-secret';
+        $this->_options->setPassword($password);
+        $this->assertEquals($password, $this->_options->getPassword(), 'Password was set incorrectly using RedisOptions');
+    }
+
 }


### PR DESCRIPTION
Set/Get methods for password were missing from RedisOptions.
