### PR TITLE
[BUG] Redis Storage won't behave correctly after libOptions were set

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -68,7 +68,7 @@ class Redis extends AbstractAdapter implements
 
         // reset initialized flag on update option(s)
         $initialized = & $this->initialized;
-        $this->getEventManager()->attach('option', function ($event) use (& $initialized) {
+        $this->getEventManager()->attach(array('option', 'lib_option'), function ($event) use (& $initialized) {
             $initialized = false;
         });
     }
@@ -80,7 +80,6 @@ class Redis extends AbstractAdapter implements
      */
     protected function getRedisResource()
     {
-
         if (!$this->initialized) {
             $options = $this->getOptions();
 
@@ -222,9 +221,10 @@ class Redis extends AbstractAdapter implements
      */
     protected function internalSetItem(& $normalizedKey, & $value)
     {
+        $redis = $this->getRedisResource();
+        $ttl = $this->getOptions()->getTtl();
+
         try {
-            $redis = $this->getRedisResource();
-            $ttl = $this->getOptions()->getTtl();
             if ($ttl) {
                 if ($this->resourceManager->getMayorVersion($this->resourceId) < 2) {
                     throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");

--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -68,7 +68,7 @@ class Redis extends AbstractAdapter implements
 
         // reset initialized flag on update option(s)
         $initialized = & $this->initialized;
-        $this->getEventManager()->attach(array('option'), function ($event) use (& $initialized) {
+        $this->getEventManager()->attach('option', function ($event) use (& $initialized) {
             $initialized = false;
         });
     }

--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -68,7 +68,7 @@ class Redis extends AbstractAdapter implements
 
         // reset initialized flag on update option(s)
         $initialized = & $this->initialized;
-        $this->getEventManager()->attach(array('option', 'lib_option'), function ($event) use (& $initialized) {
+        $this->getEventManager()->attach(array('option'), function ($event) use (& $initialized) {
             $initialized = false;
         });
     }

--- a/library/Zend/Cache/Storage/Adapter/RedisOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisOptions.php
@@ -172,6 +172,7 @@ class RedisOptions extends AdapterOptions
     */
     public function setLibOptions(array $libOptions)
     {
+        $this->triggerOptionEvent('lib_option', $libOptions);
         $this->getResourceManager()->setLibOptions($this->getResourceId(), $libOptions);
         return $this;
     }

--- a/library/Zend/Cache/Storage/Adapter/RedisOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisOptions.php
@@ -237,4 +237,27 @@ class RedisOptions extends AdapterOptions
     {
         return $this->getResourceManager()->getDatabase($this->getResourceId());
     }
+
+    /**
+     * Set resource password
+     *
+     * @param string $password Password
+     *
+     * @return RedisOptions
+     */
+    public function setPassword($password)
+    {
+        $this->getResourceManager()->setPassword($this->getResourceId(), $password);
+        return $this;
+    }
+
+    /**
+     * Get resource password
+     *
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->getResourceManager()->getPassword($this->getResourceId());
+    }
 }

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -108,17 +108,6 @@ class RedisResourceManager
             throw new Exception\RuntimeException('Could not estabilish connection with Redis instance');
         }
 
-        if ($resource['lib_options']) {
-            $libOptions = & $resource['lib_options'];
-            if (method_exists($redis, 'setOptions')) {
-                $redis->setOptions($libOptions);
-            } else {
-                foreach ($libOptions as $key => $value) {
-                    $redis->setOption($key, $value);
-                }
-            }
-        }
-
         $resource['initialized'] = true;
         if ($resource['password']) {
             $redis->auth($resource['password']);
@@ -271,8 +260,18 @@ class RedisResourceManager
         $resource = & $this->resources[$id];
 
         //this needs reconnect and reinitialization of an resource
-        $resource['initialized'] = false;
         $resource['lib_options'] = $libOptions;
+
+        if ($resource['resource'] instanceof RedisResource) {
+            $redis = & $resource['resource'];
+            if (method_exists($redis, 'setOptions')) {
+                $redis->setOptions($libOptions);
+            } else {
+                foreach ($libOptions as $key => $value) {
+                    $redis->setOption($key, $value);
+                }
+            }
+        }
 
         return $this;
     }

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -259,7 +259,6 @@ class RedisResourceManager
         $this->normalizeLibOptions($libOptions);
         $resource = & $this->resources[$id];
 
-        //this needs reconnect and reinitialization of an resource
         $resource['lib_options'] = $libOptions;
 
         if ($resource['resource'] instanceof RedisResource) {

--- a/library/Zend/Cache/Storage/AdapterPluginManager.php
+++ b/library/Zend/Cache/Storage/AdapterPluginManager.php
@@ -32,6 +32,7 @@ class AdapterPluginManager extends AbstractPluginManager
         'filesystem'     => 'Zend\Cache\Storage\Adapter\Filesystem',
         'memcached'      => 'Zend\Cache\Storage\Adapter\Memcached',
         'memory'         => 'Zend\Cache\Storage\Adapter\Memory',
+        'redis'          => 'Zend\Cache\Storage\Adapter\Redis',
         'session'        => 'Zend\Cache\Storage\Adapter\Session',
         'xcache'         => 'Zend\Cache\Storage\Adapter\XCache',
         'wincache'       => 'Zend\Cache\Storage\Adapter\WinCache',

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -191,7 +191,7 @@ class RedisTest extends CommonAdapterTest
         );
     }
 
-    public function testGetSetLibOptions()
+    public function testGetSetLibOptionsOnExistingRedisResourceInstance()
     {
         $options = array('serializer', RedisResource::SERIALIZER_PHP);
         $this->_options->setLibOptions($options);
@@ -200,15 +200,34 @@ class RedisTest extends CommonAdapterTest
         $key    = 'key';
         //test if it's still possible to set/get item and if lib serializer works
         $this->_storage->setItem($key, $value);
-        $this->assertEquals($value, $this->_storage->getItem($key), 'this->_storage should return an array, lib options were not set correctly');
+        $this->assertEquals($value, $this->_storage->getItem($key), 'Redis should return an array, lib options were not set correctly');
 
 
         $options = array('serializer', RedisResource::SERIALIZER_NONE);
         $this->_options->setLibOptions($options);
-        $this->_storage = $this->_storage;
         $this->_storage->setItem($key, $value);
         //should not serialize array correctly
         $this->assertFalse(is_array($this->_storage->getItem($key)), 'Redis should not serialize automatically anymore, lib options were not set correctly');
+    }
+
+    public function testGetSetLibOptionsWithCleanRedisResourceInstance()
+    {
+        $options = array('serializer', RedisResource::SERIALIZER_PHP);
+        $this->_options->setLibOptions($options);
+
+        $redis = new Cache\Storage\Adapter\Redis($this->_options);
+        $value  = array('value');
+        $key    = 'key';
+        //test if it's still possible to set/get item and if lib serializer works
+        $redis->setItem($key, $value);
+        $this->assertEquals($value, $redis->getItem($key), 'Redis should return an array, lib options were not set correctly');
+
+
+        $options = array('serializer', RedisResource::SERIALIZER_NONE);
+        $this->_options->setLibOptions($options);
+        $redis->setItem($key, $value);
+        //should not serialize array correctly
+        $this->assertFalse(is_array($redis->getItem($key)), 'Redis should not serialize automatically anymore, lib options were not set correctly');
     }
 
     /* RedisOptions */

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -191,6 +191,26 @@ class RedisTest extends CommonAdapterTest
         );
     }
 
+    public function testGetSetLibOptions()
+    {
+        $options = array('serializer', RedisResource::SERIALIZER_PHP);
+        $this->_options->setLibOptions($options);
+
+        $value  = array('value');
+        $key    = 'key';
+        //test if it's still possible to set/get item and if lib serializer works
+        $this->_storage->setItem($key, $value);
+        $this->assertEquals($value, $this->_storage->getItem($key), 'this->_storage should return an array, lib options were not set correctly');
+
+
+        $options = array('serializer', RedisResource::SERIALIZER_NONE);
+        $this->_options->setLibOptions($options);
+        $this->_storage = $this->_storage;
+        $this->_storage->setItem($key, $value);
+        //should not serialize array correctly
+        $this->assertFalse(is_array($this->_storage->getItem($key)), 'Redis should not serialize automatically anymore, lib options were not set correctly');
+    }
+
     /* RedisOptions */
 
     public function testGetSetNamespace()

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -261,4 +261,11 @@ class RedisTest extends CommonAdapterTest
         $this->assertEquals($database, $this->_options->getDatabase(), 'Database not set correctly using RedisOptions');
     }
 
+    public function testOptionsGetSetPassword()
+    {
+        $password = 'my-secret';
+        $this->_options->setPassword($password);
+        $this->assertEquals($password, $this->_options->getPassword(), 'Password was set incorrectly using RedisOptions');
+    }
+
 }


### PR DESCRIPTION
This is a PR that extends PR https://github.com/zendframework/zf2/pull/4577 and solves issue https://github.com/zendframework/zf2/issues/4576

Because Redis doesn't allow for some reason setting options before connect it required some additional fixing than the PR mentioned earlier. Also added test checking if lib options are working correctly.
