### PR TITLE
Added the backward compatibility support on bcrypt verify

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -112,7 +112,21 @@ class Bcrypt implements PasswordInterface
      */
     public function verify($password, $hash)
     {
-        return ($hash === crypt($password, $hash));
+        if ($hash === crypt($password, $hash)) {
+            return true;
+        }
+        if (substr($hash, 0, 3) === '$2y' && version_compare(PHP_VERSION, '5.3.7', '<')) {
+            if (!$this->backwardCompatibility) {
+                throw new Exception\RuntimeException(
+                    'I cannot verify an hash generated with PHP 5.3.7+ using PHP ' . PHP_VERSION .
+                    '. Please, upgrade to PHP 5.3.7 or above'
+                );                
+            }
+            $hash = str_replace('$2y$', '$2a$', $hash);                                                                              
+            trigger_error("Please upgrade to PHP 5.3.7+ to be sure to use a secure version of crypt()", E_USER_WARNING);
+            return ($hash === crypt($password, $hash)); 
+        }
+        return false;   
     }
 
     /**

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -155,4 +155,26 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('$2a$', substr($password, 0, 4));
         $this->assertEquals(substr($password, 4), substr($this->bcryptPassword, 4));
     }
+
+    public function testBackwardCompatibilityVerify()
+    {
+        $this->bcrypt->setSalt($this->salt);
+        $hash = str_replace ('$2a$', '$2y$', $this->bcryptPassword);
+        $this->bcrypt->setBackwardCompatibility(true);
+        if (version_compare(PHP_VERSION, '5.3.7', '<')) {
+            $this->setExpectedException('PHPUnit_Framework_Error');
+        }
+        $this->assertTrue($this->bcrypt->verify($this->password, $hash));
+    }
+
+    public function testBackwardCompatibiltyVerifyFail()
+    {
+        $this->bcrypt->setSalt($this->salt);
+        $hash = str_replace ('$2a$', '$2y$', $this->bcryptPassword);
+        if (version_compare(PHP_VERSION, '5.3.7', '<')) {
+            $this->setExpectedException('Zend\Crypt\Password\Exception\RuntimeException');
+        }
+        $this->assertTrue($this->bcrypt->verify($this->password, $hash));
+    }
+
 }


### PR DESCRIPTION
Possible solution to the issue #4538. When the user explicit set the backwardCompatibility to true, the verify method of Zend\Crypt\Password\Bcrypt tries to substitute the new $2y$ with $2a$ if PHP < 5.3.7 (and generate a WARNING suggesting to upgrade to PHP 5.3.7+). 
If backwardComaptibility is set to false the verify method throws and Exception with a message to upgrade to PHP 5.3.7+.
