### PR TITLE
Allow the 'gc_probability' option to be set to zero.

### DIFF
--- a/library/Zend/Session/Config/StandardConfig.php
+++ b/library/Zend/Session/Config/StandardConfig.php
@@ -297,7 +297,7 @@ class StandardConfig implements ConfigInterface
             throw new Exception\InvalidArgumentException('Invalid gc_probability; must be numeric');
         }
         $gcProbability = (int) $gcProbability;
-        if (1 > $gcProbability || 100 < $gcProbability) {
+        if (0 > $gcProbability || 100 < $gcProbability) {
             throw new Exception\InvalidArgumentException('Invalid gc_probability; must be a percentage');
         }
         $this->setOption('gc_probability', $gcProbability);

--- a/tests/ZendTest/Session/Config/StandardConfigTest.php
+++ b/tests/ZendTest/Session/Config/StandardConfigTest.php
@@ -67,6 +67,12 @@ class StandardConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(20, $this->config->getGcProbability());
     }
 
+    public function testGcProbabilityCanBeSetToZero()
+    {
+        $this->config->setGcProbability(0);
+        $this->assertEquals(0, $this->config->getGcProbability());
+    }
+
     public function testSettingInvalidGcProbabilityRaisesException()
     {
         $this->setExpectedException('Zend\Session\Exception\InvalidArgumentException', 'Invalid gc_probability; must be numeric');


### PR DESCRIPTION
This is valid because PHP divides gc_divisor into gc_probability - it would only
be invalid to set gc_divisor to 0 (divide-by-zero), so this commit leaves the
same test for that option alone.
