### PR TITLE
Logger: Error/Exception Handler: fixed 3853 & 4456

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -519,7 +519,7 @@ class Logger implements LoggerInterface
 
         $errorHandlerMap = static::$errorPriorityMap;
 
-        $previous = set_error_handler(function ($level, $message, $file, $line, $context)
+        $previous = set_error_handler(function ($level, $message, $file, $line)
             use ($logger, $errorHandlerMap, $continueNativeHandler)
         {
             $iniLevel = error_reporting();
@@ -534,7 +534,6 @@ class Logger implements LoggerInterface
                     'errno'   => $level,
                     'file'    => $file,
                     'line'    => $line,
-                    'context' => $context,
                 ));
             }
 

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -147,11 +147,11 @@ class Logger implements LoggerInterface
             }
 
             if (isset($options['exceptionhandler']) && $options['exceptionhandler'] === true) {
-                self::registerExceptionHandler($this);
+                static::registerExceptionHandler($this);
             }
 
             if (isset($options['errorhandler']) && $options['errorhandler'] === true) {
-                self::registerErrorHandler($this);
+                static::registerErrorHandler($this);
             }
 
         }

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -517,16 +517,16 @@ class Logger implements LoggerInterface
             return false;
         }
 
-        $errorHandlerMap = static::$errorPriorityMap;
+        $errorPriorityMap = static::$errorPriorityMap;
 
         $previous = set_error_handler(function ($level, $message, $file, $line)
-            use ($logger, $errorHandlerMap, $continueNativeHandler)
+            use ($logger, $errorPriorityMap, $continueNativeHandler)
         {
             $iniLevel = error_reporting();
 
             if ($iniLevel & $level) {
-                if (isset(Logger::$errorPriorityMap[$level])) {
-                    $priority = $errorHandlerMap[$level];
+                if (isset($errorPriorityMap[$level])) {
+                    $priority = $errorPriorityMap[$level];
                 } else {
                     $priority = Logger::INFO;
                 }


### PR DESCRIPTION
see #3853 & #4456

I also noted that `Zend\Log\Formatter\Base::normalize($value)` can result in an infinite loop if called with self referencing array - but this is another issue.
