### PR TITLE
Fix #4579 day_attributes could not be passed in construct

### DIFF
--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -33,9 +33,9 @@ class DateSelect extends MonthSelect
      */
     public function __construct($name = null, $options = array())
     {
-        parent::__construct($name, $options);
-
         $this->dayElement = new Select('day');
+
+        parent::__construct($name, $options);
     }
 
     /**

--- a/tests/ZendTest/Form/Element/DateSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateSelectTest.php
@@ -70,4 +70,11 @@ class DateSelectTest extends TestCase
         $element  = new DateSelectElement();
         $element->setValue('hello world');
     }
+
+    public function testConstructAcceptsDayAttributes()
+    {
+        $sut = new DateSelectElement('dateSelect', array('day_attributes' => array('class' => 'test')));
+        $dayAttributes = $sut->getDayAttributes();
+        $this->assertEquals('test', $dayAttributes['class']);
+    }
 }


### PR DESCRIPTION
This pull request fixes a bug in DateSelect. When you pass "day_attributes" into the construct, the "setDayAttributes" method is called on a non-object, because the object was initialized after calling "setDayAttributes". The Fix creates the Select element before calling parent::__construct.
