### PR TITLE
Zend\Code: Docblock generates empty line under @tags if docblock was read from existing code

### DIFF
--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -218,7 +218,7 @@ class DocBlockGenerator extends AbstractGenerator
     public function generate()
     {
         if (!$this->isSourceDirty()) {
-            return $this->docCommentize($this->getSourceContent());
+            return $this->docCommentize(trim($this->getSourceContent()));
         }
 
         $output = '';

--- a/library/Zend/Code/Generator/ParameterGenerator.php
+++ b/library/Zend/Code/Generator/ParameterGenerator.php
@@ -61,7 +61,14 @@ class ParameterGenerator extends AbstractGenerator
         } else {
             $typeClass = $reflectionParameter->getClass();
             if ($typeClass) {
-                $param->setType($typeClass->getName());
+				$parameterType = $typeClass->getName();
+				$currentNamespace = $reflectionParameter->getDeclaringClass()->getNamespaceName();
+
+				if (substr($parameterType, 0, strlen($currentNamespace)) == $currentNamespace) {
+					$parameterType = substr($parameterType, strlen($currentNamespace)+1);
+				}
+
+                $param->setType($parameterType);
             }
         }
 

--- a/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
@@ -68,7 +68,6 @@ class MethodGeneratorTest extends \PHPUnit_Framework_TestCase
      * Enter description here...
      *
      * @return bool
-     *
      */
     public function someMethod()
     {


### PR DESCRIPTION
it does not generate that line if docblock was newly created.
