### PR TITLE
Ensure router factory is used by SM factory

### DIFF
--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -73,11 +73,12 @@ class SimpleRouteStack implements RouteStackInterface
             throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
         }
 
-        $instance = new static();
-
+        $routePluginManager = null;
         if (isset($options['route_plugins'])) {
-            $instance->setRoutePluginManager($options['route_plugins']);
+            $routePluginManager = $options['route_plugins'];
         }
+
+        $instance = new static($routePluginManager);
 
         if (isset($options['routes'])) {
             $instance->addRoutes($options['routes']);

--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -32,38 +32,33 @@ class RouterFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator, $cName = null, $rName = null)
     {
         $config             = $serviceLocator->get('Config');
+        $routerConfig       = array();
         $routePluginManager = $serviceLocator->get('RoutePluginManager');
 
-        if (
-            $rName === 'ConsoleRouter' ||                   // force console router
-            ($cName === 'router' && Console::isConsole())       // auto detect console
+        if ($rName === 'ConsoleRouter'                       // force console router
+            || ($cName === 'router' && Console::isConsole()) // auto detect console
         ) {
             // We are in a console, use console router.
             if (isset($config['console']) && isset($config['console']['router'])) {
                 $routerConfig = $config['console']['router'];
-            } else {
-                $routerConfig = array();
             }
 
-            $router = new ConsoleRouter($routePluginManager);
-        } else {
-            // This is an HTTP request, so use HTTP router
-            $router       = new HttpRouter($routePluginManager);
-            $routerConfig = isset($config['router']) ? $config['router'] : array();
+            if (!isset($routerConfig['route_plugins'])) {
+                $routerConfig['route_plugins'] = $routePluginManager;
+            }
+
+            return ConsoleRouter::factory($routerConfig);
         }
 
-        if (isset($routerConfig['route_plugins'])) {
-            $router->setRoutePluginManager($routerConfig['route_plugins']);
+        // This is an HTTP request, so use HTTP router
+        if (isset($config['router'])) {
+            $routerConfig = $config['router'];
         }
 
-        if (isset($routerConfig['routes'])) {
-            $router->addRoutes($routerConfig['routes']);
+        if (!isset($routerConfig['route_plugins'])) {
+            $routerConfig['route_plugins'] = $routePluginManager;
         }
 
-        if (isset($routerConfig['default_params'])) {
-            $router->setDefaultParams($routerConfig['default_params']);
-        }
-
-        return $router;
+        return HttpRouter::factory($routerConfig);
     }
 }


### PR DESCRIPTION
As reported on the mailing list, prototypes are not being injected into the router due to the fact that `Zend\Mvc\Service\RouterFactory` is not using the `factory()` method to create a router instance. This PR accomplishes that.
