### PR TITLE
Add bcrypt errors if verification fails on an invalid hash.

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -108,11 +108,32 @@ class Bcrypt implements PasswordInterface
      *
      * @param  string $password
      * @param  string $hash
+     * @throws Exception\RuntimeException when the hash is unable to be processed
      * @return bool
      */
     public function verify($password, $hash)
     {
-        return ($hash === crypt($password, $hash));
+        $result = crypt($password, $hash);
+        if ($result === $hash) {
+            return true;
+        }
+        if (strlen($result) <= strlen($hash)) {
+            /* This should only happen if the algorithm that generated hash is
+             * either unsupported by this version of crypt(), or is invalid.
+             *
+             * An example of when this can happen, is if you generate 
+             * non-backwards-compatible hashes on 5.3.7+, and then try to verify
+             * them on < 5.3.7.
+             *
+             * This is needed, because version comparisons are not possible due
+             * to back-ported functionality by some distributions.
+             */
+            throw new Exception\RuntimeException(
+                'The supplied password hash could not be verified. Please check ' .
+                'backwards compatibility settings.'
+            );
+        }
+        return false;
     }
 
     /**

--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -117,7 +117,7 @@ class Bcrypt implements PasswordInterface
         if ($result === $hash) {
             return true;
         }
-        if (strlen($result) <= strlen($hash)) {
+        if (strlen($result) <= 13) {
             /* This should only happen if the algorithm that generated hash is
              * either unsupported by this version of crypt(), or is invalid.
              *

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -122,6 +122,22 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->bcrypt->verify(substr($this->password, -1), $this->bcryptPassword));
     }
 
+    public function testVerifyFailureVersion()
+    {
+        $test = (substr(crypt('test', '$2y$04$012345678901234567890123456789'), 0, 3) === '$2y');
+        if (!$test) {
+            // We don't support new style hashes, test verify failure
+            $hash = '$y2$14$MTIzNDU2Nzg5MDEyMzQ1NeWUUefVlefsTbFhsbqKFv/vPSZBrSFVm';
+            $this->setExpectedException('Zend\Crypt\Password\Exception\RuntimeException',
+                'The supplied password hash could not be verified. Please check ' .
+                'backwards compatibility settings.'
+            );
+            $this->bcrypt->verify('test', $hash);
+        } else {
+            $this->skip('Test requires PHP which does not support $2y hashes (<5.3.7)');
+        }
+    }
+
     public function testPasswordWith8bitCharacter()
     {
         $password = 'test' . chr(128);

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -134,7 +134,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
             );
             $this->bcrypt->verify('test', $hash);
         } else {
-            $this->skip('Test requires PHP which does not support $2y hashes (<5.3.7)');
+            $this->markTestSkipped('Test requires PHP which does not support $2y hashes (<5.3.7)');
         }
     }
 


### PR DESCRIPTION
This can occur if verifying new-style hashes on old versions.

This is IMHO a better approach to solving #4607 rather than trying to mutate the password, as it's a hard-failure, and indicates that the password wasn't necessarily invalid, but it was the hash itself that was invalid...
