### PR TITLE
Use Zend\Http\Client in Zend\Version

### DIFF
--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Version;
 
+use Zend\Http;
 use Zend\Json\Json;
 
 /**
@@ -52,6 +53,7 @@ final class Version
     {
         $version = strtolower($version);
         $version = preg_replace('/(\d)pr(\d?)/', '$1a$2', $version);
+
         return version_compare($version, strtolower(self::VERSION));
     }
 
@@ -64,54 +66,160 @@ final class Version
      * numbers with version_compare().
      *
      * If $service is set to VERSION_SERVICE_ZEND this will fall back to calling the
-     * classic style of version retreival.
+     * classic style of version retrieval.
      *
-     *
-     * @see http://developer.github.com/v3/git/refs/#get-all-references
-     * @link https://api.github.com/repos/zendframework/zf2/git/refs/tags/release-
-     * @link http://framework.zend.com/api/zf-version?v=2
-     * @param string $service Version Service with which to retrieve the version
+     * @see    http://developer.github.com/v3/git/refs/#get-all-references
+     * @link   https://api.github.com/repos/zendframework/zf2/git/refs/tags/release-
+     * @link   http://framework.zend.com/api/zf-version?v=2
+     * @param  string      $service    Version service with which to retrieve the version
+     * @param  Http\Client $httpClient HTTP client with which to retrieve the version
      * @return string
      */
-    public static function getLatest($service = self::VERSION_SERVICE_ZEND)
+    public static function getLatest($service = self::VERSION_SERVICE_ZEND, Http\Client $httpClient = null)
     {
-        if (null === static::$latestVersion) {
-            static::$latestVersion = 'not available';
-            if ($service == self::VERSION_SERVICE_GITHUB) {
-                $url  = 'https://api.github.com/repos/zendframework/zf2/git/refs/tags/release-';
-
-                $apiResponse = Json::decode(file_get_contents($url), Json::TYPE_ARRAY);
-
-                // Simplify the API response into a simple array of version numbers
-                $tags = array_map(function ($tag) {
-                    return substr($tag['ref'], 18); // Reliable because we're filtering on 'refs/tags/release-'
-                }, $apiResponse);
-
-                // Fetch the latest version number from the array
-                static::$latestVersion = array_reduce($tags, function ($a, $b) {
-                    return version_compare($a, $b, '>') ? $a : $b;
-                });
-            } elseif ($service == self::VERSION_SERVICE_ZEND) {
-                $handle = fopen('http://framework.zend.com/api/zf-version?v=2', 'r');
-                if (false !== $handle) {
-                    static::$latestVersion = stream_get_contents($handle);
-                    fclose($handle);
-                }
-            }
+        if (null !== self::$latestVersion) {
+            return self::$latestVersion;
         }
 
-        return static::$latestVersion;
+        self::$latestVersion = 'not available';
+
+        if (null === $httpClient && !ini_get('allow_url_fopen')) {
+            trigger_error(
+                sprintf(
+                    'allow_url_fopen is not set, and no Zend\Http\Client ' .
+                    'was passed. You must either set allow_url_fopen in ' .
+                    'your PHP configuration or pass a configured ' .
+                    'Zend\Http\Client as the second argument to %s.',
+                    __METHOD__
+                ),
+                E_USER_WARNING
+            );
+
+            return self::$latestVersion;
+        }
+
+        $response = false;
+        if ($service === self::VERSION_SERVICE_GITHUB) {
+            $response = self::getLatestFromGithub($httpClient);
+        } elseif ($service === self::VERSION_SERVICE_ZEND) {
+            $response = self::getLatestFromZend($httpClient);
+        } else {
+            trigger_error(
+                sprintf(
+                    'Unknown version service: %s',
+                    $service
+                ),
+                E_USER_WARNING
+            );
+        }
+
+        if ($response) {
+            self::$latestVersion = $response;
+        }
+
+        return self::$latestVersion;
     }
 
     /**
      * Returns true if the running version of Zend Framework is
      * the latest (or newer??) than the latest tag on GitHub,
-     * which is returned by static::getLatest().
+     * which is returned by self::getLatest().
      *
      * @return bool
      */
     public static function isLatest()
     {
-        return static::compareVersion(static::getLatest()) < 1;
+        return self::compareVersion(self::getLatest()) < 1;
+    }
+
+    /**
+     * Get the API response to a call from a configured HTTP client
+     *
+     * @param  Http\Client  $httpClient Configured HTTP client
+     * @return string|false API response or false on error
+     */
+    protected static function getApiResponse(Http\Client $httpClient)
+    {
+        try {
+            $response = $httpClient->send();
+        } catch (Http\Exception\RuntimeException $e) {
+            return false;
+        }
+
+        if (!$response->isSuccess()) {
+            return false;
+        }
+
+        return $response->getBody();
+    }
+
+    /**
+     * Get the latest version from Github
+     *
+     * @param  Http\Client $httpClient Configured HTTP client
+     * @return string|null API response or false on error
+     */
+    protected static function getLatestFromGithub(Http\Client $httpClient = null)
+    {
+        $url = 'https://api.github.com/repos/zendframework/zf2/git/refs/tags/release-';
+
+        if ($httpClient === null) {
+            $context = stream_context_create(
+                array(
+                    'http' => array(
+                        'user_agent' => sprintf('Zend-Version/%s', self::VERSION),
+                    ),
+                )
+            );
+            $apiResponse = file_get_contents($url, false, $context);
+        } else {
+            $request = new Http\Request();
+            $request->setUri($url);
+            $httpClient->setRequest($request);
+            $apiResponse = self::getApiResponse($httpClient);
+        }
+
+        if (!$apiResponse) {
+            return false;
+        }
+
+        $decodedResponse = Json::decode($apiResponse, Json::TYPE_ARRAY);
+
+        // Simplify the API response into a simple array of version numbers
+        $tags = array_map(function ($tag) {
+            return substr($tag['ref'], 18); // Reliable because we're
+                                            // filtering on 'refs/tags/release-'
+        }, $decodedResponse);
+
+        // Fetch the latest version number from the array
+        return array_reduce($tags, function ($a, $b) {
+            return version_compare($a, $b, '>') ? $a : $b;
+        });
+    }
+
+    /**
+     * Get the latest version from framework.zend.com
+     *
+     * @param  Http\Client $httpClient Configured HTTP client
+     * @return string|null API response or false on error
+     */
+    protected static function getLatestFromZend(Http\Client $httpClient = null)
+    {
+        $url = 'http://framework.zend.com/api/zf-version?v=2';
+
+        if ($httpClient === null) {
+            $apiResponse = file_get_contents($url);
+        } else {
+            $request = new Http\Request();
+            $request->setUri($url);
+            $httpClient->setRequest($request);
+            $apiResponse = self::getApiResponse($httpClient);
+        }
+
+        if (!$apiResponse) {
+            return false;
+        }
+
+        return $apiResponse;
     }
 }

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -15,6 +15,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "suggest": {
+        "zendframework/zend-http": "Allows use of Zend\\Http\\Client to check version information"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.2-dev",


### PR DESCRIPTION
With this update, we can perform version checks without relying on the
environment having allow_url_fopen = 1.

We can now optionally pass in a Zend\Http\Client instance.

Tests were enhanced to run in a separate process to avoid problems during online
tests where tests would not actually be run because the class would cache the
first response, and subsequent responses would use that cached response.

This addresses https://github.com/zendframework/zf2/issues/4610
