### PR TITLE
Check return value of crypt() such that the check matches the PHP documentation

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -117,7 +117,7 @@ class Bcrypt implements PasswordInterface
         if ($result === $hash) {
             return true;
         }
-        if (strlen($result) <= 13) {
+        if (strlen($result) < 13) {
             /* This should only happen if the algorithm that generated hash is
              * either unsupported by this version of crypt(), or is invalid.
              *


### PR DESCRIPTION
As discussed in https://github.com/zendframework/zf2/pull/4623

Reference: http://php.net/manual/en/function.crypt.php
