### PR TITLE
Zend\Cache\Pattern\CallbackCache doesn't work with NULL

### DIFF
--- a/library/Zend/Cache/Pattern/CallbackCache.php
+++ b/library/Zend/Cache/Pattern/CallbackCache.php
@@ -48,7 +48,7 @@ class CallbackCache extends AbstractPattern
         $key     = $this->generateCallbackKey($callback, $args);
         $result  = $storage->getItem($key, $success);
         if ($success) {
-            if (!isset($result[0])) {
+            if (!array_key_exists(0, $result)) {
                 throw new Exception\RuntimeException("Invalid cached data for key '{$key}'");
             }
 

--- a/tests/ZendTest/Cache/Pattern/CallbackCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/CallbackCacheTest.php
@@ -35,6 +35,14 @@ class TestCallbackCache
 
 }
 
+class FailableCallback
+{
+    public function __invoke()
+    {
+        throw new \Exception('This callback should either fail or never be invoked');
+    }
+}
+
 /**
  * Test function
  * @see ZendTest\Cache\Pattern\Foo::bar
@@ -164,5 +172,18 @@ class CallbackCacheTest extends CommonPatternTest
         } else {
             $this->assertEquals('', $data);
         }
+    }
+
+    /**
+     * @group 4629
+     * @return void
+     */
+    public function testCallCanReturnCachedNullValues()
+    {
+        $callback = new FailableCallback();
+        $key      = $this->_pattern->generateKey($callback, array());
+        $this->_storage->setItem($key, array(null));
+        $value    = $this->_pattern->call($callback);
+        $this->assertNull($value);
     }
 }


### PR DESCRIPTION
https://github.com/zendframework/zf2/blob/master/library/Zend/Cache/Pattern/CallbackCache.php#L51

<code>if (!isset($result[0])) {
 throw new Exception\RuntimeException("Invalid cached data for key '{$key}'");
}</code>

The cache has been saved and loaded correct but this condition returns false because <strong>isset</strong> returns false on <em>NULL</em> - should be replaced by <strong>array_key_exists</strong>

;)
