### PR TITLE
Missed method findRealpathInIncludePath() in Zend\Code\Reflection\FileReflection

### DIFF
--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -73,13 +73,14 @@ class FileGenerator extends AbstractGenerator
     {
         $realpath = realpath($filePath);
 
-        if (
-            $realpath === false
-            && ($realpath = FileReflection::findRealpathInIncludePath($filePath)) === false
-        ) {
+        if ($realpath === false) {
+            $realpath = stream_resolve_include_path($filePath);
+        }
+
+        if (!$realpath || !in_array($realPath, get_included_files())) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'No file for %s was found.',
-                $realpath
+                $filePath
             ));
         }
 

--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -298,4 +298,10 @@ EOS;
         $class = $fileGenerator->getClass('bar');
         $this->assertInstanceOf('Zend\Code\Generator\ClassGenerator', $class);
     }
+
+    public function testGeneratingFromAReflectedFilenameShouldRaiseExceptionIfFileDoesNotExist()
+    {
+        $this->setExpectedException('Zend\Code\Generator\Exception\InvalidArgumentException', 'found');
+        $generator = FileGenerator::fromReflectedFileName(__DIR__ . '/does/not/exist.really');
+    }
 }


### PR DESCRIPTION
Fatal error: Call to undefined method Zend\Code\Reflection\FileReflection::findRealpathInIncludePath() in /home/home/www/vendor/library/Zend/Code/Generator/FileGenerator.php on line 78

This occurs when data is non-existent file

$generator =  new \Zend\Code\Generator\FileGenerator();
$file = $generator->fromReflectedFileName('/home/user/www/not_exists.php');
