### PR TITLE
Allow selecting the TranslatorAwareTreeRouteStack via configuration

### DIFF
--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -32,10 +32,12 @@ class RouterFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator, $cName = null, $rName = null)
     {
         $config             = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
-        $routerClass        = null;
-        $routerConfig       = array();
-        $routePluginManager = $serviceLocator->get('RoutePluginManager');
 
+        // Defaults
+        $routerClass        = 'Zend\Mvc\Router\Http\TreeRouteStack';
+        $routerConfig       = isset($config['router']) ? $config['router'] : array();
+
+        // Console environment?
         if ($rName === 'ConsoleRouter'                       // force console router
             || ($cName === 'router' && Console::isConsole()) // auto detect console
         ) {
@@ -45,25 +47,21 @@ class RouterFactory implements FactoryInterface
             }
 
             $routerClass = 'Zend\Mvc\Router\Console\SimpleRouteStack';
-        } else {
-            // This is an HTTP request, so use HTTP router
-            if (isset($config['router'])) {
-                $routerConfig = $config['router'];
-            }
-
-            $routerClass = 'Zend\Mvc\Router\Http\TreeRouteStack';
         }
 
+        // Obtain the configured router class, if any
         if (isset($routerConfig['router_class']) && class_exists($routerConfig['router_class'])) {
             $routerClass = $routerConfig['router_class'];
         }
 
+        // Inject the route plugins
         if (!isset($routerConfig['route_plugins'])) {
+            $routePluginManager = $serviceLocator->get('RoutePluginManager');
             $routerConfig['route_plugins'] = $routePluginManager;
         }
 
+        // Obtain an instance
         $factory = sprintf('%s::factory', $routerClass);
-
         return call_user_func($factory, $routerConfig);
     }
 }

--- a/tests/ZendTest/Mvc/Service/RouterFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/RouterFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mvc
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
+use Zend\Mvc\Router\RoutePluginManager;
+use Zend\Mvc\Service\RouterFactory;
+use Zend\ServiceManager\ServiceManager;
+
+class RouterFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->services = new ServiceManager();
+        $this->services->setService('RoutePluginManager', new RoutePluginManager());
+        $this->factory  = new RouterFactory();
+    }
+
+    public function testFactoryCanCreateRouterBasedOnConfiguredName()
+    {
+        $this->services->setService('Config', array(
+            'router' => array(
+                'router_class' => 'ZendTest\Mvc\Service\TestAsset\Router',
+            ),
+            'console' => array(
+                'router' => array(
+                    'router_class' => 'ZendTest\Mvc\Service\TestAsset\Router',
+                ),
+            ),
+        ));
+
+        $router = $this->factory->createService($this->services, 'router', 'Router');
+        $this->assertInstanceOf('ZendTest\Mvc\Service\TestAsset\Router', $router);
+    }
+}

--- a/tests/ZendTest/Mvc/Service/TestAsset/Router.php
+++ b/tests/ZendTest/Mvc/Service/TestAsset/Router.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service\TestAsset;
+
+use Zend\Mvc\Router\RouteStackInterface;
+use Zend\Stdlib\RequestInterface as Request;
+
+class Router implements RouteStackInterface
+{
+    /**
+     * Create a new route with given options.
+     *
+     * @param  array|\Traversable $options
+     * @return void
+     */
+    public static function factory($options = array())
+    {
+        return new static();
+    }
+
+    /**
+     * Match a given request.
+     *
+     * @param  Request $request
+     * @return RouteMatch|null
+     */
+    public function match(Request $request)
+    {
+    }
+
+    /**
+     * Assemble the route.
+     *
+     * @param  array $params
+     * @param  array $options
+     * @return mixed
+     */
+    public function assemble(array $params = array(), array $options = array())
+    {
+    }
+    /**
+     * Add a route to the stack.
+     *
+     * @param  string  $name
+     * @param  mixed   $route
+     * @param  int $priority
+     * @return RouteStackInterface
+     */
+    public function addRoute($name, $route, $priority = null)
+    {
+    }
+
+    /**
+     * Add multiple routes to the stack.
+     *
+     * @param  array|\Traversable $routes
+     * @return RouteStackInterface
+     */
+    public function addRoutes($routes)
+    {
+    }
+
+    /**
+     * Remove a route from the stack.
+     *
+     * @param  string $name
+     * @return RouteStackInterface
+     */
+    public function removeRoute($name)
+    {
+    }
+
+    /**
+     * Remove all routes from the stack and set new ones.
+     *
+     * @param  array|\Traversable $routes
+     * @return RouteStackInterface
+     */
+    public function setRoutes($routes)
+    {
+    }
+}

--- a/tests/ZendTest/Mvc/Service/TestAsset/Router.php
+++ b/tests/ZendTest/Mvc/Service/TestAsset/Router.php
@@ -45,6 +45,7 @@ class Router implements RouteStackInterface
     public function assemble(array $params = array(), array $options = array())
     {
     }
+
     /**
      * Add a route to the stack.
      *


### PR DESCRIPTION
Per the mailing list, there's currently no way to opt-in to using the TranslatorAwareTreeRouteStack without overwriting the "Router" service. This PR fixes that situation, by allowing a new configuration item inside the router configuration, "router_class", which allows you to specify the router to use. The factory will then invoke that class' `factory()` method to retrieve an instance. This can be done for either console or HTTP router types.

``` php
return array(
    'console' => array(
        'router' => array(
            'router_class' => 'My\Custom\Console\Router',
            'routes' => array( /* ... */ ),
        ),
    ),
    'router' => array(
        'router_class' => 'My\Custom\Http\Router',
        'routes' => array( /* ... */ ),
    ),
);
```
