### PR TITLE
removed checks of not existing class Zend\Math\BigInteger

### DIFF
--- a/library/Zend/XmlRpc/AbstractValue.php
+++ b/library/Zend/XmlRpc/AbstractValue.php
@@ -10,7 +10,6 @@
 namespace Zend\XmlRpc;
 
 use DateTime;
-use Zend\Math\BigInteger;
 
 /**
  * Represent a native XML-RPC value entity, used as parameters for the methods
@@ -277,17 +276,8 @@ abstract class AbstractValue
     protected static function _phpVarToNativeXmlRpc($value)
     {
         // @see http://framework.zend.com/issues/browse/ZF-8623
-        if (is_object($value)) {
-            if ($value instanceof AbstractValue) {
-                return $value;
-            }
-            if ($value instanceof BigInteger) {
-                throw new Exception\InvalidArgumentException(
-                    'Using Zend\Math\BigInteger to get an ' .
-                    'instance of Value_BigInteger is not ' .
-                    'available anymore.'
-                );
-            }
+        if ($value instanceof AbstractValue) {
+            return $value;
         }
 
         switch (static::getXmlRpcTypeByValue($value)) {

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -79,7 +79,6 @@ class Server extends AbstractServer
         'i4'                         => 'i4',
         'int'                        => 'int',
         'integer'                    => 'int',
-        'Zend\Math\BigInteger'       => 'i8',
         'i8'                         => 'i8',
         'ex:i8'                      => 'i8',
         'double'                     => 'double',


### PR DESCRIPTION
This addresses the last note of #3512 
The second note seems  to be fixed already

but the first one is already there and I cant fix:

```
#grep -iHrn 'ConstraintKeyObject' library/Zend/Db/
../library/Zend/Db/Metadata/Source/AbstractSource.php:398:                $keys[] = $key = new Object\ConstraintKeyObject($constraintKeyInfo['column_name']);
```

@ralphschindler @Maks3w ping
