### PR TITLE
Navigation\Page\Mvc Can't return false whithout call parent::isActive

### DIFF
--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -132,15 +132,15 @@ class Mvc extends AbstractPage
                 }
 
                 if (null !== $this->getRoute()) {
-                    $this->active = false;
                     if (
                         $this->routeMatch->getMatchedRouteName() === $this->getRoute()
                         && (count(array_intersect_assoc($reqParams, $myParams)) == count($myParams))
                     ) {
                         $this->active = true;
+                        return $this->active;
+                    } else {
+                        return parent::isActive($recursive);
                     }
-
-                    return $this->active;
                 }
             }
 


### PR DESCRIPTION
Sorry, my previous commit  https://github.com/zendframework/zf2/pull/4628, introduced this bug.
