### PR TITLE
Punycode decoding fails if encoded string has not hyphen

### DIFF
--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -635,22 +635,19 @@ class Hostname extends AbstractValidator
      */
     protected function decodePunycode($encoded)
     {
-        $found = preg_match('/([^a-z0-9\x2d]{1,10})$/i', $encoded);
-        if (empty($encoded) || ($found > 0)) {
-            // no punycode encoded string, return as is
+        if (!preg_match('/^[a-z0-9-]+$/i', $encoded)) {
+            // no punycode encoded string
             $this->error(self::CANNOT_DECODE_PUNYCODE);
             return false;
         }
 
+        $decoded = array();
         $separator = strrpos($encoded, '-');
         if ($separator > 0) {
             for ($x = 0; $x < $separator; ++$x) {
                 // prepare decoding matrix
                 $decoded[] = ord($encoded[$x]);
             }
-        } else {
-            $this->error(self::CANNOT_DECODE_PUNYCODE);
-            return false;
         }
 
         $lengthd = count($decoded);

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -312,7 +312,7 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
 
         // Check TLD matching
         $valuesExpected = array(
-            array(true, array('xn--brger-kva.com')),
+            array(true, array('xn--brger-kva.com', 'xn--eckwd4c7cu47r2wf.jp')),
             array(false, array('xn--brger-x45d2va.com', 'xn--bürger.com', 'xn--'))
             );
         foreach ($valuesExpected as $element) {


### PR DESCRIPTION
When validating host name like "xn--eckwd4c7cu47r2wf.jp", punycode decoder fails.

In typically case of Japanese(Maybe also Chinese and Korean) domain name, it hasn't ASCII characters. Then, encoded string has not hyphen after "xn--". In this case, current code reports decode error.

And, ZF1 also has this problem.
