### PR TITLE
Prevent population of Submit elements

### DIFF
--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -10,7 +10,6 @@
 namespace Zend\Form;
 
 use Traversable;
-use Zend\Form\Element\Submit;
 use Zend\Stdlib\Hydrator;
 use Zend\Stdlib\Hydrator\HydratorAwareInterface;
 use Zend\Stdlib\Hydrator\HydratorInterface;
@@ -403,7 +402,7 @@ class Fieldset extends Element implements FieldsetInterface
                 continue;
             }
 
-            if ($element instanceof Submit) {
+            if ($element instanceof Element\Submit) {
                 continue;
             }
 

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -10,6 +10,7 @@
 namespace Zend\Form;
 
 use Traversable;
+use Zend\Form\Element\Submit;
 use Zend\Stdlib\Hydrator;
 use Zend\Stdlib\Hydrator\HydratorAwareInterface;
 use Zend\Stdlib\Hydrator\HydratorInterface;
@@ -399,6 +400,10 @@ class Fieldset extends Element implements FieldsetInterface
 
             if ($element instanceof FieldsetInterface && is_array($value)) {
                 $element->populateValues($value);
+                continue;
+            }
+
+            if ($element instanceof Submit) {
                 continue;
             }
 

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1542,4 +1542,28 @@ class FormTest extends TestCase
         $rootForm->prepare();
         $this->assertEquals('form[element]', $element->getName());
     }
+
+    public function testPopulateValuesDoesNotPopulateSubmitElement()
+    {
+        $this->form->add(array(
+            'name' => 'submit',
+            'type' => 'Submit',
+            'options' => array(
+                'value' => 'Click me',
+            ),
+        ));
+
+        $expected = $this->form->get('submit')->getValue();
+
+        $this->form->populateValues(array(
+            'submit' => 'Go away',
+        ));
+
+        $actual = $this->form->get('submit')->getValue();
+
+        $this->assertSame(
+            $actual,
+            $expected
+        );
+    }
 }


### PR DESCRIPTION
When populating a form with data using `$form->setData()`, the value of a submit element (an instance of `Zend\Form\Element\Submit`) will be populated with the value that was submitted with the form.

This PR prevents population of submit elements.

See [ML](http://zend-framework-community.634137.n4.nabble.com/Populating-a-submit-element-tp4660309.html).
