### PR TITLE
Zend\Paginator\Adapter\DbSelect alternative solution to count, with subselect

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -478,7 +478,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $this->quantifier = null;
                 break;
             case self::COLUMNS:
-                $this->columns = array();
+                $this->columns = array(self::SQL_STAR);
                 break;
             case self::JOINS:
                 $this->joins = array();

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -478,7 +478,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $this->quantifier = null;
                 break;
             case self::COLUMNS:
-                $this->columns = array(self::SQL_STAR);
+                $this->columns = array();
                 break;
             case self::JOINS:
                 $this->joins = array();

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -103,7 +103,6 @@ class DbSelect implements AdapterInterface
         }
 
         $select = clone $this->select;
-        $select->reset(Select::COLUMNS);
         $select->reset(Select::LIMIT);
         $select->reset(Select::OFFSET);
         $select->reset(Select::ORDER);

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -107,18 +107,12 @@ class DbSelect implements AdapterInterface
         $select->reset(Select::LIMIT);
         $select->reset(Select::OFFSET);
         $select->reset(Select::ORDER);
-        $select->reset(Select::GROUP);
 
-        // get join information, clear, and repopulate without columns
-        $joins = $select->getRawState(Select::JOINS);
-        $select->reset(Select::JOINS);
-        foreach ($joins as $join) {
-            $select->join($join['name'], $join['on'], array(), $join['type']);
-        }
+        $countSelect = new Select;
+        $countSelect->columns(array('c' => new Expression('COUNT(1)')));
+        $countSelect->from(array('original_select' => $select));
 
-        $select->columns(array('c' => new Expression('COUNT(1)')));
-
-        $statement = $this->sql->prepareStatementForSqlObject($select);
+        $statement = $this->sql->prepareStatementForSqlObject($countSelect);
         $result    = $statement->execute();
         $row       = $result->current();
 


### PR DESCRIPTION
This is a generic solution that should work across all database platforms (I've tested against the Zend_Db-Examples repository schema, and it works on Sqlite, MySQL, and Postgres.)

Ideally, in the future, we will have a module per vendor of database so that we can have platform specific solutions that take advantage of platform specific features.  For example, MySQL could use SQL_CALC_FOUND_ROWS.
