### PR TITLE
Predicate in Update

### DIFF
--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -125,6 +125,8 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         if ($predicate instanceof Where) {
             $this->where = $predicate;
+        } elseif ($predicate instanceof Predicate\PredicateInterface) {
+            $this->where->addPredicate($predicate, $combination);
         } elseif ($predicate instanceof \Closure) {
             $predicate($this->where);
         } else {


### PR DESCRIPTION
Modified Zend\Sql\Update so that you can add a predicate like this:

$update->where(new Predicate...);
