### PR TITLE
router defaults not being set properly in console

### DIFF
--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -41,12 +41,9 @@ class RouterFactory implements FactoryInterface
         if ($rName === 'ConsoleRouter'                       // force console router
             || ($cName === 'router' && Console::isConsole()) // auto detect console
         ) {
-            // We are in a console, use console router.
-            if (isset($config['console']) && isset($config['console']['router'])) {
-                $routerConfig = $config['console']['router'];
-            }
-
+            // We are in a console, use console router defaults.
             $routerClass = 'Zend\Mvc\Router\Console\SimpleRouteStack';
+            $routerConfig = isset($config['console']['router']) ? $config['console']['router'] : array();
         }
 
         // Obtain the configured router class, if any

--- a/tests/ZendTest/Mvc/Service/RouterFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/RouterFactoryTest.php
@@ -41,4 +41,16 @@ class RouterFactoryTest extends TestCase
         $router = $this->factory->createService($this->services, 'router', 'Router');
         $this->assertInstanceOf('ZendTest\Mvc\Service\TestAsset\Router', $router);
     }
+
+    public function testFactoryCanCreateRouterWhenOnlyHttpRouterConfigPresent()
+    {
+        $this->services->setService('Config', array(
+            'router' => array(
+                'router_class' => 'ZendTest\Mvc\Service\TestAsset\Router',
+            ),
+        ));
+
+        $router = $this->factory->createService($this->services, 'router', 'Router');
+        $this->assertInstanceOf('Zend\Mvc\Router\Console\SimpleRouteStack', $router);
+    }
 }


### PR DESCRIPTION
The router configuration defaults were not being set correctly when the `console.router` config was not present.
