### PR TITLE
Zend\Mvc\Controller\AbstractController::getRequest() docblock return value should be HttpRequest

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -126,7 +126,7 @@ abstract class AbstractController implements
     /**
      * Get request object
      *
-     * @return Request
+     * @return HttpRequest
      */
     public function getRequest()
     {


### PR DESCRIPTION
Currently, this method shows

```
@return Request
```

It should show

```
@return HttpRequest
```

The issue this solves is that `Zend\Stdlib\RequestInterface` does not implement such methods as `isPost()` or `getPost()`, making IDE intellisense break. This fixes that.
