### PR TITLE
Changed default Version service back to GitHub

### DIFF
--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -73,7 +73,7 @@ final class Version
      * @param string $service Version Service with which to retrieve the version
      * @return string
      */
-    public static function getLatest($service = self::VERSION_SERVICE_ZEND)
+    public static function getLatest($service = self::VERSION_SERVICE_GITHUB)
     {
         if (null === static::$latestVersion) {
             static::$latestVersion = 'not available';


### PR DESCRIPTION
Checking if server accept fopen with URL, some disable for security reasons, yes this is weird:
- Adding cURL crawling
- Setting default crawler to cURL instead of file_get_content/fopen (Performance)

Github work-around:
- Added User-Agent Support
- Disabling SSL verify
