### PR TITLE
Zend\Paginator\Adapter\DbSelect additional for mistake elimination

### DIFF
--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -103,9 +103,18 @@ class DbSelect implements AdapterInterface
         }
 
         $select = clone $this->select;
+        $select->reset(Select::COLUMNS);
+        $select->columns(array(Select::SQL_STAR));
         $select->reset(Select::LIMIT);
         $select->reset(Select::OFFSET);
         $select->reset(Select::ORDER);
+        
+        // get join information, clear, and repopulate without columns
+        $joins = $select->getRawState(Select::JOINS);
+        $select->reset(Select::JOINS);
+        foreach ($joins as $join) {
+            $select->join($join['name'], $join['on'], array(), $join['type']);
+        }
 
         $countSelect = new Select;
         $countSelect->columns(array('c' => new Expression('COUNT(1)')));

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -84,20 +84,20 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
 
     public function testCount()
     {
-         $this->mockSelect->expects($this->once())->method('columns')->with($this->equalTo(array('c' => new Expression('COUNT(1)'))));
--        $this->mockResult->expects($this->any())->method('current')->will($this->returnValue(array('c' => 5)));
+        $this->mockSelect->expects($this->once())->method('columns')->with($this->equalTo(array('c' => new Expression('COUNT(1)'))));
+-       $this->mockResult->expects($this->any())->method('current')->will($this->returnValue(array('c' => 5)));
 -
--        $this->mockSelect->expects($this->exactly(6))->method('reset'); // called for columns, limit, offset, order
--        $this->mockSelect->expects($this->once())->method('getRawState')->with($this->equalTo(Select::JOINS))
--            ->will($this->returnValue(array(array('name' => 'Foo', 'on' => 'On Stuff', 'columns' => array('foo', 'bar'), 'type' => Select::JOIN_INNER))));
--        $this->mockSelect->expects($this->once())->method('join')->with(
--            'Foo',
--            'On Stuff',
--            array(),
--            Select::JOIN_INNER
--        );
+-       $this->mockSelect->expects($this->exactly(6))->method('reset'); // called for columns, limit, offset, order
+-       $this->mockSelect->expects($this->once())->method('getRawState')->with($this->equalTo(Select::JOINS))
+-           ->will($this->returnValue(array(array('name' => 'Foo', 'on' => 'On Stuff', 'columns' => array('foo', 'bar'), 'type' => Select::JOIN_INNER))));
+-       $this->mockSelect->expects($this->once())->method('join')->with(
+-           'Foo',
+-           'On Stuff',
+-           array(),
+-           Select::JOIN_INNER
+-       );
 
-         $count = $this->dbSelect->count();
-         $this->assertEquals(5, $count);
+        $count = $this->dbSelect->count();
+        $this->assertEquals(5, $count);
     }
 }

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -84,11 +84,20 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
 
     public function testCount()
     {
-        $this->mockResult->expects($this->once())->method('current')->will($this->returnValue(array('c' => 5)));
+         $this->mockSelect->expects($this->once())->method('columns')->with($this->equalTo(array('c' => new Expression('COUNT(1)'))));
+-        $this->mockResult->expects($this->any())->method('current')->will($this->returnValue(array('c' => 5)));
+-
+-        $this->mockSelect->expects($this->exactly(6))->method('reset'); // called for columns, limit, offset, order
+-        $this->mockSelect->expects($this->once())->method('getRawState')->with($this->equalTo(Select::JOINS))
+-            ->will($this->returnValue(array(array('name' => 'Foo', 'on' => 'On Stuff', 'columns' => array('foo', 'bar'), 'type' => Select::JOIN_INNER))));
+-        $this->mockSelect->expects($this->once())->method('join')->with(
+-            'Foo',
+-            'On Stuff',
+-            array(),
+-            Select::JOIN_INNER
+-        );
 
-        $this->mockSelect->expects($this->exactly(3))->method('reset'); // called for columns, limit, offset, order
-
-        $count = $this->dbSelect->count();
-        $this->assertEquals(5, $count);
+         $count = $this->dbSelect->count();
+         $this->assertEquals(5, $count);
     }
 }

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -85,17 +85,23 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
     public function testCount()
     {
         $this->mockSelect->expects($this->once())->method('columns')->with($this->equalTo(array('c' => new Expression('COUNT(1)'))));
--       $this->mockResult->expects($this->any())->method('current')->will($this->returnValue(array('c' => 5)));
--
--       $this->mockSelect->expects($this->exactly(6))->method('reset'); // called for columns, limit, offset, order
--       $this->mockSelect->expects($this->once())->method('getRawState')->with($this->equalTo(Select::JOINS))
--           ->will($this->returnValue(array(array('name' => 'Foo', 'on' => 'On Stuff', 'columns' => array('foo', 'bar'), 'type' => Select::JOIN_INNER))));
--       $this->mockSelect->expects($this->once())->method('join')->with(
--           'Foo',
--           'On Stuff',
--           array(),
--           Select::JOIN_INNER
--       );
+        $this->mockResult->expects($this->any())->method('current')->will($this->returnValue(array('c' => 5)));
+
+        $this->mockSelect->expects($this->exactly(6))->method('reset'); // called for columns, limit, offset, order
+        $this->mockSelect->expects($this->once())->method('getRawState')->with($this->equalTo(Select::JOINS))
+            ->will($this->returnValue(array(array('name' => 'Foo', 'on' => 'On Stuff', 'columns' => array('foo', 'bar'), 'type' => Select::JOIN_INNER))));
+        $this->mockSelect->expects($this->once())->method('join')->with(
+            'Foo',
+            'On Stuff',
+            array(),
+            Select::JOIN_INNER
+        );
+
+        $this->mockSql->expects($this->once())
+            ->method('prepareStatementForSqlObject')
+            ->with($this->isInstanceOf('Zend\Db\Sql\Select'))
+            ->will($this->returnValue($this->mockStatement));
+        $this->mockSql->expects($this->any())->method('execute')->will($this->returnValue($this->mockResult));
 
         $count = $this->dbSelect->count();
         $this->assertEquals(5, $count);


### PR DESCRIPTION
This is a fix for issue #4641

Eliminates an error: "PDOException: SQLSTATE[42S21]: Column already exists: 1060 Duplicate column..." when original_select contains columns called in selection by the same name ( e.g. TRIM(str_column) as str_column ).

In issue did not reset columns in select query to determine the count of rows in the grouped queries. Here there was a problem in my opinion. The count() method throws an error when original_select will be such:

SELECT *, TRIM(str_column) as str_column FROM table

PDOException: SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'str_column'

Query is good work: SELECT *, TRIM(str_column) as str_column FROM table

But query determine the count of rows throws an error: 
SELECT COUNT(1) AS "c" FROM ( SELECT *, TRIM(str_column) as str_column FROM table ) AS "original_select"

The error resulted in higher.

I think need to reset columns original_select on '*'.

$select->reset(Select::COLUMNS);
$select->columns(array(Select::SQL_STAR));

So everything will work correctly.

If in join uses the same technique ( e.g. TRIM(str_column) as str_column ) appears the same error. For this need to reset the column in join. Since it was originally.
