### PR TITLE
Add Form\Element labelOptions property w/ implemented use case

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -16,6 +16,7 @@ use Zend\Stdlib\InitializableInterface;
 class Element implements
     ElementAttributeRemovalInterface,
     ElementInterface,
+    LabelAwareInterface,
     InitializableInterface
 {
     /**
@@ -34,9 +35,13 @@ class Element implements
     protected $labelAttributes;
 
     /**
-     * @var array label specific options
+     * Label specific options
+     *
+     * @var array
      */
-    protected $labelOptions = array();
+    protected $labelOptions = array(
+        'disable_html_escape' => false
+    );
 
     /**
      * @var array Validation error messages

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -34,6 +34,11 @@ class Element implements
     protected $labelAttributes;
 
     /**
+     * @var array label specific options
+     */
+    protected $labelOptions = array();
+
+    /**
      * @var array Validation error messages
      */
     protected $messages = array();
@@ -121,6 +126,10 @@ class Element implements
 
         if (isset($options['label_attributes'])) {
             $this->setLabelAttributes($options['label_attributes']);
+        }
+
+        if (isset($options['label_options'])) {
+            $this->setLabelOptions($options['label_options']);
         }
 
         $this->options = $options;
@@ -335,6 +344,28 @@ class Element implements
     public function getLabelAttributes()
     {
         return $this->labelAttributes;
+    }
+
+    /**
+     * Set label specific options
+     *
+     * @param array $labelOptions
+     * @return Element|ElementInterface
+     */
+    public function setLabelOptions(array $labelOptions)
+    {
+        $this->labelOptions = $labelOptions;
+        return $this;
+    }
+
+    /**
+     * Get label specific options
+     *
+     * @return array
+     */
+    public function getLabelOptions()
+    {
+        return $this->labelOptions;
     }
 
     /**

--- a/library/Zend/Form/ElementInterface.php
+++ b/library/Zend/Form/ElementInterface.php
@@ -112,6 +112,7 @@ interface ElementInterface
     /**
      * Set the label (if any) used for this element
      *
+     * @todo remove redundancy with LabelAwareInterface
      * @param  $label
      * @return ElementInterface
      */
@@ -120,6 +121,7 @@ interface ElementInterface
     /**
      * Retrieve the label (if any) used for this element
      *
+     * @todo remove redundancy with LabelAwareInterface
      * @return string
      */
     public function getLabel();

--- a/library/Zend/Form/LabelAwareInterface.php
+++ b/library/Zend/Form/LabelAwareInterface.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form;
+
+interface LabelAwareInterface
+{
+    /**
+     * Set the label (if any) used for this element
+     *
+     * @param  $label
+     * @return LabelAwareInterface
+     */
+    public function setLabel($label);
+
+    /**
+     * Retrieve the label (if any) used for this element
+     *
+     * @return string
+     */
+    public function getLabel();
+
+    /**
+     * Set the attributes to use with the label
+     *
+     * @param array $labelAttributes
+     * @return LabelAwareInterface
+     */
+    public function setLabelAttributes(array $labelAttributes);
+
+    /**
+     * Get the attributes to use with the label
+     *
+     * @return array
+     */
+    public function getLabelAttributes();
+
+    /**
+     * Set label specific options
+     *
+     * @param array $labelOptions
+     * @return LabelAwareInterface
+     */
+    public function setLabelOptions(array $labelOptions);
+
+    /**
+     * Get label specific options
+     *
+     * @return array
+     */
+    public function getLabelOptions();
+}

--- a/library/Zend/Form/LabelAwareTrait.php
+++ b/library/Zend/Form/LabelAwareTrait.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form;
+
+class LabelAwareTrait
+{
+    /**
+     * Label content
+     *
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * Label specific html attributes
+     *
+     * @var array
+     */
+    protected $labelAttributes;
+
+    /**
+     * Label specific options
+     *
+     * @var array
+     */
+    protected $labelOptions = array(
+        'disable_html_escape' => false
+    );
+
+    /**
+     * Set the label used for this element
+     *
+     * @param $label
+     * @return LabelAwareInterface
+     */
+    public function setLabel($label)
+    {
+        if (is_string($label)) {
+            $this->label = $label;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the label used for this element
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * Set the attributes to use with the label
+     *
+     * @param array $labelAttributes
+     * @return LabelAwareInterface
+     */
+    public function setLabelAttributes(array $labelAttributes)
+    {
+        $this->labelAttributes = $labelAttributes;
+        return $this;
+    }
+
+    /**
+     * Get the attributes to use with the label
+     *
+     * @return array
+     */
+    public function getLabelAttributes()
+    {
+        return $this->labelAttributes;
+    }
+
+    /**
+     * Set label specific options
+     *
+     * @param array $labelOptions
+     * @return LabelAwareInterface
+     */
+    public function setLabelOptions(array $labelOptions)
+    {
+        $this->labelOptions = $labelOptions;
+        return $this;
+    }
+
+    /**
+     * Get label specific options
+     *
+     * @return array
+     */
+    public function getLabelOptions()
+    {
+        return $this->labelOptions;
+    }
+}

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -11,6 +11,7 @@ namespace Zend\Form\View\Helper;
 
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
+use Zend\Form\LabelAwareInterface;
 
 class FormLabel extends AbstractHelper
 {
@@ -118,14 +119,14 @@ class FormLabel extends AbstractHelper
             ));
         }
 
-        // @todo ElementInterface may not provide label specific methods
-        if (method_exists($attributesOrElement, 'getLabelAttributes')) {
+        $labelAttributes = array();
+        if ($attributesOrElement instanceof LabelAwareInterface) {
             $labelAttributes = $attributesOrElement->getLabelAttributes();
         }
 
         $attributes = array('for' => $id);
 
-        if (isset($labelAttributes) && !empty($labelAttributes)) {
+        if (!empty($labelAttributes)) {
             $attributes = array_merge($labelAttributes, $attributes);
         }
 

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -118,10 +118,14 @@ class FormLabel extends AbstractHelper
             ));
         }
 
-        $labelAttributes = $attributesOrElement->getLabelAttributes();
+        // @todo ElementInterface may not provide label specific methods
+        if (method_exists($attributesOrElement, 'getLabelAttributes')) {
+            $labelAttributes = $attributesOrElement->getLabelAttributes();
+        }
+
         $attributes = array('for' => $id);
 
-        if (!empty($labelAttributes)) {
+        if (isset($labelAttributes) && !empty($labelAttributes)) {
             $attributes = array_merge($labelAttributes, $attributes);
         }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -12,6 +12,7 @@ namespace Zend\Form\View\Helper;
 use Zend\Form\Element\Button;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
+use Zend\Form\LabelAwareInterface;
 use Zend\Form\View\Helper\AbstractHelper;
 
 class FormRow extends AbstractHelper
@@ -160,19 +161,20 @@ class FormRow extends AbstractHelper
         $elementString = $elementHelper->render($element);
 
         if (isset($label) && '' !== $label) {
-            // @todo ElementInterface may not provide label specific methods
-            if (method_exists($element, 'getLabelOptions')) {
+
+            $labelOptions = array();
+            $labelAttributes = array();
+
+            if ($element instanceof LabelAwareInterface) {
                 $labelOptions = $element->getLabelOptions();
-            }
-            if (method_exists($element, 'getLabelAttributes')) {
                 $labelAttributes = $element->getLabelAttributes();
             }
 
-            if ( !isset($labelOptions['disable_escape']) || $labelOptions['disable_escape'] == false) {
+            if (empty($labelOptions) || $labelOptions['disable_html_escape'] == false) {
                 $label = $escapeHtmlHelper($label);
             }
 
-            if ( !isset($labelAttributes) || empty($labelAttributes)) {
+            if (empty($labelAttributes)) {
                 $labelAttributes = $this->labelAttributes;
             }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -160,10 +160,19 @@ class FormRow extends AbstractHelper
         $elementString = $elementHelper->render($element);
 
         if (isset($label) && '' !== $label) {
-            $label = $escapeHtmlHelper($label);
-            $labelAttributes = $element->getLabelAttributes();
+            // ElementInterface may not provide label specific methods
+            if (method_exists($element, 'getLabelOptions')) {
+                $labelOptions = $element->getLabelOptions();
+            }
+            if (method_exists($element, 'getLabelAttributes')) {
+                $labelAttributes = $element->getLabelAttributes();
+            }
 
-            if (empty($labelAttributes)) {
+            if ( !isset($labelOptions['disable_escape']) || $labelOptions['disable_escape'] == false) {
+                $label = $escapeHtmlHelper($label);
+            }
+
+            if ( !isset($labelAttributes) || empty($labelAttributes)) {
                 $labelAttributes = $this->labelAttributes;
             }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -160,7 +160,7 @@ class FormRow extends AbstractHelper
         $elementString = $elementHelper->render($element);
 
         if (isset($label) && '' !== $label) {
-            // ElementInterface may not provide label specific methods
+            // @todo ElementInterface may not provide label specific methods
             if (method_exists($element, 'getLabelOptions')) {
                 $labelOptions = $element->getLabelOptions();
             }

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -159,8 +159,8 @@ class ElementTest extends TestCase
     {
         $element = new Element('foo');
         $element->setOptions(array(
-                                 'label' => 'foo',
-                                 'label_attributes' => array('bar' => 'baz')
+                                  'label' => 'foo',
+                                  'label_attributes' => array('bar' => 'baz')
                              ));
         $option = $element->getOption('label_attributes');
         $this->assertEquals(array('bar' => 'baz'), $option);

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -155,23 +155,26 @@ class ElementTest extends TestCase
         $this->assertEquals('option', $option);
     }
 
+    public function testSpecificOptionsSetLabelAttributes()
+    {
+        $element = new Element('foo');
+        $element->setOptions(array(
+                                 'label' => 'foo',
+                                 'label_attributes' => array('bar' => 'baz')
+                             ));
+        $option = $element->getOption('label_attributes');
+        $this->assertEquals(array('bar' => 'baz'), $option);
+    }
+
     public function testLabelOptionsAccessors()
     {
         $element = new Element('foo');
         $element->setOptions(array(
-                                  'label' => 'foo',
-                                  'label_attributes' => array('bar' => 'baz'),
                                   'label_options' => array('moar' => 'foo')
                              ));
 
-        $option = $element->getLabel();
-        $this->assertEquals('foo', $option);
-
-        $option = $element->getLabelAttributes();
-        $this->assertEquals(array('bar' => 'baz'), $option);
-
-        $option = $element->getLabelOptions();
-        $this->assertEquals(array('moar' => 'foo'), $option);
+        $labelOptions = $element->getLabelOptions();
+        $this->assertEquals(array('moar' => 'foo'), $labelOptions);
     }
 
     public function testSetOptionsWrongInputRaisesException()

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -155,15 +155,23 @@ class ElementTest extends TestCase
         $this->assertEquals('option', $option);
     }
 
-    public function testSpecificOptionsSetLabelAttributes()
+    public function testLabelOptionsAccessors()
     {
         $element = new Element('foo');
         $element->setOptions(array(
                                   'label' => 'foo',
-                                  'label_attributes' => array('bar' => 'baz')
+                                  'label_attributes' => array('bar' => 'baz'),
+                                  'label_options' => array('moar' => 'foo')
                              ));
-        $option = $element->getOption('label_attributes');
+
+        $option = $element->getLabel();
+        $this->assertEquals('foo', $option);
+
+        $option = $element->getLabelAttributes();
         $this->assertEquals(array('bar' => 'baz'), $option);
+
+        $option = $element->getLabelOptions();
+        $this->assertEquals(array('moar' => 'foo'), $option);
     }
 
     public function testSetOptionsWrongInputRaisesException()

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -159,9 +159,9 @@ class ElementTest extends TestCase
     {
         $element = new Element('foo');
         $element->setOptions(array(
-                                  'label' => 'foo',
-                                  'label_attributes' => array('bar' => 'baz')
-                             ));
+            'label' => 'foo',
+            'label_attributes' => array('bar' => 'baz')
+        ));
         $option = $element->getOption('label_attributes');
         $this->assertEquals(array('bar' => 'baz'), $option);
     }
@@ -170,8 +170,8 @@ class ElementTest extends TestCase
     {
         $element = new Element('foo');
         $element->setOptions(array(
-                                  'label_options' => array('moar' => 'foo')
-                             ));
+            'label_options' => array('moar' => 'foo')
+        ));
 
         $labelOptions = $element->getLabelOptions();
         $this->assertEquals(array('moar' => 'foo'), $labelOptions);

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -391,7 +391,7 @@ class FormRowTest extends TestCase
         $label = '<span>foo</span>';
         $element = new Element('fooname');
         $element->setLabel($label);
-        $element->setLabelOptions(array('disable_escape' => true));
+        $element->setLabelOptions(array('disable_html_escape' => true));
 
         $markup = $this->helper->__invoke($element);
 

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -372,4 +372,29 @@ class FormRowTest extends TestCase
         $markup = $this->helper->render($element);
         $this->assertRegexp('#^<button type="button" name="button" value=""\/?>foo</button>$#', $markup);
     }
+
+    public function testAssertLabelHtmlEscapeIsOnByDefault()
+    {
+        $element = new Element('fooname');
+        $escapeHelper = $this->renderer->getHelperPluginManager()->get('escapeHtml');
+
+        $label = '<span>foo</span>';
+        $element->setLabel($label);
+
+        $markup = $this->helper->__invoke($element);
+
+        $this->assertContains($escapeHelper->__invoke($label), $markup);
+    }
+
+    public function testCanDisableLabelHtmlEscape()
+    {
+        $label = '<span>foo</span>';
+        $element = new Element('fooname');
+        $element->setLabel($label);
+        $element->setLabelOptions(array('disable_escape' => true));
+
+        $markup = $this->helper->__invoke($element);
+
+        $this->assertContains($label, $markup);
+    }
 }


### PR DESCRIPTION
Having a `labelOptions` array of dedicated properties for the form labels makes custom rendering of the form a bit easier.

One use case is the possibilty to disable HTML escaping of the label text.

A common use case for this is an hyper link inside the label, which pretty much any html form with a 'privacy terms' checkbox needs.

Since `Form\View\Helper\FormRow` escapes the label content, the only way of doing this at the moment is using custom view templates using a wide range of form view helpers.

That denies the purpose of `Form\View\Helper\Form` and `Form\View\Helper\FormRow`.

This PR adds `labelOptions` property and accessors to the `Form\Element` class, and handles the `disable_html_escape` option in `Form\View\Helper\FormRow`.

I reckon that adding an array to the `Form\Element` class just to handle a view helper option may seem a bit overkill in this case, but I'm looking from a wider angle: being able to tie custom options to the form element label itself gives much more flexibility when developing custom view templates and helpers; the example above is just the simplest I had to deal with.
