### PR TITLE
!IE support for conditional comments powered viewhelper

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -289,6 +289,10 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             && !empty($attributes['conditionalStylesheet'])
             && is_string($attributes['conditionalStylesheet']))
         {
+            // inner wrap with comment end and start if !IE
+            if (str_replace(' ', '', $attributes['conditionalStylesheet']) === '!IE') {
+                $link = ' <!-->' . $link . '<!-- ';
+            }
             $link = '<!--[if ' . $attributes['conditionalStylesheet'] . ']> ' . $link . '<![endif]-->';
         }
 

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -291,9 +291,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $attributes['conditionalStylesheet']) === '!IE') {
-                $link = ' <!-->' . $link . '<!-- ';
+                $link = '<!-->' . $link . '<!--';
             }
-            $link = '<!--[if ' . $attributes['conditionalStylesheet'] . ']> ' . $link . '<![endif]-->';
+            $link = '<!--[if ' . $attributes['conditionalStylesheet'] . ']>' . $link . '<![endif]-->';
         }
 
         return $link;

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -271,7 +271,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
         {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $item->modifiers['conditional']) === '!IE') {
-                $meta = ' <!-->' . $meta . '<!-- ';
+                $meta = '<!-->' . $meta . '<!--';
             }
             $meta = '<!--[if ' . $this->escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
         }

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -269,6 +269,10 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             && !empty($item->modifiers['conditional'])
             && is_string($item->modifiers['conditional']))
         {
+            // inner wrap with comment end and start if !IE
+            if (str_replace(' ', '', $item->modifiers['conditional']) === '!IE') {
+                $meta = ' <!-->' . $meta . '<!-- ';
+            }
             $meta = '<!--[if ' . $this->escape($item->modifiers['conditional']) . ']>' . $meta . '<![endif]-->';
         }
 

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -408,6 +408,10 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
             && !empty($item->attributes['conditional'])
             && is_string($item->attributes['conditional']))
         {
+            // inner wrap with comment end and start if !IE
+            if (str_replace(' ', '', $item->attributes['conditional']) === '!IE') {
+                $html = ' <!-->' . $html . '<!-- ';
+            }
             $html = $indent . '<!--[if ' . $item->attributes['conditional'] . ']>' . $html . '<![endif]-->';
         } else {
             $html = $indent . $html;

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -410,7 +410,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $item->attributes['conditional']) === '!IE') {
-                $html = ' <!-->' . $html . '<!-- ';
+                $html = '<!-->' . $html . '<!--';
             }
             $html = $indent . '<!--[if ' . $item->attributes['conditional'] . ']>' . $html . '<![endif]-->';
         } else {

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -335,9 +335,9 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
         if (null == $escapeStart && null == $escapeEnd) {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $item->attributes['conditional']) === '!IE') {
-                $html = ' <!-->' . $html . '<!-- ';
+                $html = '<!-->' . $html . '<!--';
             }
-            $html = '<!--[if ' . $item->attributes['conditional'] . ']> ' . $html . '<![endif]-->';
+            $html = '<!--[if ' . $item->attributes['conditional'] . ']>' . $html . '<![endif]-->';
         }
 
         return $html;

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -333,6 +333,10 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
             . '</style>';
 
         if (null == $escapeStart && null == $escapeEnd) {
+            // inner wrap with comment end and start if !IE
+            if (str_replace(' ', '', $item->attributes['conditional']) === '!IE') {
+                $html = ' <!-->' . $html . '<!-- ';
+            }
             $html = '<!--[if ' . $item->attributes['conditional'] . ']> ' . $html . '<![endif]-->';
         }
 

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -277,6 +277,32 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('<![endif]-->', $string);
     }
 
+    public function testConditionalStylesheetCreationNoIE()
+    {
+        $this->helper->setStylesheet('/styles.css', 'screen', '!IE');
+        $item = $this->helper->getValue();
+        $this->assertObjectHasAttribute('conditionalStylesheet', $item);
+        $this->assertEquals('!IE', $item->conditionalStylesheet);
+
+        $string = $this->helper->toString();
+        $this->assertContains('/styles.css', $string);
+        $this->assertContains('<!--[if !IE]><!--><', $string);
+        $this->assertContains('<!--<![endif]-->', $string);
+    }
+
+    public function testConditionalStylesheetCreationNoIEWidthSpaces()
+    {
+        $this->helper->setStylesheet('/styles.css', 'screen', '! IE');
+        $item = $this->helper->getValue();
+        $this->assertObjectHasAttribute('conditionalStylesheet', $item);
+        $this->assertEquals('! IE', $item->conditionalStylesheet);
+
+        $string = $this->helper->toString();
+        $this->assertContains('/styles.css', $string);
+        $this->assertContains('<!--[if ! IE]><!--><', $string);
+        $this->assertContains('<!--<![endif]-->', $string);
+    }
+
     public function testSettingAlternateWithTooFewArgsRaisesException()
     {
         try {

--- a/tests/ZendTest/View/Helper/HeadMetaTest.php
+++ b/tests/ZendTest/View/Helper/HeadMetaTest.php
@@ -529,5 +529,20 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp("|^<!--\[if lt IE 7\]>|", $html);
         $this->assertRegExp("|<!\[endif\]-->$|", $html);
     }
+    
+    public function testConditionalNoIE()
+    {
+        $html = $this->helper->appendHttpEquiv('foo', 'bar', array('conditional' => '!IE'))->toString();
+        
+        $this->assertContains('<!--[if !IE]><!--><', $html);
+        $this->assertContains('<!--<![endif]-->', $html);
+    }
 
+    public function testConditionalNoIEWidthSpace()
+    {
+        $html = $this->helper->appendHttpEquiv('foo', 'bar', array('conditional' => '! IE'))->toString();
+        
+        $this->assertContains('<!--[if ! IE]><!--><', $html);
+        $this->assertContains('<!--<![endif]-->', $html);
+    }
 }

--- a/tests/ZendTest/View/Helper/HeadScriptTest.php
+++ b/tests/ZendTest/View/Helper/HeadScriptTest.php
@@ -379,6 +379,30 @@ document.write(bar.strlen());');
         $this->assertContains('    <!--[if lt IE 7]>', $test);
     }
 
+    public function testConditionalScriptNoIE()
+    {
+        $this->helper->setAllowArbitraryAttributes(true);
+        $this->helper->appendFile(
+            '/js/foo.js', 'text/javascript', array('conditional' => '!IE')
+        );
+        $test = $this->helper->toString();
+
+        $this->assertContains('<!--[if !IE]><!--><', $test);
+        $this->assertContains('<!--<![endif]-->', $test);
+    }
+
+    public function testConditionalScriptNoIEWidthSpace()
+    {
+        $this->helper->setAllowArbitraryAttributes(true);
+        $this->helper->appendFile(
+            '/js/foo.js', 'text/javascript', array('conditional' => '! IE')
+        );
+        $test = $this->helper->toString();
+
+        $this->assertContains('<!--[if ! IE]><!--><', $test);
+        $this->assertContains('<!--<![endif]-->', $test);
+    }
+    
     /**
      * @issue ZF-5435
      */

--- a/tests/ZendTest/View/Helper/HeadStyleTest.php
+++ b/tests/ZendTest/View/Helper/HeadStyleTest.php
@@ -362,6 +362,28 @@ a {
         $this->assertContains('<!--[if lt IE 7]>', $test);
     }
 
+    public function testConditionalScriptNoIE()
+    {
+        $this->helper->appendStyle('
+a {
+    display: none;
+}', array('media' => 'screen,projection', 'conditional' => '!IE'));
+        $test = $this->helper->toString();
+        $this->assertContains('<!--[if !IE]><!--><', $test);
+        $this->assertContains('<!--<![endif]-->', $test);
+    }
+    
+    public function testConditionalScriptNoIEWidthSpace()
+    {
+        $this->helper->appendStyle('
+a {
+    display: none;
+}', array('media' => 'screen,projection', 'conditional' => '! IE'));
+        $test = $this->helper->toString();
+        $this->assertContains('<!--[if ! IE]><!--><', $test);
+        $this->assertContains('<!--<![endif]-->', $test);
+    }
+
     /**
      * @issue ZF-5435
      */


### PR DESCRIPTION
Support for conditional comments with !IE by adding the inner wrap with comment end and start.

&lt;!--[if IE 6]&gt;
&lt;p&gt;You are using Internet Explorer 6.&lt;/p&gt;
&lt;![endif]--&gt;
&lt;!--[if !IE]&gt;&lt;!--&gt;
&lt;p&gt;You are not using Internet Explorer.&lt;/p&gt;
&lt;!--&lt;![endif]--&gt;
