### PR TITLE
StripTags filter should not touch non-strings

### DIFF
--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -173,6 +173,11 @@ class StripTags extends AbstractFilter
      */
     public function filter($value)
     {
+        // Do not filter non-string values
+        if (!is_string($value)) {
+            return $value;
+        }
+
         $value = (string) $value;
 
         // Strip HTML comments first

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Filter;
 
+use stdClass;
 use Zend\Filter\StripTags as StripTagsFilter;
 
 /**
@@ -537,5 +538,18 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
         $this->_filter->setAttributesAllowed(array('data-id','data-name'));
 
         $this->assertEquals($expected, $this->_filter->filter($input));
+    }
+
+    public function testFilterDoesNotTouchNonStrings()
+    {
+        $input = new stdClass();
+
+        $expected = $input;
+        $actual = $this->_filter->filter($input);
+
+        $this->assertSame(
+            $expected,
+            $actual
+        );
     }
 }


### PR DESCRIPTION
In my opinion, the `StripTags` filter should not touch non-string values.

This PR fixes that.

For comparison, see e.g., `StringTrim` filter.
