### PR TITLE
The Redirect plugin now supports a code for the redirect, either 301 or ...

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -63,14 +63,14 @@ class Redirect extends AbstractPlugin
     public function toUrl($url, $code = Response::STATUS_CODE_302)
     {
         //ensure we only allow one of these 2 redirect codes
-        if ($code == Response::STATUS_CODE_301 || $code == Response::STATUS_CODE_302) {
-            $response = $this->getResponse();
-            $response->getHeaders()->addHeaderLine('Location', $url);
-            $response->setStatusCode($code);
-            return $response;
-        } else {
+        if ($code != Response::STATUS_CODE_301 && $code != Response::STATUS_CODE_302) {
             throw new Exception\InvalidArgumentException('Redirect needs to be 301 or 302');
         }
+        
+        $response = $this->getResponse();
+        $response->getHeaders()->addHeaderLine('Location', $url);
+        $response->setStatusCode($code);
+        return $response;
     }
 
     /**

--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -29,11 +29,18 @@ class Redirect extends AbstractPlugin
      * @param  array $params Parameters to use in url generation, if any
      * @param  array $options RouteInterface-specific options to use in url generation, if any
      * @param  bool $reuseMatchedParams Whether to reuse matched parameters
+     * @param  int $code The redirect code, either 301 or 302 (default 302)
      * @return Response
      * @throws Exception\DomainException if composed controller does not implement InjectApplicationEventInterface, or
      *         router cannot be found in controller event
      */
-    public function toRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false)
+    public function toRoute(
+        $route = null,
+        $params = array(),
+        $options = array(),
+        $reuseMatchedParams = false,
+        $code = Response::STATUS_CODE_302
+    )
     {
         $controller = $this->getController();
         if (!$controller || !method_exists($controller, 'plugin')) {
@@ -48,7 +55,7 @@ class Redirect extends AbstractPlugin
             $url = $urlPlugin->fromRoute($route, $params, $options, $reuseMatchedParams);
         }
 
-        return $this->toUrl($url);
+        return $this->toUrl($url, $code);
     }
 
     /**

--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -55,14 +55,22 @@ class Redirect extends AbstractPlugin
      * Redirect to the given URL
      *
      * @param  string $url
+     * @param  int $code Either 301 or 302, depending on type (default 302)
      * @return Response
+     * @throws Exception\InvalidArgumentException if the redirect type is
+     *         not a valid type (i.e. not 301 or 302)
      */
-    public function toUrl($url)
+    public function toUrl($url, $code = Response::STATUS_CODE_302)
     {
-        $response = $this->getResponse();
-        $response->getHeaders()->addHeaderLine('Location', $url);
-        $response->setStatusCode(302);
-        return $response;
+        //ensure we only allow one of these 2 redirect codes
+        if ($code == Response::STATUS_CODE_301 || $code == Response::STATUS_CODE_302) {
+            $response = $this->getResponse();
+            $response->getHeaders()->addHeaderLine('Location', $url);
+            $response->setStatusCode($code);
+            return $response;
+        } else {
+            throw new Exception\InvalidArgumentException('Redirect needs to be 301 or 302');
+        }
     }
 
     /**

--- a/tests/ZendTest/Mvc/Controller/Plugin/RedirectTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/RedirectTest.php
@@ -69,6 +69,22 @@ class RedirectTest extends TestCase
         $this->assertEquals('/foo', $location->getFieldValue());
     }
 
+    public function testPluginCanRedirectToUrlWithPermanentCode()
+    {
+        $response = $this->plugin->toUrl('/foo', Response::STATUS_CODE_301);
+        $this->assertTrue($response->isRedirect());
+        $this->assertEquals(Response::STATUS_CODE_301, $response->getStatusCode());
+        $headers = $response->getHeaders();
+        $location = $headers->get('Location');
+        $this->assertEquals('/foo', $location->getFieldValue());
+    }
+
+    public function testPluginRedirectFailsWithInvalidCode()
+    {
+        $this->setExpectedException('Zend\Mvc\Exception\InvalidArgumentException', 'Redirect needs to be 301 or 302');
+        $response = $this->plugin->toUrl('/sauce', 200);
+    }
+
     public function testPluginWithoutControllerRaisesDomainException()
     {
         $plugin = new RedirectPlugin();


### PR DESCRIPTION
Hi there!

The redirect plugin for controllers needs to be a bit more configureable for redirects. In some cases a 301 redirect is desirable, so I've made a small modification to allow for that. By default, the plugin works as it did before. It issues a 302 (temporary) redirect. All the Mvc tests pass with this modification.

The modification allows you to call the plugin with a second parameter that must be either `\Zend\Http\Response::STATUS_CODE_301` or `\Zend\Http\Response::STATUS_CODE_302` otherwise a `\Zend\Mvc\Exception\InvalidArgumentException` will be thrown.

The associated test changes are also in this commit (runs and passes, woo hoo!).

Note that this is not an API break.

Thank you for your consideration!

Nick
