### PR TITLE
Update InputFilter Factory

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -273,14 +273,14 @@ class Factory
             $inputFilterSpecification = ArrayUtils::iteratorToArray($inputFilterSpecification);
         }
 
-        $type = 'Zend\InputFilter\InputFilter';
-
         if (isset($inputFilterSpecification['type']) && is_string($inputFilterSpecification['type'])) {
-            $type = $inputFilterSpecification['type'];
+            $inputFilter = $this->getInputFilterManager()->get($inputFilterSpecification['type']);
             unset($inputFilterSpecification['type']);
         }
+        else {
+            $inputFilter = new InputFilter;
+        }
 
-        $inputFilter = $this->getInputFilterManager()->get($type);
 
         if ($inputFilter instanceof CollectionInputFilter) {
             if (isset($inputFilterSpecification['input_filter'])) {


### PR DESCRIPTION
Use InputFilterManager only if there is a input filter type specified in the $inputFilterSpecification.

In case where we implements InputFilterProviderInterface in differents sub fieldsets, we get an error because the InputFilter is shared between fieldsets and all fields are in the same root of input filter.
