### PR TITLE
Zend\Mail\Protocol\Smtp does not reset protected $auth after disconnect

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -348,6 +348,7 @@ class Smtp extends AbstractProtocol
     public function quit()
     {
         if ($this->sess) {
+            $this->auth = false;
             $this->_send('QUIT');
             $this->_expect(221, 300); // Timeout set for 5 minutes as per RFC 2821 4.5.3.2
             $this->_stopSession();

--- a/tests/ZendTest/Mail/Protocol/SmtpTest.php
+++ b/tests/ZendTest/Mail/Protocol/SmtpTest.php
@@ -66,4 +66,14 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->connection->disconnect();
         $this->assertTrue($this->connection->calledQuit);
     }
+
+    public function testDisconnectResetsAuthFlag()
+    {
+        $this->connection->connect();
+        $this->connection->setSessionStatus(true);
+        $this->connection->setAuth(true);
+        $this->assertTrue($this->connection->getAuth());
+        $this->connection->disconnect();
+        $this->assertFalse($this->connection->getAuth());
+    }
 }

--- a/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
+++ b/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
@@ -29,6 +29,7 @@ class SmtpProtocolSpy extends Smtp
     public function connect()
     {
         $this->connect = true;
+
         return true;
     }
 
@@ -121,12 +122,13 @@ class SmtpProtocolSpy extends Smtp
     /**
      * Set Auth Status
      *
-     * @param bool $status
+     * @param  bool $status
      * @return self
      */
     public function setAuth($status)
     {
         $this->auth = (bool) $status;
+
         return $this;
     }
 
@@ -143,12 +145,13 @@ class SmtpProtocolSpy extends Smtp
     /**
      * Set Session Status
      *
-     * @param bool $status
+     * @param  bool $status
      * @return self
      */
     public function setSessionStatus($status)
     {
         $this->sess = (bool) $status;
+
         return $this;
     }
 }

--- a/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
+++ b/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
@@ -107,4 +107,48 @@ class SmtpProtocolSpy extends Smtp
     {
         return $this->rcptTest;
     }
+
+    /**
+     * Get Auth Status
+     *
+     * @return bool
+     */
+    public function getAuth()
+    {
+        return $this->auth;
+    }
+
+    /**
+     * Set Auth Status
+     *
+     * @param bool $status
+     * @return self
+     */
+    public function setAuth($status)
+    {
+        $this->auth = (bool) $status;
+        return $this;
+    }
+
+    /**
+     * Get Session Status
+     *
+     * @return bool
+     */
+    public function getSessionStatus()
+    {
+        return $this->sess;
+    }
+
+    /**
+     * Set Session Status
+     *
+     * @param bool $status
+     * @return self
+     */
+    public function setSessionStatus($status)
+    {
+        $this->sess = (bool) $status;
+        return $this;
+    }
 }


### PR DESCRIPTION
I use an offline worker process to process sending out of emails, as such keeping a connection open too long can cause issues with timeouts.  Therefore I have my worker disconnect when it hits an internal timeout.  Example:

``` php
    public function wait()
    {   
        if ($this->isConnected) {
            $this->log('disconnecting');
            $this->mail->disconnect();
            $this->isConnected = false;
        }   

        return parent::wait();
    } 
```

When it re-connects and attempts to send out an email, it fatally errors: Fatal error: Already authenticated for this session in /var/www/vendor/zendframework/zendframework/library/Zend/Mail/Protocol/Smtp.php on line 368

This is due to when the disconnect portion of the mail code is hit, it does not actually reset the $auth flag.  As you can see from a greg command there is no place in where the flag is set back to false and is always true if you keep the same instance around and reuse it.

This change does 2 things:
1. The SmtpProtocolSpy test asset has to have methods to set and get the protected members ($auth and $sess).
    We need both of these for simple reasons; $auth because we need to manually set it since we actually never really call any of the methods and secondly $sess because otherwise the ->quit() method would never actually make it into the block.
1. Changes the quit() method to contain $this->auth = false (since this is indeed where most of the cleanup methods are for disconnect().
