### PR TITLE
added zendframework/zend-resources to the global composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "zendframework/zend-permissions-acl": "self.version",
         "zendframework/zend-permissions-rbac": "self.version",
         "zendframework/zend-progressbar": "self.version",
+        "zendframework/zend-resources": "self.version",
         "zendframework/zend-serializer": "self.version",
         "zendframework/zend-server": "self.version",
         "zendframework/zend-servicemanager": "self.version",

--- a/library/Zend/Captcha/composer.json
+++ b/library/Zend/Captcha/composer.json
@@ -21,7 +21,8 @@
         "zendframework/zendservice-recaptcha": "*"
     },
     "suggest": {
-        "zendframework/zendservice-recaptcha": "ZendService\\ReCaptcha component"
+        "zendframework/zendservice-recaptcha": "ZendService\\ReCaptcha component",
+        "zendframework/zend-resources": "Translations of captcha messages"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/I18n/composer.json
+++ b/library/Zend/I18n/composer.json
@@ -21,7 +21,8 @@
         "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",
         "zendframework/zend-filter": "You should install this package to use the provided filters",
         "zendframework/zend-validator": "You should install this package to use the provided validators",
-        "zendframework/zend-view": "You should install this package to use the provided view helpers"
+        "zendframework/zend-view": "You should install this package to use the provided view helpers",
+        "zendframework/zend-resources": "Translation resources"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -25,6 +25,7 @@
         "zendframework/zend-db": "Zend\\Db component",
         "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
         "zendframework/zend-math": "Zend\\Math component",
+        "zendframework/zend-resources": "Translations of validator messages",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains"
     },
     "extra": {


### PR DESCRIPTION
I added `zendframework/zend-resources` to the global `composer.json` file (on `replace` section) to make it installable without installing the hole framework.

_NOTE:_ The package `zendframework/zend-resources` is also missing on https://packages.zendframework.com/
