### PR TITLE
[WIP] Enforcing composer version in travis builds

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,6 +24,7 @@
                 <arg value="--version" />
             </exec>
             <exec executable="composer" failonerror="true">
+                <env key="COMPOSER_ROOT_VERSION" value="dev-master"/>
                 <arg value="install" />
                 <arg value="--dev" />
                 <arg value="--prefer-source" />


### PR DESCRIPTION
Since travis now checks out branches in detached head, this fix basically tells composer that the current branch is "dev-master"
