### PR TITLE
Error messages in Zend\Form\View\Helper\FormElementErrors are now being translated

### DIFF
--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -78,8 +78,9 @@ class FormElementErrors extends AbstractHelper
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml) {
-                $messagesToPrint[] = $escapeHtml($item);
+        $translator = $this->getTranslator();
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, $translator) {
+                $messagesToPrint[] = $escapeHtml($translator->translate($item));
             });
 
         if (empty($messagesToPrint)) {


### PR DESCRIPTION
This is regarding issue Issue #4697.

Custom validation errors were not translated by the view helper, what made it inconsistant with other form view helpers, for example FormLabel.
