### PR TITLE
PHP 5.5 can't fail anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
   - 5.4
   - 5.5
 
-matrix:
-  allow_failures:
-    - php: 5.5
-
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
 


### PR DESCRIPTION
With the release of the first stable PHP 5.5 version, travis is no more allowed to fail.
