### PR TITLE
Removing 5.5 from allowed failures now that it is stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
   - 5.4
   - 5.5
 
-matrix:
-  allow_failures:
-    - php: 5.5
-
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
 


### PR DESCRIPTION
As of http://php.net/archive/2013.php#id2013-06-20-1
