### PR TITLE
Use Zend\Crypt\Hmac for CRAM-MD5

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp/Auth/Crammd5.php
+++ b/library/Zend/Mail/Protocol/Smtp/Auth/Crammd5.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mail\Protocol\Smtp\Auth;
 
+use Zend\Crypt\Hmac;
 use Zend\Mail\Protocol\Smtp;
 
 /**
@@ -66,8 +67,7 @@ class Crammd5 extends Smtp
 
 
     /**
-     * @todo Perform CRAM-MD5 authentication with supplied credentials
-     *
+     * Performs CRAM-MD5 authentication with supplied credentials
      */
     public function auth()
     {
@@ -132,23 +132,11 @@ class Crammd5 extends Smtp
      *
      * @param  string $key   Challenge key (usually password)
      * @param  string $data  Challenge data
-     * @param  int    $block Length of blocks
+     * @param  int    $block Length of blocks (deprecated; unused)
      * @return string
      */
     protected function _hmacMd5($key, $data, $block = 64)
     {
-        if (strlen($key) > 64) {
-            $key = pack('H32', md5($key));
-        } elseif (strlen($key) < 64) {
-            $key = str_pad($key, $block, "\0");
-        }
-
-        $kIpad = substr($key, 0, 64) ^ str_repeat(chr(0x36), 64);
-        $kOpad = substr($key, 0, 64) ^ str_repeat(chr(0x5C), 64);
-
-        $inner = pack('H32', md5($kIpad . $data));
-        $digest = md5($kOpad . $inner);
-
-        return $digest;
+        return Hmac::compute($key, 'md5', $data);
     }
 }

--- a/library/Zend/Mail/composer.json
+++ b/library/Zend/Mail/composer.json
@@ -14,6 +14,7 @@
     "target-dir": "Zend/Mail",
     "require": {
         "php": ">=5.3.3",
+        "zendframework/zend-crypt": "self.version",
         "zendframework/zend-loader": "self.version",
         "zendframework/zend-mime": "self.version",
         "zendframework/zend-stdlib": "self.version"

--- a/tests/ZendTest/Mail/Protocol/Smtp/Auth/Crammd5Test.php
+++ b/tests/ZendTest/Mail/Protocol/Smtp/Auth/Crammd5Test.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Mail
+ */
+
+namespace ZendTest\Mail\Protocol\Smtp\Auth;
+
+use ReflectionClass;
+use Zend\Mail\Protocol\Smtp\Auth\Crammd5;
+
+/**
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @group      Zend_Mail
+ */
+class Crammd5Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Crammd5
+     */
+    protected $auth;
+
+    public function setUp()
+    {
+        $this->auth = new Crammd5();
+    }
+
+    public function testHmacMd5ReturnsExpectedHash()
+    {
+        $class = new ReflectionClass('Zend\Mail\Protocol\Smtp\Auth\Crammd5');
+        $method = $class->getMethod('_hmacMd5');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs(
+            $this->auth,
+            array('frodo', 'speakfriendandenter')
+        );
+
+        $this->assertEquals('be56fa81a5671e0c62e00134180aae2c', $result);
+    }
+}


### PR DESCRIPTION
I think we should be using a built-in implementation of HMAC-MD5 for CRAM-MD5. This does add a dependency on `Zend\Crypt`.

The simple test I added I have verified passed before my change.

I think the MD5 algorithm is available on all versions of PHP which support hash_hmac (PHP >= 5.1.2), but this change may not be possible if somebody knows that to be otherwise. Some evidence: http://3v4l.org/Zm8Rp#v512 matches the hash in my added test on PHP >= 5.1.2
