### PR TITLE
fixes 4684: ExpiresHeader does not accept 0

### DIFF
--- a/library/Zend/Http/Header/Expires.php
+++ b/library/Zend/Http/Header/Expires.php
@@ -20,6 +20,11 @@ use DateTimeZone;
 class Expires extends AbstractDate
 {
     /**
+     * 
+     */
+    protected $invalidDate = '';
+
+    /**
      * Get header name
      *
      * @return string
@@ -30,20 +35,44 @@ class Expires extends AbstractDate
     }
 
     /**
-     * {@inheritdoc}
+     * Checks if the current date is invalid
      *
-     * Allows to set 0 as a valid expired date
-     * and will be parsed as 1097-01-01 00:00 GMT
-     *
-     * @param string|DateTime $date
-     * @return AbstractDate
-     * @throws Exception\InvalidArgumentException
+     * @return boolean
      */
-    public function setDate($date)
+    public function isDateInvalid()
     {
-        if ($date === '0') {
-            $date = new DateTime('@0', new DateTimeZone('UTC'));
+        return ($this->invalidDate === false);
+    }
+
+    /**
+     * Get the invalid date
+     *
+     * @return string
+     */
+    public function getInvalidDate()
+    {
+        if (!$this->isDateInvalid()) {
+            throw new Exception\RuntimeException("The current date isn't invalid");
         }
-        return parent::setDate($date);
+        return $this->invalidDate;
+    }
+
+    /**
+     * Set an invalid date string
+     * 
+     * @param string $invalidDate
+     */
+    public function setInvalidDate($invalidDate)
+    {
+        try {
+            new DateTime($invalidDate);
+        } catch (\Exception $e) {
+            $this->invalidDate = $invalidDate;
+            return;
+        }
+
+        throw new Exception\InvalidArgumentException(
+            "The date {$invalidDate} is valid and can't be used as an invalid date"
+        );
     }
 }

--- a/library/Zend/Http/Header/Expires.php
+++ b/library/Zend/Http/Header/Expires.php
@@ -9,6 +9,9 @@
 
 namespace Zend\Http\Header;
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * Expires Header
  *
@@ -24,5 +27,23 @@ class Expires extends AbstractDate
     public function getFieldName()
     {
         return 'Expires';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Allows to set 0 as a valid expired date
+     * and will be parsed as 1097-01-01 00:00 GMT
+     *
+     * @param string|DateTime $date
+     * @return AbstractDate
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setDate($date)
+    {
+        if ($date === '0') {
+            $date = new DateTime('@0', new DateTimeZone('UTC'));
+        }
+        return parent::setDate($date);
     }
 }

--- a/tests/ZendTest/Http/Header/ExpiresTest.php
+++ b/tests/ZendTest/Http/Header/ExpiresTest.php
@@ -10,6 +10,7 @@
 
 namespace ZendTest\Http\Header;
 
+use DateTime;
 use Zend\Http\Header\Expires;
 
 class ExpiresTest extends \PHPUnit_Framework_TestCase
@@ -39,6 +40,13 @@ class ExpiresTest extends \PHPUnit_Framework_TestCase
         $expiresHeader = new Expires();
         $expiresHeader->setDate('Sun, 06 Nov 1994 08:49:37 GMT');
         $this->assertEquals('Expires: Sun, 06 Nov 1994 08:49:37 GMT', $expiresHeader->toString());
+    }
+
+    public function test0WillBeTratedAsValidExpiredDate()
+    {
+        $expiresHeader = new Expires();
+        $expiresHeader->setDate('0');
+        $this->assertSame(-1, $expiresHeader->compareTo(new DateTime('now')));
     }
 
     /**


### PR DESCRIPTION
This will fix #4684

It's a quick fix as with this it isn't possible to generate an expires header with `0` as value but it accepts it as a valid date and converts it internally as `1970-01-01 00:00 UTC` so it will be an valid expired date.
