### PR TITLE
Update FormDateSelect and FormMonthSelect to support 5.3.3 as is recommended in composer.json

### DIFF
--- a/library/Zend/Form/View/Helper/FormDateSelect.php
+++ b/library/Zend/Form/View/Helper/FormDateSelect.php
@@ -92,8 +92,8 @@ class FormDateSelect extends FormMonthSelectHelper
 
         $result = array();
         for ($day = 1; $day <= 31; $day++) {
-            $key   = $keyFormatter->format($date);
-            $value = $valueFormatter->format($date);
+            $key   = $keyFormatter->format($date->getTimestamp());
+            $value = $valueFormatter->format($date->getTimestamp());
             $result[$key] = $value;
 
             $date->modify('+1 day');

--- a/library/Zend/Form/View/Helper/FormMonthSelect.php
+++ b/library/Zend/Form/View/Helper/FormMonthSelect.php
@@ -257,8 +257,8 @@ class FormMonthSelect extends AbstractHelper
 
         $result = array();
         for ($month = 1; $month <= 12; $month++) {
-            $key   = $keyFormatter->format($date);
-            $value = $valueFormatter->format($date);
+            $key   = $keyFormatter->format($date->getTimestamp());
+            $value = $valueFormatter->format($date->getTimestamp());
             $result[$key] = $value;
 
             $date->modify('+1 month');


### PR DESCRIPTION
Support for passing in a DateTime object was only added in 5.3.4.
http://www.php.net/manual/en/intldateformatter.format.php
