### PR TITLE
Provide ability to configure ReCaptcha Service public and private keys via options

### DIFF
--- a/library/Zend/Captcha/ReCaptcha.php
+++ b/library/Zend/Captcha/ReCaptcha.php
@@ -126,6 +126,14 @@ class ReCaptcha extends AbstractAdapter
         parent::__construct($options);
 
         if (!empty($options)) {
+            //set private key if specified
+            if (array_key_exists('private_key', $options)) {
+                $this->getService()->setPrivateKey($options['private_key']);
+            }
+            //set public key if specified
+            if (array_key_exists('public_key', $options)) {
+                $this->getService()->setPublicKey($options['public_key']);
+            }
             $this->setOptions($options);
         }
     }

--- a/tests/ZendTest/Captcha/ReCaptchaTest.php
+++ b/tests/ZendTest/Captcha/ReCaptchaTest.php
@@ -88,6 +88,19 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($privKey, $captcha->getService()->getPrivateKey());
     }
 
+    public function testSetAndGetRecaptchaServicePublicAndPrivateKeysFromOptions()
+    {
+        $publicKey = 'publicKey';
+        $privateKey = 'privateKey';
+        $options = array(
+            'public_key' => $publicKey,
+            'private_key' => $privateKey
+        );
+        $captcha = new ReCaptcha($options);
+        $this->assertSame($publicKey, $captcha->getService()->getPublicKey());
+        $this->assertSame($privateKey, $captcha->getService()->getPrivateKey());
+    }
+
     /** @group ZF-7654 */
     public function testConstructorShouldAllowSettingLangOptionOnServiceObject()
     {


### PR DESCRIPTION
Provide ability to configure ReCaptcha Service public and private keys via array specification to FormFactory::createForm()

eg:

```
array(
    'spec' => array(
        'type' => 'Zend\Form\Element\Captcha',
        'name' => 'captcha',
        'options' => array(
            'label' => '',
            'captcha' => array(
                'class' => 'recaptcha',
                'options' => array(
                    'public_key' => 'hshs',
                    'private_key' => penp',
                ),
            ),
        ),
    ),
);
```

Issue https://github.com/zendframework/zf2/issues/4718
