### PR TITLE
Fix for #4727

### DIFF
--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -28,7 +28,7 @@ class BaseName extends AbstractFilter
                 (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
-        
+
         return basename((string) $value);
     }
 }

--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -21,6 +21,14 @@ class BaseName extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be scalar, "%s" given',
+                __METHOD__,
+                (is_object($value) ? get_class($value) : gettype($value))
+            ));
+        }
+        
         return basename((string) $value);
     }
 }

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -30,7 +30,7 @@ class Digits extends AbstractFilter
                 (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
-        
+
         if (!StringUtils::hasPcreUnicodeSupport()) {
             // POSIX named classes are not supported, use alternative 0-9 match
             $pattern = '/[^0-9]/';

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -23,6 +23,14 @@ class Digits extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be scalar, "%s" given',
+                __METHOD__,
+                (is_object($value) ? get_class($value) : gettype($value))
+            ));
+        }
+        
         if (!StringUtils::hasPcreUnicodeSupport()) {
             // POSIX named classes are not supported, use alternative 0-9 match
             $pattern = '/[^0-9]/';

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -179,6 +179,14 @@ class HtmlEntities extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be scalar, "%s" given',
+                __METHOD__,
+                (is_object($value) ? get_class($value) : gettype($value))
+            ));
+        }
+        
         $filtered = htmlentities((string) $value, $this->getQuoteStyle(), $this->getEncoding(), $this->getDoubleQuote());
         if (strlen((string) $value) && !strlen($filtered)) {
             if (!function_exists('iconv')) {

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -186,7 +186,7 @@ class HtmlEntities extends AbstractFilter
                 (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
-        
+
         $filtered = htmlentities((string) $value, $this->getQuoteStyle(), $this->getEncoding(), $this->getDoubleQuote());
         if (strlen((string) $value) && !strlen($filtered)) {
             if (!function_exists('iconv')) {

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -28,7 +28,7 @@ class Int extends AbstractFilter
                 (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
-        
+
         return (int) ((string) $value);
     }
 }

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -21,6 +21,14 @@ class Int extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be scalar, "%s" given',
+                __METHOD__,
+                (is_object($value) ? get_class($value) : gettype($value))
+            ));
+        }
+        
         return (int) ((string) $value);
     }
 }

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -78,7 +78,7 @@ class RealPath extends AbstractFilter
                 (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
-        
+
         $path = (string) $value;
         if ($this->options['exists']) {
             return realpath($path);

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -71,6 +71,14 @@ class RealPath extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be scalar, "%s" given',
+                __METHOD__,
+                (is_object($value) ? get_class($value) : gettype($value))
+            ));
+        }
+        
         $path = (string) $value;
         if ($this->options['exists']) {
             return realpath($path);

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -46,6 +46,14 @@ class StringToLower extends AbstractUnicode
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be string, "%s" given',
+                __METHOD__,
+                (is_object($limit) ? get_class($limit) : gettype($limit))
+            ));
+        }
+        
         if ($this->options['encoding'] !== null) {
             return mb_strtolower((string) $value,  $this->options['encoding']);
         }

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -50,7 +50,7 @@ class StringToLower extends AbstractUnicode
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects parameter to be string, "%s" given',
                 __METHOD__,
-                (is_object($limit) ? get_class($limit) : gettype($limit))
+                (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
 

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -48,7 +48,7 @@ class StringToLower extends AbstractUnicode
     {
         if(!is_scalar($value)){
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be string, "%s" given',
+                '%s expects parameter to be scalar, "%s" given',
                 __METHOD__,
                 (is_object($value) ? get_class($value) : gettype($value))
             ));

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -53,7 +53,7 @@ class StringToLower extends AbstractUnicode
                 (is_object($limit) ? get_class($limit) : gettype($limit))
             ));
         }
-        
+
         if ($this->options['encoding'] !== null) {
             return mb_strtolower((string) $value,  $this->options['encoding']);
         }

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -48,7 +48,7 @@ class StringToUpper extends AbstractUnicode
     {
         if(!is_scalar($value)){
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be string, "%s" given',
+                '%s expects parameter to be scalar, "%s" given',
                 __METHOD__,
                 (is_object($value) ? get_class($value) : gettype($value))
             ));

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -53,7 +53,7 @@ class StringToUpper extends AbstractUnicode
                 (is_object($limit) ? get_class($limit) : gettype($limit))
             ));
         }
-        
+
         if ($this->options['encoding'] !== null) {
             return mb_strtoupper((string) $value,  $this->options['encoding']);
         }

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -46,6 +46,14 @@ class StringToUpper extends AbstractUnicode
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be string, "%s" given',
+                __METHOD__,
+                (is_object($limit) ? get_class($limit) : gettype($limit))
+            ));
+        }
+        
         if ($this->options['encoding'] !== null) {
             return mb_strtoupper((string) $value,  $this->options['encoding']);
         }

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -50,7 +50,7 @@ class StringToUpper extends AbstractUnicode
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects parameter to be string, "%s" given',
                 __METHOD__,
-                (is_object($limit) ? get_class($limit) : gettype($limit))
+                (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
 

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -177,7 +177,7 @@ class StripTags extends AbstractFilter
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects parameter to be string, "%s" given',
                 __METHOD__,
-                (is_object($limit) ? get_class($limit) : gettype($limit))
+                (is_object($value) ? get_class($value) : gettype($value))
             ));
         }
 

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -173,6 +173,14 @@ class StripTags extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects parameter to be string, "%s" given',
+                __METHOD__,
+                (is_object($limit) ? get_class($limit) : gettype($limit))
+            ));
+        }
+        
         $value = (string) $value;
 
         // Strip HTML comments first

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -180,7 +180,7 @@ class StripTags extends AbstractFilter
                 (is_object($limit) ? get_class($limit) : gettype($limit))
             ));
         }
-        
+
         $value = (string) $value;
 
         // Strip HTML comments first

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -175,7 +175,7 @@ class StripTags extends AbstractFilter
     {
         if(!is_scalar($value)){
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be string, "%s" given',
+                '%s expects parameter to be scalar, "%s" given',
                 __METHOD__,
                 (is_object($value) ? get_class($value) : gettype($value))
             ));

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -36,4 +36,23 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($output, $filter($input));
         }
     }
+    
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $filter = new BaseNameFilter();
+        $input = array('/path/to/filename', '/path/to/filename.ext');
+    
+        try {
+            $filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+    
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -36,7 +36,7 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($output, $filter($input));
         }
     }
-    
+
     /**
      * Ensures that an InvalidArgumentException is raised if array is used
      *
@@ -46,13 +46,13 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new BaseNameFilter();
         $input = array('/path/to/filename', '/path/to/filename.ext');
-    
+
         try {
             $filter->filter($input);
         } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
             return;
         }
-    
+
         $this->fail('An expected InvalidArgumentException has not been raised.');
     }
 }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -85,7 +85,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
                 );
         }
     }
-    
+
     /**
      * Ensures that an InvalidArgumentException is raised if array is used
      *
@@ -95,13 +95,13 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new DigitsFilter();
         $input = array('abc123', 'abc 123');
-    
+
         try {
             $filter->filter($input);
         } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
             return;
         }
-    
+
         $this->fail('An expected InvalidArgumentException has not been raised.');
     }
 }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -85,4 +85,23 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
                 );
         }
     }
+    
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $filter = new DigitsFilter();
+        $input = array('abc123', 'abc 123');
+    
+        try {
+            $filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+    
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -257,6 +257,24 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($e instanceof Exception\DomainException);
         }
     }
+    
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $input = array('<', '>');
+    
+        try {
+            $this->_filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+    
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 
     /**
      * Null error handler; used when wanting to ignore specific error types

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -257,7 +257,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($e instanceof Exception\DomainException);
         }
     }
-    
+
     /**
      * Ensures that an InvalidArgumentException is raised if array is used
      *
@@ -266,13 +266,13 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
     public function testExceptionRaisedIfArrayUsed()
     {
         $input = array('<', '>');
-    
+
         try {
             $this->_filter->filter($input);
         } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
             return;
         }
-    
+
         $this->fail('An expected InvalidArgumentException has not been raised.');
     }
 

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -41,4 +41,23 @@ class IntTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($output, $filter($input));
         }
     }
+    
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $filter = new IntFilter();
+        $input = array('123 test', '456 test');
+    
+        try {
+            $filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+    
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -41,7 +41,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($output, $filter($input));
         }
     }
-    
+
     /**
      * Ensures that an InvalidArgumentException is raised if array is used
      *
@@ -51,13 +51,13 @@ class IntTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new IntFilter();
         $input = array('123 test', '456 test');
-    
+
         try {
             $filter->filter($input);
         } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
             return;
         }
-    
+
         $this->fail('An expected InvalidArgumentException has not been raised.');
     }
 }

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -106,7 +106,7 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
                . DIRECTORY_SEPARATOR . '_files';
         $this->assertEquals($path, $filter($path3));
     }
-    
+
     /**
      * Ensures that an InvalidArgumentException is raised if array is used
      *
@@ -119,13 +119,13 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
             $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
             $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
         );
-    
+
         try {
             $filter->filter($input);
         } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
             return;
         }
-    
+
         $this->fail('An expected InvalidArgumentException has not been raised.');
     }
 }

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -106,4 +106,26 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
                . DIRECTORY_SEPARATOR . '_files';
         $this->assertEquals($path, $filter($path3));
     }
+    
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $filter   = $this->_filter;
+        $input = array(
+            $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
+            $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
+        );
+    
+        try {
+            $filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+    
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -158,4 +158,22 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
+
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $input = array('ABC', 'DEF');
+
+        try {
+            $this->_filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -158,4 +158,22 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
+
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $input = array('abc', 'def');
+
+        try {
+            $this->_filter->filter($input);
+            } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -538,4 +538,22 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $this->_filter->filter($input));
     }
+
+    /**
+     * Ensures that an InvalidArgumentException is raised if array is used
+     *
+     * @return void
+     */
+    public function testExceptionRaisedIfArrayUsed()
+    {
+        $input = array('<li data-name="Test User" data-id="11223"></li>', '<li data-name="Test User 2" data-id="456789"></li>');
+
+        try {
+            $this->_filter->filter($input);
+        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
+            return;
+        }
+
+        $this->fail('An expected InvalidArgumentException has not been raised.');
+    }
 }


### PR DESCRIPTION
Check if parameter is scalar before cast to string
If not throw InvalidArgumentException
Fix for #4727
