### PR TITLE
Enhance failure error message in Zend\Session\Config\SessionConfig

### DIFF
--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -87,8 +87,16 @@ class SessionConfig extends StandardConfig
 
         $result = ini_set($key, $storageValue);
         if (FALSE === $result) {
-            throw new \InvalidArgumentException("'" . $key .
-                    "' is not a valid sessions-related ini setting.");
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '"%s" is not a valid session-related PHP configuration ' .
+                    'option, or your PHP configuration does not allow it to ' .
+                    'be overridden. Check that the setting is spelled ' .
+                    'correctly and that it was not previously set via ' .
+                    '"php_admin_value" or "php_admin_flag".',
+                    $key
+                )
+            );
         }
         return $this;
     }


### PR DESCRIPTION
 This helps with cases of hard-to-debug errors involving `php_admin_value` and `php_admin_flag`, as seen in https://github.com/zendframework/zf2/issues/4733.
