### PR TITLE
Sql limit accept null value

### DIFF
--- a/library/Zend/Config/Reader/Ini.php
+++ b/library/Zend/Config/Reader/Ini.php
@@ -12,7 +12,7 @@ namespace Zend\Config\Reader;
 use Zend\Config\Exception;
 
 /**
- * XML config reader.
+ * INI config reader.
  */
 class Ini implements ReaderInterface
 {

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -408,9 +408,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function limit($limit)
     {
-        if (!is_numeric($limit)) {
+        if (!is_numeric($limit) && !is_null($limit)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be numeric, "%s" given',
+                '%s expects parameter to be numeric or null, "%s" given',
                 __METHOD__,
                 (is_object($limit) ? get_class($limit) : gettype($limit))
             ));
@@ -426,9 +426,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function offset($offset)
     {
-        if (!is_numeric($offset)) {
+        if (!is_numeric($offset) && !is_null($offset)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be numeric, "%s" given',
+                '%s expects parameter to be numeric or null, "%s" given',
                 __METHOD__,
                 (is_object($offset) ? get_class($offset) : gettype($offset))
             ));

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -390,6 +390,17 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      * @testdox: unit test: test limit() throws execption when invalid parameter passed
      * @covers Zend\Db\Sql\Select::limit
      */
+    public function testLimitNullValueIsValidParameter()
+    {
+        $select = new Select;
+        $select->limit(null);
+        $this->assertNull($select->getRawState($select::LIMIT));
+    }
+
+    /**
+     * @testdox: unit test: test limit() throws execption when invalid parameter passed
+     * @covers Zend\Db\Sql\Select::limit
+     */
     public function testLimitExceptionOnInvalidParameter()
     {
         $select = new Select;
@@ -416,6 +427,17 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     public function testGetRawStateViaOffset(Select $select)
     {
         $this->assertEquals(10, $select->getRawState($select::OFFSET));
+    }
+
+    /**
+     * @testdox: unit test: test limit() throws execption when invalid parameter passed
+     * @covers Zend\Db\Sql\Select::limit
+     */
+    public function testOffsetNullValueIsValidParameter()
+    {
+        $select = new Select;
+        $select->offset(null);
+        $this->assertNull($select->getRawState($select::OFFSET));
     }
 
     /**


### PR DESCRIPTION
Restore the backward compatibility break introduced by the PR #4568 : accept `NULL` value for both methods `limit` and `offset`
