### PR TITLE
Bumping supported ProxyManager version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/annotations": ">=1.0",
         "ircmaxell/random-lib": "dev-master",
         "ircmaxell/security-lib": "dev-master",
-        "ocramius/proxy-manager": "0.3.*",
+        "ocramius/proxy-manager": "0.4.*",
         "phpunit/PHPUnit": "3.7.*"
     },
     "suggest": {

--- a/tests/ZendTest/ServiceManager/Proxy/LazyServiceFactoryFactoryTest.php
+++ b/tests/ZendTest/ServiceManager/Proxy/LazyServiceFactoryFactoryTest.php
@@ -64,17 +64,16 @@ class LazyServiceFactoryFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager->addDelegator('foo', 'foo-delegator');
 
         /* @var $proxy self|\ProxyManager\Proxy\ValueHolderInterface|\ProxyManager\Proxy\LazyLoadingInterface */
-        $proxy = $serviceManager->create('foo');
+        $proxy          = $serviceManager->create('foo');
+        $proxyClassName = get_class($proxy);
 
         $this->assertInstanceOf('ProxyManager\\Proxy\\LazyLoadingInterface', $proxy);
         $this->assertInstanceOf(__CLASS__, $proxy);
-        $this->assertSame(
-            $namespace . '\__PM__\ZendTest\ServiceManager\Proxy\LazyServiceFactoryFactoryTest',
-            get_class($proxy)
+        $this->assertStringMatchesFormat(
+            $namespace . '\__PM__\ZendTest\ServiceManager\Proxy\LazyServiceFactoryFactoryTest%s',
+            $proxyClassName
         );
-        $this->assertFileExists(
-            sys_get_temp_dir() . '/' . $namespace . '__PM__ZendTestServiceManagerProxyLazyServiceFactoryFactoryTest.php'
-        );
+        $this->assertFileExists(sys_get_temp_dir() . '/' . str_replace('\\', '', $proxyClassName) . '.php');
         $this->assertFalse($proxy->isProxyInitialized());
         $this->assertEquals($this->invalidConfigProvider(), $proxy->invalidConfigProvider());
         $this->assertTrue($proxy->isProxyInitialized());
@@ -99,17 +98,16 @@ class LazyServiceFactoryFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager->addDelegator('foo', 'foo-delegator');
 
         /* @var $proxy self|\ProxyManager\Proxy\ValueHolderInterface|\ProxyManager\Proxy\LazyLoadingInterface */
-        $proxy = $serviceManager->create('foo');
+        $proxy          = $serviceManager->create('foo');
+        $proxyClassName = get_class($proxy);
 
         $this->assertInstanceOf('ProxyManager\\Proxy\\LazyLoadingInterface', $proxy);
         $this->assertInstanceOf(__CLASS__, $proxy);
-        $this->assertSame(
-            $namespace . '\__PM__\ZendTest\ServiceManager\Proxy\LazyServiceFactoryFactoryTest',
-            get_class($proxy)
+        $this->assertStringMatchesFormat(
+            $namespace . '\__PM__\ZendTest\ServiceManager\Proxy\LazyServiceFactoryFactoryTest%s',
+            $proxyClassName
         );
-        $this->assertFileNotExists(
-            sys_get_temp_dir() . '/' . $namespace . '__PM__ZendTestServiceManagerProxyLazyServiceFactoryFactoryTest.php'
-        );
+        $this->assertFileNotExists(sys_get_temp_dir() . '/' . str_replace('\\', '', $proxyClassName) . '.php');
         $this->assertFalse($proxy->isProxyInitialized());
         $this->assertEquals($this->invalidConfigProvider(), $proxy->invalidConfigProvider());
         $this->assertTrue($proxy->isProxyInitialized());

--- a/tests/ZendTest/ServiceManager/Proxy/LazyServiceFactoryTest.php
+++ b/tests/ZendTest/ServiceManager/Proxy/LazyServiceFactoryTest.php
@@ -24,6 +24,9 @@ class LazyServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected $proxyFactory;
 
+    /**
+     * @var \Zend\ServiceManager\ServiceLocatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $locator;
 
     /**


### PR DESCRIPTION
Note: changes in tests were required since ProxyManager changed how class naming is handled internally.
