### PR TITLE
Another fix for #4727

### DIFF
--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -21,13 +21,8 @@ class BaseName extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
-        }
+        if(!is_string($value))
+            return $value;
 
         return basename((string) $value);
     }

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -24,11 +24,7 @@ class Digits extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            return $value;
         }
 
         if (!StringUtils::hasPcreUnicodeSupport()) {

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -179,12 +179,8 @@ class HtmlEntities extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+        if(!is_string($value)){
+            return $value;
         }
 
         $filtered = htmlentities((string) $value, $this->getQuoteStyle(), $this->getEncoding(), $this->getDoubleQuote());

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -22,11 +22,7 @@ class Int extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            return $value;
         }
 
         return (int) ((string) $value);

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -71,12 +71,8 @@ class RealPath extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+        if(!is_string($value)){
+            return $value;
         }
 
         $path = (string) $value;

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -46,12 +46,8 @@ class StringToLower extends AbstractUnicode
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+        if(!is_string($value)){
+            return $value;
         }
 
         if ($this->options['encoding'] !== null) {

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -46,12 +46,8 @@ class StringToUpper extends AbstractUnicode
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+        if(!is_string($value)){
+            return $value;
         }
 
         if ($this->options['encoding'] !== null) {

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -173,12 +173,8 @@ class StripTags extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+        if(!is_string($value)){
+            return $value;
         }
 
         $value = (string) $value;

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -37,22 +37,34 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function dataNotStringValues()
+    {
+        return array(
+            'int' => array(
+                'value' => 1
+            ),
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
+
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
+     * @dataProvider dataNotStringValues
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testFilterNotString($value)
     {
         $filter = new BaseNameFilter();
-        $input = array('/path/to/filename', '/path/to/filename.ext');
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
-
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -86,22 +86,31 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function dataNotScalarValues()
+    {
+        return array(
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
+
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
+     * @dataProvider dataNotScalarValues
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testFilterNotString($value)
     {
         $filter = new DigitsFilter();
-        $input = array('abc123', 'abc 123');
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
-
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -258,22 +258,35 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
-     */
-    public function testExceptionRaisedIfArrayUsed()
+    public function dataNotStringValues()
     {
-        $input = array('<', '>');
+        return array(
+            'int' => array(
+                'value' => 1
+            ),
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
 
-        try {
-            $this->_filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+    /**
+     * @dataProvider dataNotStringValues
+     */
+    public function testFilterNotString($value)
+    {
+        $filter = new $this->_filter();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 
     /**

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -42,22 +42,31 @@ class IntTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function dataNotScalarValues()
+    {
+        return array(
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
+
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
+     * @dataProvider dataNotScalarValues
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testFilterNotString($value)
     {
         $filter = new IntFilter();
-        $input = array('123 test', '456 test');
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
-
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -107,25 +107,34 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($path, $filter($path3));
     }
 
-    /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
-     */
-    public function testExceptionRaisedIfArrayUsed()
+    public function dataNotStringValues()
     {
-        $filter   = $this->_filter;
-        $input = array(
-            $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
-            $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
+        return array(
+            'int' => array(
+                'value' => 1
+            ),
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
         );
+    }
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+    /**
+     * @dataProvider dataNotStringValues
+     */
+    public function testFilterNotString($value)
+    {
+        $filter = $this->_filter;
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -159,21 +159,34 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
-    /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
-     */
-    public function testExceptionRaisedIfArrayUsed()
+    public function dataNotStringValues()
     {
-        $input = array('ABC', 'DEF');
+        return array(
+            'int' => array(
+                'value' => 1
+            ),
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
 
-        try {
-            $this->_filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+    /**
+     * @dataProvider dataNotStringValues
+     */
+    public function testFilterNotString($value)
+    {
+        $filter = $this->_filter;
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -159,21 +159,34 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
-    /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
-     */
-    public function testExceptionRaisedIfArrayUsed()
+    public function dataNotStringValues()
     {
-        $input = array('abc', 'def');
+        return array(
+            'int' => array(
+                'value' => 1
+            ),
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
 
-        try {
-            $this->_filter->filter($input);
-            } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+    /**
+     * @dataProvider dataNotStringValues
+     */
+    public function testFilterNotString($value)
+    {
+        $filter = $this->_filter;
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -539,21 +539,34 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->_filter->filter($input));
     }
 
-    /**
-     * Ensures that an InvalidArgumentException is raised if array is used
-     *
-     * @return void
-     */
-    public function testExceptionRaisedIfArrayUsed()
+    public function dataNotStringValues()
     {
-        $input = array('<li data-name="Test User" data-id="11223"></li>', '<li data-name="Test User 2" data-id="456789"></li>');
+        return array(
+            'int' => array(
+                'value' => 1
+            ),
+            'null' => array(
+                'value' => null
+            ),
+            'object' => array(
+                'value' => new \ArrayObject()
+            ),
+            'array' => array(
+                'value' => array()
+            ),
+            'closure' => array(
+                'value' => function(){}
+            )
+        );
+    }
 
-        try {
-            $this->_filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+    /**
+     * @dataProvider dataNotStringValues
+     */
+    public function testFilterNotString($value)
+    {
+        $filter = $this->_filter;
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertSame($value, $filter->filter($value));
     }
 }


### PR DESCRIPTION
This pull request https://github.com/zendframework/zf2/pull/4734 give problem with null values, and with InputFilter\Input::getValue()

example:

```
public function testGetNotScalarValue()
{
    $filter = $this->getMockBuilder('Zend\Filter\FilterInterface')
        ->disableOriginalConstructor()
        ->getMock();

    $filter->expects($this->any())
        ->method('filter')
        ->will($this->throwException(new \Zend\Filter\Exception\InvalidArgumentException()));
    //Filters such as: StripTags, StringToUpper, StringToLower, HtmlEntities throw exception if value is not scalar

    $filterChain = new \Zend\Filter\FilterChain();
    $filterChain->attach($filter);

    $input = new Input();
    $input->setFilterChain($filterChain);

    $value = null; //or any not scalar value array(), object, closure

    $input->setValue($value);

    $this->assertSame($value, $input->getValue()); //fail: give exception
    $this->assertFalse($input->isValid()); //also give exception

}
```
