### PR TITLE
getValue() for MonthSelect, DateSelect and DateTimeSelect Form Elements 

### DIFF
--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -115,6 +115,18 @@ class DateSelect extends MonthSelect
     }
 
     /**
+     * @return String
+     */
+    public function getValue()
+    {
+        return sprintf('%s-%s-%s',
+            $this->getYearElement()->getValue(),
+            $this->getMonthElement()->getValue(),
+            $this->getDayElement()->getValue()
+        );
+    }
+
+    /**
      * Prepare the form element (mostly used for rendering purposes)
      *
      * @param  FormInterface $form

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -244,6 +244,21 @@ class DateTimeSelect extends DateSelect
     }
 
     /**
+     * @return String
+     */
+    public function getValue()
+    {
+        return sprintf('%s-%s-%s %s:%s:%s',
+            $this->getYearElement()->getValue(),
+            $this->getMonthElement()->getValue(),
+            $this->getDayElement()->getValue(),
+            $this->getHourElement()->getValue(),
+            $this->getMinuteElement()->getValue(),
+            $this->getSecondElement()->getValue()
+        );
+    }
+
+    /**
      * Prepare the form element (mostly used for rendering purposes)
      *
      * @param  FormInterface $form

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -277,6 +277,17 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     }
 
     /**
+     * @return String
+     */
+    public function getValue()
+    {
+        return sprintf('%s-%s',
+            $this->getYearElement()->getValue(),
+            $this->getMonthElement()->getValue()
+        );
+    }
+
+    /**
      * Prepare the form element (mostly used for rendering purposes)
      *
      * @param  FormInterface $form

--- a/tests/ZendTest/Form/Element/DateSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateSelectTest.php
@@ -62,6 +62,14 @@ class DateSelectTest extends TestCase
         $this->assertEquals('24', $element->getDayElement()->getValue());
     }
 
+    public function testCanGetValue()
+    {
+        $element  = new DateSelectElement();
+        $element->setValue(new DateTime('2012-09-24'));
+
+        $this->assertEquals('2012-09-24', $element->getValue());
+    }
+
     /**
      * @expectedException \Zend\Form\Exception\InvalidArgumentException
      */

--- a/tests/ZendTest/Form/Element/DateTimeSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeSelectTest.php
@@ -88,6 +88,14 @@ class DateTimeSelectTest extends TestCase
         $this->assertEquals('05', $element->getSecondElement()->getValue());
     }
 
+    public function testCanGetValue()
+    {
+        $element  = new DateTimeSelectElement();
+        $element->setValue(new DateTime('2012-09-24 03:04:05'));
+        
+        $this->assertEquals('2012-09-24 03:04:05', $element->getValue());
+    }
+
     /**
      * @expectedException \Zend\Form\Exception\InvalidArgumentException
      */

--- a/tests/ZendTest/Form/Element/DateTimeSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeSelectTest.php
@@ -92,7 +92,7 @@ class DateTimeSelectTest extends TestCase
     {
         $element  = new DateTimeSelectElement();
         $element->setValue(new DateTime('2012-09-24 03:04:05'));
-        
+
         $this->assertEquals('2012-09-24 03:04:05', $element->getValue());
     }
 

--- a/tests/ZendTest/Form/Element/MonthSelectTest.php
+++ b/tests/ZendTest/Form/Element/MonthSelectTest.php
@@ -81,4 +81,11 @@ class MonthSelectTest extends TestCase
         $this->assertEquals('2012', $element->getYearElement()->getValue());
         $this->assertEquals('09', $element->getMonthElement()->getValue());
     }
+
+    public function testCanGetValue()
+    {
+        $element  = new MonthSelectElement();
+        $element->setValue(new DateTime('2012-09'));
+        $this->assertEquals('2012-09', $element->getValue());
+    }
 }


### PR DESCRIPTION
Tests added to check it is possible to get the value set on a DateTime,Date or Month Select Form Element.

getValue() methods implemented for each DateTime,Date and Month Select Form Elements using sprintf to return the designated format.

Fixes Issue https://github.com/zendframework/zf2/issues/4755
