### PR TITLE
Remove exceptions from #4734

### DIFF
--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -21,7 +21,11 @@ class BaseName extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -22,11 +22,15 @@ class BaseName extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         return basename((string) $value);

--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -14,10 +14,13 @@ class BaseName extends AbstractFilter
     /**
      * Defined by Zend\Filter\FilterInterface
      *
-     * Returns basename($value)
+     * Returns basename($value).
+     *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
-     * @return string
+     * @return string|mixed
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -24,11 +24,15 @@ class Digits extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         if (!StringUtils::hasPcreUnicodeSupport()) {

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -23,7 +23,11 @@ class Digits extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -18,8 +18,11 @@ class Digits extends AbstractFilter
      *
      * Returns the string $value, removing all but digit characters
      *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
+     *
      * @param  string $value
-     * @return string
+     * @return string|mixed
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -174,17 +174,21 @@ class HtmlEntities extends AbstractFilter
      * equivalents where they exist
      *
      * @param  string $value
-     * @throws Exception\DomainException
      * @return string
+     * @throws Exception\InvalidArgumentException
      */
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         $filtered = htmlentities((string) $value, $this->getQuoteStyle(), $this->getEncoding(), $this->getDoubleQuote());

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -179,7 +179,11 @@ class HtmlEntities extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -173,9 +173,12 @@ class HtmlEntities extends AbstractFilter
      * Returns the string $value, converting characters to their corresponding HTML entity
      * equivalents where they exist
      *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
+     *
      * @param  string $value
-     * @return string
-     * @throws Exception\InvalidArgumentException
+     * @return string|mixed
+     * @throws Exception\DomainException on encoding mismatches
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -21,7 +21,11 @@ class Int extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -22,11 +22,15 @@ class Int extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         return (int) ((string) $value);

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -16,8 +16,11 @@ class Int extends AbstractFilter
      *
      * Returns (int) $value
      *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
+     *
      * @param  string $value
-     * @return int
+     * @return int|mixed
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -72,11 +72,15 @@ class RealPath extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         $path = (string) $value;

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -71,7 +71,11 @@ class RealPath extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -66,8 +66,11 @@ class RealPath extends AbstractFilter
      *
      * Returns realpath($value)
      *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
+     *
      * @param  string $value
-     * @return string
+     * @return string|mixed
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -47,11 +47,15 @@ class StringToLower extends AbstractUnicode
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         if ($this->options['encoding'] !== null) {

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -46,7 +46,11 @@ class StringToLower extends AbstractUnicode
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -41,8 +41,11 @@ class StringToLower extends AbstractUnicode
      *
      * Returns the string $value, converting characters to lowercase as necessary
      *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
+     *
      * @param  string $value
-     * @return string
+     * @return string|mixed
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -46,7 +46,11 @@ class StringToUpper extends AbstractUnicode
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -47,11 +47,15 @@ class StringToUpper extends AbstractUnicode
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         if ($this->options['encoding'] !== null) {

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -39,10 +39,13 @@ class StringToUpper extends AbstractUnicode
     /**
      * Defined by Zend\Filter\FilterInterface
      *
-     * Returns the string $value, converting characters to lowercase as necessary
+     * Returns the string $value, converting characters to uppercase as necessary
+     *
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
-     * @return string
+     * @return string|mixed
      */
     public function filter($value)
     {

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -173,7 +173,11 @@ class StripTags extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value)){
             trigger_error(
                 sprintf(
                     '%s expects parameter to be scalar, "%s" given; cannot filter',

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -174,11 +174,15 @@ class StripTags extends AbstractFilter
     public function filter($value)
     {
         if(!is_scalar($value)){
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects parameter to be scalar, "%s" given',
-                __METHOD__,
-                (is_object($value) ? get_class($value) : gettype($value))
-            ));
+            trigger_error(
+                sprintf(
+                    '%s expects parameter to be scalar, "%s" given; cannot filter',
+                    __METHOD__,
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ),
+                E_USER_WARNING
+            );
+            return $value;
         }
 
         $value = (string) $value;

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -166,10 +166,12 @@ class StripTags extends AbstractFilter
     /**
      * Defined by Zend\Filter\FilterInterface
      *
-     * @todo improve docblock descriptions
+     * If the value provided is non-scalar, the value will remain unfiltered
+     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
+     * @todo   improve docblock descriptions
      * @param  string $value
-     * @return string
+     * @return string|mixed
      */
     public function filter($value)
     {

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\BaseName as BaseNameFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -38,21 +39,21 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $filter = new BaseNameFilter();
         $input = array('/path/to/filename', '/path/to/filename.ext');
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -56,4 +56,14 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filter   = new BaseNameFilter();
+        $filtered = $filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\Digits as DigitsFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -87,21 +88,21 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that an error is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $filter = new DigitsFilter();
         $input = array('abc123', 'abc 123');
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -105,4 +105,14 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filter   = new DigitsFilter();
+        $filtered = $filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -278,6 +278,15 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filtered = $this->_filter->filter(null);
+        $this->assertNull($filtered);
+    }
+
+    /**
      * Null error handler; used when wanting to ignore specific error types
      */
     public function errorHandler($errno, $errstr)

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Filter;
 
 use Zend\Filter\HtmlEntities as HtmlEntitiesFilter;
 use Zend\Filter\Exception;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -259,21 +260,21 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $input = array('<', '>');
 
-        try {
-            $this->_filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $this->_filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 
     /**

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\Int as IntFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -43,21 +44,21 @@ class IntTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $filter = new IntFilter();
         $input = array('123 test', '456 test');
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -61,4 +61,14 @@ class IntTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filter   = new IntFilter();
+        $filtered = $filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -129,4 +129,13 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filtered = $this->_filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\RealPath as RealPathFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -108,11 +109,11 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $filter   = $this->_filter;
         $input = array(
@@ -120,12 +121,12 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
             $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
         );
 
-        try {
-            $filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\StringToLower as StringToLowerFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -160,20 +161,20 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $input = array('ABC', 'DEF');
 
-        try {
-            $this->_filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $this->_filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -177,4 +177,13 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filtered = $this->_filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\StringToUpper as StringToUpperFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -160,20 +161,20 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $input = array('abc', 'def');
 
-        try {
-            $this->_filter->filter($input);
-            } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $this->_filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -177,4 +177,13 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filtered = $this->_filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\StripTags as StripTagsFilter;
+use Zend\Stdlib\ErrorHandler;
 
 /**
  * @category   Zend
@@ -540,20 +541,20 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an InvalidArgumentException is raised if array is used
+     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testExceptionRaisedIfArrayUsed()
+    public function testWarningIsRaisedIfArrayUsed()
     {
         $input = array('<li data-name="Test User" data-id="11223"></li>', '<li data-name="Test User 2" data-id="456789"></li>');
 
-        try {
-            $this->_filter->filter($input);
-        } catch (\Zend\Filter\Exception\InvalidArgumentException $expected) {
-            return;
-        }
+        ErrorHandler::start(E_USER_WARNING);
+        $filtered = $this->_filter->filter($input);
+        $err = ErrorHandler::stop();
 
-        $this->fail('An expected InvalidArgumentException has not been raised.');
+        $this->assertEquals($input, $filtered);
+        $this->assertInstanceOf('ErrorException', $err);
+        $this->assertContains('cannot filter', $err->getMessage());
     }
 }

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -557,4 +557,13 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ErrorException', $err);
         $this->assertContains('cannot filter', $err->getMessage());
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnsNullIfNullIsUsed()
+    {
+        $filtered = $this->_filter->filter(null);
+        $this->assertNull($filtered);
+    }
 }


### PR DESCRIPTION
#4734 introduced some type checking into a number of filters in order to remove notices that were being raised about "array to string" conversions. However, it did so by raising exceptions, which will be a non-starter for anybody who was previously passing arrays and/or objects to these filters.

Likely the more appropriate method would be to simply return the value presented, and potentially raise an `E_USER_WARNING` indicating the filter's inability to process the value.
