### PR TITLE
Make include_path functionality of Config and Translator opt-in

### DIFF
--- a/library/Zend/Config/Factory.php
+++ b/library/Zend/Config/Factory.php
@@ -13,14 +13,6 @@ use Zend\Stdlib\ArrayUtils;
 
 class Factory
 {
-    /**@+
-     * Constants defining rules for whether or not to use the include_path;
-     * used with fromFile() and fromFiles().
-     */
-    const NO_USE_INCLUDE_PATH = false;
-    const USE_INCLUDE_PATH = true;
-    /**@-*/
-
     /**
      * Plugin manager for loading readers
      *
@@ -72,7 +64,7 @@ class Factory
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
-    public static function fromFile($filename, $returnConfigObject = false, $useIncludePath = self::NO_USE_INCLUDE_PATH)
+    public static function fromFile($filename, $returnConfigObject = false, $useIncludePath = false)
     {
         $filepath = $filename;
         if (!file_exists($filename)) {
@@ -141,7 +133,7 @@ class Factory
      * @param  bool $useIncludePath
      * @return array|Config
      */
-    public static function fromFiles(array $files, $returnConfigObject = false, $useIncludePath = self::NO_USE_INCLUDE_PATH)
+    public static function fromFiles(array $files, $returnConfigObject = false, $useIncludePath = false)
     {
         $config = array();
 

--- a/library/Zend/I18n/Translator/Loader/AbstractFileLoader.php
+++ b/library/Zend/I18n/Translator/Loader/AbstractFileLoader.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n\Translator\Loader;
+
+/**
+ * Abstract file loader implementation; provides facilities around resolving 
+ * files via the include_path.
+ */
+abstract class AbstractFileLoader implements FileLoaderInterface
+{
+    /**
+     * Whether or not to consult the include_path when locating files
+     * 
+     * @var bool
+     */
+    protected $useIncludePath = false;
+
+    /**
+     * Indicate whether or not to use the include_path to resolve translation files
+     * 
+     * @param bool $flag 
+     * @return self
+     */
+    public function setUseIncludePath($flag = true)
+    {
+        $this->useIncludePath = (bool) $flag;
+        return $this;
+    }
+
+    /**
+     * Are we using the include_path to resolve translation files? 
+     * 
+     * @return bool
+     */
+    public function useIncludePath()
+    {
+        return $this->useIncludePath;
+    }
+
+    /**
+     * Resolve a translation file
+     *
+     * Checks if the file exists and is readable, returning a boolean false if not; if the "useIncludePath" 
+     * flag is enabled, it will attempt to resolve the file from the 
+     * include_path if the file does not exist on the current working path.
+     * 
+     * @param string $filename 
+     * @return string|false
+     */
+    protected function resolveFile($filename)
+    {
+        if (!is_file($filename) || !is_readable($filename)) {
+            if (!$this->useIncludePath()) {
+                return false;
+            }
+            return $this->resolveViaIncludePath($filename);
+        }
+        return $filename;
+    }
+
+    /**
+     * Resolve a translation file via the include_path
+     * 
+     * @param string $filename 
+     * @return string|false
+     */
+    protected function resolveViaIncludePath($filename)
+    {
+        $resolvedIncludePath = stream_resolve_include_path($filename);
+        if (!$resolvedIncludePath || !is_file($resolvedIncludePath) || !is_readable($resolvedIncludePath)) {
+            return false;
+        }
+        return $resolvedIncludePath;
+    }
+}

--- a/library/Zend/I18n/Translator/Loader/AbstractFileLoader.php
+++ b/library/Zend/I18n/Translator/Loader/AbstractFileLoader.php
@@ -10,22 +10,22 @@
 namespace Zend\I18n\Translator\Loader;
 
 /**
- * Abstract file loader implementation; provides facilities around resolving 
+ * Abstract file loader implementation; provides facilities around resolving
  * files via the include_path.
  */
 abstract class AbstractFileLoader implements FileLoaderInterface
 {
     /**
      * Whether or not to consult the include_path when locating files
-     * 
+     *
      * @var bool
      */
     protected $useIncludePath = false;
 
     /**
      * Indicate whether or not to use the include_path to resolve translation files
-     * 
-     * @param bool $flag 
+     *
+     * @param bool $flag
      * @return self
      */
     public function setUseIncludePath($flag = true)
@@ -35,8 +35,8 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     }
 
     /**
-     * Are we using the include_path to resolve translation files? 
-     * 
+     * Are we using the include_path to resolve translation files?
+     *
      * @return bool
      */
     public function useIncludePath()
@@ -47,11 +47,11 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     /**
      * Resolve a translation file
      *
-     * Checks if the file exists and is readable, returning a boolean false if not; if the "useIncludePath" 
-     * flag is enabled, it will attempt to resolve the file from the 
+     * Checks if the file exists and is readable, returning a boolean false if not; if the "useIncludePath"
+     * flag is enabled, it will attempt to resolve the file from the
      * include_path if the file does not exist on the current working path.
-     * 
-     * @param string $filename 
+     *
+     * @param string $filename
      * @return string|false
      */
     protected function resolveFile($filename)
@@ -67,8 +67,8 @@ abstract class AbstractFileLoader implements FileLoaderInterface
 
     /**
      * Resolve a translation file via the include_path
-     * 
-     * @param string $filename 
+     *
+     * @param string $filename
      * @return string|false
      */
     protected function resolveViaIncludePath($filename)

--- a/library/Zend/I18n/Translator/Loader/Gettext.php
+++ b/library/Zend/I18n/Translator/Loader/Gettext.php
@@ -17,7 +17,7 @@ use Zend\Stdlib\ErrorHandler;
 /**
  * Gettext loader.
  */
-class Gettext implements FileLoaderInterface
+class Gettext extends AbstractFileLoader
 {
     /**
      * Current file pointer.
@@ -44,9 +44,8 @@ class Gettext implements FileLoaderInterface
      */
     public function load($locale, $filename)
     {
-        $resolvedIncludePath = stream_resolve_include_path($filename);
-        $fromIncludePath = ($resolvedIncludePath !== false) ? $resolvedIncludePath : $filename;
-        if (!$fromIncludePath || !is_file($fromIncludePath) || !is_readable($fromIncludePath)) {
+        $resolvedFile = $this->resolveFile($filename);
+        if (!$resolvedFile) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Could not find or open file %s for reading',
                 $filename
@@ -56,7 +55,7 @@ class Gettext implements FileLoaderInterface
         $textDomain = new TextDomain();
 
         ErrorHandler::start();
-        $this->file = fopen($fromIncludePath, 'rb');
+        $this->file = fopen($resolvedFile, 'rb');
         $error = ErrorHandler::stop();
         if (false === $this->file) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/library/Zend/I18n/Translator/Loader/Ini.php
+++ b/library/Zend/I18n/Translator/Loader/Ini.php
@@ -17,7 +17,7 @@ use Zend\I18n\Translator\TextDomain;
 /**
  * PHP INI format loader.
  */
-class Ini implements FileLoaderInterface
+class Ini extends AbstractFileLoader
 {
     /**
      * load(): defined by FileLoaderInterface.

--- a/library/Zend/I18n/Translator/Loader/PhpArray.php
+++ b/library/Zend/I18n/Translator/Loader/PhpArray.php
@@ -16,7 +16,7 @@ use Zend\I18n\Translator\TextDomain;
 /**
  * PHP array loader.
  */
-class PhpArray implements FileLoaderInterface
+class PhpArray extends AbstractFileLoader
 {
     /**
      * load(): defined by FileLoaderInterface.

--- a/library/Zend/I18n/Translator/LoaderPluginManager.php
+++ b/library/Zend/I18n/Translator/LoaderPluginManager.php
@@ -18,6 +18,39 @@ use Zend\ServiceManager\AbstractPluginManager;
  * Enforces that loaders retrieved are either instances of
  * Loader\FileLoaderInterface or Loader\RemoteLoaderInterface. Additionally,
  * it registers a number of default loaders.
+ *
+ * If you are wanting to use the ability to load translation files from the
+ * include_path, you will need to create a factory to override the defaults
+ * defined in this class. A simple factory might look like:
+ *
+ * <code>
+ * function ($translators) {
+ *     $adapter = new Gettext();
+ *     $adapter->setUseIncludePath(true);
+ *     return $adapter;
+ * }
+ * </code>
+ *
+ * You may need to override the Translator service factory to make this happen
+ * more easily. That can be done by extending it:
+ *
+ * <code>
+ * use Zend\I18n\Translator\TranslatorServiceFactory;
+ * // or Zend\Mvc\I18n\TranslatorServiceFactory
+ * use Zend\ServiceManager\ServiceLocatorInterface;
+ *
+ * class MyTranslatorServiceFactory extends TranslatorServiceFactory
+ * {
+ *     public function createService(ServiceLocatorInterface $services)
+ *     {
+ *         $translator = parent::createService($services);
+ *         $translator->getLoaderPluginManager()->setFactory(...);
+ *         return $translator;
+ *     }
+ * }
+ * </code>
+ *
+ * You would then specify your custom factory in your service configuration.
  */
 class LoaderPluginManager extends AbstractPluginManager
 {

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -122,7 +122,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'Xml/include-base2.xml',
             'Php/include-base3.php',
         );
-        $config = Factory::fromFiles($files, false, Factory::USE_INCLUDE_PATH);
+        $config = Factory::fromFiles($files, false, true);
 
         $this->assertEquals('bar', $config['base']['foo']);
         $this->assertEquals('baz', $config['test']['bar']);

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -122,7 +122,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'Xml/include-base2.xml',
             'Php/include-base3.php',
         );
-        $config = Factory::fromFiles($files, Factory::USE_INCLUDE_PATH);
+        $config = Factory::fromFiles($files, false, Factory::USE_INCLUDE_PATH);
 
         $this->assertEquals('bar', $config['base']['foo']);
         $this->assertEquals('baz', $config['test']['bar']);

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -122,7 +122,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'Xml/include-base2.xml',
             'Php/include-base3.php',
         );
-        $config = Factory::fromFiles($files);
+        $config = Factory::fromFiles($files, Factory::USE_INCLUDE_PATH);
 
         $this->assertEquals('bar', $config['base']['foo']);
         $this->assertEquals('baz', $config['test']['bar']);

--- a/tests/ZendTest/I18n/Translator/Loader/GettextTest.php
+++ b/tests/ZendTest/I18n/Translator/Loader/GettextTest.php
@@ -90,6 +90,7 @@ class GettextTest extends TestCase
     public function testLoaderLoadsFromIncludePath()
     {
         $loader = new GettextLoader();
+        $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'translation_en.mo');
 
         $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);
@@ -99,6 +100,7 @@ class GettextTest extends TestCase
     public function testLoaderLoadsFromPhar()
     {
         $loader = new GettextLoader();
+        $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'phar://' . $this->testFilesDir . '/translations.phar/translation_en.mo');
 
         $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);

--- a/tests/ZendTest/I18n/Translator/Loader/IniTest.php
+++ b/tests/ZendTest/I18n/Translator/Loader/IniTest.php
@@ -104,6 +104,7 @@ class IniTest extends TestCase
     public function testLoaderLoadsFromIncludePath()
     {
         $loader = new IniLoader();
+        $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'translation_en.ini');
 
         $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);
@@ -113,6 +114,7 @@ class IniTest extends TestCase
     public function testLoaderLoadsFromPhar()
     {
         $loader = new IniLoader();
+        $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'phar://' . $this->testFilesDir . '/translations.phar/translation_en.ini');
 
         $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);

--- a/tests/ZendTest/I18n/Translator/Loader/PhpArrayTest.php
+++ b/tests/ZendTest/I18n/Translator/Loader/PhpArrayTest.php
@@ -83,6 +83,7 @@ class PhpArrayTest extends TestCase
     public function testLoaderLoadsFromIncludePath()
     {
         $loader = new PhpArrayLoader();
+        $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'translation_en.php');
 
         $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);
@@ -92,6 +93,7 @@ class PhpArrayTest extends TestCase
     public function testLoaderLoadsFromPhar()
     {
         $loader = new PhpArrayLoader();
+        $loader->setUseIncludePath(true);
         $textDomain = $loader->load('en_EN', 'phar://' . $this->testFilesDir . '/translations.phar/translation_en.php');
 
         $this->assertEquals('Message 1 (en)', $textDomain['Message 1']);


### PR DESCRIPTION
#4515 (which addresses #4443) and #4574 both introduce features that use PHP's `include_path` to identify application assets. While the functionality has reasonable use cases, as implemented, it introduces some performance impact, as the components look on the `include_path` for each and every file. Additionally, if `.` is not on the `include_path`, files that resolve from the current working directory will not resolve.
