### PR TITLE
fix Zend\Db\Adapter\Platform\PlatformInterface::quoteIdentifierInFragment

### DIFF
--- a/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
@@ -30,7 +30,7 @@ abstract class AbstractPlatform implements PlatformInterface
 
         $parts = preg_split('/([\.\s]' . $safeRegex . ')/i', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
-        $safeWords = array_merge($safeWords, array(' '=>1, '.'=>1, 'as'=>1));
+        $safeWords = array_merge($safeWords, array('*'=>1,  ' '=>1, '.'=>1, 'as'=>1));
         foreach ($parts as $i => $part) {
             if (!isset($safeWords[strtolower($part)])) {
                 $parts[$i] = $this->quoteIdentifier($part);

--- a/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Adapter\Platform;
+
+abstract class AbstractPlatform implements PlatformInterface
+{
+    /**
+     * Quote identifier in fragment
+     *
+     * @param  string $identifier
+     * @param  array $safeWords
+     * @return string
+     */
+    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
+    {
+        $safeRegex = '';
+        foreach($safeWords as $k=>$sWord) {
+            unset($safeWords[$k]);
+            $sWordQuoted = preg_quote($sWord);
+            $safeWords[strtolower($sWord)] = $sWordQuoted;
+            $safeRegex .= '|' . $sWordQuoted;
+        }
+
+        $parts = preg_split('/([\.\s]' . $safeRegex . ')/i', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
+        $safeWords = array_merge($safeWords, array(' '=>1, '.'=>1, 'as'=>1));
+        foreach ($parts as $i => $part) {
+            if (!isset($safeWords[strtolower($part)])) {
+                $parts[$i] = $this->quoteIdentifier($part);
+            }
+        }
+
+        return implode('', $parts);
+    }
+
+    /**
+     * Quote value list
+     *
+     * @param string|string[] $valueList
+     * @return string
+     */
+    public function quoteValueList($valueList)
+    {
+        if (!is_array($valueList)) {
+            return $this->quoteValue($valueList);
+        }
+
+        $value = reset($valueList);
+        do {
+            $valueList[key($valueList)] = $this->quoteValue($value);
+        } while ($value = next($valueList));
+        return implode(', ', $valueList);
+    }
+}

--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class IbmDb2 implements PlatformInterface
+class IbmDb2 extends AbstractPlatform
 {
 
     protected $quoteValueAllowed = false;
@@ -138,25 +138,6 @@ class IbmDb2 implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -164,46 +145,6 @@ class IbmDb2 implements PlatformInterface
     public function getIdentifierSeparator()
     {
         return $this->identifierSeparator;
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        if ($this->quoteIdentifiers === false) {
-            return $identifier;
-        }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-
-        return implode('', $parts);
     }
 
 }

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -14,7 +14,7 @@ use Zend\Db\Adapter\Driver\Mysqli;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class Mysql implements PlatformInterface
+class Mysql extends AbstractPlatform
 {
     /** @var \mysqli|\PDO */
     protected $resource = null;
@@ -149,25 +149,6 @@ class Mysql implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -177,38 +158,4 @@ class Mysql implements PlatformInterface
         return '.';
     }
 
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        // regex taken from @link http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
-        $parts = preg_split('#([^0-9,a-z,A-Z$_])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '`' . str_replace('`', '``', $part) . '`';
-            }
-        }
-        return implode('', $parts);
-    }
 }

--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class Oracle implements PlatformInterface
+class Oracle extends AbstractPlatform
 {
 
     /**
@@ -121,25 +121,6 @@ class Oracle implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -147,43 +128,6 @@ class Oracle implements PlatformInterface
     public function getIdentifierSeparator()
     {
         return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        if ($this->quoteIdentifiers === false) {
-            return $identifier;
-        }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
     }
 
 }

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -14,7 +14,7 @@ use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Driver\Pgsql;
 use Zend\Db\Adapter\Exception;
 
-class Postgresql implements PlatformInterface
+class Postgresql extends AbstractPlatform
 {
     /** @var resource|\PDO */
     protected $resource = null;
@@ -148,25 +148,6 @@ class Postgresql implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -174,40 +155,6 @@ class Postgresql implements PlatformInterface
     public function getIdentifierSeparator()
     {
         return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
     }
 
 }

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class Sql92 implements PlatformInterface
+class Sql92 extends AbstractPlatform
 {
     /**
      * Get name
@@ -95,25 +95,6 @@ class Sql92 implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -121,42 +102,6 @@ class Sql92 implements PlatformInterface
     public function getIdentifierSeparator()
     {
         return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-
-        return implode('', $parts);
     }
 
 }

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -13,7 +13,7 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class SqlServer implements PlatformInterface
+class SqlServer extends AbstractPlatform
 {
 
     /** @var resource|\PDO */
@@ -140,24 +140,6 @@ class SqlServer implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -165,40 +147,6 @@ class SqlServer implements PlatformInterface
     public function getIdentifierSeparator()
     {
         return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '[' . $part . ']';
-            }
-        }
-        return implode('', $parts);
     }
 
 }

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -13,7 +13,7 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class Sqlite implements PlatformInterface
+class Sqlite extends AbstractPlatform
 {
 
     /** @var \PDO */
@@ -140,24 +140,6 @@ class Sqlite implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -165,40 +147,6 @@ class Sqlite implements PlatformInterface
     public function getIdentifierSeparator()
     {
         return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
     }
 
 }

--- a/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
@@ -151,5 +151,11 @@ class IbmDb2Test extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -51,6 +51,7 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('`identifier`', $this->platform->quoteIdentifier('identifier'));
         $this->assertEquals('`ident``ifier`', $this->platform->quoteIdentifier('ident`ifier'));
+        $this->assertEquals('`namespace:$identifier`', $this->platform->quoteIdentifier('namespace:$identifier'));
     }
 
     /**
@@ -128,6 +129,7 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('`foo`.`bar`', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('`foo` as `bar`', $this->platform->quoteIdentifierInFragment('foo as bar'));
         $this->assertEquals('`$TableName`.`bar`', $this->platform->quoteIdentifierInFragment('$TableName.bar'));
+        $this->assertEquals('`cmis:$TableName` as `cmis:TableAlias`', $this->platform->quoteIdentifierInFragment('cmis:$TableName as cmis:TableAlias'));
 
         // single char words
         $this->assertEquals('(`foo`.`bar` = `boo`.`baz`)', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
@@ -136,6 +138,11 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             '(`foo`.`bar` = `boo`.`baz`) AND (`foo`.`baz` = `boo`.`baz`)',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
+        );
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '(`foo`.`bar` = `boo`.baz) AND (`foo`.baz = `boo`.baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
         );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -143,5 +143,10 @@ class OracleTest extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
@@ -131,5 +131,10 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
@@ -131,5 +131,10 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
@@ -129,5 +129,10 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
             '([foo].[bar] = [boo].[baz]) AND ([foo].[baz] = [boo].[baz])',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '([foo].[bar] = [boo].baz) AND ([foo].baz = [boo].baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
@@ -131,5 +131,10 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }


### PR DESCRIPTION
Current implementation is wrong because quoteIdentifierInFragment and quoteIdentifier methods should work in a similar way.
quoteIdentifierInFragment shoud split string by "." and " ", thereafter call quoteIdentifier for each part.
