### PR TITLE
Form\View\Helper\FormRow label position gets overwritten by __invoke()

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -92,7 +92,7 @@ class FormRow extends AbstractHelper
 
         if ($labelPosition !== null) {
             $this->setLabelPosition($labelPosition);
-        } else {
+        } elseif ($this->labelPosition === null) {
             $this->setLabelPosition(self::LABEL_PREPEND);
         }
 

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -372,4 +372,14 @@ class FormRowTest extends TestCase
         $markup = $this->helper->render($element);
         $this->assertRegexp('#^<button type="button" name="button" value=""\/?>foo</button>$#', $markup);
     }
+
+    public function testCanSetLabelPositionBeforeInvoke()
+    {
+        $element = new Element('foo');
+
+        $this->helper->setLabelPosition('append');
+        $this->helper->__invoke($element);
+
+        $this->assertSame('append', $this->helper->getLabelPosition());
+    }
 }


### PR DESCRIPTION
I noticed this when using the Form view helper, which in turn invokes FormRow helper passing only the element.

``` php
// inside view template
$this->formRow()->setLabelPosition('append');

/** @var Zend\Form\Form $form */
echo $this->form($form); // this does actually output prepended labels
```
