### PR TITLE
Adding missing "NOT IN" predicate

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -302,7 +302,7 @@ class Predicate extends PredicateSet
     }
 
     /**
-     * Create "in" predicate
+     * Create "IN" predicate
      *
      * Utilizes In predicate
      *
@@ -314,6 +314,26 @@ class Predicate extends PredicateSet
     {
         $this->addPredicate(
             new In($identifier, $valueSet),
+            ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
+        );
+        $this->nextPredicateCombineOperator = null;
+
+        return $this;
+    }
+
+    /**
+     * Create "NOT IN" predicate
+     *
+     * Utilizes NotIn predicate
+     *
+     * @param  string $identifier
+     * @param  array|\Zend\Db\Sql\Select $valueSet
+     * @return Predicate
+     */
+    public function notIn($identifier, $valueSet = null)
+    {
+        $this->addPredicate(
+            new NotIn($identifier, $valueSet),
             ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
         );
         $this->nextPredicateCombineOperator = null;

--- a/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
@@ -129,6 +129,16 @@ class PredicateTest extends TestCase
         $this->assertContains(array('foo.bar', 'foo', 'bar'), $parts[0]);
     }
 
+    public function testNotInCreatesNotInPredicate()
+    {
+        $predicate = new Predicate();
+        $predicate->notIn('foo.bar', array('foo', 'bar'));
+        $parts = $predicate->getExpressionData();
+        $this->assertEquals(1, count($parts));
+        $this->assertContains('%s NOT IN (%s, %s)', $parts[0]);
+        $this->assertContains(array('foo.bar', 'foo', 'bar'), $parts[0]);
+    }
+
     public function testBetweenCreatesBetweenPredicate()
     {
         $predicate = new Predicate();


### PR DESCRIPTION
Added "NOT IN" predicate.

Can be used while chaining where expressions:
->where->notIn(..., ...)
