### PR TITLE
Fix Zend\Config\Reader\Ini class comment block

### DIFF
--- a/library/Zend/Config/Reader/Ini.php
+++ b/library/Zend/Config/Reader/Ini.php
@@ -12,7 +12,7 @@ namespace Zend\Config\Reader;
 use Zend\Config\Exception;
 
 /**
- * XML config reader.
+ * INI config reader.
  */
 class Ini implements ReaderInterface
 {


### PR DESCRIPTION
Fix Ini class comment block from "XML" to "INI" for documentation purposes.
