### PR TITLE
[validator] Validate quoted local part of email addresses

### DIFF
--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -337,15 +337,12 @@ class EmailAddress extends AbstractValidator
         if (preg_match('/^[' . $atext . ']+(\x2e+[' . $atext . ']+)*$/', $this->localPart)) {
             $result = true;
         } else {
-            // Try quoted string format
+            // Try quoted string format (RFC 5321 Chapter 4.1.2)
 
-            // Quoted-string characters are: DQUOTE *([FWS] qtext/quoted-pair) [FWS] DQUOTE
-            // qtext: Non white space controls, and the rest of the US-ASCII characters not
-            //   including "\" or the quote character
-            $noWsCtl = '\x01-\x08\x0b\x0c\x0e-\x1f\x7f';
-            $qtext   = $noWsCtl . '\x21\x23-\x5b\x5d-\x7e';
-            $ws      = '\x20\x09';
-            if (preg_match('/^\x22([' . $ws . $qtext . '])*[$ws]?\x22$/', $this->localPart)) {
+            // Quoted-string characters are: DQUOTE *(qtext/quoted-pair) DQUOTE
+            $qtext      = '\x20-\x21\x23-\x5b\x5d-\x7e'; // %d32-33 / %d35-91 / %d93-126
+            $quotedPair = '\x20-\x7e'; // %d92 %d32-126
+            if (preg_match('/^"(['. $qtext .']|\x5c[' . $quotedPair . '])*"$/', $this->localPart)) {
                 $result = true;
             } else {
                 $this->error(self::DOT_ATOM);

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -157,6 +157,19 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
     public function testQuotedString()
     {
         $emailAddresses = array(
+            '""@domain.com', // Optional
+            '" "@domain.com', // x20
+            '"!"@domain.com', // x21
+            '"\""@domain.com', // \" (escaped x22)
+            '"#"@domain.com', // x23
+            '"$"@domain.com', // x24
+            '"Z"@domain.com', // x5A
+            '"["@domain.com', // x5B
+            '"\\\"@domain.com', // \\ (escaped x5C)
+            '"]"@domain.com', // x5D
+            '"^"@domain.com', // x5E
+            '"}"@domain.com', // x7D
+            '"~"@domain.com', // x7E
             '"username"@example.com',
             '"bob%jones"@domain.com',
             '"bob jones"@domain.com',
@@ -166,6 +179,28 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
             );
         foreach ($emailAddresses as $input) {
             $this->assertTrue($this->validator->isValid($input), "$input failed to pass validation:\n"
+                            . implode("\n", $this->validator->getMessages()));
+        }
+    }
+
+    /**
+     * Ensures that quoted-string local part is considered invalid
+     *
+     * @return void
+     */
+    public function testInvalidQuotedString()
+    {
+        $emailAddresses = array(
+            "\"\x00\"@example.com",
+            "\"\x01\"@example.com",
+            "\"\x1E\"@example.com",
+            "\"\x1F\"@example.com",
+            '"""@example.com', // x22 (not escaped)
+            '"\"@example.com', // x92 (not escaped)
+            "\"\x7F\"@example.com",
+            );
+        foreach ($emailAddresses as $input) {
+            $this->assertFalse($this->validator->isValid($input), "$input failed to pass validation:\n"
                             . implode("\n", $this->validator->getMessages()));
         }
     }

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -196,7 +196,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
             "\"\x1E\"@example.com",
             "\"\x1F\"@example.com",
             '"""@example.com', // x22 (not escaped)
-            '"\"@example.com', // x92 (not escaped)
+            '"\"@example.com', // x5C (not escaped)
             "\"\x7F\"@example.com",
             );
         foreach ($emailAddresses as $input) {


### PR DESCRIPTION
Test and fix for validate quoted local parts following the [RFC 5321](https://tools.ietf.org/html/rfc5321#section-4.1.2)

This should be backported to ZF1
