### PR TITLE
Default mode variables HeadScript and InlineScript

### DIFF
--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -115,7 +115,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  string $type      Script type and/or array of script attributes
      * @return HeadScript
      */
-    public function __invoke($mode = static::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+    public function __invoke($mode = self::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
     {
         if ((null !== $spec) && is_string($spec)) {
             $action    = ucfirst(strtolower($mode));

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -115,7 +115,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      * @param  string $type      Script type and/or array of script attributes
      * @return HeadScript
      */
-    public function __invoke($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+    public function __invoke($mode = static::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
     {
         if ((null !== $spec) && is_string($spec)) {
             $action    = ucfirst(strtolower($mode));

--- a/library/Zend/View/Helper/InlineScript.php
+++ b/library/Zend/View/Helper/InlineScript.php
@@ -35,7 +35,7 @@ class InlineScript extends HeadScript
      * @param  string $type      Script type and/or array of script attributes
      * @return InlineScript
      */
-    public function __invoke($mode = HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+    public function __invoke($mode = static::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
     {
         return parent::__invoke($mode, $spec, $placement, $attrs, $type);
     }

--- a/library/Zend/View/Helper/InlineScript.php
+++ b/library/Zend/View/Helper/InlineScript.php
@@ -35,7 +35,7 @@ class InlineScript extends HeadScript
      * @param  string $type      Script type and/or array of script attributes
      * @return InlineScript
      */
-    public function __invoke($mode = static::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
+    public function __invoke($mode = self::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
     {
         return parent::__invoke($mode, $spec, $placement, $attrs, $type);
     }


### PR DESCRIPTION
Default mode variables use static:: constants
