### PR TITLE
Zend\I18n\View\Helper\CurrencyFormat | showDecimals parameter overrides the default value

### DIFF
--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -90,13 +90,33 @@ class CurrencyFormat extends AbstractHelper
         if (null === $currencyCode) {
             $currencyCode = $this->getCurrencyCode();
         }
-        if (null !== $showDecimals) {
-            $this->setShouldShowDecimals($showDecimals);
+        if (null === $showDecimals) {
+            $showDecimals = $this->shouldShowDecimals();
         }
         if (null === $pattern) {
             $pattern = $this->getCurrencyPattern();
         }
 
+        return $this->formatCurrency($number, $currencyCode, $showDecimals, $locale, $pattern);
+    }
+
+    /**
+     * Format a number
+     *
+     * @param  float  $number
+     * @param  string $currencyCode
+     * @param  bool   $showDecimals
+     * @param  string $locale
+     * @param  string $pattern
+     * @return string
+     */
+    protected function formatCurrency(
+        $number,
+        $currencyCode,
+        $showDecimals,
+        $locale,
+        $pattern
+    ) {
         $formatterId = md5($locale);
 
         if (!isset($this->formatters[$formatterId])) {
@@ -110,7 +130,7 @@ class CurrencyFormat extends AbstractHelper
             $this->formatters[$formatterId]->setPattern($pattern);
         }
 
-        if ($this->shouldShowDecimals()) {
+        if ($showDecimals) {
             $this->formatters[$formatterId]->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
         } else {
             $this->formatters[$formatterId]->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);

--- a/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
@@ -103,6 +103,16 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
         $this->assertMbStringEquals($expected, $this->helper->__invoke($number));
     }
 
+    public function testViewhelperExecutedSequentially()
+    {
+        $helper = $this->helper;
+        $helper->setShouldShowDecimals(true);
+
+        $this->assertEquals('1.234,43 €', $helper(1234.4321, 'EUR', null, 'de_DE'));
+        $this->assertEquals('1.234 €', $helper(1234.4321, 'EUR', false, 'de_DE'));
+        $this->assertEquals('1.234,43 €', $helper(1234.4321, 'EUR', null, 'de_DE'));
+    }
+
     public function testDefaultLocale()
     {
         $this->assertMbStringEquals(Locale::getDefault(), $this->helper->getLocale());


### PR DESCRIPTION
The showDecimals parameter overrides the default value. This leads to a strange behavior when the helper is often used (test added).
Additionally, I have split the function to make it easier to extend the viewhelper.
