### PR TITLE
Zend log filter sample

### DIFF
--- a/library/Zend/Log/Filter/Sample.php
+++ b/library/Zend/Log/Filter/Sample.php
@@ -52,6 +52,6 @@ class Sample implements FilterInterface
      */
     public function filter(array $event)
     {
-        return (mt_rand() / mt_getrandmax()) <= $this->$_sampleRate;
+        return (mt_rand() / mt_getrandmax()) <= $this->_sampleRate;
     }
 }

--- a/library/Zend/Log/Filter/Sample.php
+++ b/library/Zend/Log/Filter/Sample.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log\Filter;
+
+use Zend\Log\Exception;
+use Zend\Log\Filter\FilterInterface;
+
+class Sample implements FilterInterface
+{
+    /**
+     * Sample rate [0-1].
+     * 
+     * @var float
+     */
+    protected $_sampleRate;
+
+    /**
+     * Filters logging by sample rate.
+     *
+     * Sample rate must be a float number between 0 and 1 included.
+     * If 0.5, only half of the values will be logged.
+     * If 0.1 only 1 among 10 values will be logged.
+     * 
+     * @param  float|int $samplerate Sample rate [0-1].
+     * @return Priority
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct($sampleRate = 1)
+    {
+        if (! is_numeric($sampleRate)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Sample rate must be numeric, received "%s"',
+                gettype($sampleRate)
+            ));
+        }
+        
+        $this->_sampleRate = (float) $sampleRate;
+    }
+    
+    /**
+     * Returns TRUE to accept the message, FALSE to block it.
+     *
+     * @param array $event event data
+     * @return bool Accepted ?
+     */
+    public function filter(array $event)
+    {
+        return (mt_rand() / mt_getrandmax()) <= $this->$_sampleRate;
+    }
+}

--- a/tests/ZendTest/Log/Filter/SampleTest.php
+++ b/tests/ZendTest/Log/Filter/SampleTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Log
+ */
+
+namespace ZendTest\Log\Filter;
+
+use Zend\Log\Filter\Sample;
+
+/**
+ * @category   Zend
+ * @package    Zend_Log
+ * @subpackage UnitTests
+ * @group      Zend_Log
+ */
+class SampleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructorThrowsOnInvalidSampleRate()
+    {
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'must be numeric');
+        new Sample('bar');
+    }
+    
+    public function testSampleLimit0()
+    {
+        // Should log nothing.
+        $filter = new Sample(0);
+
+        // Since sampling is a random process, let's test several times.
+        $ret = false;
+        for ($i = 0; $i < 100; $i ++) {
+            if ($filter->filter(array())) {
+                break;	
+                $ret = true;
+            }            
+        }
+        
+        $this->assertFalse($ret);
+    }
+}


### PR DESCRIPTION
This filter is intended to sample events by a given factor for events intensive scripts.

Never forget this is a random based sampling, thus, you never exactly know which event will be logged.

Usage:

``` php

$logger = new Zend\Log\Logger();

$writer = new Zend\Log\Writer\Stream('/path/to/first/logfile');
$logger->addWriter($writer);

// No event is logged
$filter = new Zend\Log\Filter\Sample(0);
$writer->addFilter($filter);

// All events are logged
$filter = new Zend\Log\Filter\Sample(1);
$writer->addFilter($filter);

// 2 random events among 3 are logged
$filter = new Zend\Log\Filter\Sample(2/3);
$writer->addFilter($filter);
```
