### PR TITLE
Make HTTP auth adapter's challengeClient() method public

### DIFF
--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -389,10 +389,10 @@ class Http implements AdapterInterface
             . ', please use the public challengeClient() instead',
             E_USER_DEPRECATED
         );
-        
-    	return $this->challengeClient();
+
+        return $this->challengeClient();
     }
-    
+
     /**
      * Challenge Client
      *

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -336,11 +336,11 @@ class Http implements AdapterInterface
 
         $headers = $this->request->getHeaders();
         if (!$headers->has($getHeader)) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
         $authHeader = $headers->get($getHeader)->getFieldValue();
         if (!$authHeader) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
 
         list($clientScheme) = explode(' ', $authHeader);
@@ -360,7 +360,7 @@ class Http implements AdapterInterface
         // client sent a scheme that is not the one required
         if (!in_array($clientScheme, $this->acceptSchemes)) {
             // challenge again the client
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
 
         switch ($clientScheme) {
@@ -385,7 +385,7 @@ class Http implements AdapterInterface
      *
      * @return Authentication\Result Always returns a non-identity Auth result
      */
-    protected function _challengeClient()
+    public function challengeClient()
     {
         if ($this->imaProxy) {
             $statusCode = 407;
@@ -474,12 +474,12 @@ class Http implements AdapterInterface
         // implementation does. If invalid credentials are detected,
         // re-challenge the client.
         if (!ctype_print($auth)) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
         // Fix for ZF-1515: Now re-challenges on empty username or password
         $creds = array_filter(explode(':', $auth));
         if (count($creds) != 2) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
 
         $result = $this->basicResolver->resolve($creds[0], $this->realm, $creds[1]);
@@ -498,7 +498,7 @@ class Http implements AdapterInterface
             return new Authentication\Result(Authentication\Result::SUCCESS, $result);
         }
 
-        return $this->_challengeClient();
+        return $this->challengeClient();
     }
 
     /**
@@ -530,17 +530,17 @@ class Http implements AdapterInterface
         // See ZF-1052. This code was a bit too unforgiving of invalid
         // usernames. Now, if the username is bad, we re-challenge the client.
         if ('::invalid::' == $data['username']) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
 
         // Verify that the client sent back the same nonce
         if ($this->_calcNonce() != $data['nonce']) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
         // The opaque value is also required to match, but of course IE doesn't
         // play ball.
         if (!$this->ieNoOpaque && $this->_calcOpaque() != $data['opaque']) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
 
         // Look up the user's password hash. If not found, deny access.
@@ -549,7 +549,7 @@ class Http implements AdapterInterface
         // to be recreatable with the current settings of this object.
         $ha1 = $this->digestResolver->resolve($data['username'], $data['realm']);
         if ($ha1 === false) {
-            return $this->_challengeClient();
+            return $this->challengeClient();
         }
 
         // If MD5-sess is used, a1 value is made of the user's password
@@ -588,7 +588,7 @@ class Http implements AdapterInterface
             return new Authentication\Result(Authentication\Result::SUCCESS, $identity);
         }
 
-        return $this->_challengeClient();
+        return $this->challengeClient();
     }
 
     /**

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -378,6 +378,22 @@ class Http implements AdapterInterface
     }
 
     /**
+     * @deprecated
+     * @see Http::challengeClient()
+     * @return Authentication\Result Always returns a non-identity Auth result
+     */
+    protected function _challengeClient()
+    {
+        trigger_error(
+            'This method is deprecated and will be removed in the feature'
+            . ', please use the public challengeClient() instead',
+            E_USER_DEPRECATED
+        );
+        
+    	return $this->challengeClient();
+    }
+    
+    /**
      * Challenge Client
      *
      * Sets a 401 or 407 Unauthorized response code, and creates the

--- a/library/Zend/Authentication/Adapter/Http.php
+++ b/library/Zend/Authentication/Adapter/Http.php
@@ -385,7 +385,7 @@ class Http implements AdapterInterface
     protected function _challengeClient()
     {
         trigger_error(
-            'This method is deprecated and will be removed in the feature'
+            'This method is deprecated and will be removed in the future'
             . ', please use the public challengeClient() instead',
             E_USER_DEPRECATED
         );

--- a/tests/ZendTest/Authentication/Adapter/HttpTest.php
+++ b/tests/ZendTest/Authentication/Adapter/HttpTest.php
@@ -14,40 +14,40 @@ use Zend\Authentication\Adapter;
 
 class HttpTest extends \PHPUnit_Framework_TestCase
 {
-	/**
-	 * @var Wrapper
-	 */
-	protected $_wrapper;
+    /**
+     * @var Wrapper
+     */
+    protected $_wrapper;
 
-	public function setUp()
-	{
-		$config = array(
-			'accept_schemes' => 'basic',
-			'realm'          => 'testing',
-		);
+    public function setUp()
+    {
+        $config = array(
+            'accept_schemes' => 'basic',
+            'realm'          => 'testing',
+        );
 
-		$this->_wrapper = new Wrapper($config);
-	}
+        $this->_wrapper = new Wrapper($config);
+    }
 
-	public function tearDown()
-	{
-		unset($this->_wrapper);
-	}
+    public function tearDown()
+    {
+        unset($this->_wrapper);
+    }
 
-	/**
-	 * @covers Adapter\Http::_challengeClient()
-	 * @expectedException PHPUnit_Framework_Error_Deprecated
-	 */
-	public function testProtectedMethodChallengeClientTriggersErrorDeprecated()
-	{
-		$this->_wrapper->_challengeClient();
-	}
+    /**
+     * @covers Adapter\Http::_challengeClient()
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     */
+    public function testProtectedMethodChallengeClientTriggersErrorDeprecated()
+    {
+        $this->_wrapper->_challengeClient();
+    }
 }
 
 class Wrapper extends Adapter\Http
 {
-	public function __call($method, $args)
-	{
-		return call_user_func_array(array($this, $method), $args);
-	}
+    public function __call($method, $args)
+    {
+        return call_user_func_array(array($this, $method), $args);
+    }
 }

--- a/tests/ZendTest/Authentication/Adapter/HttpTest.php
+++ b/tests/ZendTest/Authentication/Adapter/HttpTest.php
@@ -35,7 +35,6 @@ class HttpTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Adapter\Http::_challengeClient()
      * @expectedException PHPUnit_Framework_Error_Deprecated
      */
     public function testProtectedMethodChallengeClientTriggersErrorDeprecated()

--- a/tests/ZendTest/Authentication/Adapter/HttpTest.php
+++ b/tests/ZendTest/Authentication/Adapter/HttpTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Authentication
+ */
+
+namespace ZendTest\Authentication\Adapter;
+
+use Zend\Authentication\Adapter;
+
+class HttpTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var Wrapper
+	 */
+	protected $_wrapper;
+
+	public function setUp()
+	{
+		$config = array(
+			'accept_schemes' => 'basic',
+			'realm'          => 'testing',
+		);
+
+		$this->_wrapper = new Wrapper($config);
+	}
+
+	public function tearDown()
+	{
+		unset($this->_wrapper);
+	}
+
+	/**
+	 * @covers Adapter\Http::_challengeClient()
+	 * @expectedException PHPUnit_Framework_Error_Deprecated
+	 */
+	public function testProtectedMethodChallengeClientTriggersErrorDeprecated()
+	{
+		$this->_wrapper->_challengeClient();
+	}
+}
+
+class Wrapper extends Adapter\Http
+{
+	public function __call($method, $args)
+	{
+		return call_user_func_array(array($this, $method), $args);
+	}
+}


### PR DESCRIPTION
- changed _challengeClient() as deprecated proxy
- pushed in the proper branch
