### PR TITLE
Simplification of the HTML class name in Tag\Cloud\Decorator\HtmlCloud

### DIFF
--- a/library/Zend/Tag/Cloud/Decorator/HtmlCloud.php
+++ b/library/Zend/Tag/Cloud/Decorator/HtmlCloud.php
@@ -20,7 +20,7 @@ class HtmlCloud extends AbstractCloud
      * @var array
      */
     protected $htmlTags = array(
-        'ul' => array('class' => 'Zend\Tag\Cloud')
+        'ul' => array('class' => 'zend-tag-cloud'),
     );
 
     /**

--- a/tests/ZendTest/Tag/Cloud/CloudTest.php
+++ b/tests/ZendTest/Tag/Cloud/CloudTest.php
@@ -39,25 +39,39 @@ class CloudTest extends \PHPUnit_Framework_TestCase
     {
         $cloud = $this->_getCloud();
 
-        $cloud->setCloudDecorator(array('decorator' => 'CloudDummy', 'options' => array('foo' => 'bar')));
-        $this->assertTrue($cloud->getCloudDecorator() instanceof TestAsset\CloudDummy);
+        $cloud->setCloudDecorator(
+            array(
+                 'decorator' => 'CloudDummy',
+                 'options'   => array('foo' => 'bar'),
+            )
+        );
+        $this->assertTrue(
+            $cloud->getCloudDecorator() instanceof TestAsset\CloudDummy
+        );
         $this->assertEquals('bar', $cloud->getCloudDecorator()->getFoo());
     }
 
     public function testGetAndSetCloudDecorator()
     {
         $cloud = $this->_getCloud();
-        $this->assertTrue($cloud->getCloudDecorator() instanceof \Zend\Tag\Cloud\Decorator\HtmlCloud);
+        $this->assertTrue(
+            $cloud->getCloudDecorator() instanceof
+            \Zend\Tag\Cloud\Decorator\HtmlCloud
+        );
 
         $cloud->setCloudDecorator(new TestAsset\CloudDummy());
-        $this->assertTrue($cloud->getCloudDecorator() instanceof TestAsset\CloudDummy);
+        $this->assertTrue(
+            $cloud->getCloudDecorator() instanceof TestAsset\CloudDummy
+        );
     }
 
     public function testSetInvalidCloudDecorator()
     {
         $cloud = $this->_getCloud();
 
-        $this->setExpectedException('Zend\Tag\Exception\InvalidArgumentException', 'DecoratorInterface');
+        $this->setExpectedException(
+            'Zend\Tag\Exception\InvalidArgumentException', 'DecoratorInterface'
+        );
         $cloud->setCloudDecorator(new \stdClass());
     }
 
@@ -65,25 +79,39 @@ class CloudTest extends \PHPUnit_Framework_TestCase
     {
         $cloud = $this->_getCloud();
 
-        $cloud->setTagDecorator(array('decorator' => 'TagDummy', 'options' => array('foo' => 'bar')));
-        $this->assertTrue($cloud->getTagDecorator() instanceof TestAsset\TagDummy);
+        $cloud->setTagDecorator(
+            array(
+                 'decorator' => 'TagDummy',
+                 'options'   => array('foo' => 'bar'),
+            )
+        );
+        $this->assertTrue(
+            $cloud->getTagDecorator() instanceof TestAsset\TagDummy
+        );
         $this->assertEquals('bar', $cloud->getTagDecorator()->getFoo());
     }
 
     public function testGetAndSetTagDecorator()
     {
         $cloud = $this->_getCloud();
-        $this->assertTrue($cloud->getTagDecorator() instanceof \Zend\Tag\Cloud\Decorator\HtmlTag);
+        $this->assertTrue(
+            $cloud->getTagDecorator() instanceof
+            \Zend\Tag\Cloud\Decorator\HtmlTag
+        );
 
         $cloud->setTagDecorator(new TestAsset\TagDummy());
-        $this->assertTrue($cloud->getTagDecorator() instanceof TestAsset\TagDummy);
+        $this->assertTrue(
+            $cloud->getTagDecorator() instanceof TestAsset\TagDummy
+        );
     }
 
     public function testSetInvalidTagDecorator()
     {
         $cloud = $this->_getCloud();
 
-        $this->setExpectedException('Zend\Tag\Exception\InvalidArgumentException', 'DecoratorInterface');
+        $this->setExpectedException(
+            'Zend\Tag\Exception\InvalidArgumentException', 'DecoratorInterface'
+        );
         $cloud->setTagDecorator(new \stdClass());
     }
 
@@ -98,7 +126,9 @@ class CloudTest extends \PHPUnit_Framework_TestCase
     public function testSetDecoratorPluginManagerViaOptions()
     {
         $decorators = new DecoratorPluginManager();
-        $cloud      = $this->_getCloud(array('decoratorPluginManager' => $decorators), null);
+        $cloud      = $this->_getCloud(
+            array('decoratorPluginManager' => $decorators), null
+        );
         $this->assertSame($decorators, $cloud->getDecoratorPluginManager());
     }
 
@@ -107,7 +137,12 @@ class CloudTest extends \PHPUnit_Framework_TestCase
         $cloud = $this->_getCloud();
         $list  = $cloud->getItemList();
 
-        $cloud->appendTag(array('title' => 'foo', 'weight' => 1));
+        $cloud->appendTag(
+            array(
+                 'title'  => 'foo',
+                 'weight' => 1,
+            )
+        );
 
         $this->assertEquals('foo', $list[0]->getTitle());
     }
@@ -117,7 +152,14 @@ class CloudTest extends \PHPUnit_Framework_TestCase
         $cloud = $this->_getCloud();
         $list  = $cloud->getItemList();
 
-        $cloud->appendTag(new Tag\Item(array('title' => 'foo', 'weight' => 1)));
+        $cloud->appendTag(
+            new Tag\Item(
+                array(
+                     'title'  => 'foo',
+                     'weight' => 1,
+                )
+            )
+        );
 
         $this->assertEquals('foo', $list[0]->getTitle());
     }
@@ -126,7 +168,9 @@ class CloudTest extends \PHPUnit_Framework_TestCase
     {
         $cloud = $this->_getCloud();
 
-        $this->setExpectedException('Zend\Tag\Exception\InvalidArgumentException', 'TaggableInterface');
+        $this->setExpectedException(
+            'Zend\Tag\Exception\InvalidArgumentException', 'TaggableInterface'
+        );
         $cloud->appendTag('foo');
     }
 
@@ -135,8 +179,18 @@ class CloudTest extends \PHPUnit_Framework_TestCase
         $cloud = $this->_getCloud();
         $list  = $cloud->getItemList();
 
-        $cloud->setTags(array(array('title' => 'foo', 'weight' => 1),
-                              array('title' => 'bar', 'weight' => 2)));
+        $cloud->setTags(
+            array(
+                 array(
+                     'title'  => 'foo',
+                     'weight' => 1,
+                 ),
+                 array(
+                     'title'  => 'bar',
+                     'weight' => 2,
+                 )
+            )
+        );
 
         $this->assertEquals('foo', $list[0]->getTitle());
         $this->assertEquals('bar', $list[1]->getTitle());
@@ -147,8 +201,22 @@ class CloudTest extends \PHPUnit_Framework_TestCase
         $cloud = $this->_getCloud();
         $list  = $cloud->getItemList();
 
-        $cloud->setTags(array(new Tag\Item(array('title' => 'foo', 'weight' => 1)),
-                              new Tag\Item(array('title' => 'bar', 'weight' => 2))));
+        $cloud->setTags(
+            array(
+                 new Tag\Item(
+                     array(
+                          'title'  => 'foo',
+                          'weight' => 1,
+                     )
+                 ),
+                 new Tag\Item(
+                     array(
+                          'title'  => 'bar',
+                          'weight' => 2,
+                     )
+                 )
+            )
+        );
 
         $this->assertEquals('foo', $list[0]->getTitle());
         $this->assertEquals('bar', $list[1]->getTitle());
@@ -159,8 +227,20 @@ class CloudTest extends \PHPUnit_Framework_TestCase
         $cloud = $this->_getCloud();
         $list  = $cloud->getItemList();
 
-        $cloud->setTags(array(array('title' => 'foo', 'weight' => 1),
-                              new Tag\Item(array('title' => 'bar', 'weight' => 2))));
+        $cloud->setTags(
+            array(
+                 array(
+                     'title'  => 'foo',
+                     'weight' => 1,
+                 ),
+                 new Tag\Item(
+                     array(
+                          'title'  => 'bar',
+                          'weight' => 2,
+                     )
+                 )
+            )
+        );
 
         $this->assertEquals('foo', $list[0]->getTitle());
         $this->assertEquals('bar', $list[1]->getTitle());
@@ -170,13 +250,24 @@ class CloudTest extends \PHPUnit_Framework_TestCase
     {
         $cloud = $this->_getCloud();
 
-        $this->setExpectedException('Zend\Tag\Exception\InvalidArgumentException', 'TaggableInterface');
+        $this->setExpectedException(
+            'Zend\Tag\Exception\InvalidArgumentException', 'TaggableInterface'
+        );
         $cloud->setTags(array('foo'));
     }
 
     public function testConstructorWithArray()
     {
-        $cloud = $this->_getCloud(array('tags' => array(array('title' => 'foo', 'weight' => 1))));
+        $cloud = $this->_getCloud(
+            array(
+                 'tags' => array(
+                     array(
+                         'title'  => 'foo',
+                         'weight' => 1,
+                     )
+                 )
+            )
+        );
         $list  = $cloud->getItemList();
 
         $this->assertEquals('foo', $list[0]->getTitle());
@@ -184,7 +275,18 @@ class CloudTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorWithConfig()
     {
-        $cloud = $this->_getCloud(new \Zend\Config\Config(array('tags' => array(array('title' => 'foo', 'weight' => 1)))));
+        $cloud = $this->_getCloud(
+            new \Zend\Config\Config(
+                array(
+                     'tags' => array(
+                         array(
+                             'title'  => 'foo',
+                             'weight' => 1
+                         )
+                     )
+                )
+            )
+        );
         $list  = $cloud->getItemList();
 
         $this->assertEquals('foo', $list[0]->getTitle());
@@ -193,8 +295,17 @@ class CloudTest extends \PHPUnit_Framework_TestCase
     public function testSetOptions()
     {
         $cloud = $this->_getCloud();
-        $cloud->setOptions(array('tags' => array(array('title' => 'foo', 'weight' => 1))));
-        $list  = $cloud->getItemList();
+        $cloud->setOptions(
+            array(
+                 'tags' => array(
+                     array(
+                         'title'  => 'foo',
+                         'weight' => 1
+                     )
+                 )
+            )
+        );
+        $list = $cloud->getItemList();
 
         $this->assertEquals('foo', $list[0]->getTitle());
     }
@@ -207,11 +318,24 @@ class CloudTest extends \PHPUnit_Framework_TestCase
 
     public function testRender()
     {
-        $cloud    = $this->_getCloud(array('tags' => array(array('title' => 'foo', 'weight' => 1), array('title' => 'bar', 'weight' => 3))));
-        $expected = '<ul class="Zend&#x5C;Tag&#x5C;Cloud">'
-                  . '<li><a href="" style="font-size: 10px;">foo</a></li> '
-                  . '<li><a href="" style="font-size: 20px;">bar</a></li>'
-                  . '</ul>';
+        $cloud    = $this->_getCloud(
+            array(
+                 'tags' => array(
+                     array(
+                         'title'  => 'foo',
+                         'weight' => 1
+                     ),
+                     array(
+                         'title'  => 'bar',
+                         'weight' => 3
+                     )
+                 )
+            )
+        );
+        $expected = '<ul class="zend-tag-cloud">'
+            . '<li><a href="" style="font-size: 10px;">foo</a></li> '
+            . '<li><a href="" style="font-size: 20px;">bar</a></li>'
+            . '</ul>';
         $this->assertEquals($expected, $cloud->render());
     }
 
@@ -223,28 +347,53 @@ class CloudTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderViaToString()
     {
-        $cloud = $this->_getCloud(array('tags' => array(array('title' => 'foo', 'weight' => 1), array('title' => 'bar', 'weight' => 3))));
-        $expected = '<ul class="Zend&#x5C;Tag&#x5C;Cloud">'
-                  . '<li><a href="" style="font-size: 10px;">foo</a></li> '
-                  . '<li><a href="" style="font-size: 20px;">bar</a></li>'
-                  . '</ul>';
-        $this->assertEquals($expected, (string) $cloud);
+        $cloud    = $this->_getCloud(
+            array(
+                 'tags' => array(
+                     array(
+                         'title'  => 'foo',
+                         'weight' => 1
+                     ),
+                     array(
+                         'title'  => 'bar',
+                         'weight' => 3
+                     )
+                 )
+            )
+        );
+        $expected = '<ul class="zend-tag-cloud">'
+            . '<li><a href="" style="font-size: 10px;">foo</a></li> '
+            . '<li><a href="" style="font-size: 20px;">bar</a></li>'
+            . '</ul>';
+        $this->assertEquals($expected, (string)$cloud);
     }
 
-    protected function _getCloud($options = null, $setDecoratorPluginManager = true)
+    protected function _getCloud(
+        $options = null, $setDecoratorPluginManager = true
+    )
     {
         $cloud = new Tag\Cloud($options);
 
         if ($setDecoratorPluginManager) {
             $decorators = $cloud->getDecoratorPluginManager();
-            $decorators->setInvokableClass('clouddummy',  'ZendTest\Tag\Cloud\TestAsset\CloudDummy');
-            $decorators->setInvokableClass('clouddummy1', 'ZendTest\Tag\Cloud\TestAsset\CloudDummy1');
-            $decorators->setInvokableClass('clouddummy2', 'ZendTest\Tag\Cloud\TestAsset\CloudDummy2');
-            $decorators->setInvokableClass('tagdummy',    'ZendTest\Tag\Cloud\TestAsset\TagDummy');
+            $decorators->setInvokableClass(
+                'clouddummy', 'ZendTest\Tag\Cloud\TestAsset\CloudDummy'
+            );
+            $decorators->setInvokableClass(
+                'clouddummy1', 'ZendTest\Tag\Cloud\TestAsset\CloudDummy1'
+            );
+            $decorators->setInvokableClass(
+                'clouddummy2', 'ZendTest\Tag\Cloud\TestAsset\CloudDummy2'
+            );
+            $decorators->setInvokableClass(
+                'tagdummy', 'ZendTest\Tag\Cloud\TestAsset\TagDummy'
+            );
         }
 
         return $cloud;
     }
 }
 
-class ItemListDummy extends Tag\ItemList {}
+class ItemListDummy extends Tag\ItemList
+{
+}

--- a/tests/ZendTest/Tag/Cloud/Decorator/HtmlCloudTest.php
+++ b/tests/ZendTest/Tag/Cloud/Decorator/HtmlCloudTest.php
@@ -25,15 +25,36 @@ class HtmlCloudTest extends \PHPUnit_Framework_TestCase
     {
         $decorator = new Decorator\HtmlCloud();
 
-        $this->assertEquals('<ul class="Zend&#x5C;Tag&#x5C;Cloud">foo bar</ul>', $decorator->render(array('foo', 'bar')));
+        $this->assertEquals(
+            '<ul class="zend-tag-cloud">foo bar</ul>',
+            $decorator->render(
+                array(
+                     'foo',
+                     'bar'
+                )
+            )
+        );
     }
 
     public function testNestedTags()
     {
         $decorator = new Decorator\HtmlCloud();
-        $decorator->setHtmlTags(array('span', 'div' => array('id' => 'tag-cloud')));
+        $decorator->setHtmlTags(
+            array(
+                 'span',
+                 'div' => array('id' => 'tag-cloud')
+            )
+        );
 
-        $this->assertEquals('<div id="tag-cloud"><span>foo bar</span></div>', $decorator->render(array('foo', 'bar')));
+        $this->assertEquals(
+            '<div id="tag-cloud"><span>foo bar</span></div>',
+            $decorator->render(
+                array(
+                     'foo',
+                     'bar'
+                )
+            )
+        );
     }
 
     public function testSeparator()
@@ -41,29 +62,73 @@ class HtmlCloudTest extends \PHPUnit_Framework_TestCase
         $decorator = new Decorator\HtmlCloud();
         $decorator->setSeparator('-');
 
-        $this->assertEquals('<ul class="Zend&#x5C;Tag&#x5C;Cloud">foo-bar</ul>', $decorator->render(array('foo', 'bar')));
+        $this->assertEquals(
+            '<ul class="zend-tag-cloud">foo-bar</ul>',
+            $decorator->render(
+                array(
+                     'foo',
+                     'bar'
+                )
+            )
+        );
     }
 
     public function testConstructorWithArray()
     {
-        $decorator = new Decorator\HtmlCloud(array('htmlTags' => array('div'), 'separator' => ' '));
+        $decorator = new Decorator\HtmlCloud(array(
+                                                  'htmlTags'  => array('div'),
+                                                  'separator' => ' '
+                                             ));
 
-        $this->assertEquals('<div>foo bar</div>', $decorator->render(array('foo', 'bar')));
+        $this->assertEquals(
+            '<div>foo bar</div>', $decorator->render(
+                array(
+                     'foo',
+                     'bar'
+                )
+            )
+        );
     }
 
     public function testConstructorWithConfig()
     {
-        $decorator = new Decorator\HtmlCloud(new \Zend\Config\Config(array('htmlTags' => array('div'), 'separator' => ' ')));
+        $decorator = new Decorator\HtmlCloud(
+            new \Zend\Config\Config(
+                array(
+                     'htmlTags'  => array('div'),
+                     'separator' => ' '
+                )
+            )
+        );
 
-        $this->assertEquals('<div>foo bar</div>', $decorator->render(array('foo', 'bar')));
+        $this->assertEquals(
+            '<div>foo bar</div>', $decorator->render(
+                array(
+                     'foo',
+                     'bar'
+                )
+            )
+        );
     }
 
     public function testSetOptions()
     {
         $decorator = new Decorator\HtmlCloud();
-        $decorator->setOptions(array('htmlTags' => array('div'), 'separator' => ' '));
+        $decorator->setOptions(
+            array(
+                 'htmlTags'  => array('div'),
+                 'separator' => ' '
+            )
+        );
 
-        $this->assertEquals('<div>foo bar</div>', $decorator->render(array('foo', 'bar')));
+        $this->assertEquals(
+            '<div>foo bar</div>', $decorator->render(
+                array(
+                     'foo',
+                     'bar'
+                )
+            )
+        );
     }
 
     public function testSkipOptions()
@@ -79,9 +144,11 @@ class HtmlCloudTest extends \PHPUnit_Framework_TestCase
             array(array('&foo')),
             array(array(' foo')),
             array(array(' foo')),
-            array(array(
-                '_foo' => array(),
-            )),
+            array(
+                array(
+                    '_foo' => array(),
+                )
+            ),
         );
     }
 
@@ -92,28 +159,36 @@ class HtmlCloudTest extends \PHPUnit_Framework_TestCase
     {
         $decorator = new Decorator\HtmlCloud();
         $decorator->setHTMLTags($tags);
-        $this->setExpectedException('Zend\Tag\Exception\InvalidElementNameException');
+        $this->setExpectedException(
+            'Zend\Tag\Exception\InvalidElementNameException'
+        );
         $decorator->render(array());
     }
 
     public function invalidAttributeProvider()
     {
         return array(
-            array(array(
-                'foo' => array(
-                    '&bar' => 'baz',
-                ),
-            )),
-            array(array(
-                'foo' => array(
-                    ':bar&baz' => 'bat',
-                ),
-            )),
-            array(array(
-                'foo' => array(
-                    'bar/baz' => 'bat',
-                ),
-            )),
+            array(
+                array(
+                    'foo' => array(
+                        '&bar' => 'baz',
+                    ),
+                )
+            ),
+            array(
+                array(
+                    'foo' => array(
+                        ':bar&baz' => 'bat',
+                    ),
+                )
+            ),
+            array(
+                array(
+                    'foo' => array(
+                        'bar/baz' => 'bat',
+                    ),
+                )
+            ),
         );
     }
 
@@ -124,7 +199,9 @@ class HtmlCloudTest extends \PHPUnit_Framework_TestCase
     {
         $decorator = new Decorator\HtmlCloud();
         $decorator->setHTMLTags($tags);
-        $this->setExpectedException('Zend\Tag\Exception\InvalidAttributeNameException');
+        $this->setExpectedException(
+            'Zend\Tag\Exception\InvalidAttributeNameException'
+        );
         $decorator->render(array());
     }
 }


### PR DESCRIPTION
Changed from "`Zend&#x5C;Tag&#x5C;Cloud`" to "zend-tag-cloud"
