### PR TITLE
Correct spelling of function getMajorVersion

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -226,7 +226,7 @@ class Redis extends AbstractAdapter implements
 
         try {
             if ($ttl) {
-                if ($this->resourceManager->getMayorVersion($this->resourceId) < 2) {
+                if ($this->resourceManager->getMajorVersion($this->resourceId) < 2) {
                     throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");
                 }
                 $success = $redis->setex($this->namespacePrefix . $normalizedKey, $ttl, $value);
@@ -260,7 +260,7 @@ class Redis extends AbstractAdapter implements
         try {
             if ($ttl > 0) {
                 //check if ttl is supported
-                if ($this->resourceManager->getMayorVersion($this->resourceId) < 2) {
+                if ($this->resourceManager->getMajorVersion($this->resourceId) < 2) {
                     throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");
                 }
                 //mSet does not allow ttl, so use transaction
@@ -402,7 +402,7 @@ class Redis extends AbstractAdapter implements
     {
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
-            $minTtl = $this->resourceManager->getMayorVersion($this->resourceId) < 2 ? 0 : 1;
+            $minTtl = $this->resourceManager->getMajorVersion($this->resourceId) < 2 ? 0 : 1;
             //without serialization redis supports only strings for simple
             //get/set methods
             $this->capabilities     = new Capabilities(

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -507,12 +507,27 @@ class RedisResourceManager
 
     /**
      * Get redis server version
+     * Proxy for corrected function name
+     * 
+     * @deprecated
      *
      * @param string $id
      * @return int
      * @throws Exception\RuntimeException
      */
     public function getMayorVersion($id)
+    {
+        return $this->getMajorVersion($id);
+    }
+
+    /**
+     * Get redis server version
+     *
+     * @param string $id
+     * @return int
+     * @throws Exception\RuntimeException
+     */
+    public function getMajorVersion($id)
     {
         if (!$this->hasResource($id)) {
             throw new Exception\RuntimeException("No resource with id '{$id}'");

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -507,9 +507,8 @@ class RedisResourceManager
 
     /**
      * Get redis server version
-     * Proxy for corrected function name
-     * 
-     * @deprecated
+     *
+     * @deprecated 2.2.2 Use getMajorVersion instead
      *
      * @param string $id
      * @return int

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -144,12 +144,12 @@ class RedisTest extends CommonAdapterTest
         $redisResource = new RedisResource();
         $redisResource->connect($host, $port);
         $info = $redisResource->info();
-        $mayorVersion = (int)$info['redis_version'];
+        $majorVersion = (int)$info['redis_version'];
 
-        $this->assertEquals($mayorVersion, $this->_options->getResourceManager()->getMayorVersion($this->_options->getResourceId()));
+        $this->assertEquals($majorVersion, $this->_options->getResourceManager()->getMajorVersion($this->_options->getResourceId()));
 
         $capabilities = $this->_storage->getCapabilities();
-        if ($mayorVersion < 2) {
+        if ($majorVersion < 2) {
             $this->assertEquals(0, $capabilities->getMinTtl(), 'Redis version < 2.0.0 does not support key expiration');
         } else {
             $this->assertEquals(1, $capabilities->getMinTtl(), 'Redis version > 2.0.0 supports key expiration');


### PR DESCRIPTION
Corrected the name of the function and provide a proxy for backwards compatibility. Refs #4804
