### PR TITLE
Zend\Mvc\Application::run returns ResponseInterface.

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -297,12 +297,13 @@ class Application implements
                 return $response;
             }
             if ($event->getError()) {
-                return $this->completeRequest($event);
+                $this->completeRequest($event);
             }
             return $event->getResponse();
         }
         if ($event->getError()) {
-            return $this->completeRequest($event);
+            $this->completeRequest($event);
+            return $event->getResponse();
         }
 
         // Trigger dispatch event
@@ -320,8 +321,7 @@ class Application implements
         $response = $this->getResponse();
         $event->setResponse($response);
         $this->completeRequest($event);
-
-        return $this;
+        return $response;
     }
 
     /**


### PR DESCRIPTION
This fixes a bug where the run function returns a \Zend\Mvc\Application in a lot of cases. According to the phpdoc and the documentation it should return a Zend\Stdlib\ResponseInterface.
