### PR TITLE
Correct Cache\Storage\Adapter\Redis DocBloc

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/RedisOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisOptions.php
@@ -21,7 +21,7 @@ class RedisOptions extends AdapterOptions
     protected $namespaceSeparator = ':';
 
     /**
-     * The memcached resource manager
+     * The redis resource manager
      *
      * @var null|RedisResourceManager
      */


### PR DESCRIPTION
It looks like a copy and paste was missed when this new adapter was created. Reference to memcached changed to properly reference Redis  resource manager.
