### PR TITLE
Fix Version::getLatest docblock

### DIFF
--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -58,14 +58,14 @@ final class Version
     /**
      * Fetches the version of the latest stable release.
      *
-     * By Default, this uses the GitHub API (v3) and only returns refs that begin with
-     * 'tags/release-'. Because GitHub returns the refs in alphabetical order,
-     * we need to reduce the array to a single value, comparing the version
-     * numbers with version_compare().
+     * By default, this uses the API provided by framework.zend.com for version 
+     * retrieval.
      *
-     * If $service is set to VERSION_SERVICE_ZEND this will fall back to calling the
-     * classic style of version retreival.
-     *
+     * If $service is set to VERSION_SERVICE_GITHUB, this will use the GitHub 
+     * API (v3) and only returns refs that begin with * 'tags/release-'.
+     * Because GitHub returns the refs in alphabetical order, we need to reduce
+     * the array to a single value, comparing the version numbers with 
+     * version_compare().
      *
      * @see http://developer.github.com/v3/git/refs/#get-all-references
      * @link https://api.github.com/repos/zendframework/zf2/git/refs/tags/release-

--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -58,13 +58,13 @@ final class Version
     /**
      * Fetches the version of the latest stable release.
      *
-     * By default, this uses the API provided by framework.zend.com for version 
+     * By default, this uses the API provided by framework.zend.com for version
      * retrieval.
      *
-     * If $service is set to VERSION_SERVICE_GITHUB, this will use the GitHub 
+     * If $service is set to VERSION_SERVICE_GITHUB, this will use the GitHub
      * API (v3) and only returns refs that begin with * 'tags/release-'.
      * Because GitHub returns the refs in alphabetical order, we need to reduce
-     * the array to a single value, comparing the version numbers with 
+     * the array to a single value, comparing the version numbers with
      * version_compare().
      *
      * @see http://developer.github.com/v3/git/refs/#get-all-references


### PR DESCRIPTION
Corrects the `getLatest` docblock to indicate that the framework.zend.com API is used by default, and how to select the GitHub API when desired.
