### PR TITLE
Fix Application::run() return values

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -268,7 +268,7 @@ class Application implements
      *           discovered controller, and controller class (if known).
      *           Typically, a handler should return a populated Response object
      *           that can be returned immediately.
-     * @return ResponseInterface
+     * @return self
      */
     public function run()
     {
@@ -294,12 +294,13 @@ class Application implements
                 $event->setTarget($this);
                 $event->setResponse($response);
                 $events->trigger(MvcEvent::EVENT_FINISH, $event);
-                return $response;
+                $this->response = $response;
+                return $this;
             }
             if ($event->getError()) {
                 return $this->completeRequest($event);
             }
-            return $event->getResponse();
+            return $this;
         }
         if ($event->getError()) {
             return $this->completeRequest($event);
@@ -314,7 +315,8 @@ class Application implements
             $event->setTarget($this);
             $event->setResponse($response);
             $events->trigger(MvcEvent::EVENT_FINISH, $event);
-            return $response;
+            $this->response = $response;
+            return $this;
         }
 
         $response = $this->getResponse();

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -332,14 +332,15 @@ class ApplicationTest extends TestCase
         });
 
         $result = $this->application->run();
-        $this->assertSame($response, $result);
+        $this->assertSame($this->application, $result);
+        $this->assertSame($response, $result->getResponse());
     }
 
     public function testControllerIsDispatchedDuringRun()
     {
         $this->setupPathController();
 
-        $response = $this->application->run();
+        $response = $this->application->run()->getResponse();
         $this->assertContains('PathController', $response->getContent());
         $this->assertContains('dispatch', $response->toString());
     }
@@ -496,7 +497,8 @@ class ApplicationTest extends TestCase
         });
 
         $result = $this->application->run();
-        $this->assertSame($response, $result, var_export($result, 1));
+        $this->assertSame($this->application, $result, get_class($result));
+        $this->assertSame($response, $result->getResponse(), get_class($result));
     }
 
     /**


### PR DESCRIPTION
This PR addresses concerns raised in #4831:
- `run()` now _always_ returns an `Application` instance; its docblock has been updated accordingly as well.
- If an event returns a response object, it is pushed into the `Application` instance.
