### PR TITLE
Allow form elements created via Annotations to have same default InputFilter as created via array specification

### DIFF
--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -321,10 +321,12 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
         // Since "type" is a reserved name in the filter specification,
         // we need to add the specification without the name as the key.
         // In all other cases, though, the name is fine.
-        if ($name === 'type') {
-            $filterSpec[] = $event->getParam('inputSpec');
-        } else {
-            $filterSpec[$name] = $event->getParam('inputSpec');
+        if ($event->getParam('inputSpec')->count() > 1) {
+            if ($name === 'type') {
+                $filterSpec[] = $event->getParam('inputSpec');
+            } else {
+                $filterSpec[$name] = $event->getParam('inputSpec');
+            }
         }
 
         $elementSpec = $event->getParam('elementSpec');

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -219,6 +219,16 @@ class AnnotationBuilderTest extends TestCase
         $this->assertTrue($sampleinput->allowEmpty());
     }
 
+    public function testInputNotRequiredByDefault()
+    {
+        $entity = new TestAsset\Annotation\SampleEntity();
+        $builder = new Annotation\AnnotationBuilder();
+        $form = $builder->createForm($entity);
+        $inputFilter = $form->getInputFilter();
+        $sampleinput = $inputFilter->get('anotherSampleInput');
+        $this->assertFalse($sampleinput->isRequired());
+    }
+
     public function testObjectElementAnnotation()
     {
         $entity = new TestAsset\Annotation\EntityUsingObjectProperty();

--- a/tests/ZendTest/Form/TestAsset/Annotation/SampleEntity.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/SampleEntity.php
@@ -20,4 +20,10 @@ class SampleEntity
      * @Annotation\AllowEmpty(true)
      */
     public $sampleinput;
+
+    /**
+     *
+     * @Annotation\Attributes({"type":"text"})
+     */
+    public $anotherSampleInput;
 }


### PR DESCRIPTION
fix for issue #4802
