### PR TITLE
ArrayObject::offsetExists - Fix check on offsetExists

### DIFF
--- a/library/Zend/Stdlib/ArrayObject/PhpReferenceCompatibility.php
+++ b/library/Zend/Stdlib/ArrayObject/PhpReferenceCompatibility.php
@@ -282,7 +282,7 @@ abstract class PhpReferenceCompatibility implements IteratorAggregate, ArrayAcce
      */
     public function offsetExists($key)
     {
-        return isset($this->storage[$key]);
+        return array_key_exists($key, $this->storage);
     }
 
     /**

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -275,6 +275,14 @@ class ArrayObjectTest extends TestCase
         $this->assertFalse(isset($ar['unknown']));
     }
 
+    public function testOffsetSetNullExists()
+    {
+        $ar = new ArrayObject();
+        $ar['foo'] = null;
+
+        $this->assertTrue($ar->offsetExists('foo'));
+    }
+
     public function testOffsetGetThrowsExceptionOnProtectedProperty()
     {
         if (version_compare(PHP_VERSION, '5.3.4') < 0) {


### PR DESCRIPTION
Fix for issue #4832 where we checked isset vs. array_key_exists.
