### PR TITLE
Allow FormElementErrors view helper to translate messages

### DIFF
--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -78,9 +78,15 @@ class FormElementErrors extends AbstractHelper
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml) {
-                $messagesToPrint[] = $escapeHtml($item);
-            });
+        $self = $this;
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, $self) {
+            if (null !== ($translator = $self->getTranslator())) {
+                $item = $translator->translate(
+                    $item, $self->getTranslatorTextDomain()
+                );
+            }
+            $messagesToPrint[] = $escapeHtml($item);
+        });
 
         if (empty($messagesToPrint)) {
             return '';

--- a/tests/ZendTest/Form/View/Helper/FormElementErrorsTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementErrorsTest.php
@@ -135,6 +135,43 @@ class FormElementErrorsTest extends CommonTestCase
         $helper = $this->helper;
         $this->assertEquals($helper(), $helper);
     }
+    
+    public function testCanTranslateContent()
+    {
+        $messages = array(
+            array(
+                'First validator message',
+            ),
+        );
+        
+        $element = new Element('foo');
+        $element->setMessages($messages);
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+                       ->method('translate')
+                       ->will($this->returnValue('translated content'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertRegexp('#<ul class="error">\s*<li>translated content</li>\s*</ul>#s', $markup);
+    }
+
+    public function testTranslatorMethods()
+    {
+        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $this->helper->setTranslator($translatorMock, 'foo');
+
+        $this->assertEquals($translatorMock, $this->helper->getTranslator());
+        $this->assertEquals('foo', $this->helper->getTranslatorTextDomain());
+        $this->assertTrue($this->helper->hasTranslator());
+        $this->assertTrue($this->helper->isTranslatorEnabled());
+
+        $this->helper->setTranslatorEnabled(false);
+        $this->assertFalse($this->helper->isTranslatorEnabled());
+    }
 
 
 }


### PR DESCRIPTION
Allow FormElementErrors view helper to translate messages

Please ignore PRs 4671 and 4672
