### PR TITLE
Zend\Validator\File\MimeType warning with no params

### DIFF
--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -106,17 +106,17 @@ class MimeType extends AbstractValidator
                 $this->setMagicFile($options['magicFile']);
                 unset($options['magicFile']);
             }
-    
+
             if (isset($options['enableHeaderCheck'])) {
                 $this->enableHeaderCheck($options['enableHeaderCheck']);
                 unset($options['enableHeaderCheck']);
             }
-    
+
             if (array_key_exists('mimeType', $options)) {
                 $this->setMimeType($options['mimeType']);
                 unset($options['mimeType']);
             }
-    
+
             // Handle cases where mimetypes are interspersed with options, or
             // options are simply an array of mime types
             foreach (array_keys($options) as $key) {

--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -101,31 +101,31 @@ class MimeType extends AbstractValidator
         } elseif (is_string($options)) {
             $this->setMimeType($options);
             $options = array();
-        }
-
-        if (isset($options['magicFile'])) {
-            $this->setMagicFile($options['magicFile']);
-            unset($options['magicFile']);
-        }
-
-        if (isset($options['enableHeaderCheck'])) {
-            $this->enableHeaderCheck($options['enableHeaderCheck']);
-            unset($options['enableHeaderCheck']);
-        }
-
-        if (array_key_exists('mimeType', $options)) {
-            $this->setMimeType($options['mimeType']);
-            unset($options['mimeType']);
-        }
-
-        // Handle cases where mimetypes are interspersed with options, or
-        // options are simply an array of mime types
-        foreach (array_keys($options) as $key) {
-            if (!is_int($key)) {
-                continue;
+        } elseif (is_array($options)) {
+            if (isset($options['magicFile'])) {
+                $this->setMagicFile($options['magicFile']);
+                unset($options['magicFile']);
             }
-            $this->addMimeType($options[$key]);
-            unset($options[$key]);
+    
+            if (isset($options['enableHeaderCheck'])) {
+                $this->enableHeaderCheck($options['enableHeaderCheck']);
+                unset($options['enableHeaderCheck']);
+            }
+    
+            if (array_key_exists('mimeType', $options)) {
+                $this->setMimeType($options['mimeType']);
+                unset($options['mimeType']);
+            }
+    
+            // Handle cases where mimetypes are interspersed with options, or
+            // options are simply an array of mime types
+            foreach (array_keys($options) as $key) {
+                if (!is_int($key)) {
+                    continue;
+                }
+                $this->addMimeType($options[$key]);
+                unset($options[$key]);
+            }
         }
 
         parent::__construct($options);


### PR DESCRIPTION
The following code will throw 3 warnings:

``` php
$mimeTypeValidator = new \Zend\Validator\File\MimeType();
```

```
Warning: array_key_exists() expects parameter 2 to be array, null given in \library\Zend\Validator
\File\MimeType.php on line 116
Warning: array_keys() expects parameter 1 to be array, null given in \library\Zend\Validator\File\MimeType.php on line 123
Warning: Invalid argument supplied for foreach() in \library\Zend\Validator\File\MimeType.php on line 123
```
