### PR TITLE
Removed @category, @package and @subpackage docblock tags in ZendTest\Config

### DIFF
--- a/tests/ZendTest/Config/ConfigTest.php
+++ b/tests/ZendTest/Config/ConfigTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config;
@@ -13,9 +12,6 @@ namespace ZendTest\Config;
 use Zend\Config\Config;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class ConfigTest extends \PHPUnit_Framework_TestCase

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config;
@@ -13,9 +12,6 @@ namespace ZendTest\Config;
 use Zend\Config\Factory;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class FactoryTest extends \PHPUnit_Framework_TestCase

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config;
@@ -23,9 +22,6 @@ use Zend\Filter\StringToUpper;
 use Zend\Filter\PregReplace;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class ProcessorTest extends \PHPUnit_Framework_TestCase

--- a/tests/ZendTest/Config/Reader/AbstractReaderTestCase.php
+++ b/tests/ZendTest/Config/Reader/AbstractReaderTestCase.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Reader;
@@ -14,9 +13,6 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Config\Reader\ReaderInterface;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 abstract class AbstractReaderTestCase extends TestCase

--- a/tests/ZendTest/Config/Reader/IniTest.php
+++ b/tests/ZendTest/Config/Reader/IniTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Reader;
@@ -13,9 +12,6 @@ namespace ZendTest\Config\Reader;
 use Zend\Config\Reader\Ini;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class IniTest extends AbstractReaderTestCase

--- a/tests/ZendTest/Config/Reader/JsonTest.php
+++ b/tests/ZendTest/Config/Reader/JsonTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Reader;
@@ -13,9 +12,6 @@ namespace ZendTest\Config\Reader;
 use Zend\Config\Reader\Json;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class JsonTest extends AbstractReaderTestCase

--- a/tests/ZendTest/Config/Reader/XmlTest.php
+++ b/tests/ZendTest/Config/Reader/XmlTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Reader;
@@ -13,9 +12,6 @@ namespace ZendTest\Config\Reader;
 use Zend\Config\Reader\Xml;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class XmlTest extends AbstractReaderTestCase

--- a/tests/ZendTest/Config/Reader/YamlTest.php
+++ b/tests/ZendTest/Config/Reader/YamlTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Reader;
@@ -13,16 +12,12 @@ namespace ZendTest\Config\Reader;
 use Zend\Config\Reader\Yaml as YamlReader;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class YamlTest extends AbstractReaderTestCase
 {
     public function setUp()
     {
-
         if (!constant('TESTS_ZEND_CONFIG_YAML_ENABLED')) {
             $this->markTestSkipped('Yaml test for Zend\Config skipped');
         }

--- a/tests/ZendTest/Config/Writer/AbstractWriterTestCase.php
+++ b/tests/ZendTest/Config/Writer/AbstractWriterTestCase.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Writer;
@@ -14,9 +13,6 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Config\Config;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 abstract class AbstractWriterTestCase extends TestCase

--- a/tests/ZendTest/Config/Writer/IniTest.php
+++ b/tests/ZendTest/Config/Writer/IniTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Writer;
@@ -15,9 +14,6 @@ use Zend\Config\Config;
 use Zend\Config\Reader\Ini as IniReader;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class IniTest extends AbstractWriterTestCase

--- a/tests/ZendTest/Config/Writer/JsonTest.php
+++ b/tests/ZendTest/Config/Writer/JsonTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Writer;
@@ -15,9 +14,6 @@ use Zend\Config\Config;
 use Zend\Config\Reader\Json as JsonReader;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class JsonTest extends AbstractWriterTestCase

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Writer;
@@ -15,9 +14,6 @@ use Zend\Config\Config;
 use ZendTest\Config\Writer\TestAssets\PhpReader;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class PhpArrayTest extends AbstractWriterTestCase

--- a/tests/ZendTest/Config/Writer/XmlTest.php
+++ b/tests/ZendTest/Config/Writer/XmlTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Writer;
@@ -15,9 +14,6 @@ use Zend\Config\Config;
 use Zend\Config\Reader\Xml as XmlReader;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class XmlTest extends AbstractWriterTestCase

--- a/tests/ZendTest/Config/Writer/YamlTest.php
+++ b/tests/ZendTest/Config/Writer/YamlTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Config
  */
 
 namespace ZendTest\Config\Writer;
@@ -15,9 +14,6 @@ use Zend\Config\Config;
 use Zend\Config\Reader\Yaml as YamlReader;
 
 /**
- * @category   Zend
- * @package    Zend_Config
- * @subpackage UnitTests
  * @group      Zend_Config
  */
 class YamlTest extends AbstractWriterTestCase


### PR DESCRIPTION
Removed the @category, @package and @subpackage docblock tags in ZendTest\Config per recommendation by @samsonasik
