### PR TITLE
Use MvcTranslator to inject view helpers

### DIFF
--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -145,7 +145,9 @@ class HelperPluginManager extends AbstractPluginManager
     {
         if ($helper instanceof TranslatorAwareInterface) {
             $locator = $this->getServiceLocator();
-            if ($locator && $locator->has('translator')) {
+            if ($locator && $locator->has('MvcTranslator')) {
+                $helper->setTranslator($locator->get('MvcTranslator'));
+            } elseif ($locator && $locator->has('translator')) {
                 $helper->setTranslator($locator->get('translator'));
             }
         }

--- a/tests/ZendTest/View/HelperPluginManagerTest.php
+++ b/tests/ZendTest/View/HelperPluginManagerTest.php
@@ -10,6 +10,8 @@
 
 namespace ZendTest\View;
 
+use Zend\I18n\Translator\Translator;
+use Zend\Mvc\I18n\Translator as MvcTranslator;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 use Zend\View\Renderer\PhpRenderer;
@@ -79,5 +81,27 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $identity = $this->helpers->get('identity');
         $expected = $services->get('Zend\Authentication\AuthenticationService');
         $this->assertSame($expected, $identity->getAuthenticationService());
+    }
+
+    public function testIfHelperIsTranslatorAwareAndMvcTranslatorIsAvailableItWillInjectTheMvcTranslator()
+    {
+        $translator = new MvcTranslator();
+        $services   = new ServiceManager();
+        $services->setService('MvcTranslator', $translator);
+        $this->helpers->setServiceLocator($services);
+
+        $helper = $this->helpers->get('HeadTitle');
+        $this->assertSame($translator, $helper->getTranslator());
+    }
+
+    public function testIfHelperIsTranslatorAwareAndMvcTranslatorIsUnavailableAndTranslatorIsAvailableItWillInjectTheTranslator()
+    {
+        $translator = new Translator();
+        $services   = new ServiceManager();
+        $services->setService('Translator', $translator);
+        $this->helpers->setServiceLocator($services);
+
+        $helper = $this->helpers->get('HeadTitle');
+        $this->assertSame($translator, $helper->getTranslator());
     }
 }


### PR DESCRIPTION
When we released 2.2.0, we neglected to update the HelperPluginManager to prefer the MvcTranslator service over the Translator service when injecting helpers that are translator-aware. This PR adds logic to do so.
