### PR TITLE
Use .eml extensions for emails stored with Zend\Mail\Transport\File

### DIFF
--- a/library/Zend/Mail/Transport/FileOptions.php
+++ b/library/Zend/Mail/Transport/FileOptions.php
@@ -88,7 +88,7 @@ class FileOptions extends AbstractOptions
     {
         if (null === $this->callback) {
             $this->setCallback(function ($transport) {
-                return 'ZendMail_' . time() . '_' . mt_rand() . '.tmp';
+                return 'ZendMail_' . time() . '_' . mt_rand() . '.eml';
             });
         }
         return $this->callback;

--- a/tests/ZendTest/Mail/Transport/FileOptionsTest.php
+++ b/tests/ZendTest/Mail/Transport/FileOptionsTest.php
@@ -35,7 +35,7 @@ class FileOptionsTest extends \PHPUnit_Framework_TestCase
         $callback = $this->options->getCallback();
         $this->assertTrue(is_callable($callback));
         $test     = call_user_func($callback, '');
-        $this->assertRegExp('#^ZendMail_\d+_\d+\.tmp$#', $test);
+        $this->assertRegExp('#^ZendMail_\d+_\d+\.eml$#', $test);
     }
 
     public function testPathIsMutable()


### PR DESCRIPTION
The widely used extension for mime emails in plain text is .eml [1]
This commit changes the currently used .tmp extension to .eml as .tmp does not make much sense in this case anyway.

By doing this one could open directly the email with the associated user agent (eg: by double clicking the file in the file browser).

[1] https://en.wikipedia.org/wiki/Email#Filename_extensions
