### PR TITLE
Method "headLink" does not exist

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -57,6 +57,21 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
     }
 
     /**
+     * Proxy to __invoke()
+     *
+     * Allows calling $helper->headLink(), but, more importantly, chaining calls
+     * like ->appendStylesheet()->headLink().
+     *
+     * @param  array  $attributes
+     * @param  string $placement
+     * @return HeadLink
+     */
+    public function headLink(array $attributes = null, $placement = Placeholder\Container\AbstractContainer::APPEND)
+    {
+        return call_user_func_array(array($this, '__invoke'), func_get_args());
+    }
+
+    /**
      * headLink() - View Helper Method
      *
      * Returns current object instance. Optionally, allows passing array of

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -92,16 +92,16 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
         $this->helper->offsetSet(1, 'foo');
     }
 
-    public function testCreatingLinkStackViaHeadScriptCreatesAppropriateOutput()
+    public function testCreatingLinkStackViaHeadLinkCreatesAppropriateOutput()
     {
         $links = array(
             'link1' => array('rel' => 'stylesheet', 'type' => 'text/css', 'href' => 'foo'),
             'link2' => array('rel' => 'stylesheet', 'type' => 'text/css', 'href' => 'bar'),
             'link3' => array('rel' => 'stylesheet', 'type' => 'text/css', 'href' => 'baz'),
         );
-        $this->helper->__invoke($links['link1'])
-                     ->__invoke($links['link2'], 'PREPEND')
-                     ->__invoke($links['link3']);
+        $this->helper->headLink($links['link1'])
+                     ->headLink($links['link2'], 'PREPEND')
+                     ->headLink($links['link3']);
 
         $string = $this->helper->toString();
         $lines  = substr_count($string, PHP_EOL);


### PR DESCRIPTION
The following **does not** work:

``` php
echo $this->headLink()
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/local/forie.css')), 'screen', 'IE9')
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/application.css')))
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/vendor/responsive.css')))
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/vendor/bootstrap.css')))
    ->headLink(array(
        'rel' => 'shortcut icon', 
        'type' => 'image/vnd.microsoft.icon',
        'href' => $this->basePath('assets/img/favicon.ico')))
    ->headLink(array(
        'rel' => 'author',
        'href' => $this->basePath('humans.txt')))
```

The following works:

``` php
echo $this->headLink()
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/local/forie.css')), 'screen', 'IE9')
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/application.css')))
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/vendor/responsive.css')))
    ->prependStylesheet($this->basePath($cacheBuster->bustPath('assets/css/vendor/bootstrap.css')))
    ->__invoke(array(
        'rel' => 'shortcut icon', 
        'type' => 'image/vnd.microsoft.icon',
        'href' => $this-basePath('assets/img/favicon.ico')))
    ->__invoke(array(
        'rel' => 'author',
        'href' => $this->basePath('humans.txt')))
```

[The documentation](http://framework.zend.com/manual/1.12/en/zend.view.helpers.html#zend.view.helpers.initial.headlink)–which is, unfortunately, the only documentation available as I don't see any 2.0 version–states:

> Example `#19` HeadLink Helper Basic Usage
> You may specify a `headLink` at any time. Typically, you will specify global links in your layout script, and application specific links in your application view scripts. In your layout script, in the &lt;head&gt; section, you will then echo the helper to output it.

And then gives the following example:

``` php
$this->headLink()->appendStylesheet('/styles/basic.css')
    ->headLink(array('rel' => 'icon',
        'href' => '/img/favicon.ico'),
        'PREPEND')
    ->prependStylesheet('/styles/moz.css',
        'screen',
        true,
        array('id' => 'my_stylesheet'));
```

It would seem that, contrary to the documentation and the intent of the accompanying [test case](https://github.com/zendframework/zf2/blob/master/tests/ZendTest/View/Helper/HeadLinkTest.php#L107) (whose method name might contain the typo `headScript` instead of `headLink`), `headLink` **cannot** appear at any time when chaining methods.
