### PR TITLE
Zend\Http\Response::getBody() tries to decode gzip that has already been decoded by cURL

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -427,6 +427,14 @@ class Curl implements HttpAdapter, StreamInterface
             $this->response = str_ireplace("Transfer-Encoding: chunked\r\n", '', $this->response);
         }
 
+        // cURL can automatically handle content encoding; prevent double-decoding from occurring
+        if (isset($this->config['curloptions'][CURLOPT_ENCODING])
+            && '' == $this->config['curloptions'][CURLOPT_ENCODING]
+            && stripos($this->response, "Content-Encoding: gzip\r\n")
+        ) {
+            $this->response = str_ireplace("Content-Encoding: gzip\r\n", '', $this->response);
+        }
+
         // Eliminate multiple HTTP responses.
         do {
             $parts  = preg_split('|(?:\r?\n){2}|m', $this->response, 2);

--- a/tests/ZendTest/Http/Client/CurlTest.php
+++ b/tests/ZendTest/Http/Client/CurlTest.php
@@ -347,4 +347,22 @@ class CurlTest extends CommonHttpTests
 
         $this->assertContains($header, $curlInfo['request_header'], 'Expecting valid basic authorization header');
     }
+
+    /**
+     * @group 4555
+     */
+    public function testResponseDoesNotDoubleDecodeGzippedBody()
+    {
+        $this->client->setUri($this->baseuri . 'testCurlGzipData.php');
+        $adapter = new Adapter\Curl();
+        $adapter->setOptions(array(
+            'curloptions' => array(
+                CURLOPT_ENCODING => '',
+            ),
+        ));
+        $this->client->setAdapter($adapter);
+        $this->client->setMethod('GET');
+        $this->client->send();
+        $this->assertEquals('Success', $this->client->getResponse()->getBody());
+    }
 }

--- a/tests/ZendTest/Http/Client/_files/testCurlGzipData.php
+++ b/tests/ZendTest/Http/Client/_files/testCurlGzipData.php
@@ -1,0 +1,3 @@
+<?php
+header('Content-Encoding: gzip');
+echo gzcompress('Success');


### PR DESCRIPTION
When performing a HTTP request to a gzipped resource via a cURL adapter that is configured to decode content, a following call to $httpResponse->getBody() fails because it looks at the still-set Content-Encoding header and tries to decode the content, which is at that point already decoded, again.

You can reproduce it like this:

``` php
$httpClient = new Zend\Http\Client($urlWithGzipEncodedStuff,  [
    'adapter'      => 'Zend\Http\Client\Adapter\Curl',
    'curloptions'  => [
        // Instruct cURL to accept and decode any supported encoding.
        CURLOPT_ENCODING => '' 
    ]
]);
$httpResponse = $httpClient->send();

// BOOM: tries to decode what has already been decoded by  cURL
$content = $httpResponse->getBody();
```
