### PR TITLE
Validator\File tests throwing errors in custom PHP 5.3.10 distributions

### DIFF
--- a/tests/ZendTest/Validator/File/IsCompressedTest.php
+++ b/tests/ZendTest/Validator/File/IsCompressedTest.php
@@ -26,7 +26,7 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
     {
         // As of PHP >= 5.3.11 and >= 5.4.1 the magic database format has changed.
         // http://doc.php.net/downloads/pdf/split/de/File-Information.pdf (page 11)
-        if (version_compare(PHP_VERSION, '5.3.10', '<=')
+        if (version_compare(PHP_VERSION, '5.3.11', '<')
             || (version_compare(PHP_VERSION, '5.4', '>=')
                 && version_compare(PHP_VERSION, '5.4.1', '<'))
         ) {

--- a/tests/ZendTest/Validator/File/IsImageTest.php
+++ b/tests/ZendTest/Validator/File/IsImageTest.php
@@ -26,8 +26,10 @@ class IsImageTest extends \PHPUnit_Framework_TestCase
     {
         // As of PHP >= 5.3.11 and >= 5.4.1 the magic database format has changed.
         // http://doc.php.net/downloads/pdf/split/de/File-Information.pdf (page 11)
-        if (version_compare(PHP_VERSION, '5.3.10', '<=') || (version_compare(PHP_VERSION, '5.4', '>=') &&
-                                                             version_compare(PHP_VERSION, '5.4.1', '<'))) {
+        if (version_compare(PHP_VERSION, '5.3.11', '<')
+            || (version_compare(PHP_VERSION, '5.4', '>=')
+                && version_compare(PHP_VERSION, '5.4.1', '<'))
+        ) {
             return __DIR__ . '/_files/magic.lte.5.3.10.mime';
         }
 


### PR DESCRIPTION
The comparison is treating custom PHP 5.3.10 distributions (like 5.3.10-1ubuntu3.7) as they were 5.3.11, so the tests don't load the 5.3.10 specific mime file.

@Dasprid this should mean that the the staple Ubuntu LTS distribution is actualy not using the new mime format ;)
