### PR TITLE
Allow replacing elements within a form collection

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -225,8 +225,10 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             }
         } else {
             foreach ($this->byName as $name => $element) {
-                $element->setAttribute('value', $data[$name]);
-                unset($data[$name]);
+                if (isset($data[$name])) {
+                    $element->setAttribute('value', $data[$name]);
+                    unset($data[$name]);
+                }
             }
         }
 

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -187,25 +187,33 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             return;
         }
 
+        // If there is fewer data and allowRemove is true, we reset the element count
         if (count($data) < $this->getCount()) {
             if (!$this->allowRemove) {
                 throw new Exception\DomainException(sprintf(
                     'There are fewer elements than specified in the collection (%s). Either set the allow_remove option ' .
                     'to true, or re-submit the form.',
                     get_class($this)
-                    )
-                );
+                ));
             }
 
-            // If there are less data and that allowRemove is true, we remove elements that are not presents
             $this->setCount(count($data));
-            foreach ($this->byName as $name => $elementOrFieldset) {
-                if (isset($data[$name])) {
-                    continue;
-                }
+        }
 
-                $this->remove($name);
+        // Check to see if elements have been replaced or removed
+        foreach ($this->byName as $name => $elementOrFieldset) {
+            if (isset($data[$name])) {
+                continue;
             }
+
+            if (!$this->allowRemove) {
+                throw new Exception\DomainException(sprintf(
+                    'Elements have been removed from the collection (%s) but the allow_remove option is not true.',
+                    get_class($this)
+                ));
+            }
+
+            $this->remove($name);
         }
 
         if ($this->targetElement instanceof FieldsetInterface) {

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -79,6 +79,45 @@ class CollectionTest extends TestCase
         $this->assertEquals(3, count($collection->getElements()));
     }
 
+    public function testCanRemoveElementsIfAllowRemoveIsTrue()
+    {
+        $collection = $this->form->get('colors');
+        $collection->setAllowRemove(true);
+        $this->assertTrue($collection->allowRemove());
+
+        $data = array();
+        $data[] = 'blue';
+        $data[] = 'green';
+
+        $collection->populateValues($data);
+        $this->assertEquals(2, count($collection->getElements()));
+
+        unset($data[0]);
+
+        $collection->populateValues($data);
+        $this->assertEquals(1, count($collection->getElements()));
+    }
+
+    public function testCanReplaceElementsIfAllowAddAndAllowRemoveIsTrue()
+    {
+        $collection = $this->form->get('colors');
+        $collection->setAllowAdd(true);
+        $collection->setAllowRemove(true);
+
+        $data = array();
+        $data[] = 'blue';
+        $data[] = 'green';
+
+        $collection->populateValues($data);
+        $this->assertEquals(2, count($collection->getElements()));
+
+        unset($data[0]);
+        $data[] = 'orange';
+
+        $collection->populateValues($data);
+        $this->assertEquals(2, count($collection->getElements()));
+    }
+
     public function testCanValidateFormWithCollectionWithoutTemplate()
     {
         $this->form->setData(array(


### PR DESCRIPTION
Currently you can only remove elements by submitting fewer elements than is requested. This patch will allow you to replace elements i.e. remove an element and add another one in its place but with a different key (element name).
