### PR TITLE
Small fix for ZendTest\Form\FormTest method name

### DIFF
--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1212,7 +1212,7 @@ class FormTest extends TestCase
         $this->assertTrue($this->form->isValid());
     }
 
-    public function testDonNotApplyEmptyInputFiltersToSubFieldsetOfCollectionElementsWithCollectionInputFilters()
+    public function testDoNotApplyEmptyInputFiltersToSubFieldsetOfCollectionElementsWithCollectionInputFilters()
     {
         $collectionFieldset = new Fieldset('item');
         $collectionFieldset->add(new Element('foo'));


### PR DESCRIPTION
Renamed method from `DonNot` to `DoNot`.
