### PR TITLE
Support file stream

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -278,18 +278,12 @@ class Curl implements HttpAdapter, StreamInterface
                 if (isset($this->config['curloptions'][CURLOPT_INFILE])) {
                     // Now we will probably already have Content-Length set, so that we have to delete it
                     // from $headers at this point:
-                    foreach ($headers AS $k => $header) {
-                        if (preg_match('/Content-Length:\s*(\d+)/i', $header, $m)) {
-                            if (is_resource($body)) {
-                                $this->config['curloptions'][CURLOPT_INFILESIZE] = (int) $m[1];
-                            }
-                            unset($headers[$k]);
-                        }
-                    }
-
-                    if (!isset($this->config['curloptions'][CURLOPT_INFILESIZE])) {
+                    if ( !isset($headers['Content-Length']) ) {
                         throw new AdapterException\RuntimeException("Cannot set a file-handle for cURL option CURLOPT_INFILE without also setting its size in CURLOPT_INFILESIZE.");
                     }
+
+                    $this->config['curloptions'][CURLOPT_INFILESIZE] = (int) $headers['Content-Length'];
+                    unset($headers['Content-Length']);
 
                     if (is_resource($body)) {
                         $body = '';


### PR DESCRIPTION
hallo I think I found a forgotten code area ;)

[near this line](https://github.com/zendframework/zf2/blob/master/library/Zend/Http/Client/Adapter/Curl.php#L278)

if we have a file resource, the CURL adapter try to get the file size from the header "content-lenght".

we have on the $headers var a array like this

``` php
array(7) {
  ["Host"]=>
  string(14) "127.0.0.1:5984"
  ["Connection"]=>
  string(5) "close"
  ["Accept-Encoding"]=>
  string(13) "gzip, deflate"
  ["User-Agent"]=>
  string(16) "Zend\Http\Client"
  ["Content-Type"]=>
  string(16) "application/json"
  ["Content-Length"]=>
  string(2) "26"
  ["content-type"]=>
  string(16) "application/json"
}
```

but he try it detect form the value with preg_match()

``` php
foreach ($headers AS $k => $header) {
    if (preg_match('/Content-Length:\s*(\d+)/i', $header, $m)) {
        if (is_resource($body)) {
            $this->config['curloptions'][CURLOPT_INFILESIZE] = (int) $m[1];
        }
    unset($headers[$k]);
    }
}
```

If the old code has a reason so correct me

best regards
