### PR TITLE
Throw the original exception instead of ServiceNotCreatedException in ServiceManager::createServiceViaCallback()

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -852,16 +852,9 @@ class ServiceManager implements ServiceLocatorInterface
             $circularDependencyResolver[$depKey] = true;
             $instance = call_user_func($callable, $this, $cName, $rName);
             unset($circularDependencyResolver[$depKey]);
-        } catch (Exception\ServiceNotFoundException $e) {
-            unset($circularDependencyResolver[$depKey]);
-            throw $e;
         } catch (\Exception $e) {
             unset($circularDependencyResolver[$depKey]);
-            throw new Exception\ServiceNotCreatedException(
-                sprintf('An exception was raised while creating "%s"; no instance returned', $rName),
-                $e->getCode(),
-                $e
-            );
+            throw $e;
         }
         if ($instance === null) {
             throw new Exception\ServiceNotCreatedException('The factory was called but did not return an instance.');

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -483,15 +483,13 @@ class ServiceManagerTest extends TestCase
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Bar', $bar);
     }
 
+    /**
+     * @expectedException ZendTest\ServiceManager\TestAsset\FooException
+     */
     public function testExceptionThrowingFactory()
     {
         $this->serviceManager->setFactory('foo', 'ZendTest\ServiceManager\TestAsset\ExceptionThrowingFactory');
-        try {
-            $this->serviceManager->get('foo');
-            $this->fail("No exception thrown");
-        } catch (Exception\ServiceNotCreatedException $e) {
-            $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooException', $e->getPrevious());
-        }
+        $this->serviceManager->get('foo');
     }
 
     /**
@@ -510,7 +508,7 @@ class ServiceManagerTest extends TestCase
     }
 
     /**
-     * @expectedException Zend\ServiceManager\Exception\ServiceNotCreatedException
+     * @expectedException RuntimeException
      */
     public function testDoNotFallbackToAbstractFactory()
     {


### PR DESCRIPTION
In my unit tests I spent a lot of time to understand why my module couldn't be loaded.
I had to read the code of the framework to figure out that the exception thrown in my module was "hidden" by the ServiceNotCreatedException.
