### PR TITLE
Changed self::SPECIFICATION_* to static::SPECIFICATION_* in non declarat...

### DIFF
--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -180,13 +180,13 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
         }
 
-        $sql = sprintf($this->specifications[self::SPECIFICATION_DELETE], $table);
+        $sql = sprintf($this->specifications[static::SPECIFICATION_DELETE], $table);
 
         // process where
         if ($this->where->count() > 0) {
             $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
-            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts->getSql());
+            $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
         $statementContainer->setSql($sql);
     }
@@ -216,11 +216,11 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $table = $adapterPlatform->quoteIdentifier($schema) . $adapterPlatform->getIdentifierSeparator() . $table;
         }
 
-        $sql = sprintf($this->specifications[self::SPECIFICATION_DELETE], $table);
+        $sql = sprintf($this->specifications[static::SPECIFICATION_DELETE], $table);
 
         if ($this->where->count() > 0) {
             $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');
-            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts->getSql());
+            $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
 
         return $sql;

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -183,7 +183,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
         }
 
         $sql = sprintf(
-            $this->specifications[self::SPECIFICATION_INSERT],
+            $this->specifications[static::SPECIFICATION_INSERT],
             $table,
             implode(', ', $columns),
             implode(', ', $values)

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -232,7 +232,7 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         $values = implode(', ', $values);
 
-        return sprintf($this->specifications[self::SPECIFICATION_INSERT], $table, $columns, $values);
+        return sprintf($this->specifications[static::SPECIFICATION_INSERT], $table, $columns, $values);
     }
 
     /**

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -228,13 +228,13 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $set = implode(', ', $setSql);
         }
 
-        $sql = sprintf($this->specifications[self::SPECIFICATION_UPDATE], $table, $set);
+        $sql = sprintf($this->specifications[static::SPECIFICATION_UPDATE], $table, $set);
 
         // process where
         if ($this->where->count() > 0) {
             $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
-            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts->getSql());
+            $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
         $statementContainer->setSql($sql);
     }
@@ -278,10 +278,10 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $set = implode(', ', $setSql);
         }
 
-        $sql = sprintf($this->specifications[self::SPECIFICATION_UPDATE], $table, $set);
+        $sql = sprintf($this->specifications[static::SPECIFICATION_UPDATE], $table, $set);
         if ($this->where->count() > 0) {
             $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');
-            $sql .= ' ' . sprintf($this->specifications[self::SPECIFICATION_WHERE], $whereParts->getSql());
+            $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
         return $sql;
     }

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -152,4 +152,70 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('DELETE FROM "sch"."foo" WHERE x = y', $this->delete->getSqlString());
     }
 
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInPrepareStatement()
+    {
+        $deleteIgnore = new DeleteIgnore();
+
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $mockStatement->expects($this->at(2))
+            ->method('setSql')
+            ->with($this->equalTo('DELETE IGNORE FROM "foo" WHERE x = y'));
+
+        $deleteIgnore->from('foo')
+            ->where('x = y');
+
+        $deleteIgnore->prepareStatement($mockAdapter, $mockStatement);
+
+
+
+        // with TableIdentifier
+        $deleteIgnore = new DeleteIgnore();
+
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $mockStatement->expects($this->at(2))
+            ->method('setSql')
+            ->with($this->equalTo('DELETE IGNORE FROM "sch"."foo" WHERE x = y'));
+
+        $deleteIgnore->from(new TableIdentifier('foo', 'sch'))
+            ->where('x = y');
+
+        $deleteIgnore->prepareStatement($mockAdapter, $mockStatement);
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInGetSqlString()
+    {
+        $deleteIgnore = new DeleteIgnore();
+
+        $deleteIgnore->from('foo')
+            ->where('x = y');
+        $this->assertEquals('DELETE IGNORE FROM "foo" WHERE x = y', $deleteIgnore->getSqlString());
+
+        // with TableIdentifier
+        $deleteIgnore = new DeleteIgnore();
+        $deleteIgnore->from(new TableIdentifier('foo', 'sch'))
+            ->where('x = y');
+        $this->assertEquals('DELETE IGNORE FROM "sch"."foo" WHERE x = y', $deleteIgnore->getSqlString());
+    }
+}
+
+class DeleteIgnore extends Delete
+{
+    const SPECIFICATION_DELETE = 'deleteIgnore';
+
+    protected $specifications = array(
+        self::SPECIFICATION_DELETE => 'DELETE IGNORE FROM %1$s',
+        self::SPECIFICATION_WHERE  => 'WHERE %1$s',
+    );
 }

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -189,4 +189,76 @@ class InsertTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInPrepareStatement()
+    {
+        $replace = new Replace();
+
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer(array());
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('REPLACE INTO "foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $replace->into('foo')
+            ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()')));
+
+        $replace->prepareStatement($mockAdapter, $mockStatement);
+
+        // with TableIdentifier
+        $replace = new Replace();
+
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer(array());
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('REPLACE INTO "sch"."foo" ("bar", "boo") VALUES (?, NOW())'));
+
+        $replace->into(new TableIdentifier('foo', 'sch'))
+            ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()')));
+
+        $replace->prepareStatement($mockAdapter, $mockStatement);
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInGetSqlString()
+    {
+        $replace = new Replace();
+        $replace->into('foo')
+            ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null));
+
+        $this->assertEquals('REPLACE INTO "foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)', $replace->getSqlString(new TrustingSql92Platform()));
+
+        // with TableIdentifier
+        $replace = new Replace();
+        $replace->into(new TableIdentifier('foo', 'sch'))
+            ->values(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null));
+
+        $this->assertEquals('REPLACE INTO "sch"."foo" ("bar", "boo", "bam") VALUES (\'baz\', NOW(), NULL)', $replace->getSqlString(new TrustingSql92Platform()));
+    }
+}
+
+class Replace extends Insert
+{
+    const SPECIFICATION_INSERT = 'replace';
+
+    protected $specifications = array(
+        self::SPECIFICATION_INSERT => 'REPLACE INTO %1$s (%2$s) VALUES (%3$s)'
+    );
 }

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -252,4 +252,62 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('UPDATE "foo" SET "bar" = \'baz\' WHERE id = \'1\'', $update2->getSqlString(new TrustingSql92Platform));
     }
 
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInPrepareStatement()
+    {
+        $updateIgnore = new UpdateIgnore();
+
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue('positional'));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $pContainer = new \Zend\Db\Adapter\ParameterContainer(array());
+        $mockStatement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($pContainer));
+
+        $mockStatement->expects($this->at(1))
+            ->method('setSql')
+            ->with($this->equalTo('UPDATE IGNORE "foo" SET "bar" = ?, "boo" = NOW() WHERE x = y'));
+
+        $updateIgnore->table('foo')
+            ->set(array('bar' => 'baz', 'boo' => new Expression('NOW()')))
+            ->where('x = y');
+
+        $updateIgnore->prepareStatement($mockAdapter, $mockStatement);
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testSpecificationconstantsCouldBeOverridedByExtensionInGetSqlString()
+    {
+        $this->update = new UpdateIgnore();
+
+        $this->update->table('foo')
+            ->set(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null))
+            ->where('x = y');
+
+        $this->assertEquals('UPDATE IGNORE "foo" SET "bar" = \'baz\', "boo" = NOW(), "bam" = NULL WHERE x = y', $this->update->getSqlString(new TrustingSql92Platform()));
+
+        // with TableIdentifier
+        $this->update = new UpdateIgnore();
+        $this->update->table(new TableIdentifier('foo', 'sch'))
+            ->set(array('bar' => 'baz', 'boo' => new Expression('NOW()'), 'bam' => null))
+            ->where('x = y');
+
+        $this->assertEquals('UPDATE IGNORE "sch"."foo" SET "bar" = \'baz\', "boo" = NOW(), "bam" = NULL WHERE x = y', $this->update->getSqlString(new TrustingSql92Platform()));
+    }
+}
+
+class UpdateIgnore extends Update
+{
+    const SPECIFICATION_UPDATE = 'updateIgnore';
+
+    protected $specifications = array(
+        self::SPECIFICATION_UPDATE => 'UPDATE IGNORE %1$s SET %2$s',
+        self::SPECIFICATION_WHERE  => 'WHERE %1$s'
+    );
 }


### PR DESCRIPTION
This patch allow to extend \Zend\Db\Sql\Delete|Insert|Update classes in order to very easily implement driver specific syntaxes like the MySql REPLACE, INSERT IGNORE or INSERT ON DUPLICATE KEY UPDATE etc.

For example : 

``` php
<?php
namespace Qapa\Db\Sql\Mysql;

class Replace extends \Zend\Db\Sql\Insert
{
    /**#@+
     * Constants
     *
     * @const
     */
    const SPECIFICATION_INSERT = 'replace';
    /**#@-*/

    /**
     * @var array Specification array
     */
    protected $specifications = array(
        self::SPECIFICATION_INSERT => 'REPLACE INTO %1$s (%2$s) VALUES (%3$s)'
    );
}
```

 or 

``` php
<?php
namespace Qapa\Db\Sql\Mysql;

class InsertIgnore extends \Zend\Db\Sql\Insert
{
    /**#@+
     * Constants
     *
     * @const
     */
    const SPECIFICATION_INSERT = 'insertIgnore';
    /**#@-*/

    /**
     * @var array Specification array
     */
    protected $specifications = array(
        self::SPECIFICATION_INSERT => 'INSERT IGNORE INTO %1$s (%2$s) VALUES (%3$s)'
    );
}
```

If agreed, I will add unit tests.
