### PR TITLE
Segregation HydratorInterface

### DIFF
--- a/library/Zend/Stdlib/Extractor/ExtractionInterface.php
+++ b/library/Zend/Stdlib/Extractor/ExtractionInterface.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Stdlib\Extractor;
 
-interface ExtractorInterface
+interface ExtractionInterface
 {
     /**
      * Extract values from an object

--- a/library/Zend/Stdlib/Extractor/ExtractorInterface.php
+++ b/library/Zend/Stdlib/Extractor/ExtractorInterface.php
@@ -7,18 +7,15 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace Zend\Stdlib\Hydrator;
+namespace Zend\Stdlib\Extractor;
 
-use Zend\Stdlib\Extractor\ExtractorInterface;
-
-interface HydratorInterface extends ExtractorInterface
+interface ExtractorInterface
 {
     /**
-     * Hydrate $object with the provided $data.
+     * Extract values from an object
      *
-     * @param  array $data
      * @param  object $object
-     * @return object
+     * @return array
      */
-    public function hydrate(array $data, $object);
+    public function extract($object);
 }

--- a/library/Zend/Stdlib/Hydrator/HydrationInterface.php
+++ b/library/Zend/Stdlib/Hydrator/HydrationInterface.php
@@ -9,9 +9,14 @@
 
 namespace Zend\Stdlib\Hydrator;
 
-use Zend\Stdlib\Extractor\ExtractionInterface;
-
-interface HydratorInterface extends HydrationInterface, ExtractionInterface
+interface HydrationInterface
 {
-
+    /**
+     * Hydrate $object with the provided $data.
+     *
+     * @param  array $data
+     * @param  object $object
+     * @return object
+     */
+    public function hydrate(array $data, $object);
 }


### PR DESCRIPTION
HydratorInterface contains two responsibilities it is Hydration and Extraction, my suggestion is to segregate this responsibilities at least with Interfaces. Some times you need only extract from objects who implement both hydrate and extract. 
