### PR TITLE
Sqlsrv varbinary and ResultSet count support

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -193,9 +193,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         $sql = ($sql) ?: $this->sql;
 
         $pRef = &$this->parameterReferences;
-        //for ($position = 0, $count = substr_count($sql, '?'); $position < $count; $position++) {
-        //    $pRef[$position] = array('', SQLSRV_PARAM_IN, null, null);
-        //}
 
         $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef);
 
@@ -276,13 +273,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         $values = $this->parameterContainer->getPositionalArray();
         $this->parameterReferences = $values;
         
-        
-        //$values = $this->parameterContainer->getPositionalArray();
-        //$position = 0;
-        //foreach ($values as $value) {
-        //    $this->parameterReferences[$position++][0] = $value;
-        //}
-
         // @todo bind errata
         //foreach ($this->parameterContainer as $name => &$value) {
         //    $p[$position][0] = $value;

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -236,7 +236,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             $this->bindParametersFromContainer();
         }
         /** END Standard ParameterContainer Merging Block */
-
         if (!$this->isPrepared) {
             $this->prepare();
         }
@@ -269,18 +268,16 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     protected function bindParametersFromContainer()
     {
-        
         $parameters = $this->parameterContainer->getNamedArray();
-
         $position = 0;
         foreach ($parameters as &$value) {
-            if(is_array($value)){
+            if (is_array($value)) {
                 $this->parameterReferences[$position++] = $value;
-            }else{
-                $this->parameterReferences[$position++] = [$value,\SQLSRV_PARAM_IN, null,null];
-            } 
+            } else {
+                $this->parameterReferences[$position++] = [$value, \SQLSRV_PARAM_IN, null, null];
+            }
         }
-        
+
         // @todo bind errata
         //foreach ($this->parameterContainer as $name => &$value) {
         //    $p[$position][0] = $value;

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -274,7 +274,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             if (is_array($value)) {
                 $this->parameterReferences[$position++] = $value;
             } else {
-                $this->parameterReferences[$position++] = [$value, \SQLSRV_PARAM_IN, null, null];
+                $this->parameterReferences[$position++] = array($value, \SQLSRV_PARAM_IN, null, null);
             }
         }
 

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -193,9 +193,9 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         $sql = ($sql) ?: $this->sql;
 
         $pRef = &$this->parameterReferences;
-        for ($position = 0, $count = substr_count($sql, '?'); $position < $count; $position++) {
-            $pRef[$position] = array('', SQLSRV_PARAM_IN, null, null);
-        }
+        //for ($position = 0, $count = substr_count($sql, '?'); $position < $count; $position++) {
+        //    $pRef[$position] = array('', SQLSRV_PARAM_IN, null, null);
+        //}
 
         $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef);
 
@@ -220,9 +220,9 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     public function execute($parameters = null)
     {
-        if (!$this->isPrepared) {
-            $this->prepare();
-        }
+        //if (!$this->isPrepared) {
+        //    $this->prepare();
+        //}
 
         /** START Standard ParameterContainer Merging Block */
         if (!$this->parameterContainer instanceof ParameterContainer) {
@@ -242,6 +242,10 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             $this->bindParametersFromContainer();
         }
         /** END Standard ParameterContainer Merging Block */
+
+        if (!$this->isPrepared) {
+            $this->prepare();
+        }
 
         if ($this->profiler) {
             $this->profiler->profilerStart($this);
@@ -271,11 +275,16 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     protected function bindParametersFromContainer()
     {
+        
         $values = $this->parameterContainer->getPositionalArray();
-        $position = 0;
-        foreach ($values as $value) {
-            $this->parameterReferences[$position++][0] = $value;
-        }
+        $this->parameterReferences = $values;
+        
+        
+        //$values = $this->parameterContainer->getPositionalArray();
+        //$position = 0;
+        //foreach ($values as $value) {
+        //    $this->parameterReferences[$position++][0] = $value;
+        //}
 
         // @todo bind errata
         //foreach ($this->parameterContainer as $name => &$value) {

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -194,7 +194,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
         $pRef = &$this->parameterReferences;
 
-        $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef);
+        $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef, array('Scrollable'=> \SQLSRV_CURSOR_STATIC));
 
         $this->isPrepared = true;
         return $this;

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -270,8 +270,16 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     protected function bindParametersFromContainer()
     {
         
-        $values = $this->parameterContainer->getPositionalArray();
-        $this->parameterReferences = $values;
+        $parameters = $this->parameterContainer->getNamedArray();
+
+        $position = 0;
+        foreach ($parameters as &$value) {
+            if(is_array($value)){
+                $this->parameterReferences[$position++] = $value;
+            }else{
+                $this->parameterReferences[$position++] = [$value,\SQLSRV_PARAM_IN, null,null];
+            } 
+        }
         
         // @todo bind errata
         //foreach ($this->parameterContainer as $name => &$value) {

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -220,9 +220,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     public function execute($parameters = null)
     {
-        //if (!$this->isPrepared) {
-        //    $this->prepare();
-        //}
 
         /** START Standard ParameterContainer Merging Block */
         if (!$this->parameterContainer instanceof ParameterContainer) {


### PR DESCRIPTION
These changes should make it possible to update/insert varbinary fields in sqlsrv by passing parameters as shown below.

$params = array(
            array(
                &$file_stream,
                \SQLSRV_PARAM_IN,
                \SQLSRV_PHPTYPE_STREAM(\SQLSRV_ENC_BINARY),
                \SQLSRV_SQLTYPE_VARBINARY('max')
            ),
            $id
);

$statement->execute($params);
