### PR TITLE
Support ng-* attributes on form element view helpers.

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -350,6 +350,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
             if (!isset($this->validGlobalAttributes[$attribute])
                 && !isset($this->validTagAttributes[$attribute])
                 && 'data-' != substr($attribute, 0, 5)
+                && 'ng-' != substr($attribute, 0, 3)
             ) {
                 // Invalid attribute for the current tag
                 unset($attributes[$key]);


### PR DESCRIPTION
The popular Angular.js framework makes use of many custom attributes, within the "ng-_" namespace. This pull request would add support for "ng-_" attributes in the same manner as the "data-*" attributes.

While there already exists a workaround (using "data-ng-_" instead of "ng-_"), this would be a small change that would make it easier to work with Angular.js.
