### PR TITLE
[suggest] Ignore methods without parameters from aware interfaces

### DIFF
--- a/library/Zend/Di/Definition/CompilerDefinition.php
+++ b/library/Zend/Di/Definition/CompilerDefinition.php
@@ -254,7 +254,7 @@ class CompilerDefinition implements DefinitionInterface
                 preg_match($interfaceInjectorPattern, $rIface->getName(), $matches);
                 if ($matches) {
                     foreach ($rIface->getMethods() as $rMethod) {
-                        if ($rMethod->getName() === '__construct') {
+                        if (($rMethod->getName() === '__construct') || (count($rMethod->getParameters()) < 1)) {
                             // constructor not allowed in interfaces
                             continue;
                         }

--- a/library/Zend/Di/Definition/CompilerDefinition.php
+++ b/library/Zend/Di/Definition/CompilerDefinition.php
@@ -254,8 +254,9 @@ class CompilerDefinition implements DefinitionInterface
                 preg_match($interfaceInjectorPattern, $rIface->getName(), $matches);
                 if ($matches) {
                     foreach ($rIface->getMethods() as $rMethod) {
-                        if (($rMethod->getName() === '__construct') || (count($rMethod->getParameters()) < 1)) {
+                        if (($rMethod->getName() === '__construct') || !count($rMethod->getParameters())) {
                             // constructor not allowed in interfaces
+                            // ignore methods without parameters
                             continue;
                         }
                         $def['methods'][$rMethod->getName()] = true;

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -302,8 +302,9 @@ class RuntimeDefinition implements DefinitionInterface
                 preg_match($interfaceInjectorPattern, $rIface->getName(), $matches);
                 if ($matches) {
                     foreach ($rIface->getMethods() as $rMethod) {
-                        if ($rMethod->getName() === '__construct') {
+                        if (($rMethod->getName() === '__construct') || (count($rMethod->getParameters()) < 1)) {
                             // constructor not allowed in interfaces
+                            // Don't call interface methods without a parameter (Some aware interfaces define setters in ZF2)
                             continue;
                         }
                         $def['methods'][$rMethod->getName()] = Di::METHOD_IS_AWARE;

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -302,7 +302,7 @@ class RuntimeDefinition implements DefinitionInterface
                 preg_match($interfaceInjectorPattern, $rIface->getName(), $matches);
                 if ($matches) {
                     foreach ($rIface->getMethods() as $rMethod) {
-                        if (($rMethod->getName() === '__construct') || (count($rMethod->getParameters()) < 1)) {
+                        if (($rMethod->getName() === '__construct') || !count($rMethod->getParameters())) {
                             // constructor not allowed in interfaces
                             // Don't call interface methods without a parameter (Some aware interfaces define setters in ZF2)
                             continue;

--- a/tests/ZendTest/Di/Definition/CompilerDefinitionTest.php
+++ b/tests/ZendTest/Di/Definition/CompilerDefinitionTest.php
@@ -119,4 +119,17 @@ class CompilerDefinitionTest extends TestCase
         $this->assertTrue($definition->hasMethod('ZendTest\Di\TestAsset\SetterInjection\StaticSetter', 'setFoo'));
         $this->assertFalse($definition->hasMethod('ZendTest\Di\TestAsset\SetterInjection\StaticSetter', 'setName'));
     }
+
+    /**
+     * Test if methods from aware interfaces without params are excluded
+     */
+    public function testExcludeAwareMethodsWithoutParameters()
+    {
+        $definition = new CompilerDefinition();
+        $definition->addDirectory(__DIR__ . '/../TestAsset/AwareClasses');
+        $definition->compile();
+
+        $this->assertTrue($definition->hasMethod('ZendTest\Di\TestAsset\AwareClasses\B', 'setSomething'));
+        $this->assertFalse($definition->hasMethod('ZendTest\Di\TestAsset\AwareClasses\B', 'getSomething'));
+    }
 }

--- a/tests/ZendTest/Di/Definition/RuntimeDefinitionTest.php
+++ b/tests/ZendTest/Di/Definition/RuntimeDefinitionTest.php
@@ -93,4 +93,14 @@ class RuntimeDefinitionTest extends TestCase
             )
         );
     }
+
+    /**
+     * Test if methods from aware interfaces without params are excluded
+     */
+    public function testExcludeAwareMethodsWithoutParameters()
+    {
+        $definition = new RuntimeDefinition();
+        $this->assertTrue($definition->hasMethod('ZendTest\Di\TestAsset\AwareClasses\B', 'setSomething'));
+        $this->assertFalse($definition->hasMethod('ZendTest\Di\TestAsset\AwareClasses\B', 'getSomething'));
+    }
 }

--- a/tests/ZendTest/Di/TestAsset/AwareClasses/A.php
+++ b/tests/ZendTest/Di/TestAsset/AwareClasses/A.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Di
+ */
+
+namespace ZendTest\Di\TestAsset\AwareClasses;
+
+class A
+{
+}

--- a/tests/ZendTest/Di/TestAsset/AwareClasses/A.php
+++ b/tests/ZendTest/Di/TestAsset/AwareClasses/A.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Di
  */
 
 namespace ZendTest\Di\TestAsset\AwareClasses;

--- a/tests/ZendTest/Di/TestAsset/AwareClasses/B.php
+++ b/tests/ZendTest/Di/TestAsset/AwareClasses/B.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Di
+ */
+
+namespace ZendTest\Di\TestAsset\AwareClasses;
+
+class B implements NoParamsAwareInterface
+{
+    /**
+     * @see \ZendTest\Di\TestAsset\AwareClasses\NoParamsAwareInterface::getSomething()
+     */
+    public function getSomething()
+    {
+    }
+
+    /**
+     * @see \ZendTest\Di\TestAsset\AwareClasses\NoParamsAwareInterface::setSomething()
+     */
+    public function setSomething(A $something)
+    {
+    }
+}

--- a/tests/ZendTest/Di/TestAsset/AwareClasses/B.php
+++ b/tests/ZendTest/Di/TestAsset/AwareClasses/B.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Di
  */
 
 namespace ZendTest\Di\TestAsset\AwareClasses;

--- a/tests/ZendTest/Di/TestAsset/AwareClasses/NoParamsAwareInterface.php
+++ b/tests/ZendTest/Di/TestAsset/AwareClasses/NoParamsAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Di
+ */
+
+namespace ZendTest\Di\TestAsset\AwareClasses;
+
+interface NoParamsAwareInterface
+{
+    public function setSomething(A $something);
+    public function getSomething();
+}

--- a/tests/ZendTest/Di/TestAsset/AwareClasses/NoParamsAwareInterface.php
+++ b/tests/ZendTest/Di/TestAsset/AwareClasses/NoParamsAwareInterface.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Di
  */
 
 namespace ZendTest\Di\TestAsset\AwareClasses;


### PR DESCRIPTION
Some aware interfaces in ZF2 define setters which do not expect any parameter.
These setters are not thought to be called by the dependency injector.

It doesn't make sense anyway to process interface methods from aware interfaces that doesn't have parameters. Even worse: Di could call a method that it should not invoke.
