### PR TITLE
Redundant conditional

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -475,7 +475,6 @@ class ServiceManager implements ServiceLocatorInterface
                 isset($this->invokableClasses[$cName])
                 || isset($this->factories[$cName])
                 || isset($this->aliases[$cName])
-                || isset($this->instances[$cName])
                 || $this->canCreateFromAbstractFactory($cName, $name)
             ) {
                 $instance = $this->create(array($cName, $name));


### PR DESCRIPTION
The previous conditional guarantees that in this block isset($this->instances[$cName]) must be false.  Otherwise we would have returned already.  No point checking it again here.
