### PR TITLE
remove unused $typeFormats property at Zend/Code/Generator/DocBlock/Tag.php

### DIFF
--- a/library/Zend/Code/Generator/DocBlock/Tag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag.php
@@ -17,24 +17,6 @@ use Zend\Code\Reflection\DocBlock\Tag\TagInterface as ReflectionDocBlockTag;
 class Tag extends AbstractGenerator
 {
     /**
-     * @var array
-     */
-    protected static $typeFormats = array(
-        array(
-            'param',
-            '@param <type> <variable> <description>'
-        ),
-        array(
-            'return',
-            '@return <type> <description>'
-        ),
-        array(
-            'tag',
-            '@<name> <description>'
-        )
-    );
-
-    /**
      * @var string
      */
     protected $name = null;


### PR DESCRIPTION
the $typeFormats property is never used.
