### PR TITLE
Add Zend\Uri as a suggest because it is required by the Uri & Sitemap\Loc validator

### DIFF
--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -28,7 +28,8 @@
         "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
         "zendframework/zend-math": "Zend\\Math component",
         "zendframework/zend-resources": "Translations of validator messages",
-        "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains"
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+        "zendframework/zend-uri": "Zend\\Uri component, required by the Uri validator"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -29,7 +29,7 @@
         "zendframework/zend-math": "Zend\\Math component",
         "zendframework/zend-resources": "Translations of validator messages",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-        "zendframework/zend-uri": "Zend\\Uri component, required by the Uri validator"
+        "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
If you don't have Zend\Uri installed and try to use Zend\Validator\Uri or Zend\Validator\Sitemap\Loc it will give you a fatal PHP error.
