### PR TITLE
Mime\Message: createFromString: really ignore unknown headers

### DIFF
--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -224,6 +224,7 @@ class Message
         foreach ($parts as $part) {
             // now we build a new MimePart for the current Message Part:
             $newPart = new Part($part['body']);
+
             foreach ($part['header'] as $header) {
                 /** @var \Zend\Mail\Header\HeaderInterface $header */
                 /**
@@ -255,7 +256,8 @@ class Message
                         $newPart->language = $fieldValue;
                         break;
                     default:
-                        throw new Exception\RuntimeException('Unknown header ignored for MimePart:' . $fieldName);
+                        // Ignore unknown header
+                        break;
                 }
             }
             $res->addPart($newPart);

--- a/tests/ZendTest/Mime/MimeTest.php
+++ b/tests/ZendTest/Mime/MimeTest.php
@@ -135,6 +135,36 @@ class MimeTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFromMessageMultiPart()
+    {
+        $message = Mime\Message::createFromMessage(
+            '--089e0141a1902f83ee04e0a07b7a'."\r\n"
+			.'Content-Type: multipart/alternative; boundary=089e0141a1902f83e904e0a07b78'."\r\n"
+            ."\r\n"
+			.'--089e0141a1902f83e904e0a07b78'."\r\n"
+			.'Content-Type: text/plain; charset=UTF-8'."\r\n"
+            ."\r\n"
+			.'Foo'."\r\n"
+            ."\r\n"
+			.'--089e0141a1902f83e904e0a07b78'."\r\n"
+			.'Content-Type: text/html; charset=UTF-8'."\r\n"
+            ."\r\n"
+			.'<p>Foo</p>'."\r\n"
+            ."\r\n"
+			.'--089e0141a1902f83e904e0a07b78--'."\r\n"
+			.'--089e0141a1902f83ee04e0a07b7a'."\r\n"
+			.'Content-Type: image/png; name="1.png"'."\r\n"
+			.'Content-Disposition: attachment; filename="1.png"'."\r\n"
+			.'Content-Transfer-Encoding: base64'."\r\n"
+			.'X-Attachment-Id: barquux'."\r\n"
+            ."\r\n"
+			.'Zm9vCg=='."\r\n"
+			.'--089e0141a1902f83ee04e0a07b7a--',
+            '089e0141a1902f83ee04e0a07b7a'
+        );
+        $this->assertSame(2, count($message->getParts()));
+    }
+
     /**
      * @group ZF-1688
      */


### PR DESCRIPTION
It is confusing that createFromString throws an exception that can't be ignored on such a small detail as an unknown header, especially given that unknown headers can be quite popular. For example, an `X-Attachment-Id` header.

It is more confusing that the exception claims to ignore the unknown header, while, of course, it's an exception.
So it doesn't ignore it.
