### PR TITLE
Implemented possibilities to inject own route plugin representation in TreeRouteStack

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -55,6 +55,7 @@ class TreeRouteStack extends SimpleRouteStack
                 'method'   => __NAMESPACE__ . '\Method',
             ) as $name => $class
         ) {
+            if ($routes->has($name, false)) continue;
             $routes->setInvokableClass($name, $class);
         };
     }


### PR DESCRIPTION
This fix will provide possibilities to inject own implementation of Router/Http/Part or Router/Http/Literal without requirements to rewrite bunch of factories. 
