### PR TITLE
Fix setLabel() to add label in option

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -314,6 +314,7 @@ class Element implements
     {
         if (is_string($label)) {
             $this->label = $label;
+            $this->options['label'] = $label;
         }
 
         return $this;


### PR DESCRIPTION
Noticed that setLabel doesn't put label in options ; so when calling
getOption('label') it doesn't work
