### PR TITLE
Allow form caching

### DIFF
--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -38,8 +38,6 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function __construct($options = null)
     {
-        $this->filters = new PriorityQueue();
-
         if (null !== $options) {
             $this->setOptions($options);
         }
@@ -96,7 +94,7 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function count()
     {
-        return count($this->filters);
+        return count($this->getFilters());
     }
 
     /**
@@ -156,7 +154,7 @@ class FilterChain extends AbstractFilter implements Countable
             }
             $callback = array($callback, 'filter');
         }
-        $this->filters->insert($callback, $priority);
+        $this->getFilters()->insert($callback, $priority);
         return $this;
     }
 
@@ -190,7 +188,7 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function merge(FilterChain $filterChain)
     {
-        foreach ($filterChain->filters->toArray(PriorityQueue::EXTR_BOTH) as $item) {
+        foreach ($filterChain->getFilters()->toArray(PriorityQueue::EXTR_BOTH) as $item) {
             $this->attach($item['data'], $item['priority']);
         }
 
@@ -204,6 +202,9 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function getFilters()
     {
+    	if (null === $this->filters) {
+    		$this->filters = new PriorityQueue();
+    	}
         return $this->filters;
     }
 
@@ -217,7 +218,7 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function filter($value)
     {
-        $chain = clone $this->filters;
+        $chain = clone $this->getFilters();
 
         $valueFiltered = $value;
         foreach ($chain as $filter) {
@@ -232,7 +233,7 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function __clone()
     {
-        $this->filters = clone $this->filters;
+        $this->filters = clone $this->getFilters();
     }
 
     /**

--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -202,9 +202,9 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function getFilters()
     {
-    	if (null === $this->filters) {
-    		$this->filters = new PriorityQueue();
-    	}
+        if (null === $this->filters) {
+            $this->filters = new PriorityQueue();
+        }
         return $this->filters;
     }
 

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -423,9 +423,9 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function getIterator()
     {
-    	if (null === $this->iterator) {
-    		$this->iterator = new PriorityQueue();
-    	}
+        if (null === $this->iterator) {
+            $this->iterator = new PriorityQueue();
+        }
         return $this->iterator;
     }
 

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -176,7 +176,7 @@ class Fieldset extends Element implements FieldsetInterface
             $order = $flags['priority'];
         }
 
-        $this->iterator->insert($elementOrFieldset, $order);
+        $this->getIterator()->insert($elementOrFieldset, $order);
         $this->byName[$name] = $elementOrFieldset;
 
         if ($elementOrFieldset instanceof FieldsetInterface) {
@@ -235,7 +235,7 @@ class Fieldset extends Element implements FieldsetInterface
         $entry = $this->byName[$elementOrFieldset];
         unset($this->byName[$elementOrFieldset]);
 
-        $this->iterator->remove($entry);
+        $this->getIterator()->remove($entry);
 
         if ($entry instanceof FieldsetInterface) {
             unset($this->fieldsets[$elementOrFieldset]);
@@ -413,7 +413,7 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function count()
     {
-        return $this->iterator->count();
+        return $this->getIterator()->count();
     }
 
     /**
@@ -423,6 +423,9 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function getIterator()
     {
+    	if (null === $this->iterator) {
+    		$this->iterator = new PriorityQueue();
+    	}
         return $this->iterator;
     }
 
@@ -613,7 +616,7 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function __clone()
     {
-        $items = $this->iterator->toArray(PriorityQueue::EXTR_BOTH);
+        $items = $this->getIterator()->toArray(PriorityQueue::EXTR_BOTH);
 
         $this->byName    = array();
         $this->elements  = array();
@@ -624,7 +627,7 @@ class Fieldset extends Element implements FieldsetInterface
             $elementOrFieldset = clone $item['data'];
             $name = $elementOrFieldset->getName();
 
-            $this->iterator->insert($elementOrFieldset, $item['priority']);
+            $this->getIterator()->insert($elementOrFieldset, $item['priority']);
             $this->byName[$name] = $elementOrFieldset;
 
             if ($elementOrFieldset instanceof FieldsetInterface) {

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -616,7 +616,8 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function __clone()
     {
-        $items = $this->getIterator()->toArray(PriorityQueue::EXTR_BOTH);
+        $iterator  = $this->getIterator();
+        $items     = $iterator->toArray(PriorityQueue::EXTR_BOTH);
 
         $this->byName    = array();
         $this->elements  = array();
@@ -627,7 +628,7 @@ class Fieldset extends Element implements FieldsetInterface
             $elementOrFieldset = clone $item['data'];
             $name = $elementOrFieldset->getName();
 
-            $this->getIterator()->insert($elementOrFieldset, $item['priority']);
+            $iterator->insert($elementOrFieldset, $item['priority']);
             $this->byName[$name] = $elementOrFieldset;
 
             if ($elementOrFieldset instanceof FieldsetInterface) {


### PR DESCRIPTION
Hello,

When using Doctrine2's AnnotationBuilder, I would like to be able to cache the form created from an entity since it is quite slow to build it from annotations (I love them nonetheless). However, some calls in the constructors for Zend\Form make it impossible to cache objects in APC since they do not call the constructors when they are unserialized.

I got rid of one call in the constructor of FilterChain but couldn't in Fieldset since it resulted in a failed test. I do not know if this is the right approach (though I think __wakeup() and __sleep() methods are out of the question IMHO) but this seems to be a light fix for this approach. The tests seem to be ok with this, The removal of the call in FilterChain might break BC when I think about it. Any thoughts ?

Another approach could be implementing a setIterator() method on FieldSet and a setFilters() on FilterChain. I do not know what approach is best, I do not know if this method is better than the other, test-wise.

Here's the problematic code :

``` php
public function getForm($entity)
{
    $cache = \Zend\Cache\StorageFactory::factory(array(
        'adapter' => 'apc',
        'plugins' => array(
            'exception_handler' => array('throw_exceptions' => false),
        ),
    ));

    $em           = $this->getManager();
    $cacheKey     = get_class($entity);
    $hydrator     = new DoctrineHydrator($em, $this->getRepoName());

    if ($cache->hasItem($cacheKey)) {
        $form = $cache->getItem($cacheKey);
    }
    else {
        $builder      = new AnnotationBuilder($em);
        $form         = $builder->createForm($entity);
        $cache->setItem($cacheKey, $form);
    }
    $form->setHydrator($hydrator);
    $form->bind($entity);

    return $form;
}
```
