### PR TITLE
Add matching capabilities to the Content-Type header

### DIFF
--- a/library/Zend/Http/Header/ContentType.php
+++ b/library/Zend/Http/Header/ContentType.php
@@ -80,6 +80,8 @@ class ContentType implements HeaderInterface
         $left      = $this->getMediaTypeObjectFromString($mediaType);
 
         foreach ($matchAgainst as $matchType) {
+            $matchType = strtolower($matchType);
+
             if ($mediaType == $matchType) {
                 return $matchType;
             }
@@ -145,7 +147,7 @@ class ContentType implements HeaderInterface
      */
     public function setMediaType($mediaType)
     {
-        $this->mediaType = $mediaType;
+        $this->mediaType = strtolower($mediaType);
         $this->value     = null;
         return $this;
     }

--- a/library/Zend/Http/Header/ContentType.php
+++ b/library/Zend/Http/Header/ContentType.php
@@ -51,7 +51,7 @@ class ContentType implements HeaderInterface
 
         if (count($parts) > 0) {
             $parameters = array();
-            foreach ($parameters as $parameter) {
+            foreach ($parts as $parameter) {
                 $parameter = trim($parameter);
                 if (!preg_match('/^(?P<key>[^\s\=]+)\=(?P<value>[^\s\=]*)$/', $parameter, $matches)) {
                     continue;

--- a/library/Zend/Http/Header/ContentType.php
+++ b/library/Zend/Http/Header/ContentType.php
@@ -9,13 +9,30 @@
 
 namespace Zend\Http\Header;
 
+use stdClass;
+
 /**
  * @throws Exception\InvalidArgumentException
  * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
  */
 class ContentType implements HeaderInterface
 {
+    /**
+     * @var string
+     */
+    protected $mediaType;
 
+    /**
+     * @var array
+     */
+    protected $parameters = array();
+
+    /**
+     * Factory method: create an object from a string representation
+     *
+     * @param  string $headerLine
+     * @return self
+     */
     public static function fromString($headerLine)
     {
         $header = new static();
@@ -27,24 +44,324 @@ class ContentType implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Type string: "' . $name . '"');
         }
 
-        // @todo implementation details
-        $header->value = $value;
+        $header->value     = $value;
+        $parts             = explode(';', $value);
+        $mediaType         = array_shift($parts);
+        $header->mediaType = trim($mediaType);
+
+        if (count($parts) > 0) {
+            $parameters = array();
+            foreach ($parameters as $parameter) {
+                $parameter = trim($parameter);
+                if (!preg_match('/^(?P<key>[^\s\=]+)\=(?P<value>[^\s\=]*)$/', $parameter, $matches)) {
+                    continue;
+                }
+                $parameters[$matches['key']] = $matches['value'];
+            }
+            $header->setParameters($parameters);
+        }
 
         return $header;
     }
 
+    /**
+     * Determine if the mediatype value in this header matches the provided criteria
+     *
+     * @param  array|string $matchAgainst
+     * @return stdClass|bool Matched value or false
+     */
+    public function match($matchAgainst)
+    {
+        if (is_string($matchAgainst)) {
+            $matchAgainst = $this->splitMediaTypesFromString($matchAgainst);
+        }
+
+        $left = $this->getMediaTypeObjectFromString($this->getMediaType());
+
+        foreach ($matchAgainst as $matchType) {
+            $right = $this->getMediaTypeObjectFromString($matchType);
+
+            // Is the right side a wildcard type?
+            if ($right->type == '*') {
+                return $this->validateSubtype($right, $left);
+            }
+
+            // Do the types match?
+            if ($right->type == $left->type) {
+                return $this->validateSubtype($right, $left);
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Create a string representation of the header
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'Content-Type: ' . $this->getFieldValue();
+    }
+
+    /**
+     * Get the field name
+     *
+     * @return string
+     */
     public function getFieldName()
     {
         return 'Content-Type';
     }
 
+    /**
+     * Get the field value
+     *
+     * @return string
+     */
     public function getFieldValue()
     {
-        return $this->value;
+        if (null !== $this->value) {
+            return $this->value;
+        }
+        return $this->assembleValue();
     }
 
-    public function toString()
+    /**
+     * Set the media type
+     *
+     * @param  string $mediaType
+     * @return self
+     */
+    public function setMediaType($mediaType)
     {
-        return 'Content-Type: ' . $this->getFieldValue();
+        $this->mediaType = $mediaType;
+        $this->value     = null;
+        return $this;
+    }
+
+    /**
+     * Get the media type
+     *
+     * @return string
+     */
+    public function getMediaType()
+    {
+        return $this->mediaType;
+    }
+
+    /**
+     * Set additional content-type parameters
+     *
+     * @param  array $parameters
+     * @return self
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = array_merge($this->parameters, $parameters);
+        $this->value      = null;
+        return $this;
+    }
+
+    /**
+     * Get any additional content-type parameters currently set
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Set the content-type character set encoding
+     *
+     * @param  string $charset
+     * @return self
+     */
+    public function setCharset($charset)
+    {
+        $this->parameters['charset'] = $charset;
+        $this->value = null;
+        return $this;
+    }
+
+    /**
+     * Get the content-type character set encoding, if any
+     *
+     * @return null|string
+     */
+    public function getCharset()
+    {
+        if (isset($this->parameters['charset'])) {
+            return $this->parameters['charset'];
+        }
+        return null;
+    }
+
+    /**
+     * Assemble the value based on the media type and any available parameters
+     *
+     * @return string
+     */
+    protected function assembleValue()
+    {
+        $mediaType = $this->getMediaType();
+        if (empty($this->parameters)) {
+            return $mediaType;
+        }
+
+        $parameters = array();
+        foreach ($this->parameters as $key => $value) {
+            $parameters[] = sprintf('%s=%s', $key, $value);
+        }
+
+        return sprintf('%s; %s', $mediaType, implode('; ', $parameters));
+    }
+
+    /**
+     * Split comma-separated media types into an array
+     *
+     * @param  string $criteria
+     * @return array
+     */
+    protected function splitMediaTypesFromString($criteria)
+    {
+        $mediaTypes = explode(',', $criteria);
+        array_walk($mediaTypes, 'trim');
+        return $mediaTypes;
+    }
+
+    /**
+     * Split a mediatype string into an object with the following parts:
+     *
+     * - type
+     * - subtype
+     * - format
+     *
+     * @param  string $string
+     * @return stdClass
+     */
+    protected function getMediaTypeObjectFromString($string)
+    {
+        if (!is_string($string)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Non-string mediatype "%s" provided',
+                (is_object($string) ? get_class($string) : gettype($string))
+            ));
+        }
+
+        $parts = explode('/', $string, 2);
+        if (1 == count($parts)) {
+            throw new Exception\DomainException(sprintf(
+                'Invalid mediatype "%s" provided',
+                $string
+            ));
+        }
+
+        $type    = array_shift($parts);
+        $subtype = array_shift($parts);
+        $format  = $subtype;
+        if (strstr($subtype, '+')) {
+            $parts   = explode('+', $subtype, 2);
+            $subtype = array_shift($parts);
+            $format  = array_shift($parts);
+        }
+
+        $mediaType = (object) array(
+            'type'    => $type,
+            'subtype' => $subtype,
+            'format'  => $format,
+        );
+
+        return $mediaType;
+    }
+
+    /**
+     * Validate a subtype
+     *
+     * @param  stdClass $right
+     * @param  stdClass $left
+     * @return bool
+     */
+    protected function validateSubtype($right, $left)
+    {
+        // Is the right side a wildcard subtype?
+        if ($right->subtype == '*') {
+            return $this->validateFormat($right, $left);
+        }
+
+        // Do the right side and left side subtypes match?
+        if ($right->subtype == $left->subtype) {
+            return $this->validateFormat($right, $left);
+        }
+
+        // Is the right side a partial wildcard?
+        if ('*' == substr($right->subtype, -1)) {
+            // validate partial-wildcard subtype
+            if (!$this->validatePartialWildcard($right->subtype, $left->subtype)) {
+                return false;
+            }
+            // Finally, verify format is valid
+            return $this->validateFormat($right, $left);
+        }
+
+        // Does the right side subtype match the left side format?
+        if ($right->subtype == $left->format) {
+            return true;
+        }
+
+        // At this point, there is no valid match
+        return false;
+    }
+
+    /**
+     * Validate the format
+     *
+     * Validate that the right side format matches what the left side defines.
+     *
+     * @param  string $right
+     * @param  string $left
+     * @return bool
+     */
+    protected function validateFormat($right, $left)
+    {
+        if ($right->format && $left->format) {
+            if ($right->format == '*') {
+                return true;
+            }
+            if ($right->format == $left->format) {
+                return true;
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a partial wildcard (i.e., string ending in '*')
+     *
+     * @param  string $right
+     * @param  string $left
+     * @return bool
+     */
+    protected function validatePartialWildcard($right, $left)
+    {
+        $requiredSegment = substr($right, 0, strlen($right) - 1);
+        if ($requiredSegment == $left) {
+            return true;
+        }
+
+        if (strlen($requiredSegment) >= strlen($left)) {
+            return false;
+        }
+
+        if (0 === strpos($left, $requiredSegment)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/library/Zend/Http/Header/ContentType.php
+++ b/library/Zend/Http/Header/ContentType.php
@@ -68,7 +68,7 @@ class ContentType implements HeaderInterface
      * Determine if the mediatype value in this header matches the provided criteria
      *
      * @param  array|string $matchAgainst
-     * @return stdClass|bool Matched value or false
+     * @return string|bool Matched value or false
      */
     public function match($matchAgainst)
     {
@@ -76,23 +76,32 @@ class ContentType implements HeaderInterface
             $matchAgainst = $this->splitMediaTypesFromString($matchAgainst);
         }
 
-        $left = $this->getMediaTypeObjectFromString($this->getMediaType());
+        $mediaType = $this->getMediaType();
+        $left      = $this->getMediaTypeObjectFromString($mediaType);
 
         foreach ($matchAgainst as $matchType) {
+            if ($mediaType == $matchType) {
+                return $matchType;
+            }
+
             $right = $this->getMediaTypeObjectFromString($matchType);
 
             // Is the right side a wildcard type?
             if ($right->type == '*') {
-                return $this->validateSubtype($right, $left);
+                if ($this->validateSubtype($right, $left)) {
+                    return $matchType;
+                }
             }
 
             // Do the types match?
             if ($right->type == $left->type) {
-                return $this->validateSubtype($right, $left);
+                if ($this->validateSubtype($right, $left)) {
+                    return $matchType;
+                }
             }
-
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/library/Zend/Http/Header/Exception/DomainException.php
+++ b/library/Zend/Http/Header/Exception/DomainException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Http\Header\Exception;
+
+class DomainException extends \DomainException implements ExceptionInterface
+{
+}

--- a/tests/ZendTest/Http/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Http/Header/ContentTypeTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Http
  */
 
 namespace ZendTest\Http\Header;
@@ -30,22 +29,40 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testContentTypeGetFieldValueReturnsProperValue()
     {
-        $this->markTestIncomplete('ContentType needs to be completed');
-
-        $contentTypeHeader = new ContentType();
-        $this->assertEquals('xxx', $contentTypeHeader->getFieldValue());
+        $header = ContentType::fromString('Content-Type: application/json');
+        $this->assertEquals('application/json', $header->getFieldValue());
     }
 
     public function testContentTypeToStringReturnsHeaderFormattedString()
     {
-        $this->markTestIncomplete('ContentType needs to be completed');
+        $header = new ContentType();
+        $header->setMediaType('application/atom+xml')
+               ->setCharset('ISO-8859-1');
 
-        $contentTypeHeader = new ContentType();
-
-        // @todo set some values, then test output
-        $this->assertEmpty('Content-Type: xxx', $contentTypeHeader->toString());
+        $this->assertEquals('Content-Type: application/atom+xml; charset=ISO-8859-1', $header->toString());
     }
 
-    /** Implmentation specific tests here */
+    /** Implementation specific tests here */
 
+    public function wildcardMatches()
+    {
+        return array(
+            'wildcard' => array('*/*'),
+            'wildcard-type-subtype-fixed-format' => array('*/*+json'),
+            'wildcard-type-format-subtype' => array('*/json'),
+            'fixed-type-wildcard-subtype' => array('application/*'),
+            'fixed-type-fixed-subtype-wildcard-format' => array('application/vnd.foobar+*'),
+            'fixed' => array('application/vnd.foobar+json'),
+        );
+    }
+
+    /**
+     * @dataProvider wildcardMatches
+     */
+    public function testMatchWildCard($matchAgainst)
+    {
+        $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
+        $result = $header->match($matchAgainst);
+        $this->assertTrue($header->match($matchAgainst));
+    }
 }

--- a/tests/ZendTest/Http/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Http/Header/ContentTypeTest.php
@@ -58,6 +58,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             'fixed-type-fixed-subtype-wildcard-format' => array('application/vnd.foobar+*'),
             'fixed-type-partial-wildcard-subtype-fixed-format' => array('application/vnd.*+json'),
             'fixed' => array('application/vnd.foobar+json'),
+            'fixed-mixed-case' => array('APPLICATION/vnd.FooBar+json'),
         );
     }
 
@@ -68,7 +69,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
         $result = $header->match($matchAgainst);
-        $this->assertEquals($matchAgainst, $result);
+        $this->assertEquals(strtolower($matchAgainst), $result);
     }
 
     public function invalidMatches()

--- a/tests/ZendTest/Http/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Http/Header/ContentTypeTest.php
@@ -48,10 +48,15 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             'wildcard' => array('*/*'),
+            'wildcard-format' => array('*/*+*'),
             'wildcard-type-subtype-fixed-format' => array('*/*+json'),
+            'wildcard-type-partial-wildcard-subtype-fixed-format' => array('*/vnd.*+json'),
             'wildcard-type-format-subtype' => array('*/json'),
             'fixed-type-wildcard-subtype' => array('application/*'),
+            'fixed-type-wildcard-subtype-fixed-format' => array('application/*+json'),
+            'fixed-type-format-subtype' => array('application/json'),
             'fixed-type-fixed-subtype-wildcard-format' => array('application/vnd.foobar+*'),
+            'fixed-type-partial-wildcard-subtype-fixed-format' => array('application/vnd.*+json'),
             'fixed' => array('application/vnd.foobar+json'),
         );
     }
@@ -64,5 +69,28 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
         $result = $header->match($matchAgainst);
         $this->assertTrue($header->match($matchAgainst));
+    }
+
+    public function invalidMatches()
+    {
+        return array(
+            'format' => array('application/vnd.foobar+xml'),
+            'wildcard-subtype' => array('application/vendor.*+json'),
+            'subtype' => array('application/vendor.foobar+json'),
+            'type' => array('text/vnd.foobar+json'),
+            'wildcard-type-format' => array('*/vnd.foobar+xml'),
+            'wildcard-type-wildcard-subtype' => array('*/vendor.*+json'),
+            'wildcard-type-subtype' => array('*/vendor.foobar+json'),
+        );
+    }
+
+    /**
+     * @dataProvider invalidMatches
+     */
+    public function testFailedMatches($matchAgainst)
+    {
+        $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
+        $result = $header->match($matchAgainst);
+        $this->assertFalse($header->match($matchAgainst));
     }
 }

--- a/tests/ZendTest/Http/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Http/Header/ContentTypeTest.php
@@ -68,7 +68,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
         $result = $header->match($matchAgainst);
-        $this->assertTrue($header->match($matchAgainst));
+        $this->assertEquals($matchAgainst, $result);
     }
 
     public function invalidMatches()
@@ -91,6 +91,30 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
         $result = $header->match($matchAgainst);
-        $this->assertFalse($header->match($matchAgainst));
+        $this->assertFalse($result);
+    }
+
+    public function multipleCriteria()
+    {
+        $criteria = array(
+            'application/vnd.foobar+xml',
+            'application/vnd.*+json',
+            'application/vendor.foobar+xml',
+            '*/vnd.foobar+json',
+        );
+        return array(
+            'array' => array($criteria),
+            'string' => array(implode(',', $criteria)),
+        );
+    }
+
+    /**
+     * @dataProvider multipleCriteria
+     */
+    public function testReturnsMatchingMediaTypeOfFirstCriteriaToValidate($criteria)
+    {
+        $header = ContentType::fromString('Content-Type: application/vnd.foobar+json');
+        $result = $header->match($criteria);
+        $this->assertEquals('application/vnd.*+json', $result);
     }
 }

--- a/tests/ZendTest/Http/Response/ResponseStreamTest.php
+++ b/tests/ZendTest/Http/Response/ResponseStreamTest.php
@@ -77,7 +77,7 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
 
         // Check header integrity
         $this->assertEquals('timeout=15,max=100', $response->getHeaders()->get('keep-alive')->getFieldValue());
-        $this->assertEquals('text/html;charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
+        $this->assertEquals('text/html; charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
     }
 
 

--- a/tests/ZendTest/Http/ResponseTest.php
+++ b/tests/ZendTest/Http/ResponseTest.php
@@ -316,7 +316,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         // Check header integrity
         $this->assertEquals('timeout=15,max=100', $response->getHeaders()->get('keep-alive')->getFieldValue());
-        $this->assertEquals('text/html;charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
+        $this->assertEquals('text/html; charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
     }
 
     /**


### PR DESCRIPTION
This pull request adds the ability to `match()` a `ContentType` header against one or more mediatype specifications. As an example, for a Content-Type of "application/vnd.foo.v1.status+json", each of the following would successfully match:
- `*/*`
- `*/*+*` (essentially the same as above - full wildcard)
- `*/*+json` (wildcard, only matching mediatypes with the format "json")
- `*/json` (subtype matching format)
- `*/vnd.foo.v1.*+*` (partial subtype wildcard with wildcard format)
- `*/vnd.foo.v1.*+json` (partial subtype wildcard)
- `application/*`
- `application/*+*`
- `application/*+json`
- `application/json`
- `application/vnd.foo.v1.*+*`
- `application/vnd.foo.v1.*+json`
- `application/vnd.foo.v1.status+json`
