### PR TITLE
Undefined variable: class in Zend/ModuleManager/Listener/ServiceListener.php

### DIFF
--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -244,7 +244,7 @@ class ServiceListener implements ServiceListenerInterface
         if (!$config instanceof ServiceConfig) {
             throw new Exception\RuntimeException(sprintf(
                 'Invalid service manager configuration class provided; received "%s", expected an instance of Zend\ServiceManager\Config',
-                is_object($config) ? get_class($config) : (is_scalar($config) ? $config : gettype($config))
+                (is_object($config) ? get_class($config) : (is_scalar($config) ? $config : gettype($config)))
             ));
         }
 

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -244,7 +244,7 @@ class ServiceListener implements ServiceListenerInterface
         if (!$config instanceof ServiceConfig) {
             throw new Exception\RuntimeException(sprintf(
                 'Invalid service manager configuration class provided; received "%s", expected an instance of Zend\ServiceManager\Config',
-                $class
+                is_object($config) ? get_class($config) : (is_scalar($config) ? $config : gettype($config))
             ));
         }
 


### PR DESCRIPTION
How to reproduce error : 

Add in config

``` php
array(
    'controller_plugins' => array(
        'configuration_classes' => array(
            'My\Unfound\Controller\PluginConfig'
        )
    ),
);
```

Well, it's a little useless because I fix an error, that occur on fatal error, but the exception message is at least more readable.
