### PR TITLE
added "ControllerManager" Manager, and make "ControllerLoader" as alias of it

### DIFF
--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -85,6 +85,7 @@ class ServiceListenerFactory implements FactoryInterface
             'Zend\View\Resolver\TemplatePathStack'   => 'ViewTemplatePathStack',
             'Zend\View\Resolver\AggregateResolver'   => 'ViewResolver',
             'Zend\View\Resolver\ResolverInterface'   => 'ViewResolver',
+            'ControllerManager'                      => 'ControllerLoader'
         ),
         'abstract_factories' => array(
             'Zend\Form\FormAbstractServiceFactory',


### PR DESCRIPTION
for consistency, "ControllerLoader" should be named "ControllerManager". It not BC break because of I made new Factory named ControllerManagerFactory and point ControllerLoader as alias of ControllerManager. It can be a preparation for ZF3. When ZF3 released, the "ControllerLoader" manager can be completely removed.
