### PR TITLE
https://github.com/zendframework/zf2/issues/4952

### DIFF
--- a/library/Zend/Stdlib/Hydrator/ClassMethods.php
+++ b/library/Zend/Stdlib/Hydrator/ClassMethods.php
@@ -183,7 +183,7 @@ class ClassMethods extends AbstractHydrator implements HydratorOptionsInterface
         foreach ($data as $property => $value) {
             $method = 'set' . ucfirst($property);
             if ($this->underscoreSeparatedKeys) {
-                $method = preg_replace_callback('/(_[a-z])/', $transform, $method);
+                $method = preg_replace_callback('/(_[a-z])/i', $transform, $method);
             }
             if (is_callable(array($object, $method))) {
                 $value = $this->hydrateValue($property, $value, $data);

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -156,8 +156,6 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($test->hasBar(), false);
     }
 
-
-
     public function testHydratorClassMethodsTitleCase()
     {
         $hydrator = new ClassMethods(false);
@@ -194,7 +192,6 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($test->getHasBar(), false);
     }
 
-
     public function testHydratorClassMethodsUnderscore()
     {
         $hydrator = new ClassMethods(true);
@@ -223,6 +220,30 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
                 'is_bar' => false,
                 'has_foo' => false,
                 'has_bar' => false,
+            ),
+            $this->classMethodsUnderscore
+        );
+        $this->assertSame($this->classMethodsUnderscore, $test);
+        $this->assertEquals($test->getFooBar(), 'foo');
+        $this->assertEquals($test->getFooBarBaz(), 'bar');
+        $this->assertEquals($test->getIsFoo(), false);
+        $this->assertEquals($test->isBar(), false);
+        $this->assertEquals($test->getHasFoo(), false);
+        $this->assertEquals($test->hasBar(), false);
+    }
+
+    public function testHydratorClassMethodsUnderscoreWithUnderscoreUpperCasedHydrateDataKeys()
+    {
+        $hydrator = new ClassMethods(true);
+        $datas = $hydrator->extract($this->classMethodsUnderscore);
+        $test = $hydrator->hydrate(
+            array(
+                'FOO_BAR' => 'foo',
+                'FOO_BAR_BAZ' => 'bar',
+                'IS_FOO' => false,
+                'IS_BAR' => false,
+                'HAS_FOO' => false,
+                'HAS_BAR' => false,
             ),
             $this->classMethodsUnderscore
         );


### PR DESCRIPTION
Fix for my own issue on array data where keys that are UPPERCASE_CAMELS are not mapping correctly to setters thus not being able to hydrate the target object.
