### PR TITLE
Sqlsrv varbinary and statement options support

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -188,7 +188,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @param string $sql
+     * @param  string $sql
      * @throws Exception\RuntimeException
      * @return Statement
      */
@@ -204,6 +204,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef, $this->options);
 
         $this->isPrepared = true;
+
         return $this;
     }
 
@@ -294,7 +295,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
                             $params = array($value, \SQLSRV_PARAM_IN, null, null);
                             $this->parameterReferences[$position++] = $params;
                         }
-            }elseif(is_array($value)){
+            } elseif (is_array($value)) {
                 $this->parameterReferences[$position++] = $value;
             } else {
                 $params = array($value, \SQLSRV_PARAM_IN, null, null);
@@ -305,9 +306,9 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     public function setQueryTimeout($queryTimeout)
     {
-        if(is_int($queryTimeout)){
+        if (is_int($queryTimeout)) {
             $this->options['QueryTimeout'] = $queryTimeout;
-        }else{
+        } else {
             $message = 'Invalid argument provided to ';
             $message.=  __METHOD__ . ' method in class ' . __CLASS__;
             throw new Exception\InvalidArgumentException($message);
@@ -316,9 +317,9 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     public function setSendStreamParamsAtExec($sendStreamParamsAtExec)
     {
-        if(is_bool($sendStreamParamsAtExec)){
+        if (is_bool($sendStreamParamsAtExec)) {
             $this->options['SendStreamParamsAtExec'] = $sendStreamParamsAtExec;
-        }else{
+        } else {
             $message = 'Invalid argument provided to ';
             $message.=  __METHOD__ . ' method in class ' . __CLASS__;
             throw new Exception\InvalidArgumentException($message);

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -62,6 +63,12 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * @var bool
      */
     protected $isPrepared = false;
+
+    /**
+     *
+     * @var array 
+     */
+    protected $options = array();
 
     /**
      * Set driver
@@ -193,11 +200,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         $sql = ($sql) ?: $this->sql;
 
         $pRef = &$this->parameterReferences;
-        for ($position = 0, $count = substr_count($sql, '?'); $position < $count; $position++) {
-            $pRef[$position] = array('', SQLSRV_PARAM_IN, null, null);
-        }
 
-        $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef);
+        $this->resource = sqlsrv_prepare($this->sqlsrv, $sql, $pRef, $this->options);
 
         $this->isPrepared = true;
         return $this;
@@ -220,9 +224,6 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     public function execute($parameters = null)
     {
-        if (!$this->isPrepared) {
-            $this->prepare();
-        }
 
         /** START Standard ParameterContainer Merging Block */
         if (!$this->parameterContainer instanceof ParameterContainer) {
@@ -242,6 +243,9 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             $this->bindParametersFromContainer();
         }
         /** END Standard ParameterContainer Merging Block */
+        if (!$this->isPrepared) {
+            $this->prepare();
+        }
 
         if ($this->profiler) {
             $this->profiler->profilerStart($this);
@@ -271,19 +275,73 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     protected function bindParametersFromContainer()
     {
-        $values = $this->parameterContainer->getPositionalArray();
+        $parameters = $this->parameterContainer->getNamedArray();
+
         $position = 0;
-        foreach ($values as $value) {
-            $this->parameterReferences[$position++][0] = $value;
+        foreach ($parameters as $key => &$value) {
+            if ($this->parameterContainer->offsetHasErrata($key)) {
+                $errata = $this->parameterContainer->offsetGetErrata($key);
+                switch ($errata) {
+                    case ParameterContainer::TYPE_BINARY:
+                        $params = array();
+                        $params[] = $value;
+                        $params[] = \SQLSRV_PARAM_IN;
+                        $params[] = \SQLSRV_PHPTYPE_STREAM(\SQLSRV_ENC_BINARY);
+                        $params[] = \SQLSRV_SQLTYPE_VARBINARY('max');
+                        $this->parameterReferences[$position++] = $params;
+                        break;
+                    default:
+                        if(is_array($errata)){
+                            $this->parameterReferences[$position++] = $errata;
+                        }else{
+                            $params = array($value, \SQLSRV_PARAM_IN, null, null);
+                            $this->parameterReferences[$position++] = $params;
+                        }
+                }
+            } else {
+                $params = array($value, \SQLSRV_PARAM_IN, null, null);
+                $this->parameterReferences[$position++] = $params;
+            }
         }
 
-        // @todo bind errata
-        //foreach ($this->parameterContainer as $name => &$value) {
-        //    $p[$position][0] = $value;
-        //    $position++;
-        //    if ($this->parameterContainer->offsetHasErrata($name)) {
-        //        $p[$position][3] = $this->parameterContainer->offsetGetErrata($name);
-        //    }
-        //}
     }
+
+    public function setQueryTimeout($queryTimeout)
+    {
+        if(is_int($queryTimeout)){
+            $this->options['QueryTimeout'] = $queryTimeout;
+        }else{
+            $message = 'Invalid argument provided to ';
+            $message.=  __METHOD__ . ' method in class ' . __CLASS__;
+            throw new Exception\InvalidArgumentException($message);
+        }
+    }
+
+    public function setSendStreamParamsAtExec($sendStreamParamsAtExec)
+    {
+        if(is_bool($sendStreamParamsAtExec)){
+            $this->options['SendStreamParamsAtExec'] = $sendStreamParamsAtExec;
+        }else{
+            $message = 'Invalid argument provided to ';
+            $message.=  __METHOD__ . ' method in class ' . __CLASS__;
+            throw new Exception\InvalidArgumentException($message);
+        }
+    }
+
+    public function setScrollable($scrollable)
+    {
+        switch ($scrollable) {
+            case \SQLSRV_CURSOR_FORWARD:
+            case \SQLSRV_CURSOR_STATIC:
+            case \SQLSRV_CURSOR_DYNAMIC:
+            case \SQLSRV_CURSOR_KEYSET:
+                $this->options['Scrollable'] = $scrollable;
+                break;
+            default:
+                $message = 'Invalid argument provided to ';
+                $message.=  __METHOD__ . ' method in class ' . __CLASS__;
+                throw new Exception\InvalidArgumentException($message);
+        }
+    }
+
 }

--- a/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Sqlsrv/Statement.php
@@ -291,19 +291,16 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
                         $this->parameterReferences[$position++] = $params;
                         break;
                     default:
-                        if(is_array($errata)){
-                            $this->parameterReferences[$position++] = $errata;
-                        }else{
                             $params = array($value, \SQLSRV_PARAM_IN, null, null);
                             $this->parameterReferences[$position++] = $params;
                         }
-                }
+            }elseif(is_array($value)){
+                $this->parameterReferences[$position++] = $value;
             } else {
                 $params = array($value, \SQLSRV_PARAM_IN, null, null);
                 $this->parameterReferences[$position++] = $params;
             }
         }
-
     }
 
     public function setQueryTimeout($queryTimeout)

--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -230,6 +230,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
 
         // prepare and execute
         $statement = $this->sql->prepareStatementForSqlObject($select);
+        $this->featureSet->apply('preSelectExecute', array($statement));
         $result = $statement->execute();
 
         // build result set
@@ -288,6 +289,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $this->featureSet->apply('preInsert', array($insert));
 
         $statement = $this->sql->prepareStatementForSqlObject($insert);
+        $this->featureSet->apply('preInsertExecute', array($statement));
         $result = $statement->execute();
         $this->lastInsertValue = $this->adapter->getDriver()->getConnection()->getLastGeneratedValue();
 
@@ -348,6 +350,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $this->featureSet->apply('preUpdate', array($update));
 
         $statement = $this->sql->prepareStatementForSqlObject($update);
+        $this->featureSet->apply('preUpdateExecute', array($statement));
         $result = $statement->execute();
 
         // apply postUpdate features
@@ -404,6 +407,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
         $this->featureSet->apply('preDelete', array($delete));
 
         $statement = $this->sql->prepareStatementForSqlObject($delete);
+        $this->featureSet->apply('preDeleteExecute', array($statement));
         $result = $statement->execute();
 
         // apply postDelete features

--- a/library/Zend/Db/TableGateway/Feature/StatementOptionsFeature.php
+++ b/library/Zend/Db/TableGateway/Feature/StatementOptionsFeature.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Zend\Db\Table\Feature;
+
+use Zend\Db\Adapter\Driver\StatementInterface;
+
+class StatementOptionsFeature extends AbstractFeature
+{
+
+    public function preSelectExecute(StatementInterface $statement)
+    {
+        $adapter = $this->tableGateway->getAdapter();
+        $platform = $adapter->getPlatform();
+        $platformName = $platform->getName();
+
+        switch ($platformName) {
+            case "SQLServer":
+                //Necessary for ResultSet count to work
+                $statement->setScrollable(\SQLSRV_CURSOR_STATIC);
+                break;
+        }
+    }
+
+//    public function preInsertExecute(StatementInterface $statement){}
+//    public function preUpdateExecute(StatementInterface $statement){}
+//    public function preDeleteExecute(StatementInterface $statement){}
+}


### PR DESCRIPTION
These changes allow varbinary fields to be updated with a parameter container or by passing an array as shown below.

$container = new ParameterContainer;
$container->offsetSet('PLAN_DOC', $file_stream);
$container->offsetSet('ID', $id);
$container->offsetSetErrata('PLAN_DOC', $container::TYPE_BINARY);

or

$params = array(
    array(
        &$file_stream,
        \SQLSRV_PARAM_IN,
        \SQLSRV_PHPTYPE_STREAM(\SQLSRV_ENC_BINARY),
        \SQLSRV_SQLTYPE_VARBINARY('max')
    ),
    $id
); 

$result = $statement->execute($params);

*Please note that both methods are order sensitive and any parameter names used must be unique.

A new TableGateway feature was also added to allow for different Sqlsrv cursor types to be used with different types of sql statements.  This resolves an issue with the ResultSet count method (sqlsrv_num_rows) which doesn't return properly with the default cursor type.  There may be a better way of using the feature, however, the one shown below should work.

$tableGateway = new TableGateway($this->table, $this->adapter, null, $resultSetPrototype);

$featureSet = $tableGateway->getFeatureSet();
$featureSet->addFeature(new \Zend\Db\TableGateway\Feature\StatementOptionsFeature);

$feature = $featureSet->getFeatureByClassName('\Zend\Db\TableGateway\Feature\StatementOptionsFeature');
$feature->setTableGateway($tableGateway);
