### PR TITLE
Form\Factory can handle config with null elements

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -335,6 +335,10 @@ class Factory
         $elements = $this->validateSpecification($elements, $method);
 
         foreach ($elements as $elementSpecification) {
+            if (null === $elementSpecification) {
+                continue;
+            }
+
             $flags = isset($elementSpecification['flags']) ? $elementSpecification['flags'] : array();
             $spec  = isset($elementSpecification['spec'])  ? $elementSpecification['spec']  : array();
 

--- a/tests/ZendTest/Form/FactoryTest.php
+++ b/tests/ZendTest/Form/FactoryTest.php
@@ -723,4 +723,31 @@ class FactoryTest extends TestCase
         $this->assertAttributeInstanceOf('Zend\Form\Factory', 'factory', $fieldset);
         $this->assertSame($fieldset->getFormFactory()->getFormElementManager(), $this->factory->getFormElementManager());
     }
+
+    public function testCanCreateFormWithNullElements()
+    {
+        $form = $this->factory->createForm(array(
+            'name' => 'foo',
+            'elements' => array(
+                'bar' => array(
+                    'spec' => array(
+                        'name' => 'bar',
+                    ),
+                ),
+                'baz' => null,
+                'bat' => array(
+                    'spec' => array(
+                        'name' => 'bat',
+                    ),
+                ),
+            ),
+        ));
+        $this->assertInstanceOf('Zend\Form\FormInterface', $form);
+
+        $elements = $form->getElements();
+        $this->assertEquals(2, count($elements));
+        $this->assertTrue($form->has('bar'));
+        $this->assertFalse($form->has('baz'));
+        $this->assertTrue($form->has('bat'));
+    }
 }


### PR DESCRIPTION
There is an use case, when I have configured form with elements, but I want to disable some elements later in the config of the other module. So I override it with null, but the Form\Factory doesn't recognize it, so it needs a little fix.
