### PR TITLE
Applied trim and strtolower to Gravatar email per Gravatar docs: https://en.gravatar.com/site/implement/hash/

### DIFF
--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -239,7 +239,7 @@ class Gravatar extends AbstractHtmlElement
     public function setEmail($email)
     {
         $this->emailIsHashed = (bool) preg_match('/^[A-Za-z0-9]{32}$/', $email);
-        $this->email = $email;
+        $this->email = strtolower(trim($email));
         return $this;
     }
 

--- a/tests/ZendTest/View/Helper/GravatarTest.php
+++ b/tests/ZendTest/View/Helper/GravatarTest.php
@@ -274,4 +274,11 @@ class GravatarTest extends TestCase
         );
         $this->helper->__invoke()->setOptions($options);
     }
+
+    public function testEmailIsProperlyNormalized()
+    {
+        $this->assertEquals('example@example.com',
+            $this->helper->__invoke('Example@Example.com ')->getEmail()
+        );
+    }
 }


### PR DESCRIPTION
Per the [Gravatar docs](https://en.gravatar.com/site/implement/hash/), the provided email address should be trimmed of all preceding and trailing white space and converted to lowercase before being hashed.  This PR adds that functionality to the ZF2 Gravatar function.
