### PR TITLE
Add multiple translation text domains to Zend\Navigation

### DIFF
--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -116,6 +116,13 @@ abstract class AbstractPage extends AbstractContainer
     protected $permission;
 
     /**
+     * Text domain for Translator
+     *
+     * @var string
+     */
+    protected $textDomain;
+
+    /**
      * Whether this page should be considered active
      *
      * @var bool
@@ -730,6 +737,33 @@ abstract class AbstractPage extends AbstractContainer
     public function getPermission()
     {
         return $this->permission;
+    }
+
+    /**
+     * Sets text domain for translation
+     *
+     * @param  string|null $textDomain  [optional] text domain to associate
+     *                                  with this page. Default is null, which
+     *                                  sets no text domain.
+     *
+     * @return AbstractPage fluent interface, returns self
+     */
+    public function setTextdomain($textDomain = null)
+    {
+        if (null !== $textDomain) {
+            $this->textDomain = $textDomain;
+        }
+        return $this;
+    }
+
+    /**
+     * Returns text domain for translation
+     *
+     * @return mixed|null  text domain or null
+     */
+    public function getTextdomain()
+    {
+        return $this->textDomain;
     }
 
     /**

--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -748,7 +748,7 @@ abstract class AbstractPage extends AbstractContainer
      *
      * @return AbstractPage fluent interface, returns self
      */
-    public function setTextdomain($textDomain = null)
+    public function setTextDomain($textDomain = null)
     {
         if (null !== $textDomain) {
             $this->textDomain = $textDomain;
@@ -761,7 +761,7 @@ abstract class AbstractPage extends AbstractContainer
      *
      * @return mixed|null  text domain or null
      */
-    public function getTextdomain()
+    public function getTextDomain()
     {
         return $this->textDomain;
     }

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -398,7 +398,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
 
         if (null !== ($translator = $this->getTranslator())) {
             if (null === ($textDomain = $page->getTextdomain())) {
-                $textDomain = $this->getTranslatorTextDomain();
+                $textDomain = $this->getTranslatorTextdomain();
             }
             if (is_string($label) && !empty($label)) {
                 $label = $translator->translate($label, $textDomain);

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -397,7 +397,9 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         $title = $page->getTitle();
 
         if (null !== ($translator = $this->getTranslator())) {
-            $textDomain = $this->getTranslatorTextDomain();
+            if (null === ($textDomain = $page->getTextdomain())) {
+                $textDomain = $this->getTranslatorTextDomain();
+            }
             if (is_string($label) && !empty($label)) {
                 $label = $translator->translate($label, $textDomain);
             }

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -397,8 +397,8 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
         $title = $page->getTitle();
 
         if (null !== ($translator = $this->getTranslator())) {
-            if (null === ($textDomain = $page->getTextdomain())) {
-                $textDomain = $this->getTranslatorTextdomain();
+            if (null === ($textDomain = $page->getTextDomain())) {
+                $textDomain = $this->getTranslatorTextDomain();
             }
             if (is_string($label) && !empty($label)) {
                 $label = $translator->translate($label, $textDomain);

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -109,7 +109,10 @@ class Breadcrumbs extends AbstractHelper
         } else {
             $html = $active->getLabel();
             if (null !== ($translator = $this->getTranslator())) {
-                $html = $translator->translate($html, $this->getTranslatorTextDomain());
+                if (null === ($textDomain = $active->getTextdomain())) {
+                    $textDomain = $this->getTranslatorTextDomain();
+                }
+                $html = $translator->translate($html, $textDomain);
             }
             $escaper = $this->view->plugin('escapeHtml');
             $html    = $escaper($html);

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -109,8 +109,8 @@ class Breadcrumbs extends AbstractHelper
         } else {
             $html = $active->getLabel();
             if (null !== ($translator = $this->getTranslator())) {
-                if (null === ($textDomain = $active->getTextdomain())) {
-                    $textDomain = $this->getTranslatorTextdomain();
+                if (null === ($textDomain = $active->getTextDomain())) {
+                    $textDomain = $this->getTranslatorTextDomain();
                 }
                 $html = $translator->translate($html, $textDomain);
             }

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -110,7 +110,7 @@ class Breadcrumbs extends AbstractHelper
             $html = $active->getLabel();
             if (null !== ($translator = $this->getTranslator())) {
                 if (null === ($textDomain = $active->getTextdomain())) {
-                    $textDomain = $this->getTranslatorTextDomain();
+                    $textDomain = $this->getTranslatorTextdomain();
                 }
                 $html = $translator->translate($html, $textDomain);
             }

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -477,8 +477,8 @@ class Menu extends AbstractHelper
 
         // translate label and title?
         if (null !== ($translator = $this->getTranslator())) {
-            if (null === ($textDomain = $page->getTextdomain())) {
-                $textDomain = $this->getTranslatorTextdomain();
+            if (null === ($textDomain = $page->getTextDomain())) {
+                $textDomain = $this->getTranslatorTextDomain();
             }
             if (is_string($label) && !empty($label)) {
                 $label = $translator->translate($label, $textDomain);

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -478,7 +478,7 @@ class Menu extends AbstractHelper
         // translate label and title?
         if (null !== ($translator = $this->getTranslator())) {
             if (null === ($textDomain = $page->getTextdomain())) {
-                $textDomain = $this->getTranslatorTextDomain();
+                $textDomain = $this->getTranslatorTextdomain();
             }
             if (is_string($label) && !empty($label)) {
                 $label = $translator->translate($label, $textDomain);

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -477,7 +477,9 @@ class Menu extends AbstractHelper
 
         // translate label and title?
         if (null !== ($translator = $this->getTranslator())) {
-            $textDomain = $this->getTranslatorTextDomain();
+            if (null === ($textDomain = $page->getTextdomain())) {
+                $textDomain = $this->getTranslatorTextDomain();
+            }
             if (is_string($label) && !empty($label)) {
                 $label = $translator->translate($label, $textDomain);
             }

--- a/tests/ZendTest/Navigation/Page/PageTest.php
+++ b/tests/ZendTest/Navigation/Page/PageTest.php
@@ -726,6 +726,17 @@ class PageTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($page->isVisible());
     }
 
+    public function testSetTranslatorTextDomainString()
+    {
+        $page = AbstractPage::factory(array(
+            'type'  => 'uri',
+            'label' => 'hello'
+        ));
+
+        $page->setTextdomain('foo');
+        $this->assertEquals('foo', $page->getTextdomain());
+    }
+
     public function testMagicOverLoadsShouldSetAndGetNativeProperties()
     {
         $page = AbstractPage::factory(array(

--- a/tests/ZendTest/View/Helper/Navigation/AbstractTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/AbstractTest.php
@@ -75,6 +75,13 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected $_nav2;
 
+    /**
+     * The third container in the config file (files/navigation.xml)
+     *
+     * @var Navigation\Navigation
+     */
+    protected $_nav3;
+
     private $_oldControllerDir;
 
     /**
@@ -92,6 +99,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         // setup containers from config
         $this->_nav1 = new Navigation($config->get('nav_test1'));
         $this->_nav2 = new Navigation($config->get('nav_test2'));
+        $this->_nav3 = new Navigation($config->get('nav_test3'));
 
         // setup view
         $view = new PhpRenderer();
@@ -202,6 +210,41 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $translator = new Translator();
         $translator->getPluginManager()->setService('default', $loader);
         $translator->addTranslationFile('default', null);
+        return $translator;
+    }
+
+    /**
+     * Returns translator with text domain
+     *
+     * @return Translator
+     */
+    protected function _getTranslatorWithTextDomain()
+    {
+        $loader1 = new TestAsset\ArrayTranslator();
+        $loader1->translations = array(
+            'Page 1'       => 'TextDomain1 1',
+            'Page 1.1'     => 'TextDomain1 1.1',
+            'Page 2'       => 'TextDomain1 2',
+            'Page 2.3'     => 'TextDomain1 2.3',
+            'Page 2.3.3'   => 'TextDomain1 2.3.3',
+            'Page 2.3.3.1' => 'TextDomain1 2.3.3.1',
+        );
+
+        $loader2 = new TestAsset\ArrayTranslator();
+        $loader2->translations = array(
+            'Page 1'       => 'TextDomain2 1',
+            'Page 1.1'     => 'TextDomain2 1.1',
+            'Page 2'       => 'TextDomain2 2',
+            'Page 2.3'     => 'TextDomain2 2.3',
+            'Page 2.3.3'   => 'TextDomain2 2.3.3',
+            'Page 2.3.3.1' => 'TextDomain2 2.3.3.1',
+        );
+
+        $translator = new Translator();
+        $translator->getPluginManager()->setService('default1', $loader1);
+        $translator->getPluginManager()->setService('default2', $loader2);
+        $translator->addTranslationFile('default1', null, 'ZendTest_1');
+        $translator->addTranslationFile('default2', null, 'ZendTest_2');
         return $translator;
     }
 }

--- a/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
@@ -171,6 +171,15 @@ class BreadcrumbsTest extends AbstractTest
         $this->assertEquals($expected, $this->_helper->render());
     }
 
+    public function testTranslationUsingZendTranslateAndCustomTextDomain()
+    {
+        $this->_helper->setTranslator($this->_getTranslatorWithTextDomain());
+
+        $expected = $this->_getExpected('bc/textdomain.html');
+
+        $this->assertEquals($expected, $this->_helper->render($this->_nav3));
+    }
+
     public function testTranslationUsingZendTranslateAdapter()
     {
         $translator = $this->_getTranslator();

--- a/tests/ZendTest/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/MenuTest.php
@@ -219,6 +219,15 @@ class MenuTest extends AbstractTest
         $this->assertEquals($expected, $this->_helper->render());
     }
 
+    public function testTranslationUsingZendTranslateWithTextDomain()
+    {
+        $translator = $this->_getTranslatorWithTextDomain();
+        $this->_helper->setTranslator($translator);
+
+        $expected = $this->_getExpected('menu/textdomain.html');
+        $this->assertEquals($expected, $this->_helper->render($this->_nav3));
+    }
+
     public function testTranslationUsingZendTranslateAdapter()
     {
         $translator = $this->_getTranslator();

--- a/tests/ZendTest/View/Helper/Navigation/_files/expected/bc/textdomain.html
+++ b/tests/ZendTest/View/Helper/Navigation/_files/expected/bc/textdomain.html
@@ -1,0 +1,1 @@
+<a href="page2">TextDomain1 2</a> &gt; <a href="page2/page2_3">Page 2.3</a> &gt; <a href="page2/page2_3/page2_3_3">TextDomain1 2.3.3</a> &gt; TextDomain2 2.3.3.1

--- a/tests/ZendTest/View/Helper/Navigation/_files/expected/menu/textdomain.html
+++ b/tests/ZendTest/View/Helper/Navigation/_files/expected/menu/textdomain.html
@@ -1,0 +1,48 @@
+<ul class="navigation">
+    <li>
+        <a href="page1">Page 1</a>
+        <ul>
+            <li>
+                <a href="page1/page1_1">TextDomain1 1.1</a>
+            </li>
+        </ul>
+    </li>
+    <li class="active">
+        <a href="page2">TextDomain1 2</a>
+        <ul>
+            <li>
+                <a href="page2/page2_1">Page 2.1</a>
+            </li>
+            <li class="active">
+                <a href="page2/page2_2">Page 2.2</a>
+                <ul>
+                    <li>
+                        <a href="page2/page2_2/page2_2_1">Page 2.2.1</a>
+                    </li>
+                    <li class="active">
+                        <a href="page2/page2_2/page2_2_2">Page 2.2.2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="active">
+                <a href="page2/page2_3">Page 2.3</a>
+                <ul>
+                    <li>
+                        <a href="page2/page2_3/page2_3_1">Page 2.3.1</a>
+                    </li>
+                    <li class="active">
+                        <a href="page2/page2_3/page2_3_3">TextDomain1 2.3.3</a>
+                        <ul>
+                            <li class="active">
+                                <a href="page2/page2_3/page2_3_3/1">TextDomain2 2.3.3.1</a>
+                            </li>
+                            <li class="active">
+                                <a href="page2/page2_3/page2_3_3/2">Page 2.3.3.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </li>
+</ul>

--- a/tests/ZendTest/View/Helper/Navigation/_files/navigation.xml
+++ b/tests/ZendTest/View/Helper/Navigation/_files/navigation.xml
@@ -209,4 +209,122 @@
 
     </nav_test2>
 
+    <nav_test3>
+
+        <page1>
+            <label>Page 1</label>
+            <uri>page1</uri>
+            <pages>
+
+                <page1_1>
+                    <label>Page 1.1</label>
+                    <uri>page1/page1_1</uri>
+                    <textdomain>ZendTest_1</textdomain>
+                </page1_1>
+
+            </pages>
+        </page1>
+
+        <page2>
+            <label>Page 2</label>
+            <uri>page2</uri>
+            <textdomain>ZendTest_1</textdomain>
+            <pages>
+
+                <page2_1>
+                    <label>Page 2.1</label>
+                    <uri>page2/page2_1</uri>
+                </page2_1>
+
+                <page2_2>
+                    <label>Page 2.2</label>
+                    <uri>page2/page2_2</uri>
+                    <pages>
+
+                        <page2_2_1>
+                            <label>Page 2.2.1</label>
+                            <uri>page2/page2_2/page2_2_1</uri>
+                        </page2_2_1>
+
+                        <page2_2_2>
+                            <label>Page 2.2.2</label>
+                            <uri>page2/page2_2/page2_2_2</uri>
+                            <active>1</active>
+                        </page2_2_2>
+
+                    </pages>
+                </page2_2>
+
+                <page2_3>
+                    <label>Page 2.3</label>
+                    <uri>page2/page2_3</uri>
+                    <textdomain>ZendTest_No</textdomain>
+                    <pages>
+
+                        <page2_3_1>
+                            <label>Page 2.3.1</label>
+                            <uri>page2/page2_3/page2_3_1</uri>
+                        </page2_3_1>
+
+                        <page2_3_2>
+                            <label>Page 2.3.2</label>
+                            <uri>page2/page2_3/page2_3_2</uri>
+                            <visible>0</visible>
+                            <pages>
+
+                                    <page2_3_2_1>
+                                        <label>Page 2.3.2.1</label>
+                                        <uri>page2/page2_3/page2_3_2/1</uri>
+                                        <active>1</active>
+                                    </page2_3_2_1>
+
+                                    <page2_3_2_2>
+                                        <label>Page 2.3.2.2</label>
+                                        <uri>page2/page2_3/page2_3_2/2</uri>
+                                        <active>1</active>
+
+                                        <pages>
+                                            <page_2_3_2_2_1>
+                                                <label>Ignore</label>
+                                                <uri>#</uri>
+                                                <active>1</active>
+                                            </page_2_3_2_2_1>
+                                        </pages>
+                                    </page2_3_2_2>
+
+                            </pages>
+                        </page2_3_2>
+
+                        <page2_3_3>
+                            <label>Page 2.3.3</label>
+                            <uri>page2/page2_3/page2_3_3</uri>
+                            <resource>admin_foo</resource>
+                            <textdomain>ZendTest_1</textdomain>
+                            <pages>
+
+                                    <page2_3_3_1>
+                                        <label>Page 2.3.3.1</label>
+                                        <uri>page2/page2_3/page2_3_3/1</uri>
+                                        <active>1</active>
+                                        <textdomain>ZendTest_2</textdomain>
+                                    </page2_3_3_1>
+
+                                    <page2_3_3_2>
+                                        <label>Page 2.3.3.2</label>
+                                        <uri>page2/page2_3/page2_3_3/2</uri>
+                                        <resource>guest_foo</resource>
+                                        <active>1</active>
+                                    </page2_3_3_2>
+
+                            </pages>
+                        </page2_3_3>
+
+                    </pages>
+                </page2_3>
+
+            </pages>
+        </page2>
+
+    </nav_test3>
+
 </navigation_test>


### PR DESCRIPTION
Add a new option "textdomain" to a navigation page. If present, the navigation view helper passes it to the translator, allowing for multiple text domains in one container/navigation block.

Example config:

```
'navigation' => array(
    'default' => array(
        'page1' => array(
            'label'      => 'Page 1',
            'route'      => 'page1',
            'textdomain' => 'MyFirstModule'
        ),
        'page2' => array(
            'label'      => 'Page 2',
            'route'      => 'page2',
            'textdomain' => 'MySecondModule'
        ),
    )
)
```
