### PR TITLE
Revise docblocks in Zend\Session\ContainerAbstractServiceFactory

### DIFF
--- a/library/Zend/Session/Service/ContainerAbstractServiceFactory.php
+++ b/library/Zend/Session/Service/ContainerAbstractServiceFactory.php
@@ -23,17 +23,15 @@ use Zend\Session\Container;
  * <code>
  * return array(
  *     'session_containers' => array(
- *         'auth',
- *         'user',
- *         'captcha',
+ *         'SessionContainer\sample',
+ *         'my_sample_session_container',
+ *         'MySessionContainer',
  *     ),
  * );
  * </code>
  *
- * Services use the prefix "SessionContainer\\":
- *
  * <code>
- * $container = $services->get('SessionContainer\captcha');
+ * $container = $services->get('MySessionContainer');
  * </code>
  */
 class ContainerAbstractServiceFactory implements AbstractFactoryInterface
@@ -138,8 +136,6 @@ class ContainerAbstractServiceFactory implements AbstractFactoryInterface
 
     /**
      * Normalize the container name in order to perform a lookup
-     *
-     * Strips off the "SessionContainer\" prefix, and lowercases the name.
      *
      * @param  string $name
      * @return string


### PR DESCRIPTION
Docblocks indicate usage of SessionConainer\ prefix

```
33  * Services use the prefix "SessionContainer\\":                                
34  *                                                                              
35  * <code>                                                                       
36  * $container = $services->get('SessionContainer\captcha');                     
37  * </code>                
```

and that normalizeContainerName strips off the prefix

```
141      *                                                                          
142      * Strips off the "SessionContainer\" prefix, and lowercases the name.      
143      *    
```

Docblocks revised to show sample configuration without stripping prefix.
