### PR TITLE
Rand bugfix

### DIFF
--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -34,6 +34,8 @@ abstract class Rand
      */
     public static function getBytes($length, $strong = false)
     {
+        $length = (int) $length;
+        
         if ($length <= 0) {
             return false;
         }


### PR DESCRIPTION
This is a simple fix to enforce $length data type to be int in getBytes.

If the data type of $length is float (even if the float is an integer value) the this `if` fails: https://github.com/zendframework/zf2/blob/master/library/Zend/Math/Rand.php#L55 and can, in some php environments, result in this error being falsely thrown:
https://github.com/zendframework/zf2/blob/master/library/Zend/Math/Rand.php#L62

Just to add the quirk, the `ciel` function always returns a float, so this line https://github.com/zendframework/zf2/blob/master/library/Zend/Math/Rand.php#L187 can cause the faulty behavior (which is how I found the problem).

There is no test attached, because I don't know how to test for this properly due to it's environment specific nature. It will only show if ssl is not installed, and these alternatives are also not available: https://github.com/zendframework/zf2/blob/master/library/Zend/Math/Rand.php#L59
