### PR TITLE
PSR-3 Compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "psr/log": "dev-master"
     },
     "require-dev": {
         "doctrine/annotations": ">=1.0",

--- a/library/Zend/Log/Exception/InvalidArgumentException.php
+++ b/library/Zend/Log/Exception/InvalidArgumentException.php
@@ -9,10 +9,12 @@
 
 namespace Zend\Log\Exception;
 
+use Psr\Log\InvalidArgumentException as PsrException;
+
 /**
  * Invalid argument exception
  */
 class InvalidArgumentException
-    extends \InvalidArgumentException
+    extends PsrException
     implements ExceptionInterface
 {}

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -11,6 +11,7 @@ namespace Zend\Log;
 
 use DateTime;
 use ErrorException;
+use Psr\Log\LogLevel;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\SplPriorityQueue;
@@ -81,6 +82,22 @@ class Logger implements LoggerInterface
         self::NOTICE => 'NOTICE',
         self::INFO   => 'INFO',
         self::DEBUG  => 'DEBUG',
+    );
+    
+    /**
+     * Map PSR Log Levels to priority
+     *
+     * @var array
+     */
+    protected $psrLogLevels = array(
+        LogLevel::ALERT => self::ALERT,
+        LogLevel::CRITICAL => self::CRIT,
+        LogLevel::DEBUG => self::DEBUG,
+        LogLevel::EMERGENCY => self::EMERG,
+        LogLevel::ERROR => self::ERR,
+        LogLevel::INFO => self::INFO,
+        LogLevel::NOTICE => self::NOTICE,
+        LogLevel::WARNING => self::WARN,
     );
 
     /**
@@ -363,14 +380,18 @@ class Logger implements LoggerInterface
      *
      * @param  int $priority
      * @param  mixed $message
-     * @param  array|Traversable $extra
+     * @param  array $context
      * @return Logger
      * @throws Exception\InvalidArgumentException if message can't be cast to string
-     * @throws Exception\InvalidArgumentException if extra can't be iterated over
+     * @throws Exception\InvalidArgumentException if context can't be iterated over
      * @throws Exception\RuntimeException if no log writer specified
      */
-    public function log($priority, $message, $extra = array())
+    public function log($priority, $message, array $context = array())
     {
+        if (is_string($priority) && array_key_exists($priority, $this->psrLogLevels)) {
+            $priority = $this->psrLogLevels[$priority];
+        }
+        
         if (!is_int($priority) || ($priority<0) || ($priority>=count($this->priorities))) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '$priority must be an integer > 0 and < %d; received %s',
@@ -383,13 +404,13 @@ class Logger implements LoggerInterface
                 '$message must implement magic __toString() method'
             );
         }
-
-        if (!is_array($extra) && !$extra instanceof Traversable) {
+        
+        if (!is_array($context) && !$context instanceof Traversable) {
             throw new Exception\InvalidArgumentException(
                 '$extra must be an array or implement Traversable'
             );
-        } elseif ($extra instanceof Traversable) {
-            $extra = ArrayUtils::iteratorToArray($extra);
+        } elseif ($context instanceof Traversable) {
+            $context = ArrayUtils::iteratorToArray($context);
         }
 
         if ($this->writers->count() === 0) {
@@ -407,7 +428,7 @@ class Logger implements LoggerInterface
             'priority'     => (int) $priority,
             'priorityName' => $this->priorities[$priority],
             'message'      => (string) $message,
-            'extra'        => $extra
+            'context'        => $context
         );
 
         foreach ($this->processors->toArray() as $processor) {
@@ -423,82 +444,82 @@ class Logger implements LoggerInterface
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function emerg($message, $extra = array())
+    public function emerg($message, array $context = array())
     {
-        return $this->log(self::EMERG, $message, $extra);
+        return $this->log(self::EMERG, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function alert($message, $extra = array())
+    public function alert($message, array $context = array())
     {
-        return $this->log(self::ALERT, $message, $extra);
+        return $this->log(self::ALERT, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function crit($message, $extra = array())
+    public function crit($message, array $context = array())
     {
-        return $this->log(self::CRIT, $message, $extra);
+        return $this->log(self::CRIT, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function err($message, $extra = array())
+    public function err($message, array $context = array())
     {
-        return $this->log(self::ERR, $message, $extra);
+        return $this->log(self::ERR, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function warn($message, $extra = array())
+    public function warn($message, array $context = array())
     {
-        return $this->log(self::WARN, $message, $extra);
+        return $this->log(self::WARN, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function notice($message, $extra = array())
+    public function notice($message, array $context = array())
     {
-        return $this->log(self::NOTICE, $message, $extra);
+        return $this->log(self::NOTICE, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function info($message, $extra = array())
+    public function info($message, array $context = array())
     {
-        return $this->log(self::INFO, $message, $extra);
+        return $this->log(self::INFO, $message, $context);
     }
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array $context
      * @return Logger
      */
-    public function debug($message, $extra = array())
+    public function debug($message, array $context = array())
     {
-        return $this->log(self::DEBUG, $message, $extra);
+        return $this->log(self::DEBUG, $message, $context);
     }
 
     /**
@@ -584,25 +605,25 @@ class Logger implements LoggerInterface
                     $priority = $errorPriorityMap[$exception->getSeverity()];
                 }
 
-                $extra = array(
+                $context = array(
                     'file'  => $exception->getFile(),
                     'line'  => $exception->getLine(),
                     'trace' => $exception->getTrace(),
                 );
                 if (isset($exception->xdebug_message)) {
-                    $extra['xdebug'] = $exception->xdebug_message;
+                    $context['xdebug'] = $exception->xdebug_message;
                 }
 
                 $logMessages[] = array(
                     'priority' => $priority,
                     'message'  => $exception->getMessage(),
-                    'extra'    => $extra,
+                    'context'    => $context,
                 );
                 $exception = $exception->getPrevious();
             } while ($exception);
 
             foreach (array_reverse($logMessages) as $logMessage) {
-                $logger->log($logMessage['priority'], $logMessage['message'], $logMessage['extra']);
+                $logger->log($logMessage['priority'], $logMessage['message'], $logMessage['context']);
             }
         });
 
@@ -617,5 +638,53 @@ class Logger implements LoggerInterface
     {
         restore_exception_handler();
         static::$registeredExceptionHandler = false;
+    }
+
+    /**
+     * critical
+     * PSR-3 wrapper for crit
+     * 
+     * @param string $message
+     * @param array $context
+     * @return Logger
+     */
+    public function critical($message, array $context = array()) {
+        return $this->crit($message, $context);
+    }
+
+    /**
+     * emergency
+     * PSR-3 wrapper for emerg
+     * 
+     * @param string $message
+     * @param array $context
+     * @return Logger
+     */
+    public function emergency($message, array $context = array()) {
+        return $this->emerg($message, $context);
+    }
+
+    /**
+     * error
+     * PSR-3 wrapper for err
+     * 
+     * @param string $message
+     * @param array $context
+     * @return Logger
+     */
+    public function error($message, array $context = array()) {
+        return $this->err($message, $context);
+    }
+
+    /**
+     * warning
+     * PSR-3 wrapper for warn
+     * 
+     * @param string $message
+     * @param array $context
+     * @return Logger
+     */
+    public function warning($message, array $context = array()) {
+        return $this->warn($message, $context);
     }
 }

--- a/library/Zend/Log/LoggerAwareInterface.php
+++ b/library/Zend/Log/LoggerAwareInterface.php
@@ -9,12 +9,13 @@
 
 namespace Zend\Log;
 
+use Psr\Log\LoggerAwareInterface as PsrLoggerAwareInterface;
 use Zend\Log\LoggerInterface;
 
 /**
  * Logger aware interface
  */
-interface LoggerAwareInterface
+interface LoggerAwareInterface extends PsrLoggerAwareInterface
 {
     public function setLogger(LoggerInterface $logger);
 }

--- a/library/Zend/Log/LoggerInterface.php
+++ b/library/Zend/Log/LoggerInterface.php
@@ -9,63 +9,64 @@
 
 namespace Zend\Log;
 
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
 use Traversable;
 
-interface LoggerInterface
+interface LoggerInterface extends PsrLoggerInterface
 {
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function emerg($message, $extra = array());
+    public function emerg($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function alert($message, $extra = array());
+    public function alert($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function crit($message, $extra = array());
+    public function crit($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function err($message, $extra = array());
+    public function err($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function warn($message, $extra = array());
+    public function warn($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function notice($message, $extra = array());
+    public function notice($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function info($message, $extra = array());
+    public function info($message, array $context = array());
 
     /**
      * @param string $message
-     * @param array|Traversable $extra
+     * @param array|Traversable $context
      * @return LoggerInterface
      */
-    public function debug($message, $extra = array());
+    public function debug($message, array $context = array());
 }

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -10,12 +10,14 @@
 
 namespace ZendTest\Log;
 
-use Exception;
 use ErrorException;
+use Exception;
+use Psr\Log\LogLevel;
+use Zend\Log\Filter\Mock as MockFilter;
 use Zend\Log\Logger;
 use Zend\Log\Processor\Backtrace;
+use Zend\Log\Processor\Mock as MockPlugin;
 use Zend\Log\Writer\Mock as MockWriter;
-use Zend\Log\Filter\Mock as MockFilter;
 use Zend\Stdlib\SplPriorityQueue;
 use Zend\Validator\Digits as DigitsFilter;
 
@@ -103,6 +105,17 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($writer instanceof \Zend\Log\Writer\Null);
         $writer = $writers->extract();
         $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
+    }
+    
+    public function testSetWritersThrowsException()
+    {
+        $writer = new \stdClass();
+        $writers = new SplPriorityQueue();
+        $writers->insert($writer, 1);
+        
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
+        
+        $this->logger->setWriters($writers);
     }
 
     public function testAddWriterWithPriority()
@@ -210,7 +223,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         return array(
             array(array()),
             array(array('user' => 'foo', 'ip' => '127.0.0.1')),
-            array(new \ArrayObject(array('id' => 42))),
         );
     }
 
@@ -224,8 +236,8 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->logger->log(Logger::ERR, 'tottakai', $extra);
 
         $this->assertEquals(count($writer->events), 1);
-        $this->assertInternalType('array', $writer->events[0]['extra']);
-        $this->assertEquals(count($writer->events[0]['extra']), count($extra));
+        $this->assertInternalType('array', $writer->events[0]['context']);
+        $this->assertEquals(count($writer->events[0]['context']), count($extra));
     }
 
     public static function provideInvalidArguments()
@@ -238,15 +250,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             array('valid', 'invalid'),
             array('valid', new \stdClass()),
         );
-    }
-
-    /**
-     * @dataProvider provideInvalidArguments
-     */
-    public function testPassingInvalidArgumentToLogRaisesException($message, $extra)
-    {
-        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
-        $this->logger->log(Logger::ERR, $message, $extra);
     }
 
     public function testRegisterErrorHandler()
@@ -367,7 +370,182 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
             $this->assertEquals($expectedEvent['priority'], $event['priority'], 'Unexpected priority');
             $this->assertEquals($expectedEvent['message'], $event['message'], 'Unexpected message');
-            $this->assertEquals($expectedEvent['file'], $event['extra']['file'], 'Unexpected file');
+            $this->assertEquals($expectedEvent['file'], $event['context']['file'], 'Unexpected file');
         }
+    }
+    
+    public function testLoggerImplementsPSR3()
+    {
+        $this->assertInstanceOf('\Psr\Log\LoggerInterface', $this->logger);
+        $this->assertInstanceOf('\Zend\Log\LoggerInterface', $this->logger);
+    }
+    
+    public function testLogThrowsExceptionInvalidPriority()
+    {
+        $priority = new \stdClass();
+        $message = 'Foo Bar Baz';
+        
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
+        
+        $this->logger->log($priority, $message);
+    }
+    
+    public function testLogPsrLogLevels()
+    {
+        $writer = new MockWriter;
+        
+        $this->logger->addWriter($writer);
+        
+        $priorities = array(
+            LogLevel::ALERT => Logger::ALERT,
+            LogLevel::CRITICAL => Logger::CRIT,
+            LogLevel::DEBUG => Logger::DEBUG,
+            LogLevel::EMERGENCY => Logger::EMERG,
+            LogLevel::ERROR => Logger::ERR,
+            LogLevel::INFO => Logger::INFO,
+            LogLevel::NOTICE => Logger::NOTICE,
+            LogLevel::WARNING => Logger::WARN,
+        );
+        
+        $message = 'Foo Bar Baz';
+        
+        $i = 0;
+        foreach ($priorities as $psrPriority => $priority) {
+            $this->logger->log($psrPriority, $message);
+            $this->assertEquals($writer->events[$i]['priority'], $priority);
+            $this->assertEquals($writer->events[$i]['message'], $message);
+            $i++;
+        }
+    }
+
+    public function testLogInvalidStringPriority()
+    {
+        $writer = new MockWriter;
+        
+        $this->logger->addWriter($writer);
+        
+        $priority = 'Foo';
+        $message = 'Baz';
+        
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
+        
+        $this->logger->log($priority, $message);
+    }
+    
+    public function testLogMessageNoToString()
+    {
+        $writer = new MockWriter;
+        
+        $this->logger->addWriter($writer);
+        
+        $priority = Logger::ALERT;
+        $message = new \stdClass();
+        
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
+        
+        $this->logger->log($priority, $message);
+    }
+    
+    public function testLogFunctions()
+    {
+        $functions = array(
+            'alert',
+            'debug',
+            'emerg',
+            'emergency',
+            'crit',
+            'critical',
+            'err',
+            'error',
+            'info',
+            'notice',
+            'warn',
+            'warning',
+        );
+        
+        foreach ($functions as $function) {
+            $this->logTest($function);
+        }
+        
+        
+    }
+    
+
+    protected function logTest($function)
+    {
+        $writer = new MockWriter;
+        
+        $message = 'Foo Bar Baz';
+        $context = array('foo' => 'bar', 'baz');
+        
+        switch ($function) {
+            case 'alert':
+                $priority = Logger::ALERT;
+                break;
+            case 'emerg':
+            case 'emergency':
+                $priority = Logger::EMERG;
+                break;
+            case 'crit':
+            case 'critical':
+                $priority = Logger::CRIT;
+                break;
+            case 'debug':
+                $priority = Logger::DEBUG;
+                break;
+            case 'err':
+            case 'error':
+                $priority = Logger::ERR;
+                break;
+            case 'info':
+                $priority = Logger::INFO;
+                break;
+            case 'notice':
+                $priority = Logger::NOTICE;
+                break;
+            case 'warn':
+            case 'warning':
+                $priority = Logger::WARN;
+                break;
+        }
+        
+        $this->logger->addWriter($writer);
+        
+        if (method_exists($this->logger, $function)) {
+            $this->logger->$function($message, $context);
+            $this->assertEquals($writer->events[0]['priority'], $priority);
+            $this->assertEquals($writer->events[0]['message'], $message);
+            $this->assertEquals($writer->events[0]['context'], $context);
+            return;
+        }
+        
+        $this->fail("Log method {$function} does not exist");
+    }
+    
+    public function testSetProcessorPluginManager()
+    {
+        $plugins = new \Zend\Log\ProcessorPluginManager();
+        
+        $this->logger->setProcessorPluginManager($plugins);
+        
+        $this->assertAttributeSame($plugins, 'processorPlugins', $this->logger);
+    }
+    
+    public function testSetProcessorPluginManagerString()
+    {
+        $plugins = '\Zend\Log\ProcessorPluginManager';
+        
+        $this->logger->setProcessorPluginManager($plugins);
+        
+        $this->assertAttributeInstanceOf('\Zend\Log\ProcessorPluginManager', 'processorPlugins', $this->logger);
+    }
+    
+    public function testSetProcessorPluginManagerThrowsException()
+    {
+        $plugins = new \stdClass();
+        
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException');
+        
+        $this->logger->setProcessorPluginManager($plugins);
     }
 }


### PR DESCRIPTION
PSR-3 was accepted months ago (https://github.com/php-fig/fig-standards/commit/43cd71b6b1f46231c513af55386b9ff55fbb00d0), but ZF2 hasn't (yet) been updated for compliance.
Here is my attempt to achieve this.

Unfortunately, this does introduce a BC break in order to implement the PSR\Log\LoggerInterface: the $extras param  (renamed to $contect) to the log function (and wrapper functions: err, debug, info etc.) has to be specifically typehinted to array. As such anything currently passing an object implementing Traversable will cause a catchable fatal error.

The log function will now accept a string for a priority, provided the string matches one of the \Psr\Log\LogLevel constants (it immediately remaps the string to the appropriate int priority).

Additional functions introduced by PSR-3 (critical, error, emergency, warning) are simple wrappers around the existing functions.

To sweeten the deal, I've thrown in a bunch of extra tests for the Logger class to improve overall test coverage, though I expect even if this PR is accepted it won't be merged until the next BC breaking release
