### PR TITLE
[Zend-Code] Fix Code Generation for non namespace classes

### DIFF
--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -118,7 +118,8 @@ class ClassGenerator extends AbstractGenerator
 
         $methods = array();
         foreach ($classReflection->getMethods() as $reflectionMethod) {
-            if ($reflectionMethod->getDeclaringClass()->getName() == $cg->getNamespaceName() . "\\" . $cg->getName()) {
+            $className = ($cg->getNamespaceName())? $cg->getNamespaceName() . "\\" . $cg->getName() : $cg->getName();
+            if ($reflectionMethod->getDeclaringClass()->getName() == $className) {
                 $methods[] = MethodGenerator::fromReflection($reflectionMethod);
             }
         }

--- a/library/Zend/Code/Generator/ParameterGenerator.php
+++ b/library/Zend/Code/Generator/ParameterGenerator.php
@@ -64,8 +64,12 @@ class ParameterGenerator extends AbstractGenerator
                 $parameterType = $typeClass->getName();
                 $currentNamespace = $reflectionParameter->getDeclaringClass()->getNamespaceName();
 
-                if (substr($parameterType, 0, strlen($currentNamespace)) == $currentNamespace) {
-                    $parameterType = substr($parameterType, strlen($currentNamespace)+1);
+                if (!empty($currentNamespace)) {
+                    if (substr($parameterType, 0, strlen($currentNamespace)) == $currentNamespace) {
+                        $parameterType = substr($parameterType, strlen($currentNamespace) + 1);
+                    }
+                } else {
+                    $parameterType = '\\' . trim($parameterType, '\\');
                 }
 
                 $param->setType($parameterType);

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -267,6 +267,18 @@ EOS;
     }
 
     /**
+     * @group gh-4988
+     */
+    public function testNonNamespaceClassReturnsAllMethods()
+    {
+        require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
+
+        $reflClass = new ClassReflection('ZendTest_Code_NsTest_BarClass');
+        $classGenerator = ClassGenerator::fromReflection($reflClass);
+        $this->assertCount(1, $classGenerator->getMethods());
+    }
+
+    /**
      * @group ZF-9602
      */
     public function testSetextendedclassShouldIgnoreEmptyClassnameOnGenerate()

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -202,4 +202,19 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $parameterGenerator->getSourceContent());
         $this->assertEquals('-', $parameterGenerator->getIndentation());
     }
+
+    /**
+     * @group gh-4988
+     */
+    public function testParameterGeneratorReturnsCorrectTypeForNonNamespaceClasses()
+    {
+        require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
+
+        $reflClass = new \Zend\Code\Reflection\ClassReflection('ZendTest_Code_NsTest_BarClass');
+        $params = $reflClass->getMethod('fooMethod')->getParameters();
+
+        $param = ParameterGenerator::fromReflection($params[0]);
+
+        $this->assertEquals('\ZendTest_Code_NsTest_BarClass', $param->getType());
+    }
 }

--- a/tests/ZendTest/Code/TestAsset/NonNamespaceClass.php
+++ b/tests/ZendTest/Code/TestAsset/NonNamespaceClass.php
@@ -1,0 +1,8 @@
+<?php
+
+class ZendTest_Code_NsTest_BarClass
+{
+    public function fooMethod(ZendTest_Code_NsTest_BarClass $parameter)
+    {
+    }
+}


### PR DESCRIPTION
ClassGenerator and ParameterGenerator had some issues with non-namespace classes.

The ClassGenerator tried to concatenate the namespace in the check if a reflectionmethod is from the same class.

The ParameterGenerator removed the first character for non-namespace classnames.
And there is a backslash missing for non-namespace classnames. As zf2 requires 5.3.3 this slash does not hurt anyone.
