### PR TITLE
[Zend-Code] Find php 5.4 traits with TokenArrayScanner

### DIFF
--- a/library/Zend/Code/Scanner/TokenArrayScanner.php
+++ b/library/Zend/Code/Scanner/TokenArrayScanner.php
@@ -299,6 +299,13 @@ class TokenArrayScanner implements ScannerInterface
         }
 
         /**
+         * Define PHP 5.4 'trait' token constant.
+         */
+        if (!defined('T_TRAIT')) {
+            define('T_TRAIT', 42001);
+        }
+
+        /**
          * Variables & Setup
          */
 
@@ -552,6 +559,7 @@ class TokenArrayScanner implements ScannerInterface
             case T_ABSTRACT:
             case T_CLASS:
             case T_INTERFACE:
+            case T_TRAIT:
 
                 $infos[$infoIndex] = array(
                     'type'        => ($tokenType === T_FUNCTION) ? 'function' : 'class',
@@ -573,7 +581,7 @@ class TokenArrayScanner implements ScannerInterface
 
                 // process the name
                 if ($infos[$infoIndex]['shortName'] == ''
-                    && (($tokenType === T_CLASS || $tokenType === T_INTERFACE) && $infos[$infoIndex]['type'] === 'class'
+                    && (($tokenType === T_CLASS || $tokenType === T_INTERFACE || $tokenType === T_TRAIT) && $infos[$infoIndex]['type'] === 'class'
                         || ($tokenType === T_FUNCTION && $infos[$infoIndex]['type'] === 'function'))
                 ) {
                     $infos[$infoIndex]['shortName'] = $tokens[$tokenIndex + 2][1];

--- a/tests/ZendTest/Code/Scanner/TokenArrayScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/TokenArrayScannerTest.php
@@ -45,6 +45,17 @@ class TokenArrayScannerTest extends TestCase
         $this->assertContains('ZendTest\Code\TestAsset\FooClass', $classes);
     }
 
+    /**
+     * @group gh-4989
+     */
+    public function testScannerReturnsClassNamesForTraits()
+    {
+        $tokenScanner = new TokenArrayScanner(token_get_all(file_get_contents((__DIR__ . '/../TestAsset/FooTrait.php'))));
+        $classes = $tokenScanner->getClassNames();
+        $this->assertInternalType('array', $classes);
+        $this->assertContains('ZendTest\Code\TestAsset\FooTrait', $classes);
+    }
+
     public function testScannerReturnsFunctions()
     {
         $tokenScanner = new TokenArrayScanner(token_get_all(file_get_contents((__DIR__ . '/../TestAsset/functions.php'))));

--- a/tests/ZendTest/Code/Scanner/TokenArrayScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/TokenArrayScannerTest.php
@@ -50,6 +50,9 @@ class TokenArrayScannerTest extends TestCase
      */
     public function testScannerReturnsClassNamesForTraits()
     {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('Skipping; PHP 5.4 or greater is needed');
+        }
         $tokenScanner = new TokenArrayScanner(token_get_all(file_get_contents((__DIR__ . '/../TestAsset/FooTrait.php'))));
         $classes = $tokenScanner->getClassNames();
         $this->assertInternalType('array', $classes);

--- a/tests/ZendTest/Code/TestAsset/BarTrait.php
+++ b/tests/ZendTest/Code/TestAsset/BarTrait.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Code\TestAsset;
+
+trait BarTrait
+{
+    public function bar()
+    {
+    }
+}

--- a/tests/ZendTest/Code/TestAsset/FooTrait.php
+++ b/tests/ZendTest/Code/TestAsset/FooTrait.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Code\TestAsset;
+
+trait FooTrait
+{
+    use BarTrait;
+
+    public function fooBarBaz()
+    {
+    }
+}


### PR DESCRIPTION
Added T_TRAIT next to T_CLASS and T_INTERFACE.

For php 5.3 T_TRAIT gets defined to not get any errors.
