### PR TITLE
[SessionManagerFactory] Configuration of validators in SessionManagerFactory

### DIFF
--- a/library/Zend/Session/Service/SessionManagerFactory.php
+++ b/library/Zend/Session/Service/SessionManagerFactory.php
@@ -53,6 +53,7 @@ class SessionManagerFactory implements FactoryInterface
      * - enable_default_container_manager: whether to inject the created instance
      *   as the default manager for Container instances. The default value for
      *   this is true; set it to false to disable.
+     * - validators: ...
      *
      * @param  ServiceLocatorInterface    $services
      * @return SessionManager
@@ -111,6 +112,15 @@ class SessionManagerFactory implements FactoryInterface
                 && is_array($configService['session_manager'])
             ) {
                 $managerConfig = array_merge($managerConfig, $configService['session_manager']);
+            }
+            // Attach validators to session manager, if any
+            if (isset($managerConfig['validators'])) {
+                $chain = $manager->getValidatorChain();
+                foreach ($managerConfig['validators'] as $validator) {
+                    $validator = new $validator();
+                    $chain->attach('session.validate', array($validator, 'isValid'));
+
+                }
             }
         }
 

--- a/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
+++ b/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
@@ -74,4 +74,17 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $manager = $this->services->get('Zend\Session\ManagerInterface');
         $this->assertNotSame($manager, Container::getDefaultManager());
     }
+
+    public function testFactoryWillAddValidatorViaConfiguration()
+    {
+        $config = array('session_manager' => array(
+            'validators' => array(
+                'Zend\Session\Validator\RemoteAddr',
+            ),
+        ));
+        $this->services->setService('Config', $config);
+        $manager = $this->services->get('Zend\Session\ManagerInterface');
+
+        $this->assertEquals(1, $manager->getValidatorChain()->getListeners('session.validate')->count());
+    }
 }


### PR DESCRIPTION
This is merely a cut and past from http://framework.zend.com/manual/2.2/en/modules/zend.session.manager.html to add handling of validators in the SessionManagerFactory

If this is a good addition I will write the tests
