### PR TITLE
generate output as double space after @param at Zend\Code docblock generate() function

### DIFF
--- a/library/Zend/Code/Generator/DocBlock/Tag/AuthorTag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag/AuthorTag.php
@@ -81,7 +81,7 @@ class AuthorTag extends Tag
      */
     public function generate()
     {
-        $output = '@param '
+        $output = '@param  '
             . (($this->datatype != null) ? $this->datatype : 'unknown')
             . (($this->paramName != null) ? ' $' . $this->paramName : '')
             . (($this->description != null) ? ' ' . $this->description : '');

--- a/library/Zend/Code/Generator/DocBlock/Tag/ParamTag.php
+++ b/library/Zend/Code/Generator/DocBlock/Tag/ParamTag.php
@@ -81,7 +81,7 @@ class ParamTag extends Tag
      */
     public function generate()
     {
-        $output = '@param '
+        $output = '@param  '
             . (($this->datatype != null) ? $this->datatype : 'unknown')
             . (($this->paramName != null) ? ' $' . $this->paramName : '')
             . (($this->description != null) ? ' ' . $this->description : '');

--- a/tests/ZendTest/Code/Generator/DocBlock/Tag/AuthorTagTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlock/Tag/AuthorTagTest.php
@@ -54,7 +54,7 @@ class AuthorTagTest extends \PHPUnit_Framework_TestCase
         $this->tag->setParamName('foo');
         $this->tag->setDatatype('string');
         $this->tag->setDescription('bar bar bar');
-        $this->assertEquals('@param string $foo bar bar bar', $this->tag->generate());
+        $this->assertEquals('@param  string $foo bar bar bar', $this->tag->generate());
     }
 
     public function testConstructorWithOptions()

--- a/tests/ZendTest/Code/Generator/DocBlock/Tag/ParamTagTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlock/Tag/ParamTagTest.php
@@ -54,7 +54,7 @@ class ParamTagTest extends \PHPUnit_Framework_TestCase
         $this->tag->setParamName('foo');
         $this->tag->setDatatype('string');
         $this->tag->setDescription('bar bar bar');
-        $this->assertEquals('@param string $foo bar bar bar', $this->tag->generate());
+        $this->assertEquals('@param  string $foo bar bar bar', $this->tag->generate());
     }
 
     public function testConstructorWithOptions()

--- a/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/DocBlockGeneratorTest.php
@@ -73,7 +73,7 @@ class DocBlockGeneratorTest extends \PHPUnit_Framework_TestCase
         $target = <<<EOS
 /**
  * @blah
- * @param string
+ * @param  string
  * @return int
  */
 


### PR DESCRIPTION
it for consistency based on #2419 and #2422
