### PR TITLE
BaseInputFilter->add deasn't work (Form Validation breaks since 2.2)

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -717,13 +717,6 @@ class Form extends Fieldset implements FormInterface
         $formFactory  = $this->getFormFactory();
         $inputFactory = $formFactory->getInputFilterFactory();
 
-        if ($fieldset === $this && $fieldset instanceof InputFilterProviderInterface) {
-            foreach ($fieldset->getInputFilterSpecification() as $name => $spec) {
-                $input = $inputFactory->createInput($spec);
-                $inputFilter->add($input, $name);
-            }
-        }
-
         if ($fieldset instanceof Collection && $fieldset->getTargetElement() instanceof FieldsetInterface) {
             $elements = $fieldset->getTargetElement()->getElements();
         } else {
@@ -751,6 +744,13 @@ class Form extends Fieldset implements FormInterface
 
                 $input = $inputFactory->createInput($spec);
                 $inputFilter->add($input, $name);
+            }
+
+            if ($fieldset instanceof InputFilterProviderInterface) {
+                foreach ($fieldset->getInputFilterSpecification() as $name => $spec) {
+                    $input = $inputFactory->createInput($spec);
+                    $inputFilter->add($input, $name);
+                }
             }
         }
 

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -73,9 +73,12 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
         }
 
         if (isset($this->inputs[$name]) && $this->inputs[$name] instanceof InputInterface) {
-            // The element already exists, so merge the config. Please note that the order is important (already existing
+            // The element already exists, so merge the config. Please note
+            // that the order is important (already existing
             // input is merged with the parameter given)
-            $input->merge($this->inputs[$name]);
+            $original = $this->inputs[$name];
+            $original->merge($input);
+            return $this;
         }
 
         $this->inputs[$name] = $input;

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1550,7 +1550,7 @@ class FormTest extends TestCase
         $form = new Form();
         $form->add($myFieldset);
         
-        $inputFilter = $form->getInputFilter();
+        $inputFilter = $form->getInputFilter()->get('my-fieldset');
         $this->assertFalse($inputFilter->get('email')->isRequired());
     }
 }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1543,6 +1543,9 @@ class FormTest extends TestCase
         $this->assertEquals('form[element]', $element->getName());
     }
 
+    /**
+     * @group 4996
+     */
     public function testCanOverrideDefaultInputSettings()
     {
         $myFieldset = new TestAsset\MyFieldset();

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1546,6 +1546,7 @@ class FormTest extends TestCase
     public function testCanOverrideDefaultInputSettings()
     {
         $myFieldset = new TestAsset\MyFieldset();
+        $myFieldset->setUseAsBaseFieldset(true);
         $form = new Form();
         $form->add($myFieldset);
         

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1542,4 +1542,14 @@ class FormTest extends TestCase
         $rootForm->prepare();
         $this->assertEquals('form[element]', $element->getName());
     }
+
+    public function testCanOverrideDefaultInputSettings()
+    {
+        $myFieldset = new TestAsset\MyFieldset();
+        $form = new Form();
+        $form->add($myFieldset);
+        
+        $inputFilter = $form->getInputFilter();
+        $this->assertFalse($inputFilter->get('email')->isRequired());
+    }
 }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1552,7 +1552,7 @@ class FormTest extends TestCase
         $myFieldset->setUseAsBaseFieldset(true);
         $form = new Form();
         $form->add($myFieldset);
-        
+
         $inputFilter = $form->getInputFilter()->get('my-fieldset');
         $this->assertFalse($inputFilter->get('email')->isRequired());
     }

--- a/tests/ZendTest/Form/TestAsset/MyFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/MyFieldset.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\InputFilter\InputFilterProviderInterface;
+use Zend\Form\Fieldset;
+
+class MyFieldset extends Fieldset implements InputFilterProviderInterface
+{
+    public function __construct()
+    {
+        parent::__construct('my-fieldset');
+        $this->add(array(
+            'type' => 'Email',
+            'name' => 'email',
+        ));
+    }
+  
+    public function getInputFilterSpecification()
+    {
+        return array(
+            'email' => array(
+                'required' => false,
+            ),
+        );
+    }
+}

--- a/tests/ZendTest/Form/TestAsset/MyFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/MyFieldset.php
@@ -22,7 +22,7 @@ class MyFieldset extends Fieldset implements InputFilterProviderInterface
             'name' => 'email',
         ));
     }
-  
+
     public function getInputFilterSpecification()
     {
         return array(

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -765,4 +765,22 @@ class BaseInputFilterTest extends TestCase
         $this->assertEquals('foo', $filters['foo']->getName());
         $this->assertEquals('bar', $filters['bar']->getName());
     }
+
+    /**
+     * @group 4996
+     */
+    public function testAddingExistingInputWillMergeIntoExisting()
+    {
+        $filter = new InputFilter();
+
+        $foo1    = new Input('foo');
+        $foo1->setRequired(true);
+        $filter->add($foo1);
+
+        $foo2    = new Input('foo');
+        $foo2->setRequired(false);
+        $filter->add($foo2);
+
+        $this->assertFalse($filter->get('foo')->isRequired());
+    }
 }


### PR DESCRIPTION
I have a form with one element and set it as `required` in input filter but it doesn't work because the form adds default input specifications before I set my own and merging of both doesn't work as it leaves the defaut specifications:

MyForm:

``` php
class NewsletterLayoutForm extends \Zend\Form\Form
{
    public function __construct()
    {
        parent::__construct('newsletter_layout');
        $this->setInputFilter(new \Zend\InputFilter\InputFilter());
        $this->addNameElement();
    }

    protected function addNameElement()
    {
        $this->add(array(
            'name' => 'name',
            'attributes' => array(
                'type'  => 'text',
            ),
            'options' => array(
                'label' => 'Name',
            ),
        ));

        $this->getInputFilter()->add(array(
            'required' => true,
            'filters' => array(
                array('name' => 'StringTrim'),
            ),
            'validators' => array(
                array(
                    'name' => 'StringLength',
                    'options' => array(
                        'encoding' => 'UTF-8',
                        'min' => 1,
                        'max' => 255,
                    ),
                ),
            ),
        ), 'name');
    }
}
```

Failing Test for `BaseInputFilterTest` that shows `BaseInputFilter->add()` doesn't work as expected (and expected by `Zend\Form`):

``` php
    public function testAddingExistingInputWillMergeIntoExisting()
    {
        $filter = new InputFilter();

        $foo1    = new Input('foo');
        $foo1->setRequired(true);
        $filter->add($foo1);

        $foo2    = new Input('foo');
        $foo2->setRequired(false);
        $filter->add($foo2);

        $this->assertFalse($filter->get('foo')->isRequired());
    }
```
