### PR TITLE
Allow iterator as parameter for Zend\Mail\Transport\Smtp constructor

### DIFF
--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -50,7 +50,7 @@ class Smtp implements TransportInterface
     public function __construct(SmtpOptions $options = null)
     {
         if (!$options instanceof SmtpOptions) {
-            $options = new SmtpOptions();
+            $options = new SmtpOptions($options);
         }
         $this->setOptions($options);
     }


### PR DESCRIPTION
I guess it is a simple oversight.
