### PR TITLE
Zend\Db transaction api unification

### DIFF
--- a/library/Zend/Db/Adapter/Driver/AbstractConnection.php
+++ b/library/Zend/Db/Adapter/Driver/AbstractConnection.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Adapter\Driver;
+
+use Zend\Db\Adapter\Profiler;
+
+abstract class AbstractConnection implements ConnectionInterface, Profiler\ProfilerAwareInterface
+{
+    /**
+     * @var array
+     */
+    protected $connectionParameters = array();
+
+    /**
+     * @var string
+     */
+    protected $driverName = null;
+
+    /**
+     * @var boolean
+     */
+    protected $inTransaction = false;
+
+    /**
+     * @var Profiler\ProfilerInterface
+     */
+    protected $profiler = null;
+
+    /**
+     * @var resource
+     */
+    protected $resource = null;
+
+    /**
+     * Disconnect
+     *
+     * @return self
+     */
+    public function disconnect()
+    {
+        if ($this->isConnected()) {
+            $this->resource = null;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get connection parameters
+     *
+     * @return array
+     */
+    public function getConnectionParameters()
+    {
+        return $this->connectionParameters;
+    }
+
+    /**
+     * Get driver name
+     *
+     * @return null|string
+     */
+    public function getDriverName()
+    {
+        return $this->driverName;
+    }
+
+    /**
+     * @return null|Profiler\ProfilerInterface
+     */
+    public function getProfiler()
+    {
+        return $this->profiler;
+    }
+
+    /**
+     * Get resource
+     *
+     * @return resource
+     */
+    public function getResource()
+    {
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
+
+        return $this->resource;
+    }
+
+    /**
+     * Checks whether the connection is in transaction state.
+     *
+     * @return boolean
+     */
+    public function inTransaction()
+    {
+        return $this->inTransaction;
+    }
+
+    /**
+     * @param  array $connectionParameters
+     * @return self
+     */
+    public function setConnectionParameters(array $connectionParameters)
+    {
+        $this->connectionParameters = $connectionParameters;
+
+        return $this;
+    }
+
+    /**
+     * @param  Profiler\ProfilerInterface $profiler
+     * @return self
+     */
+    public function setProfiler(Profiler\ProfilerInterface $profiler)
+    {
+        $this->profiler = $profiler;
+
+        return $this;
+    }
+}

--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -9,38 +9,16 @@
 
 namespace Zend\Db\Adapter\Driver\IbmDb2;
 
+use Zend\Db\Adapter\Driver\AbstractConnection;
 use Zend\Db\Adapter\Driver\ConnectionInterface;
 use Zend\Db\Adapter\Exception;
-use Zend\Db\Adapter\Profiler;
 
-class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
+class Connection extends AbstractConnection
 {
     /**
-     *  @var IbmDb2
+     * @var IbmDb2
      */
     protected $driver = null;
-
-    /**
-     * @var array
-     */
-    protected $connectionParameters = null;
-
-    /**
-     * @var resource
-     */
-    protected $resource = null;
-
-    /**
-     * @var Profiler\ProfilerInterface
-     */
-    protected $profiler = null;
-
-    /**
-     * In transaction
-     *
-     * @var bool
-     */
-    protected $inTransaction = false;
 
     /**
      * i5 OS
@@ -78,54 +56,19 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Set driver
      *
-     * @param  IbmDb2     $driver
-     * @return Connection
+     * @param  IbmDb2 $driver
+     * @return self
      */
     public function setDriver(IbmDb2 $driver)
     {
         $this->driver = $driver;
+
         return $this;
     }
 
     /**
-     * @param  Profiler\ProfilerInterface $profiler
-     * @return Connection
-     */
-    public function setProfiler(Profiler\ProfilerInterface $profiler)
-    {
-        $this->profiler = $profiler;
-        return $this;
-    }
-
-    /**
-     * @return null|Profiler\ProfilerInterface
-     */
-    public function getProfiler()
-    {
-        return $this->profiler;
-    }
-
-    /**
-     * @param  array      $connectionParameters
-     * @return Connection
-     */
-    public function setConnectionParameters(array $connectionParameters)
-    {
-        $this->connectionParameters = $connectionParameters;
-        return $this;
-    }
-
-    /**
-     * @return array
-     */
-    public function getConnectionParameters()
-    {
-        return $this->connectionParameters;
-    }
-
-    /**
-     * @param  resource   $resource DB2 resource
-     * @return Connection
+     * @param  resource $resource DB2 resource
+     * @return self
      */
     public function setResource($resource)
     {
@@ -133,6 +76,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             throw new Exception\InvalidArgumentException('The resource provided must be of type "DB2 Connection"');
         }
         $this->resource = $resource;
+
         return $this;
     }
 
@@ -148,17 +92,8 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $info = db2_server_info($this->resource);
-        return (isset($info->DB_NAME) ? $info->DB_NAME : '');
-    }
 
-    /**
-     * Get resource
-     *
-     * @return mixed
-     */
-    public function getResource()
-    {
-        return $this->resource;
+        return (isset($info->DB_NAME) ? $info->DB_NAME : '');
     }
 
     /**
@@ -233,7 +168,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Begin transaction
      *
-     * @return ConnectionInterface
+     * @return self
      */
     public function beginTransaction()
     {
@@ -250,23 +185,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         $this->prevAutocommit = db2_autocommit($this->resource);
         db2_autocommit($this->resource, DB2_AUTOCOMMIT_OFF);
         $this->inTransaction = true;
-        return $this;
-    }
 
-    /**
-     * In transaction
-     *
-     * @return bool
-     */
-    public function inTransaction()
-    {
-        return $this->inTransaction;
+        return $this;
     }
 
     /**
      * Commit
      *
-     * @return ConnectionInterface
+     * @return self
      */
     public function commit()
     {
@@ -283,21 +209,22 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $this->inTransaction = false;
+
         return $this;
     }
 
     /**
      * Rollback
      *
-     * @return ConnectionInterface
+     * @return self
      */
     public function rollback()
     {
-        if (!$this->resource) {
+        if (!$this->isConnected()) {
             throw new Exception\RuntimeException('Must be connected before you can rollback.');
         }
 
-        if (!$this->inTransaction) {
+        if (!$this->inTransaction()) {
             throw new Exception\RuntimeException('Must call beginTransaction() before you can rollback.');
         }
 
@@ -310,6 +237,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $this->inTransaction = false;
+
         return $this;
     }
 
@@ -368,6 +296,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $this->i5 = php_uname('s') == 'OS400' ? true : false;
+
         return $this->i5;
     }
 }

--- a/library/Zend/Db/Adapter/Driver/Oci8/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Oci8/Connection.php
@@ -9,11 +9,10 @@
 
 namespace Zend\Db\Adapter\Driver\Oci8;
 
-use Zend\Db\Adapter\Driver\ConnectionInterface;
+use Zend\Db\Adapter\Driver\AbstractConnection;
 use Zend\Db\Adapter\Exception;
-use Zend\Db\Adapter\Profiler;
 
-class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
+class Connection extends AbstractConnection
 {
     /**
      * @var Oci8
@@ -21,33 +20,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     protected $driver = null;
 
     /**
-     * @var Profiler\ProfilerInterface
-     */
-    protected $profiler = null;
-
-    /**
-     * Connection parameters
-     *
-     * @var array
-     */
-    protected $connectionParameters = array();
-
-    /**
-     * @var
-     */
-    protected $resource = null;
-
-    /**
-     * In transaction
-     *
-     * @var bool
-     */
-    protected $inTransaction = false;
-
-    /**
      * Constructor
      *
-     * @param array|resource|null $connectionInfo
+     * @param  array|resource|null                                 $connectionInfo
      * @throws \Zend\Db\Adapter\Exception\InvalidArgumentException
      */
     public function __construct($connectionInfo = null)
@@ -62,53 +37,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @param Oci8 $driver
-     * @return Connection
+     * @param  Oci8 $driver
+     * @return self
      */
     public function setDriver(Oci8 $driver)
     {
         $this->driver = $driver;
+
         return $this;
-    }
-
-    /**
-     * @param Profiler\ProfilerInterface $profiler
-     * @return Connection
-     */
-    public function setProfiler(Profiler\ProfilerInterface $profiler)
-    {
-        $this->profiler = $profiler;
-        return $this;
-    }
-
-    /**
-     * @return null|Profiler\ProfilerInterface
-     */
-    public function getProfiler()
-    {
-        return $this->profiler;
-    }
-
-    /**
-     * Set connection parameters
-     *
-     * @param  array $connectionParameters
-     * @return Connection
-     */
-    public function setConnectionParameters(array $connectionParameters)
-    {
-        $this->connectionParameters = $connectionParameters;
-        return $this;
-    }
-
-    /**
-     * Get connection parameters
-     *
-     * @return array
-     */
-    public function getConnectionParameters()
-    {
-        return $this->connectionParameters;
     }
 
     /**
@@ -126,6 +62,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         $stmt = oci_parse($this->resource, $query);
         oci_execute($stmt);
         $dbNameArray = oci_fetch_array($stmt, OCI_ASSOC);
+
         return $dbNameArray['current_schema'];
     }
 
@@ -133,7 +70,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  resource $resource
-     * @return Connection
+     * @return self
      */
     public function setResource($resource)
     {
@@ -141,24 +78,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             throw new Exception\InvalidArgumentException('A resource of type "oci8 connection" was expected');
         }
         $this->resource = $resource;
-        return $this;
-    }
 
-    /**
-     * Get resource
-     *
-     * @return \oci8
-     */
-    public function getResource()
-    {
-        $this->connect();
-        return $this->resource;
+        return $this;
     }
 
     /**
      * Connect
      *
-     * @return Connection
+     * @return self
      */
     public function connect()
     {
@@ -176,6 +103,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                     return $p[$name];
                 }
             }
+
             return null;
         };
 
@@ -232,6 +160,8 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
 
     /**
      * Begin transaction
+     *
+     * @return self
      */
     public function beginTransaction()
     {
@@ -241,48 +171,46 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
 
         // A transaction begins when the first SQL statement that changes data is executed with oci_execute() using the OCI_NO_AUTO_COMMIT flag.
         $this->inTransaction = true;
-    }
 
-    /**
-     * In transaction
-     *
-     * @return bool
-     */
-    public function inTransaction()
-    {
-        return $this->inTransaction;
+        return $this;
     }
 
     /**
      * Commit
+     *
+     * @return self
      */
     public function commit()
     {
-        if (!$this->resource) {
+        if (!$this->isConnected()) {
             $this->connect();
         }
 
-        if ($this->inTransaction) {
+        if ($this->inTransaction()) {
             $valid = oci_commit($this->resource);
             if ($valid === false) {
                 $e = oci_error($this->resource);
                 throw new Exception\InvalidQueryException($e['message'], $e['code']);
             }
+
+            $this->inTransaction = false;
         }
+
+        return $this;
     }
 
     /**
      * Rollback
      *
-     * @return Connection
+     * @return self
      */
     public function rollback()
     {
-        if (!$this->resource) {
+        if (!$this->isConnected()) {
             throw new Exception\RuntimeException('Must be connected before you can rollback.');
         }
 
-        if (!$this->inTransaction) {
+        if (!$this->inTransaction()) {
             throw new Exception\RuntimeException('Must call commit() before you can rollback.');
         }
 
@@ -291,6 +219,8 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             $e = oci_error($this->resource);
             throw new Exception\InvalidQueryException($e['message'], $e['code']);
         }
+
+        $this->inTransaction = false;
 
         return $this;
     }
@@ -329,6 +259,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $resultPrototype = $this->driver->createResult($ociStmt);
+
         return $resultPrototype;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -9,11 +9,10 @@
 
 namespace Zend\Db\Adapter\Driver\Pdo;
 
-use Zend\Db\Adapter\Driver\ConnectionInterface;
+use Zend\Db\Adapter\Driver\AbstractConnection;
 use Zend\Db\Adapter\Exception;
-use Zend\Db\Adapter\Profiler;
 
-class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
+class Connection extends AbstractConnection
 {
     /**
      * @var Pdo
@@ -21,29 +20,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     protected $driver = null;
 
     /**
-     * @var Profiler\ProfilerInterface
-     */
-    protected $profiler = null;
-
-    /**
-     * @var string
-     */
-    protected $driverName = null;
-
-    /**
-     * @var array
-     */
-    protected $connectionParameters = array();
-
-    /**
      * @var \PDO
      */
     protected $resource = null;
-
-    /**
-     * @var bool
-     */
-    protected $inTransaction = false;
 
     /**
      * @var string
@@ -53,7 +32,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Constructor
      *
-     * @param array|\PDO|null $connectionParameters
+     * @param  array|\PDO|null                    $connectionParameters
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($connectionParameters = null)
@@ -70,47 +49,20 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Set driver
      *
-     * @param Pdo $driver
-     * @return Connection
+     * @param  Pdo  $driver
+     * @return self
      */
     public function setDriver(Pdo $driver)
     {
         $this->driver = $driver;
+
         return $this;
-    }
-
-    /**
-     * @param Profiler\ProfilerInterface $profiler
-     * @return Connection
-     */
-    public function setProfiler(Profiler\ProfilerInterface $profiler)
-    {
-        $this->profiler = $profiler;
-        return $this;
-    }
-
-    /**
-     * @return null|Profiler\ProfilerInterface
-     */
-    public function getProfiler()
-    {
-        return $this->profiler;
-    }
-
-    /**
-     * Get driver name
-     *
-     * @return null|string
-     */
-    public function getDriverName()
-    {
-        return $this->driverName;
     }
 
     /**
      * Set connection parameters
      *
-     * @param array $connectionParameters
+     * @param  array $connectionParameters
      * @return void
      */
     public function setConnectionParameters(array $connectionParameters)
@@ -128,16 +80,6 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                 3
             ));
         }
-    }
-
-    /**
-     * Get connection parameters
-     *
-     * @return array
-     */
-    public function getConnectionParameters()
-    {
-        return $this->connectionParameters;
     }
 
     /**
@@ -186,6 +128,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         if ($result instanceof \PDOStatement) {
             return $result->fetchColumn();
         }
+
         return false;
     }
 
@@ -193,32 +136,20 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  \PDO $resource
-     * @return Connection
+     * @return self
      */
     public function setResource(\PDO $resource)
     {
         $this->resource = $resource;
         $this->driverName = strtolower($this->resource->getAttribute(\PDO::ATTR_DRIVER_NAME));
-        return $this;
-    }
 
-    /**
-     * Get resource
-     *
-     * @return \PDO
-     */
-    public function getResource()
-    {
-        if (!$this->isConnected()) {
-            $this->connect();
-        }
-        return $this->resource;
+        return $this;
     }
 
     /**
      * Connect
      *
-     * @return Connection
+     * @return self
      * @throws Exception\InvalidConnectionParametersException
      * @throws Exception\RuntimeException
      */
@@ -345,47 +276,26 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * Disconnect
-     *
-     * @return Connection
-     */
-    public function disconnect()
-    {
-        if ($this->isConnected()) {
-            $this->resource = null;
-        }
-        return $this;
-    }
-
-    /**
      * Begin transaction
      *
-     * @return Connection
+     * @return self
      */
     public function beginTransaction()
     {
         if (!$this->isConnected()) {
             $this->connect();
         }
+
         $this->resource->beginTransaction();
         $this->inTransaction = true;
-        return $this;
-    }
 
-    /**
-     * In transaction
-     *
-     * @return bool
-     */
-    public function inTransaction()
-    {
-        return $this->inTransaction;
+        return $this;
     }
 
     /**
      * Commit
      *
-     * @return Connection
+     * @return self
      */
     public function commit()
     {
@@ -395,13 +305,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
 
         $this->resource->commit();
         $this->inTransaction = false;
+
         return $this;
     }
 
     /**
      * Rollback
      *
-     * @return Connection
+     * @return self
      * @throws Exception\RuntimeException
      */
     public function rollback()
@@ -410,11 +321,13 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             throw new Exception\RuntimeException('Must be connected before you can rollback');
         }
 
-        if (!$this->inTransaction) {
+        if (!$this->inTransaction()) {
             throw new Exception\RuntimeException('Must call beginTransaction() before you can rollback');
         }
 
         $this->resource->rollBack();
+        $this->inTransaction = false;
+
         return $this;
     }
 
@@ -447,6 +360,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $result = $this->driver->createResult($resultResource, $sql);
+
         return $result;
 
     }
@@ -454,7 +368,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Prepare
      *
-     * @param string $sql
+     * @param  string    $sql
      * @return Statement
      */
     public function prepare($sql)
@@ -464,13 +378,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $statement = $this->driver->createStatement($sql);
+
         return $statement;
     }
 
     /**
      * Get last generated id
      *
-     * @param string $name
+     * @param  string            $name
      * @return string|null|false
      */
     public function getLastGeneratedValue($name = null)
@@ -484,6 +399,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         } catch (\Exception $e) {
             // do nothing
         }
+
         return false;
     }
 

--- a/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
@@ -9,40 +9,15 @@
 
 namespace Zend\Db\Adapter\Driver\Pgsql;
 
-use Zend\Db\Adapter\Driver\ConnectionInterface;
+use Zend\Db\Adapter\Driver\AbstractConnection;
 use Zend\Db\Adapter\Exception;
-use Zend\Db\Adapter\Profiler;
 
-class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
+class Connection extends AbstractConnection
 {
     /**
      * @var Pgsql
      */
     protected $driver = null;
-
-    /**
-     * @var Profiler\ProfilerInterface
-     */
-    protected $profiler = null;
-
-    /**
-     * Connection parameters
-     *
-     * @var array
-     */
-    protected $connectionParameters = array();
-
-    /**
-     * @var resource
-     */
-    protected $resource = null;
-
-    /**
-     * In transaction
-     *
-     * @var bool
-     */
-    protected $inTransaction = false;
 
     /**
      * Constructor
@@ -59,57 +34,16 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * Set connection parameters
-     *
-     * @param  array $connectionParameters
-     * @return Connection
-     */
-    public function setConnectionParameters(array $connectionParameters)
-    {
-        $this->connectionParameters = $connectionParameters;
-        return $this;
-    }
-
-    /**
      * Set driver
      *
      * @param  Pgsql $driver
-     * @return Connection
+     * @return self
      */
     public function setDriver(Pgsql $driver)
     {
         $this->driver = $driver;
+
         return $this;
-    }
-
-    /**
-     * @param Profiler\ProfilerInterface $profiler
-     * @return Connection
-     */
-    public function setProfiler(Profiler\ProfilerInterface $profiler)
-    {
-        $this->profiler = $profiler;
-        return $this;
-    }
-
-    /**
-     * @return null|Profiler\ProfilerInterface
-     */
-    public function getProfiler()
-    {
-        return $this->profiler;
-    }
-
-    /**
-     * Set resource
-     *
-     * @param  resource $resource
-     * @return Connection
-     */
-    public function setResource($resource)
-    {
-        $this->resource = $resource;
-        return;
     }
 
     /**
@@ -127,26 +61,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         if ($result == false) {
             return null;
         }
-        return pg_fetch_result($result, 0, 'currentschema');
-    }
 
-    /**
-     * Get resource
-     *
-     * @return resource
-     */
-    public function getResource()
-    {
-        if (!$this->isConnected()) {
-            $this->connect();
-        }
-        return $this->resource;
+        return pg_fetch_result($result, 0, 'currentschema');
     }
 
     /**
      * Connect to the database
      *
-     * @return Connection
+     * @return self
      * @throws Exception\RuntimeException on failure
      */
     public function connect()
@@ -165,6 +87,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                     return $p[$name];
                 }
             }
+
             return null;
         };
 
@@ -214,11 +137,13 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return void
+     * Begin transaction
+     *
+     * @return self
      */
     public function beginTransaction()
     {
-        if ($this->inTransaction) {
+        if ($this->inTransaction()) {
             throw new Exception\RuntimeException('Nested transactions are not supported');
         }
 
@@ -228,46 +153,54 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
 
         pg_query($this->resource, 'BEGIN');
         $this->inTransaction = true;
+
+        return $this;
     }
 
     /**
-     * In transaction
+     * Commit
      *
-     * @return bool
-     */
-    public function inTransaction()
-    {
-        return $this->inTransaction;
-    }
-
-    /**
-     * @return void
+     * @return self
      */
     public function commit()
     {
-        if (!$this->inTransaction) {
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
+
+        if (!$this->inTransaction()) {
             return; // We ignore attempts to commit non-existing transaction
         }
 
         pg_query($this->resource, 'COMMIT');
         $this->inTransaction = false;
+
+        return $this;
     }
 
     /**
-     * @return void
+     * Rollback
+     *
+     * @return self
      */
     public function rollback()
     {
-        if (!$this->inTransaction) {
-            return;
+        if (!$this->isConnected()) {
+            throw new Exception\RuntimeException('Must be connected before you can rollback');
+        }
+
+        if (!$this->inTransaction()) {
+            throw new Exception\RuntimeException('Must call beginTransaction() before you can rollback');
         }
 
         pg_query($this->resource, 'ROLLBACK');
         $this->inTransaction = false;
+
+        return $this;
     }
 
     /**
-     * @param  string $sql
+     * @param  string                                         $sql
      * @throws Exception\InvalidQueryException
      * @return resource|\Zend\Db\ResultSet\ResultSetInterface
      */
@@ -293,11 +226,12 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $resultPrototype = $this->driver->createResult(($resultResource === true) ? $this->resource : $resultResource);
+
         return $resultPrototype;
     }
 
     /**
-     * @param  null $name Ignored
+     * @param  null   $name Ignored
      * @return string
      */
     public function getLastGeneratedValue($name = null)
@@ -306,6 +240,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             return null;
         }
         $result = pg_query($this->resource, 'SELECT CURRVAL(\'' . str_replace('\'', '\\\'', $name) . '\') as "currval"');
+
         return pg_fetch_result($result, 0, 'currval');
     }
 }

--- a/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTransactionsTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTransactionsTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Adapter\Driver\Pdo;
+
+use \Zend\Db\Adapter\Driver\Pdo\Connection;
+
+class ConnectionTransactionsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Connection
+     */
+    protected $connection = null;
+
+    protected function setUp()
+    {
+        /**
+         * @todo Use a real mock object
+         */
+        $pdo = new \ZendTest\Db\Adapter\Driver\TestAsset\PdoMock();
+
+        $this->connection = new Connection();
+        $this->connection->setResource($pdo);
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::beginTransaction()
+     */
+    public function testBeginTransactionReturnsInstanceOfConnection()
+    {
+        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\Pdo\Connection', $this->connection->beginTransaction());
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::beginTransaction()
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::inTransaction()
+     */
+    public function testBeginTransactionSetsInTransactionAtTrue()
+    {
+        $this->connection->beginTransaction();
+        $this->assertTrue($this->connection->inTransaction());
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::commit()
+     */
+    public function testCommitReturnsInstanceOfConnection()
+    {
+        $this->connection->beginTransaction();
+        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\Pdo\Connection', $this->connection->commit());
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::commit()
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::inTransaction()
+     */
+    public function testCommitSetsInTransactionAtFalse()
+    {
+        $this->connection->beginTransaction();
+        $this->connection->commit();
+        $this->assertFalse($this->connection->inTransaction());
+    }
+
+    /**
+     * Standalone commit is possible after a SET autocommit=0;
+     *
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::commit()
+     */
+    public function testCommitWithoutBeginReturnsInstanceOfConnection()
+    {
+        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\Pdo\Connection', $this->connection->commit());
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::rollback()
+     * @expectedException \Zend\Db\Adapter\Exception\RuntimeException
+     * @expectedExceptionMessage Must be connected before you can rollback
+     */
+    public function testRollbackDisconnectedThrowsException()
+    {
+        $this->connection->disconnect();
+        $this->connection->rollback();
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::rollback()
+     */
+    public function testRollbackReturnsInstanceOfConnection()
+    {
+        $this->connection->beginTransaction();
+        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\Pdo\Connection', $this->connection->rollback());
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::rollback()
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::inTransaction()
+     */
+    public function testRollbackSetsInTransactionAtFalse()
+    {
+        $this->connection->beginTransaction();
+        $this->connection->rollback();
+        $this->assertFalse($this->connection->inTransaction());
+    }
+
+    /**
+     * @covers \Zend\Db\Adapter\Driver\Pdo\Connection::rollback()
+     * @expectedException \Zend\Db\Adapter\Exception\RuntimeException
+     * @expectedExceptionMessage Must call beginTransaction() before you can rollback
+     */
+    public function testRollbackWithoutBeginThrowsException()
+    {
+        $this->connection->rollback();
+    }
+}

--- a/tests/ZendTest/Db/Adapter/Driver/TestAsset/PdoMock.php
+++ b/tests/ZendTest/Db/Adapter/Driver/TestAsset/PdoMock.php
@@ -1,0 +1,29 @@
+<?php
+namespace ZendTest\Db\Adapter\Driver\TestAsset;
+
+/**
+ * @todo Use a real mock object
+ */
+class PdoMock extends \PDO
+{
+    public function __construct()
+    {}
+
+    public function beginTransaction()
+    {
+        return true;
+    }
+
+    public function commit()
+    {
+        return true;
+    }
+
+    public function getAttribute($attribute)
+    {}
+
+    public function rollBack()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
- Added an abstract to avoid repetiting code between adapters.
- Fixed contracts (for example dockblock said @return self for fluent interface but method didn't actually return $this).
- Added more consistancy in the methods between adapters
- Added unit tests

This work is an introduction to another PR to come.
