### PR TITLE
deprecated feature in classmap generator

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -228,7 +228,13 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
-$content = preg_replace('(\n\s+([^=]+)=>)e', "'\n    \\1' . str_repeat(' ', " . $maxWidth . " - strlen('\\1')) . '=>'", $content);
+$content = preg_replace_callback(
+    '(\n\s+([^=]+)=>)',
+    function ($match) use ($maxWidth) {
+        return "\n  " . $match[1] . str_repeat(" ", $maxWidth - strlen($match[1])) . '=>';
+    },
+    $content
+);
 
 // Make the file end by EOL
 $content = rtrim($content, "\n") . "\n";


### PR DESCRIPTION
The /e modifier in preg_replace is deprecated since 5.5.0, use preg_replace_callback instead
