### PR TITLE
Allow set Form::setPreferFormInputFilter via options

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -125,7 +125,7 @@ class Form extends Fieldset implements FormInterface
 
     /**
      * Set options for a form. Accepted options are:
-     * - prefer_form_input_filter: is form input filter is prefered?
+     * - prefer_form_input_filter: is form input filter is preferred?
      *
      * @param  array|Traversable $options
      * @return Element|ElementInterface

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -122,6 +122,26 @@ class Form extends Fieldset implements FormInterface
      */
     protected $validationGroup;
 
+
+    /**
+     * Set options for a form. Accepted options are:
+     * - prefer_form_input_filter: is form input filter is prefered?
+     *
+     * @param  array|Traversable $options
+     * @return Element|ElementInterface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        if (isset($options['prefer_form_input_filter'])) {
+            $this->setPreferFormInputFilter($options['prefer_form_input_filter']);
+        }
+
+        return $this;
+    }
+
     /**
      * Add an element or fieldset
      *


### PR DESCRIPTION
Allow set setPreferFormInputFilter options while building forms by FormFactory using form spec. 
