### PR TITLE
[BC Break] Added the set /getPbkdf2HashAlgorithm() in BlockCipher

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -79,7 +79,7 @@ class BlockCipher
     /**
      * Constructor
      *
-     * @param SymmetricInterface $cipher
+     * @param  SymmetricInterface $cipher
      */
     public function __construct(SymmetricInterface $cipher)
     {
@@ -167,7 +167,7 @@ class BlockCipher
     /**
      * Set the number of iterations for Pbkdf2
      *
-     * @param  int     $num
+     * @param  int $num
      * @return BlockCipher
      */
     public function setKeyIteration($num)
@@ -190,7 +190,7 @@ class BlockCipher
     /**
      * Set the salt (IV)
      *
-     * @param  string                             $salt
+     * @param  string $salt
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -229,7 +229,7 @@ class BlockCipher
     /**
      * Enable/disable the binary output
      *
-     * @param  bool        $value
+     * @param  bool $value
      * @return BlockCipher
      */
     public function setBinaryOutput($value)
@@ -279,7 +279,7 @@ class BlockCipher
     /**
      * Set algorithm of the symmetric cipher
      *
-     * @param  string                             $algo
+     * @param  string $algo
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -357,7 +357,7 @@ class BlockCipher
     /**
      * Set the hash algorithm for the Pbkdf2
      *
-     * @params string $hash
+     * @param  string $hash
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -386,7 +386,7 @@ class BlockCipher
     /**
      * Encrypt then authenticate using HMAC
      *
-     * @param  string                             $data
+     * @param  string $data
      * @return string
      * @throws Exception\InvalidArgumentException
      */

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -103,6 +103,13 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sha1', $this->blockCipher->getHashAlgorithm());
     }
 
+    public function testSetPbkdf2HashAlgorithm()
+    {
+        $result = $this->blockCipher->setPbkdf2HashAlgorithm('sha1');
+        $this->assertEquals($result, $this->blockCipher);
+        $this->assertEquals('sha1', $this->blockCipher->getPbkdf2HashAlgorithm());
+    }
+
     public function testSetKeyIteration()
     {
         $result = $this->blockCipher->setKeyIteration(1000);


### PR DESCRIPTION
This feature can set/get the Pbkdf2 Hash algorithm used by Zend\Crypt\BlockCipher to generate the encryption key. This new feature can be useful to configure the BlockCipher internals with more details.
