### PR TITLE
Fix forms regression introduced in 2.2.3

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -106,7 +106,7 @@ class Form extends Fieldset implements FormInterface
      *
      * @var bool
      */
-    protected $preferFormInputFilter = false;
+    protected $preferFormInputFilter = true;
 
     /**
      * Are the form elements/fieldsets wrapped by the form name ?

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1640,6 +1640,9 @@ class FormTest extends TestCase
             ->isRequired());
     }
 
+    /**
+     * @group 5015
+     */
     public function testCanSetPreferFormInputFilterFlagViaSetOptions()
     {
         $flag = ! $this->form->getPreferFormInputFilter();
@@ -1649,6 +1652,9 @@ class FormTest extends TestCase
         $this->assertSame($flag, $this->form->getPreferFormInputFilter());
     }
 
+    /**
+     * @group 5015
+     */
     public function testFactoryCanSetPreferFormInputFilterFlag()
     {
         $factory = new Factory();
@@ -1661,5 +1667,10 @@ class FormTest extends TestCase
             ));
             $this->assertSame($flag, $form->getPreferFormInputFilter());
         }
+    }
+
+    public function testPreferFormInputFilterFlagIsEnabledByDefault()
+    {
+        $this->assertTrue($this->form->getPreferFormInputFilter());
     }
 }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1669,6 +1669,9 @@ class FormTest extends TestCase
         }
     }
 
+    /**
+     * @group 5028
+     */
     public function testPreferFormInputFilterFlagIsEnabledByDefault()
     {
         $this->assertTrue($this->form->getPreferFormInputFilter());


### PR DESCRIPTION
Fixes a "regression" discovered in #5007. Basically, fixes from #4996 made the `preferFormInputFilter` flag actually have semantic meaning finally, and I discovered that the default value needed to be switched in order to retain the pre-2.2.3 form behavior.
