### PR TITLE
Locale aware fix

### DIFF
--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -9,6 +9,7 @@
 
 namespace Zend\I18n\Validator;
 
+use Locale;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
@@ -86,6 +87,9 @@ class PhoneNumber extends AbstractValidator
 
         if (array_key_exists('country', $options)) {
             $this->setCountry($options['country']);
+        } else {
+            $country = Locale::getRegion(Locale::getDefault());
+            $this->setCountry($country);
         }
 
         if (array_key_exists('allowed_types', $options)) {

--- a/tests/ZendTest/I18n/Validator/PhoneNumberTest.php
+++ b/tests/ZendTest/I18n/Validator/PhoneNumberTest.php
@@ -10,6 +10,7 @@
 
 namespace Zend\I18nTest\Validator;
 
+use Locale;
 use Zend\I18n\Validator\PhoneNumber;
 
 class PhoneNumberTest extends \PHPUnit_Framework_TestCase
@@ -3032,6 +3033,49 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
         $this->validator = new PhoneNumber();
     }
 
+    /**
+     * @covers PhoneNumber::__construct()
+     * @dataProvider constructDataProvider
+     *
+     * @param array  $args
+     * @param array  $options
+     * @param string $locale
+     */
+    public function testConstruct(array $args, array $options, $locale = null)
+    {
+        if ($locale) {
+            Locale::setDefault($locale);
+        }
+
+        $validator = new PhoneNumber($args);
+
+        $this->assertSame($options['country'], $validator->getCountry());
+    }
+
+    public function constructDataProvider()
+    {
+        return array(
+            array(
+                array(),
+                array('country' => Locale::getRegion(Locale::getDefault())),
+                null
+            ),
+            array(
+                array(),
+                array('country' => 'CN'),
+                'zh_CN'
+            ),
+            array(
+                array('country' => 'CN'),
+                array('country' => 'CN'),
+                null
+            ),
+        );
+    }
+
+    /**
+     * @TODO: use dataProvider for this in order to enforce clean context
+     */
     public function testExampleNumbers()
     {
         foreach ($this->phone as $country => $parameters) {
@@ -3046,6 +3090,9 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @TODO: use dataProvider for this in order to enforce clean context
+     */
     public function testExampleNumbersAgainstPossible()
     {
         $this->validator->allowPossible(true);


### PR DESCRIPTION
- This patch makes PhoneNumber validator locale aware.
- This installs a new dependency on INTL extension which was already there for a lot of filters/validators in Zend/I18n.
- If agreed, I will add unit tests.
