### PR TITLE
updated Zend_Validate_Hostname translation message IDs and translations

### DIFF
--- a/resources/languages/sk/Zend_Validate.php
+++ b/resources/languages/sk/Zend_Validate.php
@@ -179,7 +179,7 @@ return array(
 
     // Zend_Validate_Hostname
     "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "The input appears to be an IP address, but IP addresses are not allowed" => "'Zadaná hodnota vyzerá ako IP adresa, ale tie nie sú dovolené",
+    "The input appears to be an IP address, but IP addresses are not allowed" => "Zadaná hodnota vyzerá ako IP adresa, ale tie nie sú dovolené",
     "The input appears to be a DNS hostname but cannot match TLD against known list" => "Zadaná hodnota vyzerá ako hostname, ale nemohol byť overený voči známym TLD",
     "The input appears to be a DNS hostname but contains a dash in an invalid position" => "Zadaná hodnota vyzerá ako hostname, ale obsahuje pomlčku na nedovolenom mieste",
     "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "Zadaná hodnota vyzerá ako hostname, ale nezodpovedá formátu hostname pre '%tld%'",

--- a/resources/languages/sk/Zend_Validate.php
+++ b/resources/languages/sk/Zend_Validate.php
@@ -179,16 +179,16 @@ return array(
 
     // Zend_Validate_Hostname
     "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",
-    "'%value%' appears to be an IP address, but IP addresses are not allowed" => "'%value%' vyzerá ako IP adresa, ale tie nie sú dovolené",
-    "'%value%' appears to be a DNS hostname but cannot match TLD against known list" => "'%value%' vyzerá ako hostname, ale nemohol byť overený voči známym TLD",
-    "'%value%' appears to be a DNS hostname but contains a dash in an invalid position" => "'%value%' vyzerá ako hostname, ale obsahuje pomlčku na nedovolenom mieste",
-    "'%value%' appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "'%value%' vyzerá ako hostname, ale nezodpovedá formátu hostname pre '%tld%'",
-    "'%value%' appears to be a DNS hostname but cannot extract TLD part" => "'%value%' síce vyzerá ako hostname, ale nemožno určiť TLD",
-    "'%value%' does not match the expected structure for a DNS hostname" => "'%value%' nezodpovedá očakávanej štruktúre hostname",
-    "'%value%' does not appear to be a valid local network name" => "'%value%' nevyzerá ako platné sieťové meno",
-    "'%value%' appears to be a local network name but local network names are not allowed" => "'%value%' vyzerá ako hostname lokálnej siete, tie ale nie sú povolené",
-    "'%value%' appears to be a DNS hostname but the given punycode notation cannot be decoded" => "'%value%' vyzerá ako DNS hostname ale zadanú punycode notáciu nie je možné dekódovať",
-    "'%value%' does not appear to be a valid URI hostname" => "'%value%' nevyzerá ako platné URI hostname",
+    "The input appears to be an IP address, but IP addresses are not allowed" => "'Zadaná hodnota vyzerá ako IP adresa, ale tie nie sú dovolené",
+    "The input appears to be a DNS hostname but cannot match TLD against known list" => "Zadaná hodnota vyzerá ako hostname, ale nemohol byť overený voči známym TLD",
+    "The input appears to be a DNS hostname but contains a dash in an invalid position" => "Zadaná hodnota vyzerá ako hostname, ale obsahuje pomlčku na nedovolenom mieste",
+    "The input appears to be a DNS hostname but cannot match against hostname schema for TLD '%tld%'" => "Zadaná hodnota vyzerá ako hostname, ale nezodpovedá formátu hostname pre '%tld%'",
+    "The input appears to be a DNS hostname but cannot extract TLD part" => "Zadaná hodnota síce vyzerá ako hostname, ale nemožno určiť TLD",
+    "The input does not match the expected structure for a DNS hostname" => "Zadaná hodnota nezodpovedá očakávanej štruktúre hostname",
+    "The input does not appear to be a valid local network name" => "Zadaná hodnota nevyzerá ako platné sieťové meno",
+    "The input appears to be a local network name but local network names are not allowed" => "Zadaná hodnota vyzerá ako hostname lokálnej siete, tie ale nie sú povolené",
+    "The input appears to be a DNS hostname but the given punycode notation cannot be decoded" => "Zadaná hodnota vyzerá ako DNS hostname ale zadanú punycode notáciu nie je možné dekódovať",
+    "The input does not appear to be a valid URI hostname" => "Zadaná hodnota nevyzerá ako platné URI hostname",
 
     // Zend_Validate_Iban
     "Unknown country within the IBAN '%value%'" => "Neznámý štát v IBAN '%value%'",


### PR DESCRIPTION
There are outdated messageIds in the Slovak translation of Zend_Validate_Hostname so I have updated them and added appropriate translation
