### PR TITLE
Correct namespace name DockBlock to DocBlock

### DIFF
--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Code\Generator;
 
-use Zend\Code\Generator\DocBlock\Tag as DockBlockTag;
+use Zend\Code\Generator\DocBlock\Tag as DocBlockTag;
 use Zend\Code\Reflection\DocBlockReflection;
 
 class DocBlockGenerator extends AbstractGenerator
@@ -56,7 +56,7 @@ class DocBlockGenerator extends AbstractGenerator
         $docBlock->setLongDescription($reflectionDocBlock->getLongDescription());
 
         foreach ($reflectionDocBlock->getTags() as $tag) {
-            $docBlock->setTag(DockBlockTag::fromReflection($tag));
+            $docBlock->setTag(DocBlockTag::fromReflection($tag));
         }
 
         return $docBlock;
@@ -162,15 +162,15 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @param  array|DockBlockTag $tag
+     * @param  array|DocBlockTag $tag
      * @throws Exception\InvalidArgumentException
      * @return DocBlockGenerator
      */
     public function setTag($tag)
     {
         if (is_array($tag)) {
-            $tag = new DockBlockTag($tag);
-        } elseif (!$tag instanceof DockBlockTag) {
+            $tag = new DocBlockTag($tag);
+        } elseif (!$tag instanceof DocBlockTag) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects either an array of method options or an instance of %s\DocBlock\Tag',
                 __METHOD__,
@@ -183,7 +183,7 @@ class DocBlockGenerator extends AbstractGenerator
     }
 
     /**
-     * @return DockBlockTag[]
+     * @return DocBlockTag[]
      */
     public function getTags()
     {


### PR DESCRIPTION
Renamed all occurrences of DockBlock to DocBlock. 
