### PR TITLE
Reflection ThrowsTag to handle types correctly

### DIFF
--- a/library/Zend/Code/Reflection/DocBlock/Tag/ThrowsTag.php
+++ b/library/Zend/Code/Reflection/DocBlock/Tag/ThrowsTag.php
@@ -12,9 +12,9 @@ namespace Zend\Code\Reflection\DocBlock\Tag;
 class ThrowsTag implements TagInterface, PhpDocTypedTagInterface
 {
     /**
-     * @var string
+     * @var array
      */
-    protected $type = null;
+    protected $types = array();
 
     /**
      * @var string
@@ -38,7 +38,7 @@ class ThrowsTag implements TagInterface, PhpDocTypedTagInterface
         $matches = array();
         preg_match('#([\w|\\\]+)(?:\s+(.*))?#', $tagDocBlockLine, $matches);
 
-        $this->type = $matches[1];
+        $this->types = explode('|', $matches[1]);
 
         if (isset($matches[2])) {
             $this->description = $matches[2];
@@ -53,14 +53,20 @@ class ThrowsTag implements TagInterface, PhpDocTypedTagInterface
      */
     public function getType()
     {
-        return $this->type;
+        return implode('|', $this->getTypes());
     }
 
+    /**
+     * @return array
+     */
     public function getTypes()
     {
-        return array($this->type);
+        return $this->types;
     }
 
+    /**
+     * @return string
+     */
     public function getDescription()
     {
         return $this->description;

--- a/tests/ZendTest/Code/Reflection/DocBlock/Tag/ThrowsTagTest.php
+++ b/tests/ZendTest/Code/Reflection/DocBlock/Tag/ThrowsTagTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Code\Reflection\DocBlock\Tag;
+
+use Zend\Code\Reflection\DocBlock\Tag\ThrowsTag;
+
+/**
+ * @group      Zend_Reflection
+ * @group      Zend_Reflection_DocBlock
+ */
+class ThrowsTagTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAllCharactersFromTypenameAreSupported()
+    {
+        $tag = new ThrowsTag();
+        $tag->initialize('\\Logic_2_Exception');
+        $this->assertEquals(array('\\Logic_2_Exception'), $tag->getTypes());
+    }
+
+    public function testSingleTypeWithDescription()
+    {
+        $tag = new ThrowsTag();
+        $tag->initialize('LogicException The Exception');
+        $this->assertEquals(array('LogicException'), $tag->getTypes());
+        $this->assertEquals('The Exception', $tag->getDescription());
+    }
+
+    public function testSingleTypeWithoutDescription()
+    {
+        $tag = new ThrowsTag();
+        $tag->initialize('LogicException');
+        $this->assertEquals(array('LogicException'), $tag->getTypes());
+        $this->assertNull($tag->getDescription());
+    }
+
+    public function testMultipleTypesWithoutDescription()
+    {
+        $tag = new ThrowsTag();
+        $tag->initialize('LogicException|RuntimeException');
+        $this->assertEquals(array('LogicException', 'RuntimeException'), $tag->getTypes());
+        $this->assertNull($tag->getDescription());
+    }
+
+    public function testMultipleTypesWithDescription()
+    {
+        $tag = new ThrowsTag();
+        $tag->initialize('LogicException|RuntimeException The Exception');
+        $this->assertEquals(array('LogicException', 'RuntimeException'), $tag->getTypes());
+        $this->assertEquals('The Exception', $tag->getDescription());
+    }
+}


### PR DESCRIPTION
throws declaration is also able to have multiple types 
phpStorm is doing it for example when generating phpDoc

no BC break.
