### PR TITLE
#4996 broke File filters management

### DIFF
--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1676,4 +1676,19 @@ class FormTest extends TestCase
     {
         $this->assertTrue($this->form->getPreferFormInputFilter());
     }
+
+    public function testFileInputFilterNotOverwritten()
+    {
+        $form = new TestAsset\FileInputFilterProviderForm();
+
+        $formInputFilter = $form->getInputFilter();
+        $fieldsetInputFilter = $formInputFilter->get('file_fieldset');
+        $fileFilter = $fieldsetInputFilter->get('file_field');
+
+        $this->assertInstanceOf('Zend\InputFilter\FileInput', $fileFilter);
+
+        $chain = $fileFilter->getFilterChain();
+
+        $this->assertCount(1, $chain);
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/FileInputFilterProviderFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/FileInputFilterProviderFieldset.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form\TestAsset;

--- a/tests/ZendTest/Form/TestAsset/FileInputFilterProviderFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/FileInputFilterProviderFieldset.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Fieldset;
+use Zend\InputFilter\InputFilterProviderInterface;
+
+class FileInputFilterProviderFieldset extends Fieldset implements InputFilterProviderInterface
+{
+    public function __construct($name = null, $options = array())
+    {
+        parent::__construct($name, $options);
+
+        $this->add(array(
+            'type' => 'file',
+            'name' => 'file_field',
+            'options' => array(
+                'label' => 'File Label',
+            ),
+        ));
+
+    }
+
+    public function getInputFilterSpecification()
+    {
+        return array(
+            'file_field' => array(
+                'filters'  => array(
+                    array(
+                        'name' => 'filerenameupload',
+                        'options' => array(
+                            'target'    => __FILE__,
+                            'randomize' => true,
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+}

--- a/tests/ZendTest/Form/TestAsset/FileInputFilterProviderForm.php
+++ b/tests/ZendTest/Form/TestAsset/FileInputFilterProviderForm.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Form
  */
 
 namespace ZendTest\Form\TestAsset;

--- a/tests/ZendTest/Form/TestAsset/FileInputFilterProviderForm.php
+++ b/tests/ZendTest/Form/TestAsset/FileInputFilterProviderForm.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Form;
+use Zend\InputFilter\InputFilterProviderInterface;
+
+class FileInputFilterProviderForm extends Form
+{
+    public function __construct($name = null, $options = array())
+    {
+        parent::__construct($name, $options);
+
+        $this->add(array(
+            'type' => __NAMESPACE__ . '\FileInputFilterProviderFieldset',
+            'name' => 'file_fieldset',
+        ));
+    }
+}


### PR DESCRIPTION
I've found PR #4996 broke how custom file input filter specification is handled; both `2.2.3` and `2.2.4` releases are affected.

I've tried hard to figure out why, but I'm sorry I was not able to :confused:

Here the tests: note that both assertions fail, not only the first.
