### PR TITLE
Add provides options trait

### DIFF
--- a/library/Zend/Stdlib/ProvidesOptionsTrait.php
+++ b/library/Zend/Stdlib/ProvidesOptionsTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib;
+
+/**
+ * Simple trait that allows any classes to accept options
+ *
+ * Options must follow some conventions in order for this to work. According to Zend
+ * Framework 2 conventions, keys must be underscore_separated. For each keys, a method
+ * following the same name must exist in the class. For instance, the key "first_name"
+ * must have a setFirstName method.
+ */
+trait ProvidesOptionsTrait
+{
+    /**
+     * Set options
+     *
+     * @param  array $options
+     * @return void
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setOptions(array $options)
+    {
+        foreach ($options as $key => $value) {
+            // Because PHP is case-insensitive, we can ignore some string manipulations
+            // to have some performance boost
+            $method = 'set' . str_replace('_', '', $key);
+
+            if (!method_exists($this, $method)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Cannot set option "%s", because class "%s" does not have a method called "%s"',
+                    $key,
+                    __CLASS__,
+                    'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)))
+                ));
+            }
+
+            $this->$method($value);
+        }
+    }
+}

--- a/tests/ZendTest/Stdlib/ProvidesOptionsTraitTest.php
+++ b/tests/ZendTest/Stdlib/ProvidesOptionsTraitTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib;
+
+use Zend\Stdlib\SplPriorityQueue;
+use ZendTest\Stdlib\TestAsset\TestOptionsTrait;
+
+/**
+ * @category   Zend
+ * @package    Zend_Stdlib
+ * @subpackage UnitTests
+ * @group      Zend_Stdlib
+ */
+class ProvidesOptionsTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanSetValidOptions()
+    {
+        $options = new TestOptionsTrait();
+        $options->setOptions(array(
+            'street'     => '1 Rue Favier',
+            'first_name' => 'Julien'
+        ));
+
+        $this->assertEquals('1 Rue Favier', $options->getStreet());
+        $this->assertEquals('Julien', $options->getFirstName());
+    }
+
+    public function testThrowExceptionForInvalidOption()
+    {
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+
+        $options = new TestOptionsTrait();
+        $options->setOptions(array('invalid_option' => 'bar'));
+    }
+}

--- a/tests/ZendTest/Stdlib/ProvidesOptionsTraitTest.php
+++ b/tests/ZendTest/Stdlib/ProvidesOptionsTraitTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Stdlib
  */
 
 namespace ZendTest\Stdlib;
@@ -14,10 +13,7 @@ use Zend\Stdlib\SplPriorityQueue;
 use ZendTest\Stdlib\TestAsset\TestOptionsTrait;
 
 /**
- * @category   Zend
- * @package    Zend_Stdlib
- * @subpackage UnitTests
- * @group      Zend_Stdlib
+ * @group Zend_Stdlib
  */
 class ProvidesOptionsTraitTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ZendTest/Stdlib/TestAsset/TestOptionsTrait.php
+++ b/tests/ZendTest/Stdlib/TestAsset/TestOptionsTrait.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Stdlib
  */
 
 namespace ZendTest\Stdlib\TestAsset;

--- a/tests/ZendTest/Stdlib/TestAsset/TestOptionsTrait.php
+++ b/tests/ZendTest/Stdlib/TestAsset/TestOptionsTrait.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Stdlib
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\ProvidesOptionsTrait;
+
+class TestOptionsTrait
+{
+    use ProvidesOptionsTrait;
+
+    /**
+     * @var string
+     */
+    protected $street;
+
+    /**
+     * @var string
+     */
+    protected $firstName;
+
+    /**
+     * @param string $firstName
+     * @return void
+     */
+    public function setFirstName($firstName)
+    {
+        $this->firstName = $firstName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @param string $street
+     * @return void
+     */
+    public function setStreet($street)
+    {
+        $this->street = $street;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreet()
+    {
+        return $this->street;
+    }
+}


### PR DESCRIPTION
In ZF2 we introduced the "AbstractOptions" class. It is very handy and a lot of modules use them for options-only classes (mainly class that configure the module).

However, a lot of classes needs options, but are not semantically "options classes". Extending from AbstractOptions for such classes has also the drawback that it's impossible to extend from something else.

This is a simple trait that focuses on speed by assuming the underscore_separated convention that we used in ZF2. Maybe we could also introduce an interface. This could be very useful for factories, because we could write a factory that would fetch options and automatically inject them in the created object by using the setOptions method.
