### PR TITLE
Failing test to reproduce the error with reflection and core classes

### DIFF
--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -59,4 +59,10 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("    {\n\n        return 'mixedValue';\n\n    }\n", $reflectionMethod->getContents(false));
     }
 
+    public function testGetContentsWithCoreClass()
+    {
+        $reflectionMethod = new MethodReflection('DateTime', 'format');
+        $this->assertEquals("???", $reflectionMethod->getContents(false));
+    }
+
 }


### PR DESCRIPTION
As reported in [Symfony2 Google group](https://groups.google.com/forum/?hl=en#!topic/symfony2/PpxQjNcG8BA), we found an issue with the reflection: MethodReflection is unable to read the source for the compiled classes (eg SoapClient, DateTime, etc).

```
1) ZendTest\Code\Reflection\MethodReflectionTest::testGetContentsWithCoreClass
file(): Filename cannot be empty

/Users/stefanosala/Sites/src/zf2/library/Zend/Code/Reflection/MethodReflection.php:123
/Users/stefanosala/Sites/src/zf2/tests/ZendTest/Code/Reflection/MethodReflectionTest.php:65
```

I created a test to reproduce this issue, but unfortunately I'm not able to find a patch. If anyone has a hint, just add a comment and I'll try to work on it.
