### PR TITLE
[Zend\Http\Client] dupplicate header keys in prepareHeaders

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1154,9 +1154,9 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Merge the headers of the request (if any)
-        $requestHeaders = $this->getRequest()->getHeaders()->toArray();
-        foreach ($requestHeaders as $key => $value) {
-            $headers[$key] = $value;
+        $requestHeaders = $this->getRequest()->getHeaders();
+        foreach ($requestHeaders as $requestHeaderElement) {
+            $headers[$requestHeaderElement->getFieldName()] = $requestHeaderElement->getFieldValue();
         }
         return $headers;
     }

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1154,6 +1154,7 @@ class Client implements Stdlib\DispatchableInterface
         }
 
         // Merge the headers of the request (if any)
+        // here we need right 'http field' and not lowercase letters
         $requestHeaders = $this->getRequest()->getHeaders();
         foreach ($requestHeaders as $requestHeaderElement) {
             $headers[$requestHeaderElement->getFieldName()] = $requestHeaderElement->getFieldValue();

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -11,6 +11,7 @@
 namespace ZendTest\Http;
 
 use ReflectionClass;
+use Zend\Uri\Http;
 use Zend\Http\Client;
 use Zend\Http\Cookies;
 use Zend\Http\Exception;

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -349,4 +349,30 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($testAdapter, $client->getAdapter());
     }
+
+    public function testPrepareHeadersCreateRightHttpField()
+    {
+        $body = json_encode(array('foofoo'=>'barbar'));
+
+        $client = new Client();
+        $prepareHeadersReflection = new \ReflectionMethod($client, 'prepareHeaders');
+        $prepareHeadersReflection->setAccessible(true);
+
+        $request= new Request();
+        $request->getHeaders()->addHeaderLine('content-type','application/json');
+        $request->getHeaders()->addHeaderLine('content-length',strlen($body));
+        $client->setRequest($request);
+
+        $client->setEncType('application/json');
+
+        $this->assertSame($client->getRequest(),$request);
+
+        $headers = $prepareHeadersReflection->invoke($client,$body,new Http('http://localhost:5984'));
+
+        $this->assertArrayNotHasKey('content-type', $headers);
+        $this->assertArrayHasKey('Content-Type', $headers);
+
+        $this->assertArrayNotHasKey('content-length', $headers);
+        $this->assertArrayHasKey('Content-Length', $headers);
+    }
 }


### PR DESCRIPTION
in my mind I found a bug in the Http Component. In my gist I write a TestCase to show the error.

if we you a toString-Methode from `\Zend\Http\Header\ContentType`

https://gist.github.com/ClemensSahs/6421612

The provenance from this issues is in the method `\Zend\Http\Client::prepareHeaders` here we use not the lowercase string for the header keys like the `\Zend\Http\Header\*` So we get this.

``` php
// 1st ( store )
array(6) {
  ["Host"]=>
  string(14) "127.0.0.1:5984"
  ["Connection"]=>
  string(5) "close"
  ["Accept-Encoding"]=>
  string(13) "gzip, deflate"
  ["User-Agent"]=>
  string(16) "Zend\Http\Client"
  ["Content-Length"]=>
  int(13)
  ["content-type"]=>
  string(16) "application/json"
}

// 2nd ( get )
array(5) {
  ["Host"]=>
  string(14) "127.0.0.1:5984"
  ["Connection"]=>
  string(5) "close"
  ["Accept-Encoding"]=>
  string(13) "gzip, deflate"
  ["User-Agent"]=>
  string(16) "Zend\Http\Client"
  ["Content-Type"]=>
  string(16) "application/json"
}
// 3rd ( store )
array(7) {
  ["Host"]=>
  string(14) "127.0.0.1:5984"
  ["Connection"]=>
  string(5) "close"
  ["Accept-Encoding"]=>
  string(13) "gzip, deflate"
  ["User-Agent"]=>
  string(16) "Zend\Http\Client"
  ["Content-Type"]=>
  string(16) "application/json"
  ["Content-Length"]=>
  int(13)
  ["content-type"]=>
  string(16) "application/json"
}
```

best regards
