### PR TITLE
__invoke parameter should be null by default

### DIFF
--- a/library/Zend/Form/View/Helper/FormCaptcha.php
+++ b/library/Zend/Form/View/Helper/FormCaptcha.php
@@ -23,7 +23,7 @@ class FormCaptcha extends AbstractHelper
      * @param  ElementInterface $element
      * @return string|FormCaptcha
      */
-    public function __invoke(ElementInterface $element)
+    public function __invoke(ElementInterface $element = null)
     {
         if (!$element) {
             return $this;


### PR DESCRIPTION
It is necessary if I want to get an instance of the helper before rendering.

Example : I want to set separator before rendering.
