### PR TITLE
using injected response object

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -905,7 +905,7 @@ class Client implements Stdlib\DispatchableInterface
                     $response->setCleanup(true);
                 }
             } else {
-                $response = Response::fromString($response);
+                $response = $this->getResponse()->fromString($response);
             }
 
             // Get the cookies from response (if any)

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -349,4 +349,48 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($testAdapter, $client->getAdapter());
     }
+
+    /**
+     * Custom response object is set but still invalid code coming back
+     * @expectedException Zend\Http\Exception\InvalidArgumentException
+     */
+    public function testUsageOfCustomResponseInvalidCode()
+    {
+        require_once(dirname(realpath(__FILE__)) . DIRECTORY_SEPARATOR .'_files' . DIRECTORY_SEPARATOR . 'CustomResponse.php');
+        $testAdapter = new Test();
+        $testAdapter->setResponse(
+            "HTTP/1.1 496 CustomResponse\r\n\r\n"
+            . "Whatever content"
+        );
+
+        $client = new Client('http://www.example.org/', array(
+            'adapter' => $testAdapter,
+        ));
+        $client->setResponse(new CustomResponse());
+        $response = $client->send();
+    }
+
+    /**
+     * Custom response object is set with defined status code 497.
+     * Should not throw an exception.
+     */
+    public function testUsageOfCustomResponseCustomCode()
+    {
+        require_once(dirname(realpath(__FILE__)) . DIRECTORY_SEPARATOR .'_files' . DIRECTORY_SEPARATOR . 'CustomResponse.php');
+        $testAdapter = new Test();
+        $testAdapter->setResponse(
+            "HTTP/1.1 497 CustomResponse\r\n\r\n"
+            . "Whatever content"
+        );
+
+        $client = new Client('http://www.example.org/', array(
+            'adapter' => $testAdapter,
+        ));
+        $client->setResponse(new CustomResponse());
+        $response = $client->send();
+
+        $this->assertInstanceOf('ZendTest\Http\CustomResponse', $response);
+        $this->assertEquals(497, $response->getStatusCode());
+        $this->assertEquals('Whatever content', $response->getContent());
+    }
 }

--- a/tests/ZendTest/Http/_files/CustomResponse.php
+++ b/tests/ZendTest/Http/_files/CustomResponse.php
@@ -1,0 +1,7 @@
+<?php
+namespace ZendTest\Http;
+
+class CustomResponse extends \Zend\Http\Response
+{
+    const STATUS_CODE_497 = 497;
+}


### PR DESCRIPTION
Scenario:
Invalid HTTP codes are coming in from a webservice (in our case 497). 
An exception is being thrown in HttpClient, if a constant with name STATUS_CODE_<codeId> is not existing in response entity. When setting a response object in the HTTP client containing the "missing" constant, i expected exactly this response object coming back from $client->send().

In The client the following happens:

```
$response = Response::fromString($response);
```

A new response object of type Zend\Http\Response is created on incoming response, instead of the injected one, which can be retrieved using $this->getResponse().

Current (dirty) Solution is to catch the exception and call the fromString method in the CustomResponse class containing the additional STATUS_CODE_<codeId>'s.
