### PR TITLE
Fixed bug that caused the PDO to throw an invalid keyword error

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -257,6 +257,14 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                 case 'sqlite':
                     $dsn[] = $database;
                     break;
+                case 'sqlsrv':
+                    if (isset($database)) {
+                        $dsn[] = "database={$database}";
+                    }
+                    if (isset($hostname)) {
+                        $dsn[] = "server={$hostname}";
+                    }
+                    break;
                 default:
                     if (isset($database)) {
                         $dsn[] = "dbname={$database}";


### PR DESCRIPTION
Without the special case for the sqlsrv driver a PDOException with the following message is thrown: SQLSTATE[IMSSP]: An invalid keyword 'dbname' was specified in the DSN string.
