### PR TITLE
Fixed typo in `Zend\Config\Config`s `$data` DocBlock.

### DIFF
--- a/library/Zend/Config/Config.php
+++ b/library/Zend/Config/Config.php
@@ -38,7 +38,7 @@ class Config implements Countable, Iterator, ArrayAccess
     protected $count;
 
     /**
-     * Data withing the configuration.
+     * Data within the configuration.
      *
      * @var array
      */


### PR DESCRIPTION
`withing` => `within`
