### PR TITLE
Enhancement/server url helper

### DIFF
--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -57,6 +57,8 @@ class ServerUrl extends AbstractHelper
     {
         if ($requestUri === true) {
             $path = $_SERVER['REQUEST_URI'];
+        } elseif ($requestUri === false) {
+            return $this;
         } elseif (is_string($requestUri)) {
             $path = $requestUri;
         } else {

--- a/tests/ZendTest/Http/Header/ExpiresTest.php
+++ b/tests/ZendTest/Http/Header/ExpiresTest.php
@@ -41,6 +41,13 @@ class ExpiresTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Expires: Sun, 06 Nov 1994 08:49:37 GMT', $expiresHeader->toString());
     }
 
+    public function testExpiresFromZeroCreatesValidExpiresHeader()
+    {
+        $expiresHeader = Expires::fromString('Expires: 0');
+        $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $expiresHeader);
+        $this->assertInstanceOf('Zend\Http\Header\Expires', $expiresHeader);
+    }
+
     /**
      * Implementation specific tests are covered by DateTest
      * @see ZendTest\Http\Header\DateTest

--- a/tests/ZendTest/View/Helper/ServerUrlTest.php
+++ b/tests/ZendTest/View/Helper/ServerUrlTest.php
@@ -184,6 +184,23 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.firsthost.org', $url->__invoke());
     }
 
+    public function testServerUrlHelperCanReturn()
+    {
+        $url = new Helper\ServerUrl();
+        $helper = $url(false);
+        $this->assertEquals($helper, $url);
+    }
+
+    public function testServerUrlWithProxyAsHelper()
+    {
+        $_SERVER['HTTP_HOST'] = 'proxyserver.com';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'www.firsthost.org';
+        $url = new Helper\ServerUrl();
+        $helper = $url(false);
+        $helper->setUseProxy(true);
+        $this->assertEquals('http://www.firsthost.org', $helper->__invoke());
+    }
+
     /**
      * @group ZF2-508
      */


### PR DESCRIPTION
It is not possible to configure the ViewHelper to use Proxy Vars, because __invoke never returns the instance. Alternative is cumbersome (and ugly):

```
$serverUrl = new \Zend\View\Helper\ServerUrl(); 
$serverUrl->setUseProxy(true); 
echo $serverUrl($this->url('home'));
```
