### PR TITLE
Test for the getArrayCopy method in AbstractRestultSet

### DIFF
--- a/library/Zend/Db/ResultSet/AbstractResultSet.php
+++ b/library/Zend/Db/ResultSet/AbstractResultSet.php
@@ -268,7 +268,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
                 $return[] = $row;
             } elseif (method_exists($row, 'toArray')) {
                 $return[] = $row->toArray();
-            } elseif ($row instanceof ArrayObject) {
+            } elseif (method_exists($row, 'getArrayCopy')) {
                 $return[] = $row->getArrayCopy();
             } else {
                 throw new Exception\RuntimeException(


### PR DESCRIPTION
If you're using the `ArraySerializable` hydrator, then you will have a method called `getArrayCopy` in your row object, However, `AbstractResultSet::toArray()`  currently checks that your row is an instance of `ArrayObject` and hence throws an exception. 

This PR changes `AbstractResultSet::toArray()` to check for the method name instead, to match the way that  `ArraySerializable::extract()` handles this. 
