### PR TITLE
Fixed console request parameters match pattern

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -196,7 +196,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $request = $this->getRequest();
         if ($this->useConsoleRequest) {
-            preg_match_all('/(--\S+[= ]"\S*\s*\S*")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
+            preg_match_all('/(--\w+[= ]"([^"]*)")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
             $params = str_replace(array(' "', '"'), array('=', ''), $matches[0]);
             $request->params()->exchangeArray($params);
             return $this;


### PR DESCRIPTION
The pattern used to match the console request parameters didn't match correctly in certain circumstances (namely, having an empty value followed by a value consisting of a quoted string with spaces).

For example, the following console syntax, perfectly valid, would not be correctly matched :

user add --room="" --block=" " --name="Eric MORAND" --town="New York" --age=37 --other "Nothing here"

With the original pattern :

Array
        (
            [0] => user
            [1] => add
            [2] => --room="" --block="
            [3] => "
            [4] => --name="Eric MORAND"
            [5] => --town="New York"
            [6] => --age=37
            [7] => --other "Nothing here"
        )

Awaited result :

Array
        (
            [0] => user
            [1] => add
            [2] => --room=""
            [3] => --block=" "
            [4] => --name="Eric MORAND"
            [5] => --town="New York"
            [6] => --age=37
            [7] => --other "Nothing here"
        )

The updated pattern return the awaited result.
