### PR TITLE
Extract and populate values for nested fieldsets in Collection elements

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -528,7 +528,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
                 if ($fieldset->allowObjectBinding($object)) {
                     $fieldset->setObject($object);
                     $values[$name] = $fieldset->extract();
-                }else {
+                } else {
                     foreach($fieldset->fieldsets as $childFieldset){
                         $childName = $childFieldset->getName();
                         if (isset($object[$childName])){

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -529,9 +529,9 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
                     $fieldset->setObject($object);
                     $values[$name] = $fieldset->extract();
                 } else {
-                    foreach($fieldset->fieldsets as $childFieldset){
+                    foreach ($fieldset->fieldsets as $childFieldset) {
                         $childName = $childFieldset->getName();
-                        if (isset($object[$childName])){
+                        if (isset($object[$childName])) {
                             $childObject = $object[$childName];
                             if ($childFieldset->allowObjectBinding($childObject)) {
                                 $fieldset->setObject($childObject);

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -519,6 +519,30 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
             }
         }
 
+        // Recursively extract and populate values for nested fieldsets
+        foreach ($this->fieldsets as $fieldset) {
+            $name = $fieldset->getName();
+            if (isset($values[$name])) {
+                $object = $values[$name];
+
+                if ($fieldset->allowObjectBinding($object)) {
+                    $fieldset->setObject($object);
+                    $values[$name] = $fieldset->extract();
+                }else {
+                    foreach($fieldset->fieldsets as $childFieldset){
+                        $childName = $childFieldset->getName();
+                        if (isset($object[$childName])){
+                            $childObject = $object[$childName];
+                            if ($childFieldset->allowObjectBinding($childObject)) {
+                                $fieldset->setObject($childObject);
+                                $values[$name][$childName] = $fieldset->extract();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         return $values;
     }
 

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -489,4 +489,52 @@ class CollectionTest extends TestCase
             'obj3' => $obj3,
         ));
     }
+
+    public function testCanBindObjectAndPopulateAndExtractNestedFieldsets()
+    {
+
+        $productFieldset = new \ZendTest\Form\TestAsset\ProductFieldset();
+        $productFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+
+        $mainFieldset = new Fieldset('shop');
+        $mainFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $mainFieldset->add($productFieldset);
+
+        $form = new Form();
+        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->add(array(
+            'name' => 'collection',
+            'type' => 'Collection',
+            'options' => array(
+                'target_element' => $mainFieldset,
+                'count' => 2
+            ),
+        ));
+        $form->get('collection')->setHydrator(new ObjectPropertyHydrator());
+
+        $market = new stdClass();
+
+        $prices = array(100, 200);
+
+        $shop1 = new stdClass();
+        $shop1->product = new Product();
+        $shop1->product->setPrice($prices[0]);
+
+        $shop2 = new stdClass();
+        $shop2->product = new Product();
+        $shop2->product->setPrice($prices[1]);
+
+        $market->collection = array($shop1, $shop2);
+        $form->bind($market);
+
+        //test for object binding
+        foreach ($form->get('collection')->getFieldsets() as $_fieldset) {
+            $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Product', $_fieldset->get('product')->getObject());
+        };
+
+        //test for correct extract and populate
+        foreach ($prices as $_k => $_price) {
+            $this->assertEquals($_price, $form->get('collection')->get($_k)->get('product')->get('price')->getValue());
+        }
+    }
 }


### PR DESCRIPTION
If collection element has nested fieldsets, objects are never bound and values are never extracted or populated. 
This should fix it
