### PR TITLE
Added a select modifier closure parameter

### DIFF
--- a/library/Zend/Paginator/Adapter/DbTableGateway.php
+++ b/library/Zend/Paginator/Adapter/DbTableGateway.php
@@ -21,10 +21,16 @@ class DbTableGateway extends DbSelect
      * @param TableGateway                $tableGateway
      * @param Where|\Closure|string|array $where
      * @param null                        $order
+     * @param null|\Closure               $selectModifier
      */
-    public function __construct(TableGateway $tableGateway, $where = null, $order = null)
+    public function __construct(TableGateway $tableGateway, $where = null, $order = null, \Closure $selectModifier = null)
     {
         $select = $tableGateway->getSql()->select();
+        
+        if ($selectModifier) {
+            $selectModifier($select);
+        }
+        
         if ($where) {
             $select->where($where);
         }


### PR DESCRIPTION
Allows to send more complex queries (for example aggregate fields on joined tables) to the paginator using a simple closure without resorting to DbSelect (parent class) adapter.
