### PR TITLE
Correct encoding issue: lost encoding when load html

### DIFF
--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -251,7 +251,7 @@ class Query
             case self::DOC_HTML:
             case self::DOC_XHTML:
             default:
-                $success = $domDoc->loadHTML($document);
+                $success = $domDoc->loadHTML(mb_convert_encoding($document, 'HTML-ENTITIES', $encoding));
                 break;
         }
         $errors = libxml_get_errors();


### PR DESCRIPTION
Query::execute return a Domdocument wich loose the encoding at it's creation
this correction load the html and keep the actual encoding previously detected
