### PR TITLE
[ServiceManager] Implemented circular alias reference detection

### DIFF
--- a/library/Zend/ServiceManager/Exception/CircularReferenceException.php
+++ b/library/Zend/ServiceManager/Exception/CircularReferenceException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager\Exception;
+
+class CircularReferenceException extends RuntimeException
+{
+}

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -433,7 +433,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Resolve the alias for the given canonical name
      *
-     * @param string $cName The canonical name to resolve
+     * @param  string $cName The canonical name to resolve
      * @return string The resolved canonical name
      */
     protected function resolveAlias($cName)

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -10,7 +10,6 @@
 namespace Zend\ServiceManager;
 
 use ReflectionClass;
-use Zend\ServiceManager\Exception\CircularReferenceException;
 
 class ServiceManager implements ServiceLocatorInterface
 {
@@ -442,7 +441,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         while ($this->hasAlias($cName)) {
             if (isset($stack[$cName])) {
-                throw new CircularReferenceException(sprintf(
+                throw new Exception\CircularReferenceException(sprintf(
                     'Circular alias reference: %s -> %s',
                     implode(' -> ', $stack), $cName
                 ));

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -812,7 +812,7 @@ class ServiceManagerTest extends TestCase
     }
 
     /**
-     * @covers Zend\ServiceMnager\ServiceManager::resolveAlias
+     * @covers Zend\ServiceManager\ServiceManager::resolveAlias
      */
     public function testCircularAliasReferenceThrowsException()
     {

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -810,4 +810,25 @@ class ServiceManagerTest extends TestCase
         $this->assertInstanceOf('stdClass', array_shift($fooDelegator->instances));
         $this->assertSame($fooDelegator, array_shift($barDelegator->instances));
     }
+
+    /**
+     * @covers Zend\ServiceMnager\ServiceManager::resolveAlias
+     */
+    public function testCircularAliasReferenceThrowsException()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\CircularReferenceException');
+
+        // Only affects service managers that allow overwriting definitions
+        $this->serviceManager->setAllowOverride(true);
+        $this->serviceManager->setInvokableClass('foo-service', 'stdClass');
+        $this->serviceManager->setAlias('foo-alias', 'foo-service');
+        $this->serviceManager->setAlias('bar-alias', 'foo-alias');
+        $this->serviceManager->setAlias('baz-alias', 'bar-alias');
+
+        // This will now cause a cyclic reference
+        $this->serviceManager->setAlias('foo-alias', 'bar-alias');
+
+        // This should throw the exception
+        $this->serviceManager->get('baz-alias');
+    }
 }


### PR DESCRIPTION
ServiceManagers that allow overwriting the service definition may
contain circular references which will cause an infinite loop. 

I extracted the alias resolving code to a protected method that will detect
circular references and throw an exception if one is encountered.
