### PR TITLE
Update label view helper to have html escape by default

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -110,6 +110,7 @@ class Element implements
      * Set options for an element. Accepted options are:
      * - label: label to associate with the element
      * - label_attributes: attributes to use when the label is rendered
+     * - label_options: label specific options
      *
      * @param  array|Traversable $options
      * @return Element|ElementInterface

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -63,6 +63,17 @@ class FormLabel extends AbstractHelper
                     $label, $this->getTranslatorTextDomain()
                 );
             }
+
+            $labelOptions = array();
+
+            if ($element instanceof LabelOptionsAwareInterface) {
+                $labelOptions = $element->getLabelOptions();
+            }
+
+            if (empty($labelOptions) || $labelOptions['disable_html_escape'] == false) {
+                $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+                $label = $escapeHtmlHelper($label);
+            }
         }
 
         if ($label && $labelContent) {

--- a/tests/ZendTest/Form/View/Helper/FormLabelTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormLabelTest.php
@@ -184,4 +184,21 @@ class FormLabelTest extends CommonTestCase
         $this->helper->setTranslatorEnabled(false);
         $this->assertFalse($this->helper->isTranslatorEnabled());
     }
+
+    public function testLabelIsEscapedByDefault()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value <a>for</a> foo:');
+        $markup = $this->helper->__invoke($element);
+        $this->assertNotContains('<a>for</a>', $markup);
+    }
+
+    public function testCanDisableLabelHtmlEscape()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value <a>for</a> foo:');
+        $element->setLabelOptions(array('disable_html_escape' => true));
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('<a>for</a>', $markup);
+    }
 }


### PR DESCRIPTION
This PR replicates the `FormRow` view helper logic, which escapes the `Element` `label` property by default and takes advantage of the new `disable_html_escape` `labelOptions` property added in #4677 to toggle the escape off when needed.

This may look like a minor BC break, because anyone who used `FormLabel` helper rather than `FormRow` will now have unexpected escaping, but since the overall policy of ZF2 is 'secure by default' I would rather consider this a minor security fix.
