### PR TITLE
Hotfix/4879

### DIFF
--- a/library/Zend/Config/Processor/Translator.php
+++ b/library/Zend/Config/Processor/Translator.php
@@ -11,12 +11,12 @@ namespace Zend\Config\Processor;
 
 use Zend\Config\Config;
 use Zend\Config\Exception;
-use Zend\I18n\Translator\Translator as ZendTranslator;
+use Zend\I18n\Translator\TranslatorInterface;
 
 class Translator implements ProcessorInterface
 {
     /**
-     * @var ZendTranslator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -34,11 +34,11 @@ class Translator implements ProcessorInterface
      * Translator uses the supplied Zend\I18n\Translator\Translator to find
      * and translate language strings in config.
      *
-     * @param  ZendTranslator $translator
-     * @param  string $textDomain
-     * @param  string|null $locale
+     * @param  TranslatorInterface $translator
+     * @param  string              $textDomain
+     * @param  string|null         $locale
      */
-    public function __construct(ZendTranslator $translator, $textDomain = 'default', $locale = null)
+    public function __construct(TranslatorInterface $translator, $textDomain = 'default', $locale = null)
     {
         $this->setTranslator($translator);
         $this->setTextDomain($textDomain);
@@ -46,17 +46,17 @@ class Translator implements ProcessorInterface
     }
 
     /**
-     * @param  ZendTranslator $translator
+     * @param  TranslatorInterface $translator
      * @return Translator
      */
-    public function setTranslator(ZendTranslator $translator)
+    public function setTranslator(TranslatorInterface $translator)
     {
         $this->translator = $translator;
         return $this;
     }
 
     /**
-     * @return ZendTranslator
+     * @return TranslatorInterface
      */
     public function getTranslator()
     {

--- a/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
+++ b/library/Zend/File/Transfer/Adapter/AbstractAdapter.php
@@ -14,7 +14,7 @@ use Zend\File\Transfer;
 use Zend\File\Transfer\Exception;
 use Zend\Filter;
 use Zend\Filter\Exception as FilterException;
-use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Stdlib\ErrorHandler;
 use Zend\Validator;
@@ -73,7 +73,7 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
     protected $messages = array();
 
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -1004,13 +1004,13 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
     /**
      * Sets translator to use in helper
      *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
+     * @param  TranslatorInterface $translator [optional] translator.
+     *                                          Default is null, which sets no translator.
+     * @param  string     $textDomain          [optional] text domain
+     *                                          Default is null, which skips setTranslatorTextDomain
      * @return AbstractAdapter
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
         if (null !== $textDomain) {
@@ -1022,7 +1022,7 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
     /**
      * Retrieve localization translator object
      *
-     * @return Translator|null
+     * @return TranslatorInterface|null
      */
     public function getTranslator()
     {

--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -23,7 +23,7 @@ use Zend\Stdlib\ArrayUtils;
 /**
  * Translator.
  */
-class Translator
+class Translator implements TranslatorInterface
 {
     /**
      * Event fired when the translation for a message is missing.

--- a/library/Zend/I18n/Translator/TranslatorAwareInterface.php
+++ b/library/Zend/I18n/Translator/TranslatorAwareInterface.php
@@ -14,18 +14,18 @@ interface TranslatorAwareInterface
     /**
      * Sets translator to use in helper
      *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
+     * @param  TranslatorInterface $translator [optional] translator.
+     *                                          Default is null, which sets no translator.
+     * @param  string              $textDomain [optional] text domain
+     *                                          Default is null, which skips setTranslatorTextDomain
      * @return TranslatorAwareInterface
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null);
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null);
 
     /**
      * Returns translator used in object
      *
-     * @return Translator|null
+     * @return TranslatorInterface|null
      */
     public function getTranslator();
 

--- a/library/Zend/I18n/Translator/TranslatorAwareTrait.php
+++ b/library/Zend/I18n/Translator/TranslatorAwareTrait.php
@@ -9,12 +9,10 @@
 
 namespace Zend\I18n\Translator;
 
-use Zend\I18n\Translator\Translator;
-
 trait TranslatorAwareTrait
 {
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator = null;
 
@@ -35,7 +33,7 @@ trait TranslatorAwareTrait
      * @param string $textDomain
      * @return mixed
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
 

--- a/library/Zend/I18n/Translator/TranslatorInterface.php
+++ b/library/Zend/I18n/Translator/TranslatorInterface.php
@@ -7,33 +7,26 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace Zend\Mvc\I18n;
+namespace Zend\I18n\Translator;
 
-use Zend\I18n\Translator\TranslatorInterface;
-use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
-
-class DummyTranslator implements
-    TranslatorInterface,
-    ValidatorTranslatorInterface
+/**
+ * Translator interface.
+ */
+interface TranslatorInterface
 {
     /**
-     * translate(): defined by ValidatorTranslatorInterface()
+     * Translate a message.
      *
-     * @see    ValidatorTranslatorInterface::translate()
      * @param  string $message
      * @param  string $textDomain
      * @param  string $locale
      * @return string
      */
-    public function translate($message, $textDomain = 'default', $locale = null)
-    {
-        return $message;
-    }
+    public function translate($message, $textDomain = 'default', $locale = null);
 
     /**
-     * translatePlural(): defined by TranslatorInterface()
+     * Translate a plural message.
      *
-     * @see    TranslatorInterface::translatePlural()
      * @param  string                         $singular
      * @param  string                         $plural
      * @param  int                            $number
@@ -48,7 +41,5 @@ class DummyTranslator implements
         $number,
         $textDomain = 'default',
         $locale = null
-    ) {
-        return ($number === 1 ? $singular : $plural);
-    }
+    );
 }

--- a/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
+++ b/library/Zend/I18n/View/Helper/AbstractTranslatorHelper.php
@@ -9,7 +9,7 @@
 
 namespace Zend\I18n\View\Helper;
 
-use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\View\Helper\AbstractHelper;
 
@@ -19,7 +19,7 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     /**
      * Translator (optional)
      *
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -40,13 +40,13 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     /**
      * Sets translator to use in helper
      *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
+     * @param  TranslatorInterface $translator [optional] translator.
+     *                                          Default is null, which sets no translator.
+     * @param  string              $textDomain [optional] text domain
+     *                                          Default is null, which skips setTranslatorTextDomain
      * @return AbstractTranslatorHelper
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
         if (null !== $textDomain) {
@@ -59,7 +59,7 @@ abstract class AbstractTranslatorHelper extends AbstractHelper implements
     /**
      * Returns translator used in helper
      *
-     * @return Translator|null
+     * @return TranslatorInterface|null
      */
     public function getTranslator()
     {

--- a/library/Zend/Mvc/I18n/DummyTranslator.php
+++ b/library/Zend/Mvc/I18n/DummyTranslator.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\I18n;
+
+use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
+
+class DummyTranslator implements ValidatorTranslatorInterface
+{
+    /**
+     * translate(): defined by ValidatorTranslatorInterface()
+     *
+     * @see    ValidatorTranslatorInterface::translate()
+     * @param  string $message
+     * @param  string $textDomain
+     * @param  string $locale
+     * @return string
+     */
+    public function translate($message, $textDomain = 'default', $locale = null)
+    {
+        return $message;
+    }
+}

--- a/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Mvc\Router\Http;
 
-use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Stdlib\RequestInterface as Request;
 
@@ -21,7 +21,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
     /**
      * Translator used for translatable segments.
      *
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -88,11 +88,11 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * setTranslator(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::setTranslator()
-     * @param  Translator $translator
-     * @param  string     $textDomain
+     * @param  TranslatorInterface $translator
+     * @param  string              $textDomain
      * @return TreeRouteStack
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
 
@@ -107,7 +107,7 @@ class TranslatorAwareTreeRouteStack extends TreeRouteStack implements Translator
      * getTranslator(): defined by TranslatorAwareInterface.
      *
      * @see    TranslatorAwareInterface::getTranslator()
-     * @return Translator
+     * @return TranslatorInterface
      */
     public function getTranslator()
     {

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -25,7 +25,7 @@ class TranslatorServiceFactory extends I18nTranslatorServiceFactory
         // Configure the translator
         $config = $serviceLocator->get('Config');
 
-        if (!isset($config['translator']) || !class_exists('Zend\I18n\Translator')) {
+        if (!isset($config['translator'])) {
             return new DummyTranslator();
         }
 

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Mvc\Service;
 
 use Zend\I18n\Translator\TranslatorServiceFactory as I18nTranslatorServiceFactory;
+use Zend\Mvc\I18n\DummyTranslator;
 use Zend\Mvc\I18n\Translator;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -22,7 +23,12 @@ class TranslatorServiceFactory extends I18nTranslatorServiceFactory
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         // Configure the translator
-        $config     = $serviceLocator->get('Config');
+        $config = $serviceLocator->get('Config');
+
+        if (!isset($config['translator']) || !class_exists('Zend\I18n\Translator')) {
+            return new DummyTranslator();
+        }
+
         $trConfig   = isset($config['translator']) ? $config['translator'] : array();
         $translator = Translator::factory($trConfig);
         return $translator;

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -9,7 +9,7 @@
 
 namespace Zend\View\Helper;
 
-use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\View\Exception;
 
@@ -36,7 +36,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     /**
      * Translator (optional)
      *
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -179,13 +179,13 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     /**
      * Sets translator to use in helper
      *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
+     * @param  TranslatorInterface $translator [optional] translator.
+     *                                          Default is null, which sets no translator.
+     * @param  string              $textDomain [optional] text domain
+     *                                          Default is null, which skips setTranslatorTextDomain
      * @return HeadTitle
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
         if (null !== $textDomain) {
@@ -197,7 +197,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     /**
      * Returns translator used in helper
      *
-     * @return Translator|null
+     * @return TranslatorInterface|null
      */
     public function getTranslator()
     {

--- a/library/Zend/View/Helper/Navigation/AbstractHelper.php
+++ b/library/Zend/View/Helper/Navigation/AbstractHelper.php
@@ -13,7 +13,7 @@ use RecursiveIteratorIterator;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
-use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Navigation;
 use Zend\Navigation\Page\AbstractPage;
@@ -101,7 +101,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Translator (optional)
      *
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -761,13 +761,13 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Sets translator to use in helper
      *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
+     * @param  TranslatorInterface $translator [optional] translator.
+     *                                          Default is null, which sets no translator.
+     * @param  string              $textDomain [optional] text domain
+     *                                          Default is null, which skips setTranslatorTextDomain
      * @return AbstractHelper
      */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
+    public function setTranslator(TranslatorInterface $translator = null, $textDomain = null)
     {
         $this->translator = $translator;
         if (null !== $textDomain) {
@@ -780,7 +780,7 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
     /**
      * Returns translator used in helper
      *
-     * @return Translator|null
+     * @return TranslatorInterface|null
      */
     public function getTranslator()
     {

--- a/tests/ZendTest/Filter/_files/home/dasprid/dev/zf2/tests/ZendTest/Filter/_files/zipextracted.txt
+++ b/tests/ZendTest/Filter/_files/home/dasprid/dev/zf2/tests/ZendTest/Filter/_files/zipextracted.txt
@@ -1,0 +1,1 @@
+compress me


### PR DESCRIPTION
This PR fixes issue #4879. It introduces a dummy translator, which is used in case the user did not configure any translator. It also adds a general TranslatorInterface to be typehinted against in our internal code. This should not affect any user-code and thus be BC-safe.
