### PR TITLE
Allow the I18n tests to run without the i18n extension loaded

### DIFF
--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -73,7 +73,7 @@ class NumberFormatTest extends TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         return array(
             array(
                 'en_US',
@@ -106,7 +106,7 @@ class NumberFormatTest extends TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         return array(
             array(
                 'en_US',

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -13,6 +13,9 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\I18n\Filter\NumberFormat as NumberFormatFilter;
 use NumberFormatter;
 
+/**
+ * @requires extension intl
+ */
 class NumberFormatTest extends TestCase
 {
     public function testConstructWithOptions()
@@ -63,8 +66,14 @@ class NumberFormatTest extends TestCase
         $this->assertEquals($expected, $filter->filter($value));
     }
 
-    public static function numberToFormattedProvider()
+    public function numberToFormattedProvider()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         return array(
             array(
                 'en_US',
@@ -90,8 +99,14 @@ class NumberFormatTest extends TestCase
         );
     }
 
-    public static function formattedToNumberProvider()
+    public function formattedToNumberProvider()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         return array(
             array(
                 'en_US',

--- a/tests/ZendTest/I18n/Filter/NumberParseTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberParseTest.php
@@ -13,6 +13,9 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\I18n\Filter\NumberParse as NumberParseFilter;
 use NumberFormatter;
 
+/**
+ * @requires extension intl
+ */
 class NumberParseTest extends TestCase
 {
     public function testConstructWithOptions()
@@ -48,8 +51,14 @@ class NumberParseTest extends TestCase
         $this->assertSame($expected, $filter->filter($value));
     }
 
-    public static function formattedToNumberProvider()
+    public function formattedToNumberProvider()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         return array(
             array(
                 'en_US',

--- a/tests/ZendTest/I18n/Filter/NumberParseTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberParseTest.php
@@ -58,7 +58,7 @@ class NumberParseTest extends TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         return array(
             array(
                 'en_US',

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -18,6 +18,7 @@ use Locale;
  * @package    Zend_Validator
  * @subpackage UnitTests
  * @group      Zend_Validator
+ * @requires   extension intl
  */
 class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
@@ -65,6 +66,12 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
     public function basicProvider()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         return array(
             array('May 30, 2013',   true, array('locale'=>'en', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),
             array('30.Mai.2013',   true, array('locale'=>'de', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -71,7 +71,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         return array(
             array('May 30, 2013',   true, array('locale'=>'en', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),
             array('30.Mai.2013',   true, array('locale'=>'de', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),

--- a/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
@@ -61,7 +61,7 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         $date = new DateTime('2012-07-02T22:44:03Z');
 
         return array(
@@ -159,7 +159,7 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         $date = new DateTime('2012-07-02T22:44:03Z');
 
         return array(

--- a/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
@@ -23,6 +23,7 @@ use Zend\I18n\View\Helper\DateFormat as DateFormatHelper;
  * @subpackage UnitTests
  * @group      Zend_View
  * @group      Zend_View_Helper
+ * @requires   extension intl
  */
 class DateFormatTest extends \PHPUnit_Framework_TestCase
 {
@@ -55,6 +56,12 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
 
     public function dateTestsDataProvider()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         $date = new DateTime('2012-07-02T22:44:03Z');
 
         return array(
@@ -147,6 +154,12 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
 
     public function dateTestsDataProviderWithPattern()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         $date = new DateTime('2012-07-02T22:44:03Z');
 
         return array(

--- a/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
@@ -60,7 +60,7 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
                 'The intl extension is not available.'
             );
         }
-    
+
         return array(
             array(
                 'de_DE',

--- a/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
@@ -22,6 +22,7 @@ use Zend\I18n\View\Helper\NumberFormat as NumberFormatHelper;
  * @subpackage UnitTests
  * @group      Zend_View
  * @group      Zend_View_Helper
+ * @requires   extension intl
  */
 class NumberFormatTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,6 +55,12 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
 
     public function currencyTestsDataProvider()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped(
+                'The intl extension is not available.'
+            );
+        }
+    
         return array(
             array(
                 'de_DE',


### PR DESCRIPTION
Presently, without the i18n extension loaded (e.g. [on HHVM](http://www.hhvm.com/blog/?p=875#fn7)), the entire test suite crashes with fatal errors if the I18n component tests are run. This is largely because data providers are executed outside of the isolation of a given test, so errors affect the greater process.

Additionally, even with @requires extension intl as an annotation to each given test, this is not resolved. Because data providers are executed before the test itself executes, this will cause the same errors.

As such, I've added both the annotation for the extension requirement (covering the tests without data providers), and I've added an extension_loaded check to each applicable data provider. This has also resulted in having to make the data providers non-static, so as to be able to skip the test.

If someone knows of a more elegant solution to this problem, I would be glad to revise my PR to use that method. It just seems that this is the only effective method.
