### PR TITLE
Fix test suite when ext/intl isn't available

### DIFF
--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -329,6 +329,10 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslator()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $config     = new Config($this->translatorData, true);
         $translator = new Translator();
         $translator->addTranslationFile('phparray', $this->translatorFile);
@@ -340,6 +344,23 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ein Hund', $config->pages[0]->label);
         $this->assertEquals('twoDogs', $config->pages[1]->id);
         $this->assertEquals('zwei Hunde', $config->pages[1]->label);
+    }
+
+    public function testTranslatorWithoutIntl()
+    {
+        if (extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl enabled');
+        }
+
+        $this->setExpectedException('Zend\I18n\Exception\ExtensionNotLoadedException',
+            'Zend\I18n\Translator component requires the intl PHP extension');
+
+        $config     = new Config($this->translatorData, true);
+        $translator = new Translator();
+        $translator->addTranslationFile('phparray', $this->translatorFile);
+        $processor  = new TranslatorProcessor($translator);
+
+        $processor->process($config);
     }
 
     public function testTranslatorReadOnly()
@@ -355,6 +376,26 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorSingleValue()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
+        $translator = new Translator();
+        $translator->addTranslationFile('phparray', $this->translatorFile);
+        $processor  = new TranslatorProcessor($translator);
+
+        $this->assertEquals('ein Hund', $processor->processValue('one dog'));
+    }
+
+    public function testTranslatorSingleValueWithoutIntl()
+    {
+        if (extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl enabled');
+        }
+
+        $this->setExpectedException('Zend\I18n\Exception\ExtensionNotLoadedException',
+            'Zend\I18n\Translator component requires the intl PHP extension');
+
         $translator = new Translator();
         $translator->addTranslationFile('phparray', $this->translatorFile);
         $processor  = new TranslatorProcessor($translator);

--- a/tests/ZendTest/Filter/InflectorTest.php
+++ b/tests/ZendTest/Filter/InflectorTest.php
@@ -111,8 +111,12 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($filter, $received);
     }
 
-    public function testSetFilterRuleWithArrayOfRulesCreatesRuleEntries()
+    public function testAddFilterRuleAppendsRuleEntries()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $rules = $this->inflector->getRules();
         $this->assertEquals(0, count($rules));
         $this->inflector->setFilterRule('controller', array('PregReplace', 'Alpha'));
@@ -120,18 +124,6 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($rules));
         $this->assertTrue($rules[0] instanceof \Zend\Filter\FilterInterface);
         $this->assertTrue($rules[1] instanceof \Zend\Filter\FilterInterface);
-    }
-
-    public function testAddFilterRuleAppendsRuleEntries()
-    {
-        $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
-        $this->inflector->setFilterRule('controller', 'PregReplace');
-        $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(1, count($rules));
-        $this->inflector->addFilterRule('controller', 'Alpha');
-        $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(2, count($rules));
     }
 
     public function testSetStaticRuleCreatesScalarRuleEntry()
@@ -170,6 +162,10 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
 
     public function testAddRulesCreatesAppropriateRuleEntries()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $rules = $this->inflector->getRules();
         $this->assertEquals(0, count($rules));
         $this->inflector->addRules(array(
@@ -184,6 +180,10 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
 
     public function testSetRulesCreatesAppropriateRuleEntries()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->inflector->setStaticRule('some-rules', 'some-value');
         $rules = $this->inflector->getRules();
         $this->assertEquals(1, count($rules));
@@ -199,6 +199,10 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRule()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->inflector->setFilterRule(':controller', array('Alpha', 'StringToLower'));
         $this->assertTrue($this->inflector->getRule('controller', 1) instanceof \Zend\Filter\StringToLower);
         $this->assertFalse($this->inflector->getRule('controller', 2));
@@ -414,6 +418,10 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddFilterRuleMultipleTimes()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $rules = $this->inflector->getRules();
         $this->assertEquals(0, count($rules));
         $this->inflector->setFilterRule('controller', 'PregReplace');

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -288,6 +288,11 @@ class CollectionTest extends TestCase
 
     public function testDoesNotCreateNewObjects()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $form = new \Zend\Form\Form();
         $form->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
         $this->productFieldset->setUseAsBaseFieldset(true);
@@ -326,6 +331,11 @@ class CollectionTest extends TestCase
 
     public function testCreatesNewObjectsIfSpecified()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->productFieldset->setUseAsBaseFieldset(true);
         $categories = $this->productFieldset->get('categories');
         $categories->setOptions(array(

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -17,6 +17,11 @@ class NumberTest extends TestCase
 {
     public function testProvidesInputSpecificationWithDefaultAttributes()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $element = new NumberElement();
 
         $inputSpec = $element->getInputSpecification();
@@ -42,6 +47,11 @@ class NumberTest extends TestCase
 
     public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $element = new NumberElement();
         $element->setAttributes(array(
             'inclusive' => true,

--- a/tests/ZendTest/Form/Element/RangeTest.php
+++ b/tests/ZendTest/Form/Element/RangeTest.php
@@ -17,6 +17,11 @@ class RangeTest extends TestCase
 {
     public function testProvidesInputSpecificationWithDefaultAttributes()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $element = new RangeElement();
 
         $inputSpec = $element->getInputSpecification();
@@ -52,6 +57,11 @@ class RangeTest extends TestCase
 
     public function testProvidesInputSpecificationThatIncludesValidator()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $element = new RangeElement();
         $element->setAttributes(array(
             'inclusive' => true,

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -208,6 +208,11 @@ class FormTest extends TestCase
 
     public function testHasValidatedFlag()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $form = new TestAsset\NewProductForm();
 
         $this->assertFalse($form->hasValidated());
@@ -247,6 +252,11 @@ class FormTest extends TestCase
 
     public function testSpecifyingValidationGroupForcesPartialValidation()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->populateForm();
         $invalidSet = array(
             'foo' => 'a',
@@ -264,6 +274,11 @@ class FormTest extends TestCase
 
     public function testSpecifyingValidationGroupForNestedFieldsetsForcesPartialValidation()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $form = new TestAsset\NewProductForm();
         $form->setData(array(
             'product' => array(
@@ -985,6 +1000,11 @@ class FormTest extends TestCase
 
     public function testCanCorrectlyExtractDataFromOneToManyRelationship()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $product = $this->getOneToManyEntity();
 
         $form = new TestAsset\NewProductForm();
@@ -1472,6 +1492,11 @@ class FormTest extends TestCase
 
     public function testPreserveEntitiesBoundToCollectionAfterValidation()
     {
+        if (!extension_loaded('intl')) {
+            // Required by \Zend\I18n\Validator\Float
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->form->setInputFilter(new \Zend\InputFilter\InputFilter());
         $fieldset = new TestAsset\ProductCategoriesFieldset();
         $fieldset->setUseAsBaseFieldset(true);

--- a/tests/ZendTest/Form/View/Helper/CommonTestCase.php
+++ b/tests/ZendTest/Form/View/Helper/CommonTestCase.php
@@ -41,17 +41,29 @@ abstract class CommonTestCase extends TestCase
 
     public function testUsesUtf8ByDefault()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->assertEquals('UTF-8', $this->helper->getEncoding());
     }
 
     public function testCanInjectEncoding()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper->setEncoding('iso-8859-1');
         $this->assertEquals('iso-8859-1', $this->helper->getEncoding());
     }
 
     public function testInjectingEncodingProxiesToEscapeHelper()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $escape = $this->renderer->plugin('escapehtml');
         $this->helper->setEncoding('iso-8859-1');
         $this->assertEquals('iso-8859-1', $escape->getEncoding());
@@ -59,6 +71,10 @@ abstract class CommonTestCase extends TestCase
 
     public function testAssumesHtml4LooseDoctypeByDefault()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $helperClass = get_class($this->helper);
         $helper = new $helperClass();
         $this->assertEquals(Doctype::HTML4_LOOSE, $helper->getDoctype());
@@ -66,12 +82,20 @@ abstract class CommonTestCase extends TestCase
 
     public function testCanInjectDoctype()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper->setDoctype(Doctype::HTML5);
         $this->assertEquals(Doctype::HTML5, $this->helper->getDoctype());
     }
 
     public function testCanGetDoctypeFromDoctypeHelper()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->renderer->doctype(Doctype::XHTML1_STRICT);
         $this->assertEquals(Doctype::XHTML1_STRICT, $this->helper->getDoctype());
     }

--- a/tests/ZendTest/Form/View/Helper/FormDateSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormDateSelectTest.php
@@ -22,6 +22,10 @@ class FormDateSelectTest extends CommonTestCase
 {
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new FormDateSelectHelper();
         parent::setUp();
     }

--- a/tests/ZendTest/Form/View/Helper/FormDateTimeSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormDateTimeSelectTest.php
@@ -22,6 +22,10 @@ class FormDateTimeSelectTest extends CommonTestCase
 {
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new FormDateTimeSelectHelper();
         parent::setUp();
     }

--- a/tests/ZendTest/Form/View/Helper/FormMonthSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormMonthSelectTest.php
@@ -22,6 +22,10 @@ class FormMonthSelectTest extends CommonTestCase
 {
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new FormMonthSelectHelper();
         parent::setUp();
     }

--- a/tests/ZendTest/Form/View/Helper/MissingIntlExtensionTest.php
+++ b/tests/ZendTest/Form/View/Helper/MissingIntlExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Form
+ */
+
+namespace ZendTest\Form\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Element\DateSelect;
+use Zend\Form\View\Helper\FormDateSelect as FormDateSelectHelper;
+use Zend\Form\View\Helper\FormDateTimeSelect as FormDateTimeSelectHelper;
+use Zend\Form\View\Helper\FormMonthSelect as FormMonthSelectHelper;
+
+/**
+ * @category   Zend
+ * @package    Zend_Form
+ * @subpackage UnitTest
+ */
+class MissingIntlExtensionTest extends TestCase
+{
+    public function setUp()
+    {
+        if (extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl enabled');
+        }
+    }
+
+    public function testFormDateSelectHelper()
+    {
+        $this->setExpectedException(
+            'Zend\Form\Exception\ExtensionNotLoadedException',
+            'Zend\Form\View\Helper component requires the intl PHP extension'
+        );
+
+        $helper = new FormDateSelectHelper();
+    }
+
+    public function testFormDateTimeSelectHelper()
+    {
+        $this->setExpectedException(
+            'Zend\Form\Exception\ExtensionNotLoadedException',
+            'Zend\Form\View\Helper component requires the intl PHP extension'
+        );
+
+        $helper = new FormDateTimeSelectHelper();
+    }
+
+    public function testFormMonthSelectHelper()
+    {
+        $this->setExpectedException(
+            'Zend\Form\Exception\ExtensionNotLoadedException',
+            'Zend\Form\View\Helper component requires the intl PHP extension'
+        );
+
+        $helper = new FormMonthSelectHelper();
+    }
+}

--- a/tests/ZendTest/I18n/Filter/AlnumTest.php
+++ b/tests/ZendTest/I18n/Filter/AlnumTest.php
@@ -56,6 +56,10 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->filter = new AlnumFilter();
 
         $this->locale               = Locale::getDefault();

--- a/tests/ZendTest/I18n/Filter/AlphaTest.php
+++ b/tests/ZendTest/I18n/Filter/AlphaTest.php
@@ -56,6 +56,10 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->filter = new AlphaFilter();
 
         $this->locale               = Locale::getDefault();

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -16,6 +16,13 @@ use NumberFormatter;
 
 class NumberFormatTest extends TestCase
 {
+    public function setUp()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+    }
+
     public function testConstructWithOptions()
     {
         $filter = new NumberFormatFilter(array(
@@ -64,8 +71,16 @@ class NumberFormatTest extends TestCase
         $this->assertEquals($expected, $filter->filter($value));
     }
 
-    public static function numberToFormattedProvider()
+    public function numberToFormattedProvider()
     {
+        if (!extension_loaded('intl')) {
+            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+                $this->markTestSkipped('ext/intl not enabled');
+            } else {
+                return array(array());
+            }
+        }
+
         return array(
             array(
                 'en_US',
@@ -91,8 +106,16 @@ class NumberFormatTest extends TestCase
         );
     }
 
-    public static function formattedToNumberProvider()
+    public function formattedToNumberProvider()
     {
+        if (!extension_loaded('intl')) {
+            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+                $this->markTestSkipped('ext/intl not enabled');
+            } else {
+                return array(array());
+            }
+        }
+
         return array(
             array(
                 'en_US',

--- a/tests/ZendTest/I18n/Translator/Loader/GettextTest.php
+++ b/tests/ZendTest/I18n/Translator/Loader/GettextTest.php
@@ -21,6 +21,10 @@ class GettextTest extends TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->originalLocale = Locale::getDefault();
         Locale::setDefault('en_EN');
 
@@ -29,7 +33,9 @@ class GettextTest extends TestCase
 
     public function tearDown()
     {
-        Locale::setDefault($this->originalLocale);
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->originalLocale);
+        }
     }
 
     public function testLoaderFailsToLoadMissingFile()

--- a/tests/ZendTest/I18n/Translator/Loader/PhpArrayTest.php
+++ b/tests/ZendTest/I18n/Translator/Loader/PhpArrayTest.php
@@ -21,6 +21,10 @@ class PhpArrayTest extends TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->originalLocale = Locale::getDefault();
         Locale::setDefault('en_EN');
 
@@ -29,7 +33,9 @@ class PhpArrayTest extends TestCase
 
     public function tearDown()
     {
-        Locale::setDefault($this->originalLocale);
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->originalLocale);
+        }
     }
 
     public function testLoaderFailsToLoadMissingFile()

--- a/tests/ZendTest/I18n/Translator/TranslatorTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorTest.php
@@ -36,6 +36,10 @@ class TranslatorTest extends TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->originalLocale = Locale::getDefault();
         $this->translator     = new Translator();
 
@@ -46,7 +50,9 @@ class TranslatorTest extends TestCase
 
     public function tearDown()
     {
-        Locale::setDefault($this->originalLocale);
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->originalLocale);
+        }
     }
 
     public function testFactoryCreatesTranslator()

--- a/tests/ZendTest/I18n/Validator/AlnumTest.php
+++ b/tests/ZendTest/I18n/Validator/AlnumTest.php
@@ -32,6 +32,10 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->validator = new AlnumValidator();
     }
 

--- a/tests/ZendTest/I18n/Validator/AlphaTest.php
+++ b/tests/ZendTest/I18n/Validator/AlphaTest.php
@@ -27,6 +27,10 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->validator = new AlphaValidator();
     }
 

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -32,6 +32,10 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->locale = Locale::getDefault();
         $this->timezone = date_default_timezone_get();
 
@@ -40,7 +44,9 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        Locale::setDefault($this->locale);
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->locale);
+        }
         date_default_timezone_set($this->timezone);
     }
 
@@ -65,6 +71,14 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
     public function basicProvider()
     {
+        if (!extension_loaded('intl')) {
+            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+                $this->markTestSkipped('ext/intl not enabled');
+            } else {
+                return array(array());
+            }
+        }
+
         return array(
             array('May 30, 2013',   true, array('locale'=>'en', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),
             array('30.Mai.2013',   true, array('locale'=>'de', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -31,13 +31,19 @@ class FloatTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->locale    = Locale::getDefault();
         $this->validator = new FloatValidator(array('locale' => 'en'));
     }
 
     public function tearDown()
     {
-        Locale::setDefault($this->locale);
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->locale);
+        }
     }
 
     /**

--- a/tests/ZendTest/I18n/Validator/IntTest.php
+++ b/tests/ZendTest/I18n/Validator/IntTest.php
@@ -26,15 +26,26 @@ class IntTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
+    /**
+     * @var string
+     */
+    protected $locale;
+
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->locale    = Locale::getDefault();
         $this->validator = new IntValidator();
     }
 
     public function tearDown()
     {
-        Locale::setDefault($this->locale);
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->locale);
+        }
     }
 
     public function intDataProvider()

--- a/tests/ZendTest/I18n/Validator/PostCodeTest.php
+++ b/tests/ZendTest/I18n/Validator/PostCodeTest.php
@@ -32,6 +32,10 @@ class PostCodeTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->validator = new PostCodeValidator(array('locale' => 'de_AT'));
     }
 

--- a/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
@@ -35,6 +35,10 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new CurrencyFormatHelper();
     }
 

--- a/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
@@ -39,6 +39,10 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new DateFormatHelper();
     }
 
@@ -55,6 +59,14 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
 
     public function dateTestsDataProvider()
     {
+        if (!extension_loaded('intl')) {
+            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+                $this->markTestSkipped('ext/intl not enabled');
+            } else {
+                return array(array());
+            }
+        }
+
         $date = new DateTime('2012-07-02T22:44:03Z');
 
         return array(
@@ -147,6 +159,14 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
 
     public function dateTestsDataProviderWithPattern()
     {
+        if (!extension_loaded('intl')) {
+            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+                $this->markTestSkipped('ext/intl not enabled');
+            } else {
+                return array(array());
+            }
+        }
+
         $date = new DateTime('2012-07-02T22:44:03Z');
 
         return array(

--- a/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
@@ -38,6 +38,10 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new NumberFormatHelper();
     }
 
@@ -54,6 +58,14 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
 
     public function currencyTestsDataProvider()
     {
+        if (!extension_loaded('intl')) {
+            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+                $this->markTestSkipped('ext/intl not enabled');
+            } else {
+                return array(array());
+            }
+        }
+
         return array(
             array(
                 'de_DE',

--- a/tests/ZendTest/I18n/View/Helper/PluralTest.php
+++ b/tests/ZendTest/I18n/View/Helper/PluralTest.php
@@ -34,6 +34,10 @@ class PluralTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->helper = new PluralHelper();
     }
 

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -188,6 +188,10 @@ class BaseInputFilterTest extends TestCase
      */
     public function testCanValidateEntireDataset($dataset, $expected)
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $filter->setData($dataset);
         $this->assertSame($expected, $filter->isValid());
@@ -195,6 +199,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanValidatePartialDataset()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $validData = array(
             'foo' => ' bazbat ',
@@ -218,6 +226,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanRetrieveInvalidInputsOnFailedValidation()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $invalidData = array(
             'foo' => ' bazbat ',
@@ -243,6 +255,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanRetrieveValidInputsOnFailedValidation()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $invalidData = array(
             'foo' => ' bazbat ',
@@ -269,6 +285,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testValuesRetrievedAreFiltered()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $validData = array(
             'foo' => ' bazbat ',
@@ -297,6 +317,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanGetRawInputValues()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $validData = array(
             'foo' => ' bazbat ',
@@ -316,6 +340,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanGetValidationMessages()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $filter->get('baz')->setRequired(true);
         $filter->get('nest')->get('baz')->setRequired(true);
@@ -622,6 +650,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanRetrieveRawValuesIndividuallyWithoutValidating()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $data = array(
             'foo' => ' bazbat ',
@@ -638,6 +670,10 @@ class BaseInputFilterTest extends TestCase
 
     public function testCanRetrieveUnvalidatedButFilteredInputValue()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $data = array(
             'foo' => ' baz 2 bat ',
@@ -672,6 +708,10 @@ class BaseInputFilterTest extends TestCase
     }
     public function testHasUnknown()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $validData = array(
             'foo' => ' bazbat ',
@@ -692,6 +732,10 @@ class BaseInputFilterTest extends TestCase
     }
     public function testGetUknown()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $filter = $this->getInputFilter();
         $unknown = array(
             'bar' => '12345',

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -111,6 +111,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testInputFilterInputsAppliedToCollection()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->filter->setInputFilter($this->getBaseInputFilter());
 
         $this->assertCount(4, $this->filter->getInputs());
@@ -158,6 +162,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testCanValidateValidData()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->filter->setInputFilter($this->getBaseInputFilter());
         $this->filter->setData($this->getValidCollectionData());
         $this->assertTrue($this->filter->isValid());
@@ -165,6 +173,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testCanValidateValidDataWithNonConsecutiveKeys()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $collectionData = $this->getValidCollectionData();
         $collectionData[2] = $collectionData[0];
         unset($collectionData[0]);
@@ -175,6 +187,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testInvalidDataReturnsFalse()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $invalidCollectionData = array(
             array(
                 'foo' => ' bazbatlong ',
@@ -195,6 +211,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testDataLessThanCountIsInvalid()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $invalidCollectionData = array(
             array(
                 'foo' => ' bazbat ',
@@ -216,6 +236,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testGetValues()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $expectedData = array(
             array(
                 'foo' => 'bazbat',
@@ -253,6 +277,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testGetRawValues()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $expectedData = array(
             array(
                 'foo' => ' bazbat ',
@@ -285,6 +313,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testGetMessagesForInvalidInputs()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $invalidCollectionData = array(
             array(
                 'foo' => ' bazbattoolong ',
@@ -327,6 +359,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testSetValidationGroupUsingFormStyle()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         // forms set an array of identical validation groups for each set of data
         $formValidationGroup = array(
             array(
@@ -367,6 +403,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testEmptyCollectionIsValidByDefault()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $data = array();
 
         $this->filter->setInputFilter($this->getBaseInputFilter());
@@ -377,6 +417,10 @@ class CollectionInputFilterTest extends TestCase
 
     public function testEmptyCollectionIsNotValidIfRequired()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $data = array();
 
         $this->filter->setInputFilter($this->getBaseInputFilter());

--- a/tests/ZendTest/Log/Filter/ValidatorTest.php
+++ b/tests/ZendTest/Log/Filter/ValidatorTest.php
@@ -13,7 +13,7 @@ namespace ZendTest\Log\Filter;
 use Zend\Log\Filter\Validator;
 use Zend\Validator\ValidatorChain;
 use Zend\Validator\Digits as DigitsFilter;
-use Zend\I18n\Validator\Int;
+use Zend\Validator\NotEmpty as NotEmptyFilter;
 
 /**
  * @category   Zend
@@ -35,8 +35,8 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidatorChain()
     {
         $validatorChain = new ValidatorChain();
+        $validatorChain->attach(new NotEmptyFilter());
         $validatorChain->attach(new DigitsFilter());
-        $validatorChain->attach(new Int());
         $filter = new Validator($validatorChain);
         $this->assertTrue($filter->filter(array('message' => '123')));
         $this->assertFalse($filter->filter(array('message' => 'test')));

--- a/tests/ZendTest/Validator/AbstractTest.php
+++ b/tests/ZendTest/Validator/AbstractTest.php
@@ -74,6 +74,10 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testErrorMessagesAreTranslatedWhenTranslatorPresent()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = array(
             'fooMessage' => 'This is the translated message for %value%',
@@ -92,6 +96,10 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testCanTranslateMessagesInsteadOfKeys()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = array(
             '%value% was passed' => 'This is the translated message for %value%',
@@ -153,6 +161,10 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testCanDisableTranslator()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = array(
             '%value% was passed' => 'This is the translated message for %value%',

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -417,6 +417,10 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
      */
     public function testHostnameValidatorMessagesShouldBeTranslated()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $hostnameValidator = new Hostname();
         $translations = array(
             'hostnameIpAddressNotAllowed'   => 'hostnameIpAddressNotAllowed translation',

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -260,6 +260,10 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidatorMessagesShouldBeTranslated()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $translations = array(
             'hostnameInvalidLocalName' => 'this is the IP error message',
         );

--- a/tests/ZendTest/Validator/StaticValidatorTest.php
+++ b/tests/ZendTest/Validator/StaticValidatorTest.php
@@ -90,6 +90,10 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testMaximumErrorMessageLength()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->assertEquals(-1, AbstractValidator::getMessageLength());
         AbstractValidator::setMessageLength(10);
         $this->assertEquals(10, AbstractValidator::getMessageLength());

--- a/tests/ZendTest/View/Helper/HeadTitleTest.php
+++ b/tests/ZendTest/View/Helper/HeadTitleTest.php
@@ -168,6 +168,10 @@ class HeadTitleTest extends \PHPUnit_Framework_TestCase
 
     public function testCanTranslateTitle()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = array(
             'Message_1' => 'Message 1 (en)',

--- a/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
@@ -165,6 +165,10 @@ class BreadcrumbsTest extends AbstractTest
 
     public function testTranslationUsingZendTranslate()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->_helper->setTranslator($this->_getTranslator());
 
         $expected = $this->_getExpected('bc/translated.html');
@@ -173,6 +177,10 @@ class BreadcrumbsTest extends AbstractTest
 
     public function testTranslationUsingZendTranslateAdapter()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $translator = $this->_getTranslator();
         $this->_helper->setTranslator($translator);
 

--- a/tests/ZendTest/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/MenuTest.php
@@ -212,6 +212,10 @@ class MenuTest extends AbstractTest
 
     public function testTranslationUsingZendTranslate()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $translator = $this->_getTranslator();
         $this->_helper->setTranslator($translator);
 
@@ -221,6 +225,10 @@ class MenuTest extends AbstractTest
 
     public function testTranslationUsingZendTranslateAdapter()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $translator = $this->_getTranslator();
         $this->_helper->setTranslator($translator);
 

--- a/tests/ZendTest/View/Helper/Navigation/NavigationTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/NavigationTest.php
@@ -187,6 +187,10 @@ class NavigationTest extends AbstractTest
 
     public function testInjectingTranslator()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->_helper->setTranslator($this->_getTranslator());
 
         $expected = $this->_getExpected('menu/translated.html');


### PR DESCRIPTION
- This will hopefully enable the testsuite to run in HHVM (see: [this
  blog post](http://www.hhvm.com/blog/?p=875))
- There were a bunch of errors caused by `Zend\I18n\Validator\Int`,
  switching some tests to use `Zend\Validation\Digits` might be a good
  idea
