### PR TITLE
Set data of inputFilter

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -332,6 +332,8 @@ class Form extends Fieldset implements FormInterface
         }
 
         $filter = $this->getInputFilter();
+        
+        $filter->setData($this->data);
 
         switch ($this->bindAs) {
             case FormInterface::VALUES_RAW:


### PR DESCRIPTION
Currently, Form->bind () assigns no value to the binded object because the InputFilter->setData() is not called.
