### PR TITLE
Zend\Navigation - add to AbstractPage static factories

### DIFF
--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -150,6 +150,13 @@ abstract class AbstractPage extends AbstractContainer
      */
     protected $properties = array();
 
+    /**
+     * Static factories list for factory pages
+     *
+     * @var array
+     */
+    protected static $factories = array();
+
     // Initialization:
 
     /**
@@ -227,6 +234,14 @@ abstract class AbstractPage extends AbstractContainer
             }
         }
 
+        if (self::$factories) {
+            foreach (self::$factories as $factoryCallBack) {
+                if (($page = call_user_func($factoryCallBack, $options))) {
+                    return $page;
+                }
+            }
+        }
+
         $hasUri = isset($options['uri']);
         $hasMvc = isset($options['action']) || isset($options['controller'])
                 || isset($options['route']);
@@ -240,6 +255,16 @@ abstract class AbstractPage extends AbstractContainer
                 'Invalid argument: Unable to determine class to instantiate'
             );
         }
+    }
+
+    /**
+     * Add static factory for self::factory function
+     *
+     * @param type $callback Any callable variable
+     */
+    public static function addFactory($callback)
+    {
+        self::$factories[] = $callback;
     }
 
     /**

--- a/tests/ZendTest/Navigation/Page/PageFactoryTest.php
+++ b/tests/ZendTest/Navigation/Page/PageFactoryTest.php
@@ -15,12 +15,31 @@ use Zend\Navigation;
 /**
  * Tests Zend_Navigation_Page::factory()
  *
-/**
  * @group      Zend_Navigation
  */
 class PageFactoryTest extends \PHPUnit_Framework_TestCase
 {
 
+    public function testDetectFactoryPage()
+    {
+        AbstractPage::addFactory(function ($page) {
+            if (isset($page['factory_uri'])) {
+                return new \Zend\Navigation\Page\Uri($page);
+            } elseif (isset($page['factory_mvc'])) {
+                return new \Zend\Navigation\Page\Mvc($page);
+            }
+        });
+
+        $this->assertInstanceOf('Zend\\Navigation\\Page\\Uri', AbstractPage::factory(array(
+            'label' => 'URI Page',
+            'factory_uri' => '#'
+        )));
+
+        $this->assertInstanceOf('Zend\\Navigation\\Page\\Mvc', AbstractPage::factory(array(
+            'label' => 'URI Page',
+            'factory_mvc' => '#'
+        )));
+    }
 
     public function testDetectMvcPage()
     {

--- a/tests/ZendTest/Navigation/Page/PageTest.php
+++ b/tests/ZendTest/Navigation/Page/PageTest.php
@@ -67,37 +67,6 @@ class PageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $page->get('Action'));
     }
 
-    /**
-     * This functionality was removed in ZF2 to comply with new URL helper; do we need it?
-     *
-     * @group disable
-     */
-    public function testSetShouldNormalizePropertyName()
-    {
-        $page = AbstractPage::factory(array(
-            'type' => 'mvc'
-        ));
-
-        $page->setResetParams(false);
-        $page->set('reset_params', true);
-        $this->assertTrue($page->getResetParams());
-    }
-
-    /**
-     * This functionality was removed in ZF2 to comply with new URL helper; do we need it?
-     *
-     * @group disable
-     */
-    public function testGetShouldNormalizePropertyName()
-    {
-        $page = AbstractPage::factory(array(
-            'type' => 'mvc'
-        ));
-
-        $page->setResetParams(false);
-        $this->assertFalse($page->get('reset_params'));
-    }
-
     public function testShouldSetAndGetShouldMapToProperties()
     {
         $page = AbstractPage::factory(array(


### PR DESCRIPTION
sometime use 'type' in $options not always possible
