### PR TITLE
Fix Container::append(), support fluid interface (same as prepend()).

### DIFF
--- a/library/Zend/Navigation/AbstractContainer.php
+++ b/library/Zend/Navigation/AbstractContainer.php
@@ -93,7 +93,7 @@ abstract class AbstractContainer implements Countable, RecursiveIterator
      * calling {@link Page\AbstractPage::setParent()}.
      *
      * @param  Page\AbstractPage|array|Traversable $page  page to add
-     * @return AbstractContainer fluent interface, returns self
+     * @return self fluent interface, returns self
      * @throws Exception\InvalidArgumentException if page is invalid
      */
     public function addPage($page)
@@ -136,7 +136,7 @@ abstract class AbstractContainer implements Countable, RecursiveIterator
      * Adds several pages at once
      *
      * @param  array|Traversable|AbstractContainer $pages pages to add
-     * @return AbstractContainer fluent interface, returns self
+     * @return self fluent interface, returns self
      * @throws Exception\InvalidArgumentException if $pages is not array,
      *                                            Traversable or AbstractContainer
      */
@@ -172,7 +172,7 @@ abstract class AbstractContainer implements Countable, RecursiveIterator
      * Sets pages this container should have, removing existing pages
      *
      * @param  array $pages pages to set
-     * @return AbstractContainer fluent interface, returns self
+     * @return self fluent interface, returns self
      */
     public function setPages(array $pages)
     {
@@ -223,7 +223,7 @@ abstract class AbstractContainer implements Countable, RecursiveIterator
     /**
      * Removes all pages in container
      *
-     * @return AbstractContainer fluent interface, returns self
+     * @return self fluent interface, returns self
      */
     public function removePages()
     {

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
@@ -260,7 +260,7 @@ abstract class AbstractContainer extends ArrayObject
      * Prepend a value to the top of the container
      *
      * @param  mixed $value
-     * @return void
+     * @return AbstractContainer
      */
     public function prepend($value)
     {
@@ -268,6 +268,18 @@ abstract class AbstractContainer extends ArrayObject
         array_unshift($values, $value);
         $this->exchangeArray($values);
 
+        return $this;
+    }
+
+    /**
+     * Append a value to the end of the container
+     *
+     * @param  mixed $value
+     * @return AbstractContainer
+     */
+    public function append($value)
+    {
+        parent::append($value);
         return $this;
     }
 

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractContainer.php
@@ -260,7 +260,7 @@ abstract class AbstractContainer extends ArrayObject
      * Prepend a value to the top of the container
      *
      * @param  mixed $value
-     * @return AbstractContainer
+     * @return self
      */
     public function prepend($value)
     {
@@ -275,7 +275,7 @@ abstract class AbstractContainer extends ArrayObject
      * Append a value to the end of the container
      *
      * @param  mixed $value
-     * @return AbstractContainer
+     * @return self
      */
     public function append($value)
     {
@@ -303,7 +303,7 @@ abstract class AbstractContainer extends ArrayObject
      * optionally, if a number is passed, it will be the number of spaces
      *
      * @param  string|int $indent
-     * @return AbstractContainer
+     * @return self
      */
     public function setIndent($indent)
     {
@@ -325,7 +325,7 @@ abstract class AbstractContainer extends ArrayObject
      * Set postfix for __toString() serialization
      *
      * @param  string $postfix
-     * @return AbstractContainer
+     * @return self
      */
     public function setPostfix($postfix)
     {
@@ -347,7 +347,7 @@ abstract class AbstractContainer extends ArrayObject
      * Set prefix for __toString() serialization
      *
      * @param  string $prefix
-     * @return AbstractContainer
+     * @return self
      */
     public function setPrefix($prefix)
     {
@@ -371,7 +371,7 @@ abstract class AbstractContainer extends ArrayObject
      * Used to implode elements in container
      *
      * @param  string $separator
-     * @return AbstractContainer
+     * @return self
      */
     public function setSeparator($separator)
     {

--- a/tests/ZendTest/View/Helper/Placeholder/ContainerTest.php
+++ b/tests/ZendTest/View/Helper/Placeholder/ContainerTest.php
@@ -126,10 +126,15 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return void
      */
-
     public function testPrependImplementsFluentInterface()
     {
         $result = $this->container->prepend( 'test' );
+        $this->assertSame($this->container, $result);
+    }
+
+    public function testAppendImplementsFluentInterface()
+    {
+        $result = $this->container->append( 'test' );
         $this->assertSame($this->container, $result);
     }
 
@@ -141,7 +146,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $result = $this->container->set( 'test' );
         $this->assertSame($this->container, $result);
     }
-
 
     /**
      * @return void


### PR DESCRIPTION
The following should be possible:

``` php
// inside view script
$this->placeholder('something')->prepend('foo')->prepend('bar');
$this->placeholder('something')->append('foo')->append('bar');
```

This PR fixes `AbstractContainer::append()` so it supports fluid interface, symmetric to `prepend()`
