### PR TITLE
[bug][i18n] Zend\I18n\Filter\NumberParse change numeric locale

### DIFF
--- a/library/Zend/I18n/Filter/NumberParse.php
+++ b/library/Zend/I18n/Filter/NumberParse.php
@@ -146,10 +146,14 @@ class NumberParse extends AbstractLocale
         ) {
             ErrorHandler::start();
 
+            $currentLocale = setlocale(LC_NUMERIC, 0);
+
             $result = $this->getFormatter()->parse(
                 $value,
                 $this->getType()
             );
+
+            setlocale(LC_NUMERIC, $currentLocale);
 
             ErrorHandler::stop();
 

--- a/tests/ZendTest/I18n/Filter/NumberParseTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberParseTest.php
@@ -74,4 +74,17 @@ class NumberParseTest extends TestCase
             ),
         );
     }
+
+
+    public function testParseDoNotChangeLocale()
+    {
+        $currentLocale = setlocale(LC_NUMERIC, 0); // get original locale
+
+        setlocale(LC_NUMERIC, 'fr_FR');
+        $filter = new NumberParseFilter('en_US', NumberFormatter::TYPE_DEFAULT);
+        $filter->filter('10.01');
+        $this->assertEquals('fr_FR', setlocale(LC_NUMERIC, 0));
+
+        setlocale(LC_NUMERIC, $currentLocale); // reset locale
+    }
 }


### PR DESCRIPTION
Sorry for my ugly english.

I am doing multilingual websites, and in france, float are displayed with comma (13,37).

So when I store float in database, I use NumberParse, and NumberFloat, with en_US locale. But it seems that NumberParse change the numeric locale setting.

``` php
setlocale(LC_ALL, 'fr_FR'); // change local to fr for french version

echo 13.37; // return "13,37"
echo setlocale(LC_ALL, 0); // return "fr_FR"

$numberParse = new NumberParse('en_US');
$numberParse->filter('3.14');

echo 13.37; // return "13.37", expected "13,37"
echo setlocale(LC_ALL, 0); // return "fr_FR/fr_FR/fr_FR/C/fr_FR/fr_FR"

```

It seems that the issue come from the method parse of php native class NumberFormatter.
The error doesn't occur the other way (en to fr), I guess NumberFormatter::parse always change the numeric locale to C, regardless of the setting.

I am using 5.4.17 on mac osx, and I can reproduce this error in 5.4.x on windows 7.
I don't know if this bug is fixed on later version of php.

This error coming from php, and not zf2, it's up to you to decide if we should push this workaround.
