### PR TITLE
Fix Validator\PhoneNumber with E.123/E.164 international numbers.

### DIFF
--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -210,8 +210,21 @@ class PhoneNumber extends AbstractValidator
             }
         }
 
-        if ($countryPattern['code'] == substr($value, 0, strlen($countryPattern['code']))) {
-            $valueNoCountry = substr($value, strlen($countryPattern['code']));
+        $codeLength = strlen($countryPattern['code']);
+
+        // Check for existence of E.123/E.164 prefix
+        if (('+' . $countryPattern['code']) == substr($value, 0, $codeLength + 1)) {
+            $valueNoCountry = substr($value, $codeLength + 1);
+        }
+
+        // Check for existence of international double-O prefix
+        elseif (('00' . $countryPattern['code']) == substr($value, 0, $codeLength + 2)) {
+            $valueNoCountry = substr($value, $codeLength + 2);
+        }
+
+        // Check for existence of bare country prefix
+        elseif ($countryPattern['code'] == substr($value, 0, $codeLength)) {
+            $valueNoCountry = substr($value, $codeLength);
         }
 
         // check against allowed types strict match:

--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -212,18 +212,17 @@ class PhoneNumber extends AbstractValidator
 
         $codeLength = strlen($countryPattern['code']);
 
-        // Check for existence of E.123/E.164 prefix
+        /*
+         * Check for existence of either:
+         *   1) E.123/E.164 international prefix
+         *   2) International double-O prefix
+         *   3) Bare country prefix
+         */
         if (('+' . $countryPattern['code']) == substr($value, 0, $codeLength + 1)) {
             $valueNoCountry = substr($value, $codeLength + 1);
-        }
-
-        // Check for existence of international double-O prefix
-        elseif (('00' . $countryPattern['code']) == substr($value, 0, $codeLength + 2)) {
+        } elseif (('00' . $countryPattern['code']) == substr($value, 0, $codeLength + 2)) {
             $valueNoCountry = substr($value, $codeLength + 2);
-        }
-
-        // Check for existence of bare country prefix
-        elseif ($countryPattern['code'] == substr($value, 0, $codeLength)) {
+        } elseif ($countryPattern['code'] == substr($value, 0, $codeLength)) {
             $valueNoCountry = substr($value, $codeLength);
         }
 

--- a/tests/ZendTest/I18n/Validator/PhoneNumberTest.php
+++ b/tests/ZendTest/I18n/Validator/PhoneNumberTest.php
@@ -3039,9 +3039,17 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
             foreach ($parameters['patterns']['example'] as $type => $value) {
                 $this->validator->allowedTypes(array($type));
                 $this->assertTrue($this->validator->isValid($value));
+
                 // check with country code:
-                $value = $parameters['code'] . $value;
-                $this->assertTrue($this->validator->isValid($value));
+                $countryCodePrefixed = $parameters['code'] . $value;
+                $this->assertTrue($this->validator->isValid($countryCodePrefixed));
+
+                // check fully qualified E.123/E.164 international variants
+                $fullyQualifiedDoubleO = '00'. $parameters['code'] . $value;
+                $this->assertTrue($this->validator->isValid($fullyQualifiedDoubleO));
+
+                $fullyQualifiedPlus = '+'. $parameters['code'] . $value;
+                $this->assertTrue($this->validator->isValid($fullyQualifiedPlus));
             }
         }
     }
@@ -3054,9 +3062,17 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
             foreach ($parameters['patterns']['example'] as $type => $value) {
                 $this->validator->allowedTypes(array($type));
                 $this->assertTrue($this->validator->isValid($value));
+
                 // check with country code:
-                $value = $parameters['code'] . $value;
-                $this->assertTrue($this->validator->isValid($value));
+                $countryCodePrefixed = $parameters['code'] . $value;
+                $this->assertTrue($this->validator->isValid($countryCodePrefixed));
+
+                // check fully qualified E.123/E.164 international variants
+                $fullyQualifiedDoubleO = '00'. $parameters['code'] . $value;
+                $this->assertTrue($this->validator->isValid($fullyQualifiedDoubleO), $fullyQualifiedDoubleO);
+
+                $fullyQualifiedPlus = '+'. $parameters['code'] . $value;
+                $this->assertTrue($this->validator->isValid($fullyQualifiedPlus), $fullyQualifiedPlus);
             }
         }
     }

--- a/tests/ZendTest/I18n/Validator/PhoneNumberTest.php
+++ b/tests/ZendTest/I18n/Validator/PhoneNumberTest.php
@@ -3045,10 +3045,10 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
                 $this->assertTrue($this->validator->isValid($countryCodePrefixed));
 
                 // check fully qualified E.123/E.164 international variants
-                $fullyQualifiedDoubleO = '00'. $parameters['code'] . $value;
+                $fullyQualifiedDoubleO = '00' . $parameters['code'] . $value;
                 $this->assertTrue($this->validator->isValid($fullyQualifiedDoubleO));
 
-                $fullyQualifiedPlus = '+'. $parameters['code'] . $value;
+                $fullyQualifiedPlus = '+' . $parameters['code'] . $value;
                 $this->assertTrue($this->validator->isValid($fullyQualifiedPlus));
             }
         }


### PR DESCRIPTION
This fixes validation for international numbers such as:

```
+48 601 123 456
00 248 2510123
```

More [info on international phone number formats here](http://en.wikipedia.org/wiki/E.123)
