### PR TITLE
Fix calling View\Helper\BasePath from CLI results in fatal error.

### DIFF
--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -84,7 +84,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
                 $basePathHelper->setBasePath($config['view_manager']['base_path']);
             } else {
                 $request = $serviceLocator->get('Request');
-                if(is_callable(array($request, 'getBasePath'))) {
+                if (is_callable(array($request, 'getBasePath'))) {
                     $basePathHelper->setBasePath($request->getBasePath());
                 }
             }

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -81,11 +81,14 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
             $config = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
             $basePathHelper = new ViewHelper\BasePath;
             if (isset($config['view_manager']) && isset($config['view_manager']['base_path'])) {
-                $basePath = $config['view_manager']['base_path'];
+                $basePathHelper->setBasePath($config['view_manager']['base_path']);
             } else {
-                $basePath = $serviceLocator->get('Request')->getBasePath();
+                $request = $serviceLocator->get('Request');
+                if(is_callable(array($request, 'getBasePath'))) {
+                    $basePathHelper->setBasePath($request->getBasePath());
+                }
             }
-            $basePathHelper->setBasePath($basePath);
+
             return $basePathHelper;
         });
 

--- a/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
@@ -10,11 +10,22 @@
 namespace ZendTest\Mvc\Service;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Console\Request as ConsoleRequest;
 use Zend\Mvc\Service\ViewHelperManagerFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class ViewHelperManagerFactoryTest extends TestCase
 {
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
+    /**
+     * @var ViewHelperManagerFactory
+     */
+    protected $factory;
+
     public function setUp()
     {
         $this->services = new ServiceManager();
@@ -45,5 +56,19 @@ class ViewHelperManagerFactoryTest extends TestCase
         $this->assertInstanceof('Zend\View\HelperPluginManager', $manager);
         $doctype = $manager->get('doctype');
         $this->assertInstanceof('Zend\View\Helper\Doctype', $doctype);
+    }
+
+    public function testConsoleRequestsResultInSilentFailure()
+    {
+        $this->services->setService('Config', array());
+        $this->services->setService('Request', new ConsoleRequest());
+
+        $manager = $this->factory->createService($this->services);
+
+        $doctype = $manager->get('doctype');
+        $this->assertInstanceof('Zend\View\Helper\Doctype', $doctype);
+
+        $basePath = $manager->get('basepath');
+        $this->assertInstanceof('Zend\View\Helper\BasePath', $basePath);
     }
 }

--- a/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
@@ -29,7 +29,7 @@ class ViewHelperManagerFactoryTest extends TestCase
     public function setUp()
     {
         $this->services = new ServiceManager();
-        $this->factory  = new ViewHelperManagerFactory();
+        $this->factory = new ViewHelperManagerFactory();
     }
 
     /**


### PR DESCRIPTION
Using

``` <?php
echo $this->basePath();
```

in view script when compiling views in CLI (with `Console\Request`) results in a fatal error:

> Fatal error: Call to undefined method Zend\Console\Request::getBasePath() in project/vendor/zendframework/zendframework/library/Zend/Mvc/Service/ViewHelperManagerFactory.php on line 86

I've fixed it so it'll construct the helper correctly, but using basePath() it in CLI will still throw a (catchable) exception. At least it's something that can be handled in userland, as opposed to PHP fatal error, though I welcome any suggestions on what else could we do with missing basePaths in such case.

Personally, I'm using view scripts to generate email bodies (in cli worker for example).
