### PR TITLE
Remove double dots from cache path without keys

### DIFF
--- a/library/Zend/ModuleManager/Listener/ListenerOptions.php
+++ b/library/Zend/ModuleManager/Listener/ListenerOptions.php
@@ -250,7 +250,11 @@ class ListenerOptions extends AbstractOptions
      */
     public function getConfigCacheFile()
     {
-        return $this->getCacheDir() . '/module-config-cache.' . $this->getConfigCacheKey().'.php';
+        if ($this->getConfigCacheKey()) {
+            return $this->getCacheDir() . '/module-config-cache.' . $this->getConfigCacheKey().'.php';
+        }
+
+        return $this->getCacheDir() . '/module-config-cache.php';
     }
 
     /**
@@ -330,7 +334,11 @@ class ListenerOptions extends AbstractOptions
      */
     public function getModuleMapCacheFile()
     {
-        return $this->getCacheDir() . '/module-classmap-cache.'.$this->getModuleMapCacheKey().'.php';
+        if ($this->getModuleMapCacheKey()) {
+            return $this->getCacheDir() . '/module-classmap-cache.' . $this->getModuleMapCacheKey() . '.php';
+        }
+
+        return $this->getCacheDir() . '/module-classmap-cache.php';
     }
 
     /**


### PR DESCRIPTION
When no key is specified, do not concat the string with two dots as it results in a double dotted file path for both cache files.

Before this patch: `cache-dir/module-config-cache..php`
After this patch: `cache-dir/module-config-cache.php`
