### PR TITLE
ZendTests windows compatibility

### DIFF
--- a/tests/ZendTest/Cache/Pattern/CaptureCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/CaptureCacheTest.php
@@ -137,18 +137,17 @@ class CaptureCacheTest extends CommonPatternTest
     public function testGetFilenameWithoutPublicDir()
     {
         $captureCache = new Cache\Pattern\CaptureCache();
-
-        $this->assertEquals('/index.html', $captureCache->getFilename('/'));
-        $this->assertEquals('/dir1/test', $captureCache->getFilename('/dir1/test'));
-        $this->assertEquals('/dir1/test.html', $captureCache->getFilename('/dir1/test.html'));
-        $this->assertEquals('/dir1/dir2/test.html', $captureCache->getFilename('/dir1/dir2/test.html'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/index.html'), $captureCache->getFilename('/'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test'), $captureCache->getFilename('/dir1/test'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename('/dir1/test.html'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/dir2/test.html'), $captureCache->getFilename('/dir1/dir2/test.html'));
     }
 
     public function testGetFilenameWithoutPublicDirAndNoPageId()
     {
         $_SERVER['REQUEST_URI'] = '/dir1/test.html';
         $captureCache = new Cache\Pattern\CaptureCache();
-        $this->assertEquals('/dir1/test.html', $captureCache->getFilename());
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename());
     }
 
     public function testGetFilenameWithPublicDir()
@@ -160,10 +159,10 @@ class CaptureCacheTest extends CommonPatternTest
         $captureCache = new Cache\Pattern\CaptureCache();
         $captureCache->setOptions($options);
 
-        $this->assertEquals($this->_tmpCacheDir . '/index.html', $captureCache->getFilename('/'));
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/test', $captureCache->getFilename('/dir1/test'));
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/test.html', $captureCache->getFilename('/dir1/test.html'));
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/dir2/test.html', $captureCache->getFilename('/dir1/dir2/test.html'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/index.html'), $captureCache->getFilename('/'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test'), $captureCache->getFilename('/dir1/test'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename('/dir1/test.html'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/dir2/test.html'), $captureCache->getFilename('/dir1/dir2/test.html'));
     }
 
     public function testGetFilenameWithPublicDirAndNoPageId()
@@ -176,6 +175,6 @@ class CaptureCacheTest extends CommonPatternTest
         $captureCache = new Cache\Pattern\CaptureCache();
         $captureCache->setOptions($options);
 
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/test.html', $captureCache->getFilename());
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename());
     }
 }

--- a/tests/ZendTest/Filter/Compress/ZipTest.php
+++ b/tests/ZendTest/Filter/Compress/ZipTest.php
@@ -26,7 +26,7 @@ class ZipTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('This adapter needs the zip extension');
         }
 
-        $this->tmp = sys_get_temp_dir() . '/' . str_replace('\\', '_', __CLASS__);
+        $this->tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . str_replace('\\', '_', __CLASS__);
 
         $files = array(
             $this->tmp . '/compressed.zip',

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -70,9 +70,9 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         mkdir($this->_filesPath);
         mkdir($this->_newDir);
 
-        $this->_oldFile    = $this->_filesPath . '/testfile.txt';
-        $this->_newFile    = $this->_filesPath . '/newfile.xml';
-        $this->_newDirFile = $this->_newDir . '/testfile.txt';
+        $this->_oldFile    = $this->_filesPath . DIRECTORY_SEPARATOR . 'testfile.txt';
+        $this->_newFile    = $this->_filesPath . DIRECTORY_SEPARATOR . 'newfile.xml';
+        $this->_newDirFile = $this->_newDir . DIRECTORY_SEPARATOR . 'testfile.txt';
 
         touch($this->_oldFile);
     }

--- a/tests/ZendTest/Mail/Header/ToTest.php
+++ b/tests/ZendTest/Mail/Header/ToTest.php
@@ -28,7 +28,7 @@ class ToTest extends \PHPUnit_Framework_TestCase
         $header = new Header\To();
         $list   = $header->getAddressList();
         for ($i = 0; $i < 10; $i++) {
-            $list->add(uniqid() . '@zend.com');
+            $list->add($i . '@zend.com');
         }
         $string = $header->getFieldValue();
         $emails = explode("\r\n ", $string);

--- a/tests/ZendTest/Mvc/Controller/TestAsset/UneventfulController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/UneventfulController.php
@@ -11,12 +11,12 @@
 namespace ZendTest\Mvc\Controller\TestAsset;
 
 use Zend\Stdlib\DispatchableInterface;
-use Zend\Stdlib\RequestInterface as Request;
+use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface as Response;
 
 class UneventfulController implements DispatchableInterface
 {
-    public function dispatch(Request $request, Response $response = null)
+    public function dispatch(RequestInterface $request, Response $response = null)
     {
     }
 }

--- a/tests/ZendTest/XmlRpc/Server/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/Server/FaultTest.php
@@ -207,6 +207,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
 
         $e = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
+        $fault->setEncoding('UTF-8');
 
         $this->assertEquals(trim($xml), trim($fault->__toString()));
     }


### PR DESCRIPTION
fixed DIRECTORY_SEPARATOR 
and if tests running with Netbeans by folders follow should be fixed:
-class usage
-uniqid()
-Server\Fault::setEncoding('UTF-8')
