### PR TITLE
Remove unused variable

### DIFF
--- a/library/Zend/Text/Table/DecoratorManager.php
+++ b/library/Zend/Text/Table/DecoratorManager.php
@@ -32,11 +32,6 @@ class DecoratorManager extends AbstractPluginManager
     );
 
     /**
-     * @var Renderer\RendererInterface
-     */
-    protected $renderer;
-
-    /**
      * Validate the plugin
      *
      * Checks that the decorator loaded is an instance of Decorator\DecoratorInterface.


### PR DESCRIPTION
It seems like it's not used.

Unless it is, then an obviously missing `use` statement needs to be added to import the namespace in which the `RendererInterface` resides.
