### PR TITLE
DblibRowCounter feature to ResultSet->count() for Pdo dblib connections

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Feature/DblibRowCounter.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Feature/DblibRowCounter.php
@@ -63,7 +63,7 @@ class DblibRowCounter extends AbstractFeature
     }
 
     /**
-     * @param $context
+     * @param \Zend\Db\Adapter\Driver\Pdo\Statement|string $context
      * @return closure
      */
     public function getRowCountClosure($context)

--- a/library/Zend/Db/Adapter/Driver/Pdo/Feature/DblibRowCounter.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Feature/DblibRowCounter.php
@@ -37,7 +37,7 @@ class DblibRowCounter extends AbstractFeature
         if ($sql == '' || stripos($sql, 'select') === false) {
             return null;
         }
-        $countSql = 'SELECT COUNT(*) as count FROM (' . $sql . ') queryResult';
+        $countSql = 'SELECT @@ROWCOUNT AS count';
         $countStmt->prepare($countSql);
         $result = $countStmt->execute();
         $countRow = $result->getResource()->fetch(\PDO::FETCH_ASSOC);
@@ -46,7 +46,7 @@ class DblibRowCounter extends AbstractFeature
     }
 
     /**
-     * @param $sql
+     * @param string $sql
      * @return null|int
      */
     public function getCountForSql($sql)
@@ -54,7 +54,7 @@ class DblibRowCounter extends AbstractFeature
         if (!stripos($sql, 'select')) {
             return null;
         }
-        $countSql = 'SELECT COUNT(*) as count FROM (' . $sql . ') queryResult';
+        $countSql = 'SELECT @@ROWCOUNT AS count';
         /** @var $pdo \PDO */
         $pdo = $this->pdoDriver->getConnection()->getResource();
         $result = $pdo->query($countSql);

--- a/library/Zend/Db/Adapter/Driver/Pdo/Feature/DblibRowCounter.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Feature/DblibRowCounter.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Adapter\Driver\Pdo\Feature;
+
+use Zend\Db\Adapter\Driver\Feature\AbstractFeature;
+use Zend\Db\Adapter\Driver\Pdo;
+
+/**
+ * DblibRowCounter
+ */
+class DblibRowCounter extends AbstractFeature
+{
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'DblibRowCounter';
+    }
+
+    /**
+     * @param \Zend\Db\Adapter\Driver\Pdo\Statement $statement
+     * @return int
+     */
+    public function getCountForStatement(Pdo\Statement $statement)
+    {
+        $countStmt = clone $statement;
+        $sql = $statement->getSql();
+        if ($sql == '' || stripos($sql, 'select') === false) {
+            return null;
+        }
+        $countSql = 'SELECT COUNT(*) as count FROM (' . $sql . ') queryResult';
+        $countStmt->prepare($countSql);
+        $result = $countStmt->execute();
+        $countRow = $result->getResource()->fetch(\PDO::FETCH_ASSOC);
+        unset($statement, $result);
+        return $countRow['count'];
+    }
+
+    /**
+     * @param $sql
+     * @return null|int
+     */
+    public function getCountForSql($sql)
+    {
+        if (!stripos($sql, 'select')) {
+            return null;
+        }
+        $countSql = 'SELECT COUNT(*) as count FROM (' . $sql . ') queryResult';
+        /** @var $pdo \PDO */
+        $pdo = $this->pdoDriver->getConnection()->getResource();
+        $result = $pdo->query($countSql);
+        $countRow = $result->fetch(\PDO::FETCH_ASSOC);
+        return $countRow['count'];
+    }
+
+    /**
+     * @param $context
+     * @return closure
+     */
+    public function getRowCountClosure($context)
+    {
+        $dblibRowCounter = $this;
+        return function () use ($dblibRowCounter, $context) {
+            /** @var $dblibRowCounter DblibRowCounter */
+            return ($context instanceof Pdo\Statement)
+                ? $dblibRowCounter->getCountForStatement($context)
+                : $dblibRowCounter->getCountForSql($context);
+        };
+    }
+
+}

--- a/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Pdo.php
@@ -156,6 +156,8 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
             $this->addFeature(null, new Feature\SqliteRowCounter);
         } elseif ($driverName == 'oci') {
             $this->addFeature(null, new Feature\OracleRowCounter);
+        } elseif ($driverName == 'dblib') {
+            $this->addFeature(null, new Feature\DblibRowCounter);
         }
         return $this;
     }
@@ -189,7 +191,6 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
                     return 'Postgresql';
                 case 'oci':
                     return 'Oracle';
-
                 default:
                     return ucfirst($name);
             }
@@ -272,6 +273,12 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
             $rowCount = $oracleRowCounter->getRowCountClosure($context);
         }
 
+        // special feature, dblib PDO counter
+        if ($this->connection->getDriverName() == 'dblib'
+                        && ($dblibRowCounter = $this->getFeature('DblibRowCounter'))
+                        && $resource->columnCount() > 0) {
+                $rowCount = $dblibRowCounter->getRowCountClosure($context);
+        }
 
         $result->initialize($resource, $this->connection->getLastGeneratedValue(), $rowCount);
         return $result;


### PR DESCRIPTION
Similar to the Oracle and Sqlite features to populate a the row count for queries made to Pdo dblib connections.

Using @@ROWCOUNT to get count of rows returned with last query.   Any concerns?
