### PR TITLE
Ensure DiAbstractServiceFactory takes lowest possible priority

### DIFF
--- a/library/Zend/Mvc/Service/DiAbstractServiceFactoryFactory.php
+++ b/library/Zend/Mvc/Service/DiAbstractServiceFactoryFactory.php
@@ -28,7 +28,7 @@ class DiAbstractServiceFactoryFactory implements FactoryInterface
 
         if ($serviceLocator instanceof ServiceManager) {
             /* @var $serviceLocator ServiceManager */
-            $serviceLocator->addAbstractFactory($factory);
+            $serviceLocator->addAbstractFactory($factory, false);
         }
 
         return $factory;


### PR DESCRIPTION
I'm far from expert on all the intricacies of Zend\Di, but this
_seemed_ necessary for my application.

AFAICT, the `Zend\ServiceManager\Di\DiAbstractServiceFactory`
will be lazily added to the shared ServiceManager at an unpredictable
time. The default behaviour of `addAbstractFactory` puts this new
abstract factory in front of abstract factories from modules, which leads
to the DiAbstractFactory trying to create things before module-defined
abstract factories get a chance.
