### PR TITLE
Fix for CamelCase filter when string contains multiple uppercase letters and Unicode is off

### DIFF
--- a/library/Zend/Filter/Word/CamelCaseToSeparator.php
+++ b/library/Zend/Filter/Word/CamelCaseToSeparator.php
@@ -25,7 +25,7 @@ class CamelCaseToSeparator extends AbstractSeparator
             $pattern     = array('#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#');
             $replacement = array($this->separator . '\1', $this->separator . '\1');
         } else {
-            $pattern     = array('#(?<=(?:[A-Z]))([A-Z]+)([A-Z][A-z])#', '#(?<=(?:[a-z0-9]))([A-Z])#');
+            $pattern     = array('#(?<=(?:[A-Z]))([A-Z]+)([A-Z][a-z])#', '#(?<=(?:[a-z0-9]))([A-Z])#');
             $replacement = array('\1' . $this->separator . '\2', $this->separator . '\1');
         }
 

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Filter
  */
 
 namespace ZendTest\Filter\Word;

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Filter
+ */
+
+namespace ZendTest\Filter\Word;
+
+use ReflectionProperty;
+use Zend\Filter\Word\CamelCaseToSeparator as CamelCaseToSeparatorFilter;
+use Zend\Stdlib\StringUtils;
+
+/**
+ * Test class for Zend\Filter\Word\CamelCaseToSeparator which simulates the 
+ * PCRE Unicode features disabled
+ */
+class CamelCaseToSeparatorNoPcreUnicodeTest extends CamelCaseToSeparatorTest
+{
+    protected $reflection;
+
+    public function setUp()
+    {
+        if (!StringUtils::hasPcreUnicodeSupport()) {
+            return $this->markTestSkipped('PCRE is not compiled with Unicode support');
+        }
+
+        $this->reflection = new ReflectionProperty('Zend\Stdlib\StringUtils', 'hasPcreUnicodeSupport');
+        $this->reflection->setAccessible(true);
+        $this->reflection->setValue(false);
+    }
+
+    public function tearDown()
+    {
+        $this->reflection->setValue(true);
+    }
+}

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
@@ -15,7 +15,7 @@ use Zend\Filter\Word\CamelCaseToSeparator as CamelCaseToSeparatorFilter;
 use Zend\Stdlib\StringUtils;
 
 /**
- * Test class for Zend\Filter\Word\CamelCaseToSeparator which simulates the 
+ * Test class for Zend\Filter\Word\CamelCaseToSeparator which simulates the
  * PCRE Unicode features disabled
  */
 class CamelCaseToSeparatorNoPcreUnicodeTest extends CamelCaseToSeparatorTest

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
@@ -41,4 +41,14 @@ class CamelCaseToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('Camel:-#Cased:-#Words', $filtered);
     }
+    
+    public function testFilterSeperatesMultipleUppercasedLettersAndUnderscores()
+    {
+        $string   = 'TheseAre_SOME_CamelCASEDWords';
+        $filter   = new CamelCaseToSeparatorFilter('_');
+        $filtered = $filter($string);
+
+        $this->assertNotEquals($string, $filtered);
+        $this->assertEquals('These_Are_SOME_Camel_CASED_Words', $filtered);
+    }
 }

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
@@ -41,7 +41,7 @@ class CamelCaseToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('Camel:-#Cased:-#Words', $filtered);
     }
-    
+
     public function testFilterSeperatesMultipleUppercasedLettersAndUnderscores()
     {
         $string   = 'TheseAre_SOME_CamelCASEDWords';


### PR DESCRIPTION
`Zend\Filter\Word\CamelCaseToSeparator` fails with strings containing camel case, non-word chars and multiple uppercase letters. This only happens when PCRE was compiled without Unicode support.

|  | TheseAre_SOME_CamelCASEDWords |
| --- | --- |
| `StringUtils::hasPcreUnicodeSupport() == true` | These_Are_SOME_Camel_CASED_Words |
| `StringUtils::hasPcreUnicodeSupport() == false` | These_Are_SOM_E_Camel_CASED_Words |

Unit test and fix attached to this PR.
