### PR TITLE
Minor bugfix: Added missing composer dependency (ServiceManager) to Math package

### DIFF
--- a/library/Zend/Math/composer.json
+++ b/library/Zend/Math/composer.json
@@ -13,7 +13,8 @@
     },
     "target-dir": "Zend/Math",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "zendframework/zend-servicemanager": "self.version"
     },
     "suggest": {
         "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable"


### PR DESCRIPTION
The Zend\Math package uses the ServiceManager. But the composer.json requirements don't define this dependency.
This PR fixes this issue.
