### PR TITLE
New feature: Added sign() method to Math\BigInteger adapters

### DIFF
--- a/library/Zend/Math/BigInteger/Adapter/AdapterInterface.php
+++ b/library/Zend/Math/BigInteger/Adapter/AdapterInterface.php
@@ -118,6 +118,16 @@ interface AdapterInterface
     public function comp($leftOperand, $rightOperand);
 
     /**
+     * Sign of big integer
+     * Returns < 0 if operand is less than 0;
+     * > 0 if operand is greater than 0, and 0 if they are equal to 0.
+     *
+     * @param  string $operand
+     * @return int
+     */
+    public function sign($operand);
+
+    /**
      * Convert big integer into it's binary number representation
      *
      * @param  string $int

--- a/library/Zend/Math/BigInteger/Adapter/Bcmath.php
+++ b/library/Zend/Math/BigInteger/Adapter/Bcmath.php
@@ -203,6 +203,19 @@ class Bcmath implements AdapterInterface
     }
 
     /**
+     * Sign of big integer
+     * Returns < 0 if operand is less than 0;
+     * > 0 if operand is greater than 0, and 0 if they are equal to 0.
+     *
+     * @param  string $operand
+     * @return int
+     */
+    public function sign($operand)
+    {
+        return $this->comp($operand, '0');
+    }
+
+    /**
      * Convert big integer into it's binary number representation
      *
      * @param  string $operand

--- a/library/Zend/Math/BigInteger/Adapter/Gmp.php
+++ b/library/Zend/Math/BigInteger/Adapter/Gmp.php
@@ -192,6 +192,19 @@ class Gmp implements AdapterInterface
     }
 
     /**
+     * Sign of big integer
+     * Returns < 0 if operand is less than 0;
+     * > 0 if operand is greater than 0, and 0 if they are equal to 0.
+     *
+     * @param  string $operand
+     * @return int
+     */
+    public function sign($operand)
+    {
+        return $this->comp($operand, '0');
+    }
+
+    /**
      * Convert big integer into it's binary number representation
      *
      * @param  string $int

--- a/tests/ZendTest/Math/BigInteger/Adapter/AbstractTestCase.php
+++ b/tests/ZendTest/Math/BigInteger/Adapter/AbstractTestCase.php
@@ -117,6 +117,16 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * @param string $op
+     * @param string $expected
+     * @dataProvider signProvider
+     */
+    public function testSign($op, $expected)
+    {
+        $this->assertEquals($expected, $this->adapter->sign($op));
+    }
+
+    /**
+     * @param string $op
      * @param string $baseFrom
      * @param string $baseTo
      * @param string $expected
@@ -296,6 +306,24 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
             array('12345678901234567890', '1234567890123456789', 1),
             array('12345678901234567890', '12345678901234567890', 0),
             array('1234567890123456789', '12345678901234567890', -1),
+        );
+    }
+
+    /**
+     * Sign function data provider
+     *
+     * @return array
+     */
+    public function signProvider()
+    {
+        return array(
+            array('0', 0),
+            array('-0', 0),
+            array('+0', 0),
+            array('1', 1),
+            array('-1', -1),
+            array('12345678901234567890', 1),
+            array('-12345678901234567890', -1),
         );
     }
 


### PR DESCRIPTION
The sign() method is usefull to get the sign information about
a big integer. This can be also achieved with the comparison method,
but it's more handy to use the shortcut sign() method.
This is very common in other languages:
Java: http://docs.oracle.com/javase/6/docs/api/java/math/BigInteger.html#signum%28%29
C#: http://msdn.microsoft.com/en-us/library/system.numerics.biginteger.sign.aspx
Go: http://golang.org/pkg/math/big/#Int.Sign
