### PR TITLE
Fix returned NamespaceType for Parameters from Reflection

### DIFF
--- a/library/Zend/Code/Generator/ParameterGenerator.php
+++ b/library/Zend/Code/Generator/ParameterGenerator.php
@@ -62,10 +62,8 @@ class ParameterGenerator extends AbstractGenerator
                 $parameterType = $typeClass->getName();
                 $currentNamespace = $reflectionParameter->getDeclaringClass()->getNamespaceName();
 
-                if (!empty($currentNamespace)) {
-                    if (substr($parameterType, 0, strlen($currentNamespace)) == $currentNamespace) {
-                        $parameterType = substr($parameterType, strlen($currentNamespace) + 1);
-                    }
+                if (!empty($currentNamespace) && substr($parameterType, 0, strlen($currentNamespace)) == $currentNamespace) {
+                    $parameterType = substr($parameterType, strlen($currentNamespace) + 1);
                 } else {
                     $parameterType = '\\' . trim($parameterType, '\\');
                 }

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -76,7 +76,7 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
         $reflectionParameter = $this->getFirstReflectionParameter('type');
         $codeGenParam = ParameterGenerator::fromReflection($reflectionParameter);
 
-        $this->assertEquals('stdClass', $codeGenParam->getType());
+        $this->assertEquals('\\stdClass', $codeGenParam->getType());
     }
 
     public function testFromReflectionGetReference()
@@ -143,7 +143,7 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('name', '$param'),
-            array('type', 'stdClass $bar'),
+            array('type', '\\stdClass $bar'),
             array('reference', '&$baz'),
             array('defaultValue', '$value = \'foo\''),
             array('defaultNull', '$value = null'),
@@ -162,7 +162,7 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param  string                               $method
-     * @return \Zend\Reflection\ReflectionParameter
+     * @return \Zend\Code\Reflection\ParameterReflection
      */
     protected function getFirstReflectionParameter($method)
     {

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -213,4 +213,19 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('\ZendTest_Code_NsTest_BarClass', $param->getType());
     }
+
+    /**
+     * @group 5193
+     */
+    public function testTypehintsWithNamespaceInNamepsacedClassReturnTypewithBackslash()
+    {
+        require_once __DIR__ . '/TestAsset/NamespaceTypeHintClass.php';
+
+        $reflClass = new \Zend\Code\Reflection\ClassReflection('Namespaced\TypeHint\Bar');
+        $params = $reflClass->getMethod('method')->getParameters();
+
+        $param = ParameterGenerator::fromReflection($params[0]);
+
+        $this->assertEquals('\OtherNamespace\ParameterClass', $param->getType());
+    }
 }

--- a/tests/ZendTest/Code/Generator/TestAsset/NamespaceTypeHintClass.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/NamespaceTypeHintClass.php
@@ -1,0 +1,19 @@
+<?php
+namespace Namespaced\TypeHint {
+
+    use OtherNamespace\ParameterClass;
+
+    class Bar {
+
+        public function method(ParameterClass $object)
+        {
+        }
+    }
+}
+
+namespace OtherNamespace {
+
+    class ParameterClass {
+
+    }
+}

--- a/tests/ZendTest/Code/Generator/TestAsset/NamespaceTypeHintClass.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/NamespaceTypeHintClass.php
@@ -11,7 +11,8 @@ namespace Namespaced\TypeHint {
 
     use OtherNamespace\ParameterClass;
 
-    class Bar {
+    class Bar
+    {
 
         public function method(ParameterClass $object)
         {
@@ -21,7 +22,8 @@ namespace Namespaced\TypeHint {
 
 namespace OtherNamespace {
 
-    class ParameterClass {
+    class ParameterClass
+    {
 
     }
 }

--- a/tests/ZendTest/Code/Generator/TestAsset/NamespaceTypeHintClass.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/NamespaceTypeHintClass.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
 namespace Namespaced\TypeHint {
 
     use OtherNamespace\ParameterClass;


### PR DESCRIPTION
If a parameter inside a namespace-class has a typehint to an other namespaced-class the returned typehint lacks the beginning backslash.
