### PR TITLE
JsonStrategy not working as described

### DIFF
--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -93,17 +93,17 @@ class JsonStrategy extends AbstractListenerAggregate
         $model = $e->getModel();
 
         if ($model instanceof Model\JsonModel) {
-			// JsonModel found
-			return $this->renderer;
+            // JsonModel found
+            return $this->renderer;
         }
 
-		if ($e->getRequest()->getHeaders()->get('Accept')->getPrioritized()[0]->getFormat() == 'json') {
-			// accept header asks for json
-			return $this->renderer;
-		}
+        if ($e->getRequest()->getHeaders()->get('Accept')->getPrioritized()[0]->getFormat() == 'json') {
+            // accept header asks for json
+            return $this->renderer;
+        }
 
-		// nothing indicating we should respond with json found
-		return;
+        // nothing indicating we should respond with json found
+        return;
     }
 
     /**

--- a/library/Zend/View/Strategy/JsonStrategy.php
+++ b/library/Zend/View/Strategy/JsonStrategy.php
@@ -92,13 +92,18 @@ class JsonStrategy extends AbstractListenerAggregate
     {
         $model = $e->getModel();
 
-        if (!$model instanceof Model\JsonModel) {
-            // no JsonModel; do nothing
-            return;
+        if ($model instanceof Model\JsonModel) {
+			// JsonModel found
+			return $this->renderer;
         }
 
-        // JsonModel found
-        return $this->renderer;
+		if ($e->getRequest()->getHeaders()->get('Accept')->getPrioritized()[0]->getFormat() == 'json') {
+			// accept header asks for json
+			return $this->renderer;
+		}
+
+		// nothing indicating we should respond with json found
+		return;
     }
 
     /**


### PR DESCRIPTION
JsonStrategy documentation suggests that setting HTTP Accept header to application/json should trigger JsonStrategy, however the code only (and always) triggers if the model is a JsonModel and has nothing to do with checking http accept headers.
I've modified the selectRenderer method to do what its phpdoc says it does by adding a check on the http access header to see if the first requested format is json.
