### PR TITLE
Get the connected dsn string that is now stored when the pdo connection is made

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -46,6 +46,11 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     protected $inTransaction = false;
 
     /**
+     * @var string
+     */
+    protected $connectedDsn = null;
+
+    /**
      * Constructor
      *
      * @param array|\PDO|null $connectionParameters
@@ -281,6 +286,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             $this->resource = new \PDO($dsn, $username, $password, $options);
             $this->resource->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $this->driverName = strtolower($this->resource->getAttribute(\PDO::ATTR_DRIVER_NAME));
+            $this->setConnectedDsn($dsn);
         } catch (\PDOException $e) {
             $code = $e->getCode();
             if (!is_long($code)) {
@@ -433,5 +439,36 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             // do nothing
         }
         return false;
+    }
+
+    /**
+     * Get the dsn string for this connection
+     * @throws \Zend\Db\Adapter\Exception\RunTimeException
+     * @return string
+     */
+    public function getConnectedDsn()
+    {
+        if (!$this->connectedDsn) {
+            if (!$this->isConnected()) {
+                $this->connect();
+            }
+
+            if (!$this->connectedDsn) {
+                throw new Exception\RunTimeException("DSN has not been set for this Connection");
+            }
+        }
+
+        return $this->connectedDsn;
+    }
+
+    /**
+     * Set the DSN for the connection
+     * @param string $dsn
+     * @return $this
+     */
+    private function setConnectedDsn($dsn)
+    {
+        $this->connectedDsn = $dsn;
+        return $this;
     }
 }

--- a/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
@@ -38,4 +38,23 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Db\Adapter\Exception\InvalidConnectionParametersException');
         $this->connection->getResource();
     }
+
+    /**
+     * Test getConnectedDsn returns a DSN string if it has been set
+     *
+     * @covers Zend\Db\Adapter\Driver\Pdo\Connection::getConnectedDsn
+     */
+    public function testGetConnectedDsn()
+    {
+        $startString = "mysql:host=localhost;dbname=test";
+
+        $reflectPdo = new \ReflectionClass($this->connection);
+        $dsnProperty = $reflectPdo->getProperty("connectedDsn");
+        $dsnProperty->setAccessible(true);
+        $dsnProperty->setValue($this->connection, $startString);
+
+        $responseString = $this->connection->getConnectedDsn();
+
+        $this->assertEquals($startString, $responseString);
+    }
 }


### PR DESCRIPTION
Issue:
https://github.com/zendframework/zf2/issues/5094

This stores the dsn that is generated when creating a pdo connection which can they be retrieved.

If connection has not yet been made it will attempt to connect first
