### PR TITLE
Bug fix for Zend\Form\Element\Collection::extract()

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -493,7 +493,7 @@ class Collection extends Fieldset implements FieldsetPrepareAwareInterface
     {
 
         if ($this->object instanceof Traversable) {
-            $this->object = ArrayUtils::iteratorToArray($this->object);
+            $this->object = ArrayUtils::iteratorToArray($this->object, false);
         }
 
         if (!is_array($this->object)) {

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -18,6 +18,9 @@ use Zend\Form\Fieldset;
 use Zend\Form\Form;
 use Zend\Stdlib\Hydrator\ObjectProperty as ObjectPropertyHydrator;
 use ZendTest\Form\TestAsset\Entity\Product;
+use Zend\Stdlib\Hydrator\ArraySerializable;
+use ZendTest\Form\TestAsset\CustomCollection;
+use ZendTest\Form\TestAsset\ArrayModel;
 
 class CollectionTest extends TestCase
 {
@@ -487,5 +490,55 @@ class CollectionTest extends TestCase
             'obj2' => $obj2,
             'obj3' => $obj3,
         ));
+    }
+
+    public function testExtractFromTraversableImplementingToArrayThroughCollectionHydrator()
+    {
+        $collection = $this->form->get('fieldsets');
+
+        // this test is using a hydrator set on the collection
+        $collection->setHydrator(new ArraySerializable());
+
+        $this->prepareForExtractWithCustomTraversable($collection);
+
+        $expected = array(
+            array('foo' => 'foo_value_1', 'bar' => 'bar_value_1', 'foobar' => 'foobar_value_1'),
+            array('foo' => 'foo_value_2', 'bar' => 'bar_value_2', 'foobar' => 'foobar_value_2'),
+        );
+
+        $this->assertEquals($expected, $collection->extract());
+    }
+
+    public function testExtractFromTraversableImplementingToArrayThroughTargetElementHydrator()
+    {
+        $collection = $this->form->get('fieldsets');
+
+        // this test is using a hydrator set on the target element of the collection
+        $targetElement = $collection->getTargetElement();
+        $targetElement->setHydrator(new ArraySerializable());
+        $obj1 = new ArrayModel();
+        $targetElement->setObject($obj1);
+
+        $this->prepareForExtractWithCustomTraversable($collection);
+
+        $expected = array(
+            array('foo' => 'foo_value_1', 'bar' => 'bar_value_1', 'foobar' => 'foobar_value_1'),
+            array('foo' => 'foo_value_2', 'bar' => 'bar_value_2', 'foobar' => 'foobar_value_2'),
+        );
+
+        $this->assertEquals($expected, $collection->extract());
+    }
+
+    protected function prepareForExtractWithCustomTraversable($collection)
+    {
+        $obj2 = new ArrayModel();
+        $obj2->exchangeArray(array('foo' => 'foo_value_1', 'bar' => 'bar_value_1', 'foobar' => 'foobar_value_1'));
+        $obj3 = new ArrayModel();
+        $obj3->exchangeArray(array('foo' => 'foo_value_2', 'bar' => 'bar_value_2', 'foobar' => 'foobar_value_2'));
+
+        $traversable = new CustomCollection();
+        $traversable->append($obj2);
+        $traversable->append($obj3);
+        $collection->setObject($traversable);
     }
 }

--- a/tests/ZendTest/Form/TestAsset/ArrayModel.php
+++ b/tests/ZendTest/Form/TestAsset/ArrayModel.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+class ArrayModel extends Model
+{
+    public function toArray()
+    {
+        return $this->getArrayCopy();
+    }
+}

--- a/tests/ZendTest/Form/TestAsset/CustomCollection.php
+++ b/tests/ZendTest/Form/TestAsset/CustomCollection.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Stdlib\ArrayObject;
+
+class CustomCollection extends ArrayObject
+{
+    public function toArray()
+    {
+        $ret = array();
+
+        foreach ($this as $key => $obj) {
+            $ret[$key] = $obj->toArray();
+        }
+
+        return $ret;
+    }
+}


### PR DESCRIPTION
When a Traversable is encountered it is converted to an array.
By default this is done recursively, so that the Traversable becomes an array representation.
The result of that is saved in `$this->object`.
In the Collection::extract method when iterating over `$this->object` there are two branches:
1.  If there is a hydrator, its extract method is called which expects `$value` as an object.
2.  If $value is an instance of the targetElement, eventualy `setObject($value)` is called on a fieldset, which also expects an object. Also the targetElement object is set to `$value`.

In both cases an object is expected, but because of recursive `iteratorToArray` call it will never be an object.

The fix is to not do it recursively, this way it still gives a key => value array representation of the traversable,
but still gives model objects that can be used by a hydrator or set as targetElement object.
