### PR TITLE
- Create temporary table instead of create table temporary

### DIFF
--- a/library/Zend/Db/Sql/Ddl/CreateTable.php
+++ b/library/Zend/Db/Sql/Ddl/CreateTable.php
@@ -39,7 +39,7 @@ class CreateTable extends AbstractSql implements SqlInterface
      * @var array
      */
     protected $specifications = array(
-        self::TABLE => 'CREATE TABLE %1$s (',
+        self::TABLE => 'CREATE %1$sTABLE %2$s (',
         self::COLUMNS  => array(
             "\n    %1\$s" => array(
                 array(1 => '%1$s', 'combinedby' => ",\n    ")
@@ -156,6 +156,7 @@ class CreateTable extends AbstractSql implements SqlInterface
                 $parameters
             );
 
+
             if ($specification
                 && is_array($parameters[$name])
                 && ($parameters[$name] != array(array()))
@@ -173,6 +174,7 @@ class CreateTable extends AbstractSql implements SqlInterface
             }
         }
 
+
         // remove last ,
         if (count($sqls) > 2) {
             array_pop($sqls);
@@ -187,8 +189,11 @@ class CreateTable extends AbstractSql implements SqlInterface
     {
         $ret = array();
         if ($this->isTemporary) {
-            $ret[] = 'TEMPORARY';
+            $ret[] = 'TEMPORARY ';
+        } else {
+            $ret[] = '';
         }
+
         $ret[] = $adapterPlatform->quoteIdentifier($this->table);
         return $ret;
     }

--- a/tests/ZendTest/Db/Sql/Ddl/CreateTableTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/CreateTableTest.php
@@ -37,6 +37,8 @@ class CreateTableTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($ct->isTemporary());
         $ct->setTemporary('yes');
         $this->assertTrue($ct->isTemporary());
+
+        $this->assertStringStartsWith("CREATE TEMPORARY TABLE", $ct->getSqlString());
     }
 
     /**


### PR DESCRIPTION
This is a fix for issue 5210:

https://github.com/zendframework/zf2/issues/5210

User spotted that temporary tables were being parsed in the order of:
CREATE TABLE TEMPORARY "name" instead of CREATE TEMPORARY TABLE "name"
