### PR TITLE
Fix/form label options

### DIFF
--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -148,6 +148,7 @@ class FormMultiCheckbox extends FormInput
         array $attributes)
     {
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+        $labelOptions     = $element->getLabelOptions();
         $labelHelper      = $this->getLabelHelper();
         $labelClose       = $labelHelper->closeTag();
         $labelPosition    = $this->getLabelPosition();
@@ -222,7 +223,9 @@ class FormMultiCheckbox extends FormInput
                 );
             }
 
-            $label     = $escapeHtmlHelper($label);
+            if (empty($labelOptions) || $labelOptions['disable_html_escape'] == false) {
+                $label = $escapeHtmlHelper($label);
+            }
             $labelOpen = $labelHelper->openTag($labelAttributes);
             $template  = $labelOpen . '%s%s' . $labelClose;
             switch ($labelPosition) {

--- a/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
@@ -402,4 +402,20 @@ class FormMultiCheckboxTest extends CommonTestCase
         $this->assertRegexp('#value="value1" checked="checked"#', $markup);
 
     }
+
+    public function testDisableEscapeHtmlHelper()
+    {
+        $element = new MultiCheckboxElement('foo');
+        $element->setLabelOptions(array(
+            'disable_html_escape' => true,
+        ));
+        $element->setValueOptions(array(
+            array(
+                'label' => '<span>label1</span>',
+                'value' => 'value1',
+            ),
+        ));
+        $markup  = $this->helper->render($element);
+        $this->assertRegexp('#<span>label1</span>#', $markup);
+    }
 }


### PR DESCRIPTION
The recently added label option "disable_html_escape" (#4677) should also work for multi option elements.
