### PR TITLE
[ZF3] [stdlib] Add guard traits

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,9 +2,7 @@
 
 Zend Framework requires no special installation steps. Simply download
 the framework, extract it to the folder you would like to keep it in,
-and add the library directory to your PHP `include_path`. To use
-components in the extras library, add the `extras/library` directory to
-your PHP `include_path` as well.
+and add the library directory to your PHP `include_path`.
 
 
 ## SYSTEM REQUIREMENTS

--- a/library/Zend/Config/WriterPluginManager.php
+++ b/library/Zend/Config/WriterPluginManager.php
@@ -14,9 +14,9 @@ use Zend\ServiceManager\AbstractPluginManager;
 class WriterPluginManager extends AbstractPluginManager
 {
     protected $invokableClasses = array(
-        'php'  => 'Zend\Config\Writer\PhpArray',
         'ini'  => 'Zend\Config\Writer\Ini',
         'json' => 'Zend\Config\Writer\Json',
+        'php'  => 'Zend\Config\Writer\PhpArray',
         'yaml' => 'Zend\Config\Writer\Yaml',
         'xml'  => 'Zend\Config\Writer\Xml',
     );

--- a/library/Zend/Stdlib/Guard/AllGuardsTrait.php
+++ b/library/Zend/Stdlib/Guard/AllGuardsTrait.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * An aggregate for all guard traits
+ */
+trait AllGuardsTrait
+{
+
+    use ArrayOrTraversableGuardTrait;
+    use EmptyGuardTrait;
+    use NullGuardTrait;
+
+}

--- a/library/Zend/Stdlib/Guard/ArrayOrTraversableGuardTrait.php
+++ b/library/Zend/Stdlib/Guard/ArrayOrTraversableGuardTrait.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Provide a guard method for array or Traversable data
+ */
+trait ArrayOrTraversableGuardTrait
+{
+
+    /**
+     * Verifies that the data is an array or Traversable
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    protected function guardForArrayOrTraversable(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
+    ) {
+        if (!is_array($data) && !($data instanceof \Traversable)) {
+            $message = sprintf(
+                "%s must be an array or Traversable, [%s] given",
+                $dataName,
+                is_object($data) ? get_class($data) : gettype($data)
+            );
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Stdlib/Guard/EmptyGuardTrait.php
+++ b/library/Zend/Stdlib/Guard/EmptyGuardTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Provide a guard method against empty data
+ */
+trait EmptyGuardTrait
+{
+
+    /**
+     * Verify that the data is not empty
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    protected function guardAgainstEmpty(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
+    ) {
+        if (empty($data)) {
+            $message = sprintf('%s cannot be empty', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Stdlib/Guard/GuardUtils.php
+++ b/library/Zend/Stdlib/Guard/GuardUtils.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Static guard helper class
+ *
+ * Bridges the gap for allowing refactoring until traits can be used by default.
+ *
+ * @deprecated
+ */
+abstract class GuardUtils
+{
+
+    const DEFAULT_EXCEPTION_CLASS = 'Zend\Stdlib\Exception\InvalidArgumentException';
+
+
+    /**
+     * Verifies that the data is an array or Traversable
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    public static function guardForArrayOrTraversable(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = self::DEFAULT_EXCEPTION_CLASS
+    ) {
+        if (!is_array($data) && !($data instanceof \Traversable)) {
+            $message = sprintf(
+                '%s must be an array or Traversable, [%s] given',
+                $dataName,
+                is_object($data) ? get_class($data) : gettype($data)
+            );
+            throw new $exceptionClass($message);
+        }
+    }
+
+    /**
+     * Verify that the data is not empty
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    public static function guardAgainstEmpty(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = self::DEFAULT_EXCEPTION_CLASS
+    ) {
+        if (empty($data)) {
+            $message = sprintf('%s cannot be empty', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+    /**
+     * Verify that the data is not null
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    public static function guardAgainstNull(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = self::DEFAULT_EXCEPTION_CLASS
+    ) {
+        if (is_null($data)) {
+            $message = sprintf('%s cannot be null', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Stdlib/Guard/NullGuardTrait.php
+++ b/library/Zend/Stdlib/Guard/NullGuardTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Provide a guard method against null data
+ */
+trait NullGuardTrait
+{
+
+    /**
+     * Verify that the data is not null
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    protected function guardAgainstNull(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
+    ) {
+        if (is_null($data)) {
+            $message = sprintf('%s cannot be null', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -20,7 +20,7 @@
         "zendframework/zend-http": "Allows use of Zend\\Http\\Client to check version information"
     },
     "suggest": {
-        "zendframework/zend-json": "Zend\\Json component to support Zend\Version\Version::getLatest('GITHUB')",
+        "zendframework/zend-json": "Zend\\Json component to support Zend\\Version\\Version::getLatest('GITHUB')",
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -22,6 +22,9 @@
     "suggest": {
         "zendframework/zend-json": "To check latest version hosted in GitHub",
     },
+    "suggest": {
+        "zendframework/zend-json": "Zend\\Json component to support Zend\Version\Version::getLatest('GITHUB')",
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.2-dev",

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -23,7 +23,7 @@
         "zendframework/zend-json": "To check latest version hosted in GitHub",
     },
     "suggest": {
-        "zendframework/zend-json": "Zend\\Json component to support Zend\Version\Version::getLatest('GITHUB')",
+        "zendframework/zend-json": "Zend\\Json component to support Zend\\Version\\Version::getLatest('GITHUB')",
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -19,6 +19,9 @@
     "suggest": {
         "zendframework/zend-http": "Allows use of Zend\\Http\\Client to check version information"
     },
+    "suggest": {
+        "zendframework/zend-json": "Zend\\Json component to support Zend\Version\Version::getLatest('GITHUB')",
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.2-dev",

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -20,7 +20,7 @@
         "zendframework/zend-http": "Allows use of Zend\\Http\\Client to check version information"
     },
     "suggest": {
-        "zendframework/zend-json": "Zend\\Json component to support Zend\\Version\\Version::getLatest('GITHUB')",
+        "zendframework/zend-json": "To check latest version hosted in GitHub",
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -20,7 +20,7 @@
         "zendframework/zend-http": "Allows use of Zend\\Http\\Client to check version information"
     },
     "suggest": {
-        "zendframework/zend-json": "To check latest version hosted in GitHub",
+        "zendframework/zend-json": "To check latest version hosted in GitHub"
     },
     "suggest": {
         "zendframework/zend-json": "Zend\\Json component to support Zend\\Version\\Version::getLatest('GITHUB')",

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -42,11 +42,10 @@ class HelperPluginManager extends AbstractPluginManager
         // basepath and url are not very useful without their factories, however the doctype
         // helper works fine as an invokable. The factory for doctype simply checks for the
         // config value from the merged config.
-        'doctype'             => 'Zend\View\Helper\Doctype', // overridden by a factory in ViewHelperManagerFactory
         'basepath'            => 'Zend\View\Helper\BasePath',
-        'url'                 => 'Zend\View\Helper\Url',
         'cycle'               => 'Zend\View\Helper\Cycle',
         'declarevars'         => 'Zend\View\Helper\DeclareVars',
+        'doctype'             => 'Zend\View\Helper\Doctype', // overridden by a factory in ViewHelperManagerFactory
         'escapehtml'          => 'Zend\View\Helper\EscapeHtml',
         'escapehtmlattr'      => 'Zend\View\Helper\EscapeHtmlAttr',
         'escapejs'            => 'Zend\View\Helper\EscapeJs',
@@ -73,6 +72,7 @@ class HelperPluginManager extends AbstractPluginManager
         'renderchildmodel'    => 'Zend\View\Helper\RenderChildModel',
         'rendertoplaceholder' => 'Zend\View\Helper\RenderToPlaceholder',
         'serverurl'           => 'Zend\View\Helper\ServerUrl',
+        'url'                 => 'Zend\View\Helper\Url',
         'viewmodel'           => 'Zend\View\Helper\ViewModel',
     );
 

--- a/tests/ZendTest/Cache/Pattern/CaptureCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/CaptureCacheTest.php
@@ -133,18 +133,17 @@ class CaptureCacheTest extends CommonPatternTest
     public function testGetFilenameWithoutPublicDir()
     {
         $captureCache = new Cache\Pattern\CaptureCache();
-
-        $this->assertEquals('/index.html', $captureCache->getFilename('/'));
-        $this->assertEquals('/dir1/test', $captureCache->getFilename('/dir1/test'));
-        $this->assertEquals('/dir1/test.html', $captureCache->getFilename('/dir1/test.html'));
-        $this->assertEquals('/dir1/dir2/test.html', $captureCache->getFilename('/dir1/dir2/test.html'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/index.html'), $captureCache->getFilename('/'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test'), $captureCache->getFilename('/dir1/test'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename('/dir1/test.html'));
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/dir2/test.html'), $captureCache->getFilename('/dir1/dir2/test.html'));
     }
 
     public function testGetFilenameWithoutPublicDirAndNoPageId()
     {
         $_SERVER['REQUEST_URI'] = '/dir1/test.html';
         $captureCache = new Cache\Pattern\CaptureCache();
-        $this->assertEquals('/dir1/test.html', $captureCache->getFilename());
+        $this->assertEquals(str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename());
     }
 
     public function testGetFilenameWithPublicDir()
@@ -156,10 +155,10 @@ class CaptureCacheTest extends CommonPatternTest
         $captureCache = new Cache\Pattern\CaptureCache();
         $captureCache->setOptions($options);
 
-        $this->assertEquals($this->_tmpCacheDir . '/index.html', $captureCache->getFilename('/'));
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/test', $captureCache->getFilename('/dir1/test'));
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/test.html', $captureCache->getFilename('/dir1/test.html'));
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/dir2/test.html', $captureCache->getFilename('/dir1/dir2/test.html'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/index.html'), $captureCache->getFilename('/'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test'), $captureCache->getFilename('/dir1/test'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename('/dir1/test.html'));
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/dir2/test.html'), $captureCache->getFilename('/dir1/dir2/test.html'));
     }
 
     public function testGetFilenameWithPublicDirAndNoPageId()
@@ -172,6 +171,6 @@ class CaptureCacheTest extends CommonPatternTest
         $captureCache = new Cache\Pattern\CaptureCache();
         $captureCache->setOptions($options);
 
-        $this->assertEquals($this->_tmpCacheDir . '/dir1/test.html', $captureCache->getFilename());
+        $this->assertEquals($this->_tmpCacheDir . str_replace('/', DIRECTORY_SEPARATOR, '/dir1/test.html'), $captureCache->getFilename());
     }
 }

--- a/tests/ZendTest/Filter/Compress/ZipTest.php
+++ b/tests/ZendTest/Filter/Compress/ZipTest.php
@@ -22,7 +22,7 @@ class ZipTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('This adapter needs the zip extension');
         }
 
-        $this->tmp = sys_get_temp_dir() . '/' . str_replace('\\', '_', __CLASS__);
+        $this->tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . str_replace('\\', '_', __CLASS__);
 
         $files = array(
             $this->tmp . '/compressed.zip',

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -66,9 +66,9 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
         mkdir($this->_filesPath);
         mkdir($this->_newDir);
 
-        $this->_oldFile    = $this->_filesPath . '/testfile.txt';
-        $this->_newFile    = $this->_filesPath . '/newfile.xml';
-        $this->_newDirFile = $this->_newDir . '/testfile.txt';
+        $this->_oldFile    = $this->_filesPath . DIRECTORY_SEPARATOR . 'testfile.txt';
+        $this->_newFile    = $this->_filesPath . DIRECTORY_SEPARATOR . 'newfile.xml';
+        $this->_newDirFile = $this->_newDir . DIRECTORY_SEPARATOR . 'testfile.txt';
 
         touch($this->_oldFile);
     }

--- a/tests/ZendTest/Mail/Header/ToTest.php
+++ b/tests/ZendTest/Mail/Header/ToTest.php
@@ -24,7 +24,7 @@ class ToTest extends \PHPUnit_Framework_TestCase
         $header = new Header\To();
         $list   = $header->getAddressList();
         for ($i = 0; $i < 10; $i++) {
-            $list->add(uniqid() . '@zend.com');
+            $list->add($i . '@zend.com');
         }
         $string = $header->getFieldValue();
         $emails = explode("\r\n ", $string);

--- a/tests/ZendTest/Mvc/Controller/TestAsset/UneventfulController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/UneventfulController.php
@@ -10,12 +10,12 @@
 namespace ZendTest\Mvc\Controller\TestAsset;
 
 use Zend\Stdlib\DispatchableInterface;
-use Zend\Stdlib\RequestInterface as Request;
+use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface as Response;
 
 class UneventfulController implements DispatchableInterface
 {
-    public function dispatch(Request $request, Response $response = null)
+    public function dispatch(RequestInterface $request, Response $response = null)
     {
     }
 }

--- a/tests/ZendTest/Stdlib/Guard/ArrayOrTraversableGuardTraitTest.php
+++ b/tests/ZendTest/Stdlib/Guard/ArrayOrTraversableGuardTraitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Stdlib\TestAsset\GuardedObject;
+use Zend\Stdlib\ArrayObject;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\ArrayOrTraversableGuardTrait
+ */
+class ArrayOrTraversableGuardTraitTest extends TestCase
+{
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped('Only valid for php >= 5.4');
+        }
+    }
+
+    public function testGuardForArrayOrTraversableThrowsException()
+    {
+        $object = new GuardedObject;
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument must be an array or Traversable, [string] given'
+        );
+        $object->setArrayOrTraversable('');
+    }
+
+    public function testGuardForArrayOrTraversableAllowsArray()
+    {
+        $object = new GuardedObject;
+        $this->assertNull($object->setArrayOrTraversable(array()));
+    }
+
+    public function testGuardForArrayOrTraversableAllowsTraversable()
+    {
+        $object      = new GuardedObject;
+        $traversable = new ArrayObject;
+        $this->assertNull($object->setArrayOrTraversable($traversable));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/EmptyGuardTraitTest.php
+++ b/tests/ZendTest/Stdlib/Guard/EmptyGuardTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Stdlib\TestAsset\GuardedObject;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\EmptyGuardTrait
+ */
+class EmptyGuardTraitTest extends TestCase
+{
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped('Only valid for php >= 5.4');
+        }
+    }
+
+    public function testGuardAgainstEmptyThrowsException()
+    {
+        $object = new GuardedObject;
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be empty'
+        );
+        $object->setNotEmpty('');
+    }
+
+    public function testGuardAgainstEmptyAllowsNonEmptyString()
+    {
+        $object = new GuardedObject;
+        $this->assertNull($object->setNotEmpty('foo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/GuardUtilsTest.php
+++ b/tests/ZendTest/Stdlib/Guard/GuardUtilsTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+use Zend\Stdlib\Guard\GuardUtils;
+use Zend\Stdlib\ArrayObject;
+
+/**
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\GuardUtils
+ */
+class GuardUtilsTest extends TestCase
+{
+
+    public function testGuardForArrayOrTraversableThrowsException()
+    {
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument must be an array or Traversable, [string] given'
+        );
+        GuardUtils::guardForArrayOrTraversable('');
+    }
+
+    public function testGuardForArrayOrTraversableAllowsArray()
+    {
+        $this->assertNull(GuardUtils::guardForArrayOrTraversable(array()));
+    }
+
+    public function testGuardForArrayOrTraversableAllowsTraversable()
+    {
+        $traversable = new ArrayObject;
+        $this->assertNull(GuardUtils::guardForArrayOrTraversable($traversable));
+    }
+
+    public function testGuardAgainstEmptyThrowsException()
+    {
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be empty'
+        );
+        GuardUtils::guardAgainstEmpty('');
+    }
+
+    public function testGuardAgainstEmptyAllowsNonEmptyString()
+    {
+        $this->assertNull(GuardUtils::guardAgainstEmpty('foo'));
+    }
+
+    public function testGuardAgainstNullThrowsException()
+    {
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be null'
+        );
+        GuardUtils::guardAgainstNull(null);
+    }
+
+    public function testGuardAgainstNullAllowsNonNull()
+    {
+        $this->assertNull(GuardUtils::guardAgainstNull('foo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/NullGuardTraitTest.php
+++ b/tests/ZendTest/Stdlib/Guard/NullGuardTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Stdlib\TestAsset\GuardedObject;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\NullGuardTrait
+ */
+class NullGuardTraitTest extends TestCase
+{
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped('Only valid for php >= 5.4');
+        }
+    }
+
+    public function testGuardAgainstNullThrowsException()
+    {
+        $object = new GuardedObject;
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be null'
+        );
+        $object->setNotNull(null);
+    }
+
+    public function testGuardAgainstNullAllowsNonNull()
+    {
+        $object = new GuardedObject;
+        $this->assertNull($object->setNotNull('foo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/TestAsset/GuardedObject.php
+++ b/tests/ZendTest/Stdlib/TestAsset/GuardedObject.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\Guard;
+
+class GuardedObject
+{
+
+    use Guard\AllGuardsTrait;
+
+    public function setArrayOrTraversable($data)
+    {
+        return $this->guardForArrayOrTraversable($data);
+    }
+
+    public function setNotNull($data)
+    {
+        return $this->guardAgainstNull($data);
+    }
+
+    public function setNotEmpty($data)
+    {
+        return $this->guardAgainstEmpty($data);
+    }
+
+}

--- a/tests/ZendTest/XmlRpc/Server/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/Server/FaultTest.php
@@ -203,6 +203,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
 
         $e = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
+        $fault->setEncoding('UTF-8');
 
         $this->assertEquals(trim($xml), trim($fault->__toString()));
     }


### PR DESCRIPTION
The check for `array` or `Traversable` code is littered throughout the framework.  This is a prime opportunity for a trait.  Included a couple extra traits for good measure.

For example, https://github.com/zendframework/zf2/blob/master/library/Zend/Form/Fieldset.php#L297 could be:

``` php
class Fieldset extends Element implements FieldsetInterface
{
    use \Zend\Stdlib\Guard\ArrayOrTraversableGuardTrait;

    // ...

    public function setMessages($messages)
    {
        $this->guardForArrayOrTraversable(
            $messages, 'Messages', 'Zend\Form\Exception\InvalidArgumentException'
        );

        foreach ($messages as $elementName => $elementMessages) {
            $this->get($elementName)->setMessages($elementMessages);
        }

        return $this;
    }

    // ...

}
```

Please see http://verraes.net/2013/09/extract-till-you-drop/
