### PR TITLE
ServiceManager - fix AbstractFactories performance and service waiting

### DIFF
--- a/tests/ZendTest/ServiceManager/TestAsset/WaitingAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/WaitingAbstractFactory.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use stdClass;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class WaitingAbstractFactory implements AbstractFactoryInterface
+{
+    public $waitingService = null;
+
+    public $canCreateCallCount = 0;
+
+    public $createNullService = false;
+
+    public $throwExceptionWhenCreate = false;
+
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $this->canCreateCallCount++;
+        return $requestedName === $this->waitingService;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ($this->throwExceptionWhenCreate) {
+            throw new FooException('E');
+        }
+        if ($this->createNullService) {
+            return null;
+        }
+        return new stdClass;
+    }
+}


### PR DESCRIPTION
When ServiceManager get service, it call canCreateFromAbstractFactory 3 times and check all abstract factories 3 times. And after this check all abstract factories for creating service. In total : 4 cycles for all abstract factories and 4 call abstractFactory::canCreateServiceWithName for each factory.

https://github.com/zendframework/zf2/pull/4285 is litle wrong - see ServiceManagerTest::testWaitingAbstractFactory(). Second call of $this->serviceManager->has('SomethingThatCanBeCreated') was failed, but the service already exists.
