### PR TITLE
allow empty fieldset labels in formCollection view helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -118,12 +118,16 @@ class FormCollection extends AbstractHelper
 
                 $label = $escapeHtmlHelper($label);
 
-                $markup = sprintf(
-                    '<fieldset><legend>%s</legend>%s</fieldset>',
-                    $label,
-                    $markup
-                );
+                $labelMarkup = sprintf('<legend>%s</legend>', $label);
+            } else {
+                $labelMarkup = '';
             }
+
+            $markup = sprintf(
+                '<fieldset>%s%s</fieldset>',
+                $labelMarkup,
+                $markup
+            );
         }
 
         return $markup;

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -176,4 +176,15 @@ class FormCollectionTest extends TestCase
 
         $this->assertContains('>translated legend<', $markup);
     }
+
+    public function testShouldWrapWithoutLabel()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('');
+        $this->helper->setShouldWrap(true);
+
+        $markup = $this->helper->render($collection);
+        $this->assertContains('<fieldset>', $markup);
+    }
 }


### PR DESCRIPTION
collections should be rendered in fieldsets if shouldWrap is set to true even if no label (legend) is given.
