### PR TITLE
fix Debug::getEscaper() never called at Debug::dump() when xdebug is loaded

### DIFF
--- a/library/Zend/Debug/Debug.php
+++ b/library/Zend/Debug/Debug.php
@@ -104,7 +104,7 @@ class Debug
                     . PHP_EOL . $output
                     . PHP_EOL;
         } else {
-            if (!extension_loaded('xdebug')) {
+            if (!extension_loaded('xdebug') || null !== static::$escaper) {
                 $output = static::getEscaper()->escapeHtml($output);
             }
 

--- a/library/Zend/Debug/Debug.php
+++ b/library/Zend/Debug/Debug.php
@@ -104,7 +104,9 @@ class Debug
                     . PHP_EOL . $output
                     . PHP_EOL;
         } else {
-            if (!extension_loaded('xdebug') || null !== static::$escaper) {
+            if (null !== static::$escaper) {
+                $output = static::$escaper->escapeHtml($output);    
+            } else if (!extension_loaded('xdebug')) {
                 $output = static::getEscaper()->escapeHtml($output);
             }
 

--- a/library/Zend/Debug/Debug.php
+++ b/library/Zend/Debug/Debug.php
@@ -105,8 +105,8 @@ class Debug
                     . PHP_EOL;
         } else {
             if (null !== static::$escaper) {
-                $output = static::$escaper->escapeHtml($output);    
-            } else if (!extension_loaded('xdebug')) {
+                $output = static::$escaper->escapeHtml($output);
+            } elseif (!extension_loaded('xdebug')) {
                 $output = static::getEscaper()->escapeHtml($output);
             }
 

--- a/library/Zend/Debug/composer.json
+++ b/library/Zend/Debug/composer.json
@@ -13,11 +13,11 @@
     },
     "target-dir": "Zend/Debug",
     "require": {
-        "php": ">=5.3.3",
-        "zendframework/zend-escaper": "self.version"
+        "php": ">=5.3.3"
     },
     "suggest": {
-        "ext/xdebug": "XDebug, for better backtrace output"
+        "ext/xdebug": "XDebug, for better backtrace output",
+        "zendframework/zend-escaper": "To support escaped output"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Debug/composer.json
+++ b/library/Zend/Debug/composer.json
@@ -15,6 +15,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "zendframework/zend-escaper": "*"
+    },
     "suggest": {
         "ext/xdebug": "XDebug, for better backtrace output",
         "zendframework/zend-escaper": "To support escaped output"

--- a/tests/ZendTest/Debug/DebugTest.php
+++ b/tests/ZendTest/Debug/DebugTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest;
 
 use Zend\Debug\Debug;
+use Zend\Escaper\Escaper;
 
 /**
  * @group      Zend_Debug
@@ -96,7 +97,7 @@ class DebugTest extends \PHPUnit_Framework_TestCase
 
     public function testDebugHaveEscaper()
     {
-        $escaper = new \Zend\Escaper\Escaper;
+        $escaper = new Escaper;
         Debug::setEscaper($escaper);
 
         $a = array("a" => "<script type=\"text/javascript\"");

--- a/tests/ZendTest/Debug/DebugTest.php
+++ b/tests/ZendTest/Debug/DebugTest.php
@@ -94,4 +94,14 @@ class DebugTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("</pre>", $result);
     }
 
+    public function testDebugHaveEscaper()
+    {
+        $escaper = new \Zend\Escaper\Escaper;
+        Debug::setEscaper($escaper);
+
+        $a = array("a" => "<script type=\"text/javascript\"");
+        $result = Debug::dump($a, "LABEL", false);
+        $this->assertContains("&lt;script type=&quot;text/javascript&quot;&quot;", $result);
+    }
+
 }


### PR DESCRIPTION
if we set Debug::setEscaper(new \Zend\Escaper\Escaper) before Debug::dump() and we have xdebug, the getEscaper() never called. added condition so getEscaper() will be called.
