### PR TITLE
form collection attributes

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -108,6 +108,12 @@ class FormCollection extends AbstractHelper
             $label = $element->getLabel();
 
             if (!empty($label)) {
+                $attributes = $element->getAttributes();
+                unset($attributes['name']);
+                $attributesString = '';
+                if (count($attributes)) {
+                    $attributesString = ' ' . $this->createAttributesString($attributes);
+                }
 
                 if (null !== ($translator = $this->getTranslator())) {
                     $label = $translator->translate(
@@ -119,7 +125,8 @@ class FormCollection extends AbstractHelper
                 $label = $escapeHtmlHelper($label);
 
                 $markup = sprintf(
-                    '<fieldset><legend>%s</legend>%s</fieldset>',
+                    '<fieldset%s><legend>%s</legend>%s</fieldset>',
+                    $attributesString,
                     $label,
                     $markup
                 );

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -186,7 +186,6 @@ class FormCollectionTest extends TestCase
         $collection->setAttribute('id', 'some-identifier');
 
         $markup = $this->helper->render($collection);
-        // die(PHP_EOL . PHP_EOL . $markup . PHP_EOL . PHP_EOL);
         $this->assertContains(' id="some-identifier"', $markup);
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -176,4 +176,17 @@ class FormCollectionTest extends TestCase
 
         $this->assertContains('>translated legend<', $markup);
     }
+
+    public function testRenderCollectionAttributes()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('label');
+        $this->helper->setShouldWrap(true);
+        $collection->setAttribute('id', 'some-identifier');
+
+        $markup = $this->helper->render($collection);
+        // die(PHP_EOL . PHP_EOL . $markup . PHP_EOL . PHP_EOL);
+        $this->assertContains(' id="some-identifier"', $markup);
+    }
 }


### PR DESCRIPTION
the attributes of form collections which are set by FormCollection::setAttribute() or FormCollection::setAttributes() should be rendered into the collection fieldset
