### PR TITLE
fix/zf-4974

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
@@ -17,6 +17,7 @@ use Zend\InputFilter\FileInput;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\Mvc\Exception\RuntimeException;
 use Zend\Session\Container;
+use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorChain;
 
 /**
@@ -80,7 +81,7 @@ class FilePostRedirectGet extends AbstractPlugin
         // Run the form validations/filters and retrieve any errors
         $postFiles = $request->getFiles()->toArray();
         $postOther = $request->getPost()->toArray();
-        $post      = array_merge_recursive($postOther, $postFiles);
+        $post      = ArrayUtils::merge($postOther, $postFiles, true);
 
         // Validate form, and capture data and errors
         $form->setData($post);
@@ -91,11 +92,12 @@ class FilePostRedirectGet extends AbstractPlugin
         // Merge and replace previous files with new valid files
         $prevFileData = $this->getEmptyUploadData($inputFilter, $previousFiles);
         $newFileData  = $this->getNonEmptyUploadData($inputFilter, $data);
-        $postFiles = array_merge_recursive(
+        $postFiles = ArrayUtils::merge(
             $prevFileData ?: array(),
-            $newFileData  ?: array()
+            $newFileData  ?: array(),
+            true
         );
-        $post = array_merge_recursive($postOther, $postFiles);
+        $post = ArrayUtils::merge($postOther, $postFiles, true);
 
         // Save form data in session
         $container->setExpirationHops(1, array('post', 'errors', 'isValid'));

--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -245,23 +245,23 @@ abstract class ArrayUtils
     /**
      * Merge two arrays together.
      *
-     * If an integer key exists in both arrays, the value from the second array
-     * will be appended the the first array. If both values are arrays, they
-     * are merged together, else the value of the second array overwrites the
-     * one of the first array.
+     * If an integer key exists in both arrays and preserveNumericKeys is false, the value
+     * from the second array will be appended to the first array. If both values are arrays, they
+     * are merged together, else the value of the second array overwrites the one of the first array.
      *
      * @param  array $a
      * @param  array $b
+     * @param  bool  $preserveNumericKeys
      * @return array
      */
-    public static function merge(array $a, array $b)
+    public static function merge(array $a, array $b, $preserveNumericKeys = false)
     {
         foreach ($b as $key => $value) {
             if (array_key_exists($key, $a)) {
-                if (is_int($key)) {
+                if (is_int($key) && !$preserveNumericKeys) {
                     $a[] = $value;
                 } elseif (is_array($value) && is_array($a[$key])) {
-                    $a[$key] = static::merge($a[$key], $value);
+                    $a[$key] = static::merge($a[$key], $value, $preserveNumericKeys);
                 } else {
                     $a[$key] = $value;
                 }

--- a/tests/ZendTest/Stdlib/ArrayUtilsTest.php
+++ b/tests/ZendTest/Stdlib/ArrayUtilsTest.php
@@ -143,20 +143,67 @@ class ArrayUtilsTest extends TestCase
     public static function mergeArrays()
     {
         return array(
-            'merge-integer-and-string keys' => array(
+            'merge-integer-and-string-keys' => array(
                 array(
                     'foo',
-                    3 => 'bar',
-                    'baz' => 'baz'
+                    3     => 'bar',
+                    'baz' => 'baz',
+                    4     => array(
+                        'a',
+                        1 => 'b',
+                        'c',
+                    ),
                 ),
                 array(
                     'baz',
+                    4 => array(
+                        'd' => 'd',
+                    ),
                 ),
+                false,
                 array(
                     0     => 'foo',
                     3     => 'bar',
                     'baz' => 'baz',
-                    4     => 'baz'
+                    4     => array(
+                        'a',
+                        1 => 'b',
+                        'c',
+                    ),
+                    5     => 'baz',
+                    6     => array(
+                        'd' => 'd',
+                    ),
+                )
+            ),
+            'merge-integer-and-string-keys-preserve-numeric' => array(
+                array(
+                    'foo',
+                    3     => 'bar',
+                    'baz' => 'baz',
+                    4     => array(
+                        'a',
+                        1 => 'b',
+                        'c',
+                    ),
+                ),
+                array(
+                    'baz',
+                    4 => array(
+                        'd' => 'd',
+                    ),
+                ),
+                true,
+                array(
+                    0     => 'baz',
+                    3     => 'bar',
+                    'baz' => 'baz',
+                    4 => array(
+                        'a',
+                        1 => 'b',
+                        'c',
+                        'd' => 'd',
+                    ),
                 )
             ),
             'merge-arrays-recursively' => array(
@@ -170,6 +217,7 @@ class ArrayUtilsTest extends TestCase
                         'baz'
                     )
                 ),
+                false,
                 array(
                     'foo' => array(
                         0 => 'baz',
@@ -186,6 +234,7 @@ class ArrayUtilsTest extends TestCase
                     'foo' => 'baz',
                     'bar' => 'bat'
                 ),
+                false,
                 array(
                     'foo' => 'baz',
                     'bar' => 'bat'
@@ -340,9 +389,9 @@ class ArrayUtilsTest extends TestCase
     /**
      * @dataProvider mergeArrays
      */
-    public function testMerge($a, $b, $expected)
+    public function testMerge($a, $b, $preserveNumericKeys, $expected)
     {
-        $this->assertEquals($expected, ArrayUtils::merge($a, $b));
+        $this->assertEquals($expected, ArrayUtils::merge($a, $b, $preserveNumericKeys));
     }
 
     /**


### PR DESCRIPTION
added new parameter $preserveNumericKeys to ArrayUtils::merge() .
replaced array_merge_recursive in FilePostRedirectGet plugin with ArrayUtils::merge() .
