### PR TITLE
Fix code reflection - getBody/getContents method

### DIFF
--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -66,10 +66,19 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             );
         }
 
+        $startLine = $this->getStartLine();
+        $endLine = $this->getEndLine();
+
+        // eval'd protect
+        if (preg_match('#\((\d+)\) : eval\(\)\'d code$#', $fileName, $matches)) {
+            $fileName = preg_replace('#\(\d+\) : eval\(\)\'d code$#', '', $fileName);
+            $startLine = $endLine = $matches[1];
+        }
+
         $lines = array_slice(
             file($fileName, FILE_IGNORE_NEW_LINES),
-            $this->getStartLine() - 1,
-            ($this->getEndLine() - ($this->getStartLine() - 1)),
+            $startLine - 1,
+            ($endLine - ($startLine - 1)),
             true
         );
 
@@ -147,10 +156,19 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             );
         }
 
+        $startLine = $this->getStartLine();
+        $endLine = $this->getEndLine();
+
+        // eval'd protect
+        if (preg_match('#\((\d+)\) : eval\(\)\'d code$#', $fileName, $matches)) {
+            $fileName = preg_replace('#\(\d+\) : eval\(\)\'d code$#', '', $fileName);
+            $startLine = $endLine = $matches[1];
+        }
+
         $lines = array_slice(
             file($fileName, FILE_IGNORE_NEW_LINES),
-            $this->getStartLine() - 1,
-            ($this->getEndLine() - ($this->getStartLine() - 1)),
+            $startLine - 1,
+            ($endLine - ($startLine - 1)),
             true
         );
 

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -54,8 +54,8 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
     /**
      * Get contents of function
      *
-     * @param  bool   $includeDocBlock
-     * @return string
+     * @param  bool        $includeDocBlock
+     * @return string|bool
      */
     public function getContents($includeDocBlock = true)
     {
@@ -83,13 +83,15 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             }
         } else {
             $name = substr($this->getName(), strrpos($this->getName(), '\\')+1);
-            preg_match('#function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)?}#', $functionLine, $matches);
+            preg_match('#function\s+' . preg_quote($name) . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)?}#', $functionLine, $matches);
             if (isset($matches[0])) {
                 $content = $matches[0];
             }
         }
 
-        return $includeDocBlock && $this->getDocComment() ? $this->getDocComment() . "\n" . $content : $content;
+        $docComment = $this->getDocComment();
+
+        return $includeDocBlock && $docComment ? $docComment . "\n" . $content : $content;
     }
 
     /**
@@ -134,7 +136,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
     /**
      * Get method body
      *
-     * @return string
+     * @return string|bool
      */
     public function getBody()
     {

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -59,9 +59,15 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
      */
     public function getContents($includeDocBlock = true)
     {
+        $fileName = $this->getFileName();
+        if (false === $fileName) {
+            throw new Exception\InvalidArgumentException(
+                'Cannot determine internals functions contents'
+            );
+        }
         return implode("\n",
             array_splice(
-                file($this->getFileName()),
+                file($fileName),
                 $this->getStartLine($includeDocBlock),
                 ($this->getEndLine() - $this->getStartLine()),
                 true
@@ -131,7 +137,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
 
         $functionLine = implode("\n", $lines);
         if ($this->isClosure()) {
-            preg_match('#^\s*\$[^\=]+=\s*function\s*\([^\)]*\)\s*\{(.*)\}\s*;\s*$#s', $functionLine, $matches);
+            preg_match('#function\s*\([^\)]*\)\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
         } else {
             preg_match('#^\s*function\s*[^\(]+\([^\)]*\)\s*\{(.*)\}\s*$#s', $functionLine, $matches);
         }

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -83,7 +83,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             }
         } else {
             $name = substr($this->getName(), strrpos($this->getName(), '\\')+1);
-            preg_match('#function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#', $functionLine, $matches);
+            preg_match('#function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)?}#', $functionLine, $matches);
             if (isset($matches[0])) {
                 $content = $matches[0];
             }

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -54,7 +54,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
     /**
      * Get contents of function
      *
-     * @param  bool $includeDocBlock
+     * @param  bool   $includeDocBlock
      * @return string
      */
     public function getContents($includeDocBlock = true)
@@ -104,7 +104,45 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
         }
 
         $tag    = $docBlock->getTag('return');
+
         return new DocBlockReflection('@return ' . $tag->getDescription());
+    }
+
+    /**
+     * Get method body
+     *
+     * @return string
+     */
+    public function getBody()
+    {
+        $fileName = $this->getFileName();
+        if (false === $fileName) {
+            throw new Exception\InvalidArgumentException(
+                'Cannot determine internals functions body'
+            );
+        }
+
+        $lines = array_slice(
+            file($fileName, FILE_IGNORE_NEW_LINES),
+            $this->getStartLine() - 1,
+            ($this->getEndLine() - ($this->getStartLine() - 1)),
+            true
+        );
+
+        $functionLine = implode(' ', $lines);
+        if ($this->isClosure()) {
+            preg_match('#^\s*\$[^\=]+=\s*function\s*\([^\)]*\)\s*\{(.*)\}\s*;\s*$#', $functionLine, $matches);
+        } else {
+            preg_match('#^\s*function\s*[^\(]+\([^\)]*\)\s*\{(.*)\}\s*$#', $functionLine, $matches);
+        }
+
+        if (!isset($matches[1])) {
+            return false;
+        }
+
+        $body = $matches[1];
+
+        return $body;
     }
 
     public function toString()

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -140,14 +140,14 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
 
         $body = false;
         if ($this->isClosure()) {
-            preg_match('#function\s*\([^\)]*\)\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
-            if ($matches[1]) {
-                $body = $matches[1];
+            preg_match('#function\s*\([^\)]*\)\s*(use\s*\([^\)]+\))?\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
+            if (isset($matches[2])) {
+                $body = $matches[2];
             }
         } else {
             $name = substr($this->getName(), strrpos($this->getName(), '\\')+1);
             preg_match('#function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#', $functionLine, $matches);
-            if ($matches[1]) {
+            if (isset($matches[1])) {
                 $body = $matches[1];
             }
         }

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -77,7 +77,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
 
         $content = false;
         if ($this->isClosure()) {
-            preg_match('#function\s*\([^\)]*\)\s*(use\s*\([^\)]+\))?\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
+            preg_match('#function\s*\([^\)]*\)\s*(use\s*\([^\)]+\))?\s*\{(.*\;)?\s*\}#s', $functionLine, $matches);
             if (isset($matches[0])) {
                 $content = $matches[0];
             }

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -139,7 +139,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
         if ($this->isClosure()) {
             preg_match('#function\s*\([^\)]*\)\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
         } else {
-            preg_match('#^\s*function\s*[^\(]+\([^\)]*\)\s*\{(.*)\}\s*$#s', $functionLine, $matches);
+            preg_match('#function\s*[^\(]+\([^\)]*\)\s*\{(.*\;)\s*\}$#s', $functionLine, $matches);
         }
 
         if (!isset($matches[1])) {

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -129,11 +129,11 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
             true
         );
 
-        $functionLine = implode(' ', $lines);
+        $functionLine = implode("\n", $lines);
         if ($this->isClosure()) {
-            preg_match('#^\s*\$[^\=]+=\s*function\s*\([^\)]*\)\s*\{(.*)\}\s*;\s*$#', $functionLine, $matches);
+            preg_match('#^\s*\$[^\=]+=\s*function\s*\([^\)]*\)\s*\{(.*)\}\s*;\s*$#s', $functionLine, $matches);
         } else {
-            preg_match('#^\s*function\s*[^\(]+\([^\)]*\)\s*\{(.*)\}\s*$#', $functionLine, $matches);
+            preg_match('#^\s*function\s*[^\(]+\([^\)]*\)\s*\{(.*)\}\s*$#s', $functionLine, $matches);
         }
 
         if (!isset($matches[1])) {

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -136,18 +136,21 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
         );
 
         $functionLine = implode("\n", $lines);
+        
+        $body = false;
         if ($this->isClosure()) {
             preg_match('#function\s*\([^\)]*\)\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
+            if ($matches[1]) {
+                $body = $matches[1];
+            }
         } else {
-            preg_match('#function\s*[^\(]+\([^\)]*\)\s*\{(.*\;)\s*\}$#s', $functionLine, $matches);
+            $name = substr($this->getName(), strrpos($this->getName(), '\\')+1);
+            preg_match('#function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#', $functionLine, $matches);
+            if ($matches[1]) {
+                $body = $matches[1];
+            }
         }
-
-        if (!isset($matches[1])) {
-            return false;
-        }
-
-        $body = $matches[1];
-
+        
         return $body;
     }
 

--- a/library/Zend/Code/Reflection/FunctionReflection.php
+++ b/library/Zend/Code/Reflection/FunctionReflection.php
@@ -65,6 +65,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
                 'Cannot determine internals functions contents'
             );
         }
+
         return implode("\n",
             array_splice(
                 file($fileName),
@@ -136,7 +137,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
         );
 
         $functionLine = implode("\n", $lines);
-        
+
         $body = false;
         if ($this->isClosure()) {
             preg_match('#function\s*\([^\)]*\)\s*\{(.*\;)\s*\}#s', $functionLine, $matches);
@@ -150,7 +151,7 @@ class FunctionReflection extends ReflectionFunction implements ReflectionInterfa
                 $body = $matches[1];
             }
         }
-        
+
         return $body;
     }
 

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -114,8 +114,8 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     /**
      * Get method contents
      *
-     * @param  bool   $includeDocBlock
-     * @return string
+     * @param  bool        $includeDocBlock
+     * @return string|bool
      */
     public function getContents($includeDocBlock = true)
     {
@@ -134,21 +134,23 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         );
 
         $functionLine = implode("\n", $lines);
-        preg_match('#[(public|protected|private|abstract|final|static)\s*]+function\s+' . $this->getName() . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)?}#s', $functionLine, $matches);
+        $name         = preg_quote($this->getName());
+        preg_match('#[(public|protected|private|abstract|final|static)\s*]*function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)?}#s', $functionLine, $matches);
 
         if (!isset($matches[0])) {
             return false;
         }
 
-        $content = $matches[0];
+        $content    = $matches[0];
+        $docComment = $this->getDocComment();
 
-        return $includeDocBlock && $this->getDocComment() ? $this->getDocComment() . "\n" . $content : $content;
+        return $includeDocBlock && $docComment ? $docComment . "\n" . $content : $content;
     }
 
     /**
      * Get method body
      *
-     * @return string
+     * @return string|bool
      */
     public function getBody()
     {

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -169,7 +169,8 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         );
 
         $functionLine = implode("\n", $lines);
-        preg_match('#[(public|protected|private|abstract|final|static)\s*]+function\s+' . $this->getName() . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#s', $functionLine, $matches);
+        $name = preg_quote($this->getName());
+        preg_match('#[(public|protected|private|abstract|final|static)\s*]*function\s+' . $name . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#s', $functionLine, $matches);
 
         if (!isset($matches[1])) {
             return false;

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -147,9 +147,9 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             ($this->getEndLine() - ($this->getStartLine() - 1)),
             true
         );
-
+        
         $functionLine = implode("\n", $lines);
-        preg_match('#^\s*[(public|protected|private|abstract|final|static)\s*]+function\s*[^\(]+\([^\)]*\)\s*\{(.*)\}\s*$#s', $functionLine, $matches);
+        preg_match('#[(public|protected|private|abstract|final|static)\s*]+function\s+' . $this->getName() . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#s', $functionLine, $matches);
 
         if (!isset($matches[1])) {
             return false;

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -114,7 +114,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     /**
      * Get method contents
      *
-     * @param  bool $includeDocBlock
+     * @param  bool   $includeDocBlock
      * @return string
      */
     public function getContents($includeDocBlock = true)
@@ -125,12 +125,24 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                 'Cannot determine internals methods contents'
             );
         }
-        
-        $fileContents = file($fileName);
-        $startNum     = $this->getStartLine($includeDocBlock);
-        $endNum       = ($this->getEndLine() - $this->getStartLine());
 
-        return implode("\n", array_splice($fileContents, $startNum, $endNum, true));
+        $lines = array_slice(
+            file($fileName, FILE_IGNORE_NEW_LINES),
+            $this->getStartLine() - 1,
+            ($this->getEndLine() - ($this->getStartLine() - 1)),
+            true
+        );
+
+        $functionLine = implode("\n", $lines);
+        preg_match('#[(public|protected|private|abstract|final|static)\s*]+function\s+' . $this->getName() . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)?}#s', $functionLine, $matches);
+
+        if (!isset($matches[0])) {
+            return false;
+        }
+
+        $content = $matches[0];
+
+        return $includeDocBlock && $this->getDocComment() ? $this->getDocComment() . "\n" . $content : $content;
     }
 
     /**
@@ -153,7 +165,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             ($this->getEndLine() - ($this->getStartLine() - 1)),
             true
         );
-        
+
         $functionLine = implode("\n", $lines);
         preg_match('#[(public|protected|private|abstract|final|static)\s*]+function\s+' . $this->getName() . '\s*\([^\)]*\)\s*{([^{}]+({[^}]+})*[^}]+)}#s', $functionLine, $matches);
 

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -10,7 +10,6 @@
 namespace Zend\Code\Reflection;
 
 use ReflectionMethod as PhpReflectionMethod;
-use Zend\Code\Annotation\AnnotationCollection;
 use Zend\Code\Annotation\AnnotationManager;
 use Zend\Code\Scanner\AnnotationScanner;
 use Zend\Code\Scanner\CachingFileScanner;
@@ -120,7 +119,14 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      */
     public function getContents($includeDocBlock = true)
     {
-        $fileContents = file($this->getFileName());
+        $fileName     = $this->getFileName();
+        if (false === $fileName) {
+            throw new Exception\InvalidArgumentException(
+                'Cannot determine internals methods contents'
+            );
+        }
+        
+        $fileContents = file($fileName);
         $startNum     = $this->getStartLine($includeDocBlock);
         $endNum       = ($this->getEndLine() - $this->getStartLine());
 

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -86,10 +86,6 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
         $body = $function->getBody();
         $this->assertEquals("", trim($body));
-
-        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function13');
-        $body = $function->getBody();
-        $this->assertEquals('return "function13";', trim($body));
     }
 
     public function testFunctionClosureBodyReturn()
@@ -190,10 +186,6 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
         $content = $function->getContents(false);
         $this->assertEquals("function function12() {}", trim($content));
-
-        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function13');
-        $content = $function->getContents(false);
-        $this->assertEquals('function function13() { return "function13"; }', trim($content));
     }
 
     public function testFunctionClosureContentsReturnWithoutDocBlock()
@@ -207,6 +199,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function9);
         $content = $function->getContents(false);
         $this->assertEquals("function() {}", trim($content));
+        
+        $function = new FunctionReflection($function10);
+        $content = $function->getContents(false);
+        $this->assertEquals("function() { return 'function10'; }", trim($content));
     }
 
     public function testFunctionContentsReturnWithDocBlock()

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -86,6 +86,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
         $body = $function->getBody();
         $this->assertEquals("", trim($body));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function13');
+        $body = $function->getBody();
+        $this->assertEquals('return "function13";', trim($body));
     }
 
     public function testFunctionClosureBodyReturn()
@@ -130,6 +134,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function9);
         $body = $function->getBody();
         $this->assertEquals("", trim($body));
+
+        $function = new FunctionReflection($function10);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function10';", trim($body));
     }
 
     public function testInternalFunctionContentsReturn()
@@ -182,6 +190,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
         $content = $function->getContents(false);
         $this->assertEquals("function function12() {}", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function13');
+        $content = $function->getContents(false);
+        $this->assertEquals('function function13() { return "function13"; }', trim($content));
     }
 
     public function testFunctionClosureContentsReturnWithoutDocBlock()

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -90,7 +90,7 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testFunctionClosureBodyReturn()
     {
-        require_once __DIR__ . '/TestAsset/closures.php';
+        require __DIR__ . '/TestAsset/closures.php';
 
         $function = new FunctionReflection($function1);
         $body = $function->getBody();
@@ -184,18 +184,35 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("function function12() {}", trim($content));
     }
 
+    public function testFunctionClosureContentsReturnWithoutDocBlock()
+    {
+        require __DIR__ . '/TestAsset/closures.php';
+
+        $function = new FunctionReflection($function2);
+        $content = $function->getContents(false);
+        $this->assertEquals("function() { return 'function2'; }", trim($content));
+
+        $function = new FunctionReflection($function9);
+        $content = $function->getContents(false);
+        $this->assertEquals("function() {}", trim($content));
+    }
+
     public function testFunctionContentsReturnWithDocBlock()
     {
         require_once __DIR__ . '/TestAsset/functions.php';
-
-        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function1');
-        $content = $function->getContents();
-        $this->assertEquals("function function1()\n{\n    return 'function1';\n}", trim($content));
-        $this->assertEquals($function->getContents(true), $function->getContents(false));
 
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function3');
         $content = $function->getContents();
         $this->assertEquals("/**\n * Enter description here...\n *\n * @param string \$one\n * @param int \$two"
                           . "\n * @return true\n */\nfunction function3(\$one, \$two = 2)\n{\n    return true;\n}", trim($content));
+    }
+
+    public function testFunctionClosureContentsReturnWithDocBlock()
+    {
+        require __DIR__ . '/TestAsset/closures.php';
+
+        $function = new FunctionReflection($function9);
+        $content = $function->getContents();
+        $this->assertEquals("/**\n * closure doc block\n */\nfunction() {}", trim($content));
     }
 }

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -118,6 +118,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function7);
         $body = $function->getBody();
         $this->assertEquals("return \$c = function() { return 'function7'; }; return \$c();", trim($body));
+
+        $function = new FunctionReflection($function8);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function 8';", trim($body));
     }
 
     public function testInternalFunctionContentsReturn()

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -83,5 +83,27 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function4);
         $body = $function->getBody();
         $this->assertEquals("\$closure = function() { return 'bar'; };\n    return 'function4';", trim($body));
+        
+        $function5 = $list1['closure'];
+        $function = new FunctionReflection($function5);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function5';", trim($body));
+        
+        $function6 = $list2[0];
+        $function = new FunctionReflection($function6);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function6';", trim($body));
+        
+        $function7 = $list3[0];
+        $function = new FunctionReflection($function7);
+        $body = $function->getBody();
+        $this->assertEquals("return \$c = function() { return 'function7'; }; return \$c();", trim($body));
+    }
+    
+    public function testInternalFunctionContentsReturn()
+    {
+        $function = new FunctionReflection('array_splice');
+        $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
+        $body = $function->getContents();
     }
 }

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -66,8 +66,24 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function7');
         $body = $function->getBody();
         $this->assertEquals("return 'function7';", trim($body));
+        
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function8');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function8';", trim($body));
+        
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function9');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function9';", trim($body));
+        
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function10');
+        $body = $function->getBody();
+        $this->assertEquals("\$closure = function() { return 'function10'; }; return \$closure();", trim($body));
+        
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function11');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function11';", trim($body));
     }
-
+    
     public function testFunctionClosureBodyReturn()
     {
         require_once __DIR__ . '/TestAsset/closures.php';

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -62,28 +62,28 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
         $body = $function->getBody();
         $this->assertEquals("\$closure = function() { return 'bar'; };\n    return 'function6';", trim($body));
-        
+
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function7');
         $body = $function->getBody();
         $this->assertEquals("return 'function7';", trim($body));
-        
+
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function8');
         $body = $function->getBody();
         $this->assertEquals("return 'function8';", trim($body));
-        
+
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function9');
         $body = $function->getBody();
         $this->assertEquals("return 'function9';", trim($body));
-        
+
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function10');
         $body = $function->getBody();
         $this->assertEquals("\$closure = function() { return 'function10'; }; return \$closure();", trim($body));
-        
+
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function11');
         $body = $function->getBody();
         $this->assertEquals("return 'function11';", trim($body));
     }
-    
+
     public function testFunctionClosureBodyReturn()
     {
         require_once __DIR__ . '/TestAsset/closures.php';
@@ -103,23 +103,23 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function4);
         $body = $function->getBody();
         $this->assertEquals("\$closure = function() { return 'bar'; };\n    return 'function4';", trim($body));
-        
+
         $function5 = $list1['closure'];
         $function = new FunctionReflection($function5);
         $body = $function->getBody();
         $this->assertEquals("return 'function5';", trim($body));
-        
+
         $function6 = $list2[0];
         $function = new FunctionReflection($function6);
         $body = $function->getBody();
         $this->assertEquals("return 'function6';", trim($body));
-        
+
         $function7 = $list3[0];
         $function = new FunctionReflection($function7);
         $body = $function->getBody();
         $this->assertEquals("return \$c = function() { return 'function7'; }; return \$c();", trim($body));
     }
-    
+
     public function testInternalFunctionContentsReturn()
     {
         $function = new FunctionReflection('array_splice');

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -61,7 +61,7 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
 
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
         $body = $function->getBody();
-        $this->assertEquals("\$closure = function() { return 'bar'; };     return 'function6';", trim($body));
+        $this->assertEquals("\$closure = function() { return 'bar'; };\n    return 'function6';", trim($body));
     }
 
     public function testFunctionClosureBodyReturn()
@@ -82,6 +82,6 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
 
         $function = new FunctionReflection($function4);
         $body = $function->getBody();
-        $this->assertEquals("\$closure = function() { return 'bar'; };     return 'function4';", trim($body));
+        $this->assertEquals("\$closure = function() { return 'bar'; };\n    return 'function4';", trim($body));
     }
 }

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -128,6 +128,62 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
     {
         $function = new FunctionReflection('array_splice');
         $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
-        $body = $function->getContents();
+        $content = $function->getContents();
+    }
+    
+    public function testFunctionContentsReturnWithoutDocBlock()
+    {
+        require_once __DIR__ . '/TestAsset/functions.php';
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function1');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function1()\n{\n    return 'function1';\n}", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function4');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function4(\$arg) {\n    return 'function4';\n}", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function5');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function5() { return 'function5'; }", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function6()\n{\n    \$closure = function() { return 'bar'; };\n    return 'function6';\n}", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function7');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function7() { return 'function7'; }", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function8');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function8() { return 'function8'; }", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function9');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function9() { return 'function9'; }", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function10');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function10() { \$closure = function() { return 'function10'; }; return \$closure(); }", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function11');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function11() { return 'function11'; }", trim($content));
+    }
+    
+    public function testFunctionContentsReturnWithDocBlock()
+    {
+        require_once __DIR__ . '/TestAsset/functions.php';
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function1');
+        $content = $function->getContents();
+        $this->assertEquals("function function1()\n{\n    return 'function1';\n}", trim($content));
+        $this->assertEquals($function->getContents(true), $function->getContents(false));
+        
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function3');
+        $content = $function->getContents();
+        $this->assertEquals("/**\n * Enter description here...\n *\n * @param string \$one\n * @param int \$two"
+                          . "\n * @return true\n */\nfunction function3(\$one, \$two = 2)\n{\n    return true;\n}", trim($content));
     }
 }

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -32,7 +32,56 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
     public function testFunctionDocBlockReturn()
     {
         require_once __DIR__ . '/TestAsset/functions.php';
-        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function3');
         $this->assertInstanceOf('Zend\Code\Reflection\DocBlockReflection', $function->getDocBlock());
+    }
+
+    public function testInternalFunctionBodyReturn()
+    {
+        $function = new FunctionReflection('array_splice');
+        $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
+        $body = $function->getBody();
+    }
+
+    public function testFunctionBodyReturn()
+    {
+        require_once __DIR__ . '/TestAsset/functions.php';
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function1');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function1';", trim($body));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function4');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function4';", trim($body));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function5');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function5';", trim($body));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
+        $body = $function->getBody();
+        $this->assertEquals("\$closure = function() { return 'bar'; };     return 'function6';", trim($body));
+    }
+
+    public function testFunctionClosureBodyReturn()
+    {
+        require_once __DIR__ . '/TestAsset/closures.php';
+
+        $function = new FunctionReflection($function1);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function1';", trim($body));
+
+        $function = new FunctionReflection($function2);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function2';", trim($body));
+
+        $function = new FunctionReflection($function3);
+        $body = $function->getBody();
+        $this->assertEquals("return 'function3';", trim($body));
+
+        $function = new FunctionReflection($function4);
+        $body = $function->getBody();
+        $this->assertEquals("\$closure = function() { return 'bar'; };     return 'function4';", trim($body));
     }
 }

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -62,6 +62,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
         $body = $function->getBody();
         $this->assertEquals("\$closure = function() { return 'bar'; };\n    return 'function6';", trim($body));
+        
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function7');
+        $body = $function->getBody();
+        $this->assertEquals("return 'function7';", trim($body));
     }
 
     public function testFunctionClosureBodyReturn()

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -82,6 +82,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function11');
         $body = $function->getBody();
         $this->assertEquals("return 'function11';", trim($body));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
+        $body = $function->getBody();
+        $this->assertEquals("", trim($body));
     }
 
     public function testFunctionClosureBodyReturn()
@@ -122,6 +126,10 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function8);
         $body = $function->getBody();
         $this->assertEquals("return 'function 8';", trim($body));
+
+        $function = new FunctionReflection($function9);
+        $body = $function->getBody();
+        $this->assertEquals("", trim($body));
     }
 
     public function testInternalFunctionContentsReturn()
@@ -130,7 +138,7 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
         $content = $function->getContents();
     }
-    
+
     public function testFunctionContentsReturnWithoutDocBlock()
     {
         require_once __DIR__ . '/TestAsset/functions.php';
@@ -170,8 +178,12 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function11');
         $content = $function->getContents(false);
         $this->assertEquals("function function11() { return 'function11'; }", trim($content));
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
+        $content = $function->getContents(false);
+        $this->assertEquals("function function12() {}", trim($content));
     }
-    
+
     public function testFunctionContentsReturnWithDocBlock()
     {
         require_once __DIR__ . '/TestAsset/functions.php';
@@ -180,7 +192,7 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $content = $function->getContents();
         $this->assertEquals("function function1()\n{\n    return 'function1';\n}", trim($content));
         $this->assertEquals($function->getContents(true), $function->getContents(false));
-        
+
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function3');
         $content = $function->getContents();
         $this->assertEquals("/**\n * Enter description here...\n *\n * @param string \$one\n * @param int \$two"

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -93,6 +93,10 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'emptyFunction');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'visibility');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'visibility';");
     }
 
     public function testInternalMethodContentsReturn()

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -72,7 +72,7 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
 
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingAgain');
         $body = $reflectionMethod->getBody();
-        $this->assertEquals(trim($body), "\$closure = function(\$foo) { return \$foo; };\n        return 'doSomethingAgain';");
+        $this->assertEquals(trim($body), "\$closure = function(\$foo) { return \$foo; };\n\n        return 'doSomethingAgain';");
 
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doStaticSomething');
         $body = $reflectionMethod->getBody();
@@ -109,10 +109,12 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testMethodContentsReturnWithoutDocBlock()
     {
-        $contents =
-              '    public function doSomething() {' . "\n"
-            . '        return \'doSomething\';' . "\n"
-            . '    }';
+        $contents = <<<CONTENTS
+    public function doSomething()
+    {
+        return 'doSomething';
+    }
+CONTENTS;
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
@@ -120,12 +122,14 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingElse');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
-        $contents =
-              '    public function doSomethingAgain()' . "\n"
-            . '    {' . "\n"
-            . '        $closure = function($foo) { return $foo; };' . "\n"
-            . '        return \'doSomethingAgain\';' . "\n"
-            . '    }';
+        $contents = <<<'CONTENTS'
+    public function doSomethingAgain()
+    {
+        $closure = function($foo) { return $foo; };
+
+        return 'doSomethingAgain';
+    }
+CONTENTS;
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingAgain');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
 
@@ -140,27 +144,39 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $contents = ' public function inline3() { return \'inline3\'; }';
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline3');
         $this->assertEquals($contents, $reflectionMethod->getContents(false));
+        
+        $contents = <<<'CONTENTS'
+    public function visibility()
+    {
+        return 'visibility';
+    }
+CONTENTS;
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'visibility');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
     }
 
     public function testFunctionContentsReturnWithDocBlock()
     {
-        $contents =
-              '/**' . "\n"
-            . '     * Doc block doSomething' . "\n"
-            . '     * @return string' . "\n"
-            . '     */' . "\n"
-            . '    public function doSomething() {' . "\n"
-            . '        return \'doSomething\';' . "\n"
-            . '    }';
+        $contents = <<<'CONTENTS'
+/**
+     * Doc block doSomething
+     * @return string
+     */
+    public function doSomething()
+    {
+        return 'doSomething';
+    }
+CONTENTS;
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
         $this->assertEquals($contents, $reflectionMethod->getContents(true));
         $this->assertEquals($contents, $reflectionMethod->getContents());
 
-        $contents =
-              '/**' . "\n"
-            . '     * Awesome doc block' . "\n"
-            . '     */' . "\n"
-            . '    public function emptyFunction() {}';
+                $contents = <<<'CONTENTS'
+/**
+     * Awesome doc block
+     */
+    public function emptyFunction() {}
+CONTENTS;
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'emptyFunction');
         $this->assertEquals($contents, $reflectionMethod->getContents(true));
     }

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -45,12 +45,30 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBodyReturnsCorrectBody()
     {
-        $body = '        //we need a multi-line method body.
+        $body = '
+        //we need a multi-line method body.
         $assigned = 1;
         $alsoAssigined = 2;
-        return \'mixedValue\';';
+        return \'mixedValue\';
+    ';
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6', 'doSomething');
         $this->assertEquals($body, $reflectionMethod->getBody());
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'doSomething';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingElse');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'doSomethingElse';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingAgain');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "\$closure = function(\$foo) { return \$foo; };\n        return 'doSomethingAgain';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doStaticSomething');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'doStaticSomething';");
     }
 
     public function testGetContentsReturnsCorrectContent()

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -42,6 +42,14 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(37, $reflectionMethod->getStartLine());
         $this->assertEquals(21, $reflectionMethod->getStartLine(true));
     }
+    
+    public function testInternalFunctionContentsReturn()
+    {
+        $reflectionMethod = new MethodReflection('DOMDocument', 'validate');
+        
+        $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
+        $contents = $reflectionMethod->getContents();
+    }
 
     public function testGetBodyReturnsCorrectBody()
     {

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -69,6 +69,22 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doStaticSomething');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doStaticSomething';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline1');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'inline1';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline2');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'inline2';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline3');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "return 'inline3';");
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'emptyFunction');
+        $body = $reflectionMethod->getBody();
+        $this->assertEquals(trim($body), "");
     }
 
     public function testGetContentsReturnsCorrectContent()

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -42,13 +42,13 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(37, $reflectionMethod->getStartLine());
         $this->assertEquals(21, $reflectionMethod->getStartLine(true));
     }
-    
-    public function testInternalFunctionContentsReturn()
+
+    public function testInternalFunctionBodyReturn()
     {
         $reflectionMethod = new MethodReflection('DOMDocument', 'validate');
-        
+
         $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
-        $contents = $reflectionMethod->getContents();
+        $body = $reflectionMethod->getBody();
     }
 
     public function testGetBodyReturnsCorrectBody()
@@ -61,44 +61,103 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
     ';
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6', 'doSomething');
         $this->assertEquals($body, $reflectionMethod->getBody());
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doSomething';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingElse');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doSomethingElse';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingAgain');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "\$closure = function(\$foo) { return \$foo; };\n        return 'doSomethingAgain';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doStaticSomething');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'doStaticSomething';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline1');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'inline1';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline2');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'inline2';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline3');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "return 'inline3';");
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'emptyFunction');
         $body = $reflectionMethod->getBody();
         $this->assertEquals(trim($body), "");
     }
 
-    public function testGetContentsReturnsCorrectContent()
+    public function testInternalMethodContentsReturn()
     {
-        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5', 'doSomething');
-        $this->assertEquals("    {\n\n        return 'mixedValue';\n\n    }\n", $reflectionMethod->getContents(false));
+        $reflectionMethod = new MethodReflection('DOMDocument', 'validate');
+
+        $this->setExpectedException('Zend\Code\Reflection\Exception\InvalidArgumentException');
+        $contents = $reflectionMethod->getContents();
     }
 
+    public function testMethodContentsReturnWithoutDocBlock()
+    {
+        $contents =
+              '    public function doSomething() {' . "\n"
+            . '        return \'doSomething\';' . "\n"
+            . '    }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
+
+        $contents = '    public function doSomethingElse($one, $two = 2, $three = \'three\') { return \'doSomethingElse\'; }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingElse');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
+
+        $contents =
+              '    public function doSomethingAgain()' . "\n"
+            . '    {' . "\n"
+            . '        $closure = function($foo) { return $foo; };' . "\n"
+            . '        return \'doSomethingAgain\';' . "\n"
+            . '    }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomethingAgain');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
+
+        $contents = '    public function inline1() { return \'inline1\'; }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline1');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
+
+        $contents = ' public function inline2() { return \'inline2\'; }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline2');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
+
+        $contents = ' public function inline3() { return \'inline3\'; }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'inline3');
+        $this->assertEquals($contents, $reflectionMethod->getContents(false));
+    }
+
+    public function testFunctionContentsReturnWithDocBlock()
+    {
+        $contents =
+              '/**' . "\n"
+            . '     * Doc block doSomething' . "\n"
+            . '     * @return string' . "\n"
+            . '     */' . "\n"
+            . '    public function doSomething() {' . "\n"
+            . '        return \'doSomething\';' . "\n"
+            . '    }';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'doSomething');
+        $this->assertEquals($contents, $reflectionMethod->getContents(true));
+        $this->assertEquals($contents, $reflectionMethod->getContents());
+
+        $contents =
+              '/**' . "\n"
+            . '     * Awesome doc block' . "\n"
+            . '     */' . "\n"
+            . '    public function emptyFunction() {}';
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', 'emptyFunction');
+        $this->assertEquals($contents, $reflectionMethod->getContents(true));
+    }
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
@@ -19,27 +19,34 @@ class TestSampleClass11
      * Doc block doSomething
      * @return string
      */
-    public function doSomething() {
+    public function doSomething()
+    {
         return 'doSomething';
     }
 
     public function doSomethingElse($one, $two = 2, $three = 'three') { return 'doSomethingElse'; }
-    
+
     public function doSomethingAgain()
     {
         $closure = function($foo) { return $foo; };
+
         return 'doSomethingAgain';
     }
-    
+
     protected static function doStaticSomething()
     {
         return 'doStaticSomething';
     }
-    
+
     public function inline1() { return 'inline1'; } public function inline2() { return 'inline2'; } public function inline3() { return 'inline3'; }
-    
+
     /**
      * Awesome doc block
      */
     public function emptyFunction() {}
+
+    public function visibility()
+    {
+        return 'visibility';
+    }
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
@@ -38,5 +38,8 @@ class TestSampleClass11
     
     public function inline1() { return 'inline1'; } public function inline2() { return 'inline2'; } public function inline3() { return 'inline3'; }
     
+    /**
+     * Awesome doc block
+     */
     public function emptyFunction() {}
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+class TestSampleClass11
+{
+    public function doSomething() {
+        return 'doSomething';
+    }
+
+    public function doSomethingElse($one, $two = 2, $three = 'three') { return 'doSomethingElse'; }
+    
+    public function doSomethingAgain()
+    {
+        $closure = function($foo) { return $foo; };
+        return 'doSomethingAgain';
+    }
+    
+    protected static function doStaticSomething()
+    {
+        return 'doStaticSomething';
+    }
+}

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass11.php
@@ -9,8 +9,16 @@
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
+/**
+ * /!\ Don't fix this file with the coding style.
+ * The class Zend\Code\Reflection\FunctionReflection must parse a lot of closure formats
+ */
 class TestSampleClass11
 {
+    /**
+     * Doc block doSomething
+     * @return string
+     */
     public function doSomething() {
         return 'doSomething';
     }
@@ -27,4 +35,8 @@ class TestSampleClass11
     {
         return 'doStaticSomething';
     }
+    
+    public function inline1() { return 'inline1'; } public function inline2() { return 'inline2'; } public function inline3() { return 'inline3'; }
+    
+    public function emptyFunction() {}
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -44,4 +44,4 @@ $function8 = function() use ($list1) { return 'function 8'; };
  */
 $function9 = function() {};
 
-eval('$function10 = function() { return \'function10\'; };');
+eval("\$function10 = function() { return 'function10'; };");

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Code
  */
 
 namespace ZendTest\Code\Reflection\TestAsset;

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -43,3 +43,5 @@ $function8 = function() use ($list1) { return 'function 8'; };
  * closure doc block
  */
 $function9 = function() {};
+
+eval('$function10 = function() { return \'function10\'; };');

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -39,4 +39,7 @@ $list3 = array(function() { return $c = function() { return 'function7'; }; retu
 
 $function8 = function() use ($list1) { return 'function 8'; };
 
+/**
+ * closure doc block
+ */
 $function9 = function() {};

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -38,3 +38,5 @@ $list2 = array(function() { return 'function6'; });
 $list3 = array(function() { return $c = function() { return 'function7'; }; return $c(); });
 
 $function8 = function() use ($list1) { return 'function 8'; };
+
+$function9 = function() {};

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -10,6 +10,11 @@
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
+/**
+ * /!\ Don't fix this file with the coding style.
+ * The class Zend\Code\Reflection\FunctionReflection must parse a lot of closure formats
+ */
+
 $function1 = function()
 {
     return 'function1';
@@ -26,3 +31,9 @@ $function4 = function()
     $closure = function() { return 'bar'; };
     return 'function4';
 };
+
+$list1 = array('closure' => function() { return 'function5'; });
+
+$list2 = array(function() { return 'function6'; });
+
+$list3 = array(function() { return $c = function() { return 'function7'; }; return $c(); });

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -36,3 +36,5 @@ $list1 = array('closure' => function() { return 'function5'; });
 $list2 = array(function() { return 'function6'; });
 
 $list3 = array(function() { return $c = function() { return 'function7'; }; return $c(); });
+
+$function8 = function() use ($list1) { return 'function 8'; };

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
-/**
+/***
  * /!\ Don't fix this file with the coding style.
  * The class Zend\Code\Reflection\FunctionReflection must parse a lot of closure formats
  */

--- a/tests/ZendTest/Code/Reflection/TestAsset/closures.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/closures.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Code
+ */
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+$function1 = function()
+{
+    return 'function1';
+};
+
+$function2 = function() { return 'function2'; };
+
+$function3 = function($arg) {
+    return 'function3';
+};
+
+$function4 = function()
+{
+    $closure = function() { return 'bar'; };
+    return 'function4';
+};

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -66,3 +66,5 @@ function function8() { return 'function8'; } function function9() { return 'func
 function function10() { $closure = function() { return 'function10'; }; return $closure(); } function function11() { return 'function11'; }
 
 function function12() {}
+
+eval('function function13() { return "function13"; }');

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Code
  */
 
 namespace ZendTest\Code\Reflection\TestAsset;

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -66,5 +66,3 @@ function function8() { return 'function8'; } function function9() { return 'func
 function function10() { $closure = function() { return 'function10'; }; return $closure(); } function function11() { return 'function11'; }
 
 function function12() {}
-
-eval('function function13() { return "function13"; }');

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -61,3 +61,7 @@ function function6()
 }
 
 $foo = 'foo'; function function7() { return 'function7'; }
+
+function function8() { return 'function8'; } function function9() { return 'function9'; }
+
+function function10() { $closure = function() { return 'function10'; }; return $closure(); } function function11() { return 'function11'; }

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
-/**
+/***
  * /!\ Don't fix this file with the coding style.
  * The class Zend\Code\Reflection\FunctionReflection must parse a lot of closure formats
  */

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -64,3 +64,5 @@ $foo = 'foo'; function function7() { return 'function7'; }
 function function8() { return 'function8'; } function function9() { return 'function9'; }
 
 function function10() { $closure = function() { return 'function10'; }; return $closure(); } function function11() { return 'function11'; }
+
+function function12() {}

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -12,7 +12,7 @@ namespace ZendTest\Code\Reflection\TestAsset;
 
 function function1()
 {
-    return 'foo';
+    return 'function1';
 }
 
 
@@ -38,7 +38,19 @@ function function2($one, $two = 'two')
  * @param int $two
  * @return true
  */
-function function6($one, $two = 2)
+function function3($one, $two = 2)
 {
     return true;
+}
+
+function function4($arg) {
+    return 'function4';
+}
+
+function function5() { return 'function5'; }
+
+function function6()
+{
+    $closure = function() { return 'bar'; };
+    return 'function6';
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -10,6 +10,11 @@
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
+/**
+ * /!\ Don't fix this file with the coding style.
+ * The class Zend\Code\Reflection\FunctionReflection must parse a lot of closure formats
+ */
+
 function function1()
 {
     return 'function1';
@@ -54,3 +59,5 @@ function function6()
     $closure = function() { return 'bar'; };
     return 'function6';
 }
+
+$foo = 'foo'; function function7() { return 'function7'; }


### PR DESCRIPTION
Zend\Code\Reflection getBody function is often broken with some code format
- [x] implement getBody in FunctionReflection
- [x] fix getBody in MethodReflection
- [x] fix getContents in FunctionReflection
- [x] fix getContents in MethodReflection
