### PR TITLE
move zendframework/zend-escaper from require to suggest dependency at Zend\Debug

### DIFF
--- a/library/Zend/Debug/composer.json
+++ b/library/Zend/Debug/composer.json
@@ -13,11 +13,11 @@
     },
     "target-dir": "Zend/Debug",
     "require": {
-        "php": ">=5.3.3",
-        "zendframework/zend-escaper": "self.version"
+        "php": ">=5.3.3"
     },
     "suggest": {
-        "ext/xdebug": "XDebug, for better backtrace output"
+        "ext/xdebug": "XDebug, for better backtrace output",
+        "zendframework/zend-escaper": "To support escaped output"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
because only used when we use setEscaper(new \Zend\Escaper\Escaper()). it related to #5240
