### PR TITLE
explode should be made only by colon (:) and not colon+space (: )

### DIFF
--- a/library/Zend/Http/Header/Etag.php
+++ b/library/Zend/Http/Header/Etag.php
@@ -15,6 +15,7 @@ namespace Zend\Http\Header;
  */
 class Etag implements HeaderInterface
 {
+    protected $value;
 
     public static function fromString($headerLine)
     {


### PR DESCRIPTION
I think that was a typo :)
