### PR TITLE
explode should be made only by colon (:) and not colon+space (: )

### DIFF
--- a/library/Zend/Http/Header/Etag.php
+++ b/library/Zend/Http/Header/Etag.php
@@ -15,15 +15,16 @@ namespace Zend\Http\Header;
  */
 class Etag implements HeaderInterface
 {
+    protected $value;
 
     public static function fromString($headerLine)
     {
         $header = new static();
 
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = explode(':', $headerLine, 2);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'etag') {
+        if (strtolower(trim($name)) !== 'etag') {
             throw new Exception\InvalidArgumentException('Invalid header line for Etag string: "' . $name . '"');
         }
 


### PR DESCRIPTION
I think that was a typo :)
Added protected property $value
