### PR TITLE
Get ViewModel children by capture

### DIFF
--- a/library/Zend/View/Model/ModelInterface.php
+++ b/library/Zend/View/Model/ModelInterface.php
@@ -121,6 +121,15 @@ interface ModelInterface extends Countable, IteratorAggregate
     public function hasChildren();
 
     /**
+     * Returns an array of ModelInterface with captureTo value $capture
+     *
+     * @param string $capture
+     * @param bool $recursive search recursive through children, default true
+     * @return array
+     */
+    public function getChildrenByCaptureTo($capture, $recursive = true);
+        
+    /**
      * Set the name of the variable to capture this model to, if it is a child model
      *
      * @param  string $capture

--- a/library/Zend/View/Model/ModelInterface.php
+++ b/library/Zend/View/Model/ModelInterface.php
@@ -128,7 +128,7 @@ interface ModelInterface extends Countable, IteratorAggregate
      * @return array
      */
     public function getChildrenByCaptureTo($capture, $recursive = true);
-        
+
     /**
      * Set the name of the variable to capture this model to, if it is a child model
      *

--- a/library/Zend/View/Model/ModelInterface.php
+++ b/library/Zend/View/Model/ModelInterface.php
@@ -121,15 +121,6 @@ interface ModelInterface extends Countable, IteratorAggregate
     public function hasChildren();
 
     /**
-     * Returns an array of ModelInterface with captureTo value $capture
-     *
-     * @param string $capture
-     * @param bool $recursive search recursive through children, default true
-     * @return array
-     */
-    public function getChildrenByCaptureTo($capture, $recursive = true);
-
-    /**
      * Set the name of the variable to capture this model to, if it is a child model
      *
      * @param  string $capture

--- a/library/Zend/View/Model/RetrievableChildrenInterface.php
+++ b/library/Zend/View/Model/RetrievableChildrenInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -6,7 +7,6 @@
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace Zend\View\Model;
 
 /**
@@ -16,6 +16,7 @@ namespace Zend\View\Model;
  */
 interface RetrievableChildrenInterface
 {
+
     /**
      * Returns an array of Viewmodels with captureTo value $capture
      *
@@ -24,5 +25,4 @@ interface RetrievableChildrenInterface
      * @return array
      */
     public function getChildrenByCaptureTo($capture, $recursive = true);
-    
 }

--- a/library/Zend/View/Model/RetrievableChildrenInterface.php
+++ b/library/Zend/View/Model/RetrievableChildrenInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Model;
+
+/**
+ * Interface describing a Retrievable Child Model
+ *
+ * Models implementing this interface provide a way to get there children by capture
+ */
+interface RetrievableChildrenInterface
+{
+    /**
+     * Returns an array of Viewmodels with captureTo value $capture
+     *
+     * @param string $capture
+     * @param bool $recursive search recursive through children, default true
+     * @return array
+     */
+    public function getChildrenByCaptureTo($capture, $recursive = true);
+    
+}

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -17,7 +17,7 @@ use Zend\View\Exception;
 use Zend\View\Model;
 use Zend\View\Variables as ViewVariables;
 
-class ViewModel implements ModelInterface, ClearableModelInterface
+class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableChildrenInterface
 {
     /**
      * What variable a parent model should capture this model to

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -380,6 +380,19 @@ class ViewModel implements ModelInterface, ClearableModelInterface
         return $this;
     }
 
+    public function getChildrenByCaptureTo($capture)
+    {
+        $children = array();
+        
+        foreach ($this->children as $child) {
+            if ($child->captureTo() === $capture) {
+                $children[] = $child;
+            }
+        }
+
+        return $children;
+    }
+
     /**
      * Set the name of the variable to capture this model to, if it is a child model
      *

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -385,6 +385,7 @@ class ViewModel implements ModelInterface, ClearableModelInterface
         $children = array();
         
         foreach ($this->children as $child) {
+            $children += $child->getChildrenByCaptureTo($capture);
             if ($child->captureTo() === $capture) {
                 $children[] = $child;
             }

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -380,7 +380,14 @@ class ViewModel implements ModelInterface, ClearableModelInterface
         return $this;
     }
 
-    public function getChildrenByCaptureTo($capture)
+    /**
+     * Returns an array of Viewmodels with captureTo value $capture
+     *
+     * @param string $capture
+     * @param bool $recursive search recursive through children, default true
+     * @return array
+     */
+    public function getChildrenByCaptureTo($capture, $recursive = true)
     {
         $children = array();
         

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -385,7 +385,10 @@ class ViewModel implements ModelInterface, ClearableModelInterface
         $children = array();
         
         foreach ($this->children as $child) {
-            $children += $child->getChildrenByCaptureTo($capture);
+            if ($recursive === true) {
+                $children += $child->getChildrenByCaptureTo($capture);
+            }
+            
             if ($child->captureTo() === $capture) {
                 $children[] = $child;
             }

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -390,12 +390,12 @@ class ViewModel implements ModelInterface, ClearableModelInterface
     public function getChildrenByCaptureTo($capture, $recursive = true)
     {
         $children = array();
-        
+
         foreach ($this->children as $child) {
             if ($recursive === true) {
                 $children += $child->getChildrenByCaptureTo($capture);
             }
-            
+
             if ($child->captureTo() === $capture) {
                 $children[] = $child;
             }

--- a/tests/ZendTest/View/Model/ViewModelTest.php
+++ b/tests/ZendTest/View/Model/ViewModelTest.php
@@ -312,4 +312,13 @@ class ViewModelTest extends TestCase
         $this->assertTrue(isset($variables['bar']));
         $this->assertEquals('baz', $variables['bar']);
     }
+
+    public function testGetChildrenByCaptureTo()
+    {
+        $model = new ViewModel();
+        $child = new ViewModel();
+        $model->addChild($child, 'foo');
+
+        $this->assertEquals(array($child), $model->getChildrenByCaptureTo('foo'));
+    }    
 }

--- a/tests/ZendTest/View/Model/ViewModelTest.php
+++ b/tests/ZendTest/View/Model/ViewModelTest.php
@@ -331,5 +331,16 @@ class ViewModelTest extends TestCase
         $model->addChild($child, 'foo');
 
         $this->assertEquals(array($subChild), $model->getChildrenByCaptureTo('bar'));
-    }    
+    }
+
+    public function testGetChildrenByCaptureToNonRecursive()
+    {
+        $model = new ViewModel();
+        $child = new ViewModel();
+        $subChild = new ViewModel();
+        $child->addChild($subChild, 'bar');
+        $model->addChild($child, 'foo');
+
+        $this->assertEmpty($model->getChildrenByCaptureTo('bar', false));
+    }
 }

--- a/tests/ZendTest/View/Model/ViewModelTest.php
+++ b/tests/ZendTest/View/Model/ViewModelTest.php
@@ -322,7 +322,7 @@ class ViewModelTest extends TestCase
         $this->assertEquals(array($child), $model->getChildrenByCaptureTo('foo'));
     }
 
-    public function testGetChildrenByCaptureToRecusive()
+    public function testGetChildrenByCaptureToRecursive()
     {
         $model = new ViewModel();
         $child = new ViewModel();

--- a/tests/ZendTest/View/Model/ViewModelTest.php
+++ b/tests/ZendTest/View/Model/ViewModelTest.php
@@ -320,5 +320,16 @@ class ViewModelTest extends TestCase
         $model->addChild($child, 'foo');
 
         $this->assertEquals(array($child), $model->getChildrenByCaptureTo('foo'));
+    }
+
+    public function testGetChildrenByCaptureToRecusive()
+    {
+        $model = new ViewModel();
+        $child = new ViewModel();
+        $subChild = new ViewModel();
+        $child->addChild($subChild, 'bar');
+        $model->addChild($child, 'foo');
+
+        $this->assertEquals(array($subChild), $model->getChildrenByCaptureTo('bar'));
     }    
 }


### PR DESCRIPTION
We wanted to add new content to the page view model using a listener. But in the MvcEvent pass to the listeners the view model is always the complete layout ViewModel and not only the page content model. So we needed a way to get a ViewModel by it's location in the template. 
