### PR TITLE
Remove hard comparation and use is_null() function

### DIFF
--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -190,7 +190,7 @@ class Request extends AbstractMessage implements RequestInterface
      */
     public function getUri()
     {
-        if ($this->uri === null || is_string($this->uri)) {
+        if (is_null($this->uri) || is_string($this->uri)) {
             $this->uri = new HttpUri($this->uri);
         }
         return $this->uri;


### PR DESCRIPTION
Is there any reason why you can not make this comparison with is_null()?
I think this may be more semantic way.
