### PR TITLE
Modified PhpArray config writer to generate better readable array format.

### DIFF
--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -49,7 +49,7 @@ class PhpArray extends AbstractWriter
 
         foreach ($config as $key => $value) {
             $arrayString .= str_repeat('    ', $indentLevel);
-            $arrayString .= (is_numeric($key) ? $key : "'" . addslashes($key) . "'") . ' => ';
+            $arrayString .= (is_int($key) ? $key : "'" . addslashes($key) . "'") . ' => ';
 
             if (is_array($value)) {
                 if ($value === array()) {

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -29,13 +29,14 @@ class PhpArray extends AbstractWriter
      */
     public function processConfig(array $config)
     {
-        $array = array(
+        $arraySyntax = array(
             'open' => $this->useBracketArraySyntax ? '[' : 'array(',
             'close' => $this->useBracketArraySyntax ? ']' : ')'
         );
 
         return "<?php\n\n" .
-               "return " . $array['open'] . "\n" . $this->processIndented($config, $array) . $array['close'] . ";\n";
+               "return " . $arraySyntax['open'] . "\n" . $this->processIndented($config, $arraySyntax) .
+               $arraySyntax['close'] . ";\n";
     }
 
     /**
@@ -52,11 +53,11 @@ class PhpArray extends AbstractWriter
      * Recursively processes a PHP config array structure into a readable format.
      *
      * @param array $config
-     * @param array $array
+     * @param array $arraySyntax
      * @param int $indentLevel
      * @return string
      */
-    protected function processIndented(array $config, array $array, &$indentLevel = 1)
+    protected function processIndented(array $config, array $arraySyntax, &$indentLevel = 1)
     {
         $arrayString = "";
 
@@ -66,12 +67,12 @@ class PhpArray extends AbstractWriter
 
             if (is_array($value)) {
                 if ($value === array()) {
-                    $arrayString .= $array['open'] . $array['close'] . ",\n";
+                    $arrayString .= $arraySyntax['open'] . $arraySyntax['close'] . ",\n";
                 } else {
                     $indentLevel++;
-                    $arrayString .= $array['open'] . "\n"
-                                  . $this->processIndented($value, $array, $indentLevel)
-                                  . str_repeat(self::INDENT_STRING, --$indentLevel) . $array['close'] . ",\n";
+                    $arrayString .= $arraySyntax['open'] . "\n"
+                                  . $this->processIndented($value, $arraySyntax, $indentLevel)
+                                  . str_repeat(self::INDENT_STRING, --$indentLevel) . $arraySyntax['close'] . ",\n";
                 }
             } elseif (is_object($value)) {
                 $arrayString .= var_export($value, true) . ",\n";

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -42,7 +42,8 @@ class PhpArray extends AbstractWriter
     /**
      * Sets whether or not to use the PHP 5.4+ "[]" array syntax.
      *
-     * @param bool $value
+     * @param  bool $value
+     * @return void
      */
     public function setUseBracketArraySyntax($value)
     {
@@ -52,9 +53,9 @@ class PhpArray extends AbstractWriter
     /**
      * Recursively processes a PHP config array structure into a readable format.
      *
-     * @param array $config
-     * @param array $arraySyntax
-     * @param int $indentLevel
+     * @param  array $config
+     * @param  array $arraySyntax
+     * @param  int   $indentLevel
      * @return string
      */
     protected function processIndented(array $config, array $arraySyntax, &$indentLevel = 1)

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -34,7 +34,7 @@ class PhpArray extends AbstractWriter
             'close' => $this->useBracketArraySyntax ? ']' : ')'
         );
 
-        return "<?php\n\n" .
+        return "<?php\n" .
                "return " . $arraySyntax['open'] . "\n" . $this->processIndented($config, $arraySyntax) .
                $arraySyntax['close'] . ";\n";
     }

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -43,11 +43,12 @@ class PhpArray extends AbstractWriter
      * Sets whether or not to use the PHP 5.4+ "[]" array syntax.
      *
      * @param  bool $value
-     * @return void
+     * @return self
      */
     public function setUseBracketArraySyntax($value)
     {
         $this->useBracketArraySyntax = $value;
+        return $this;
     }
 
     /**

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -48,6 +48,14 @@ class PhpArray extends AbstractWriter
         $this->useBracketArraySyntax = $value;
     }
 
+    /**
+     * Recursively processes a PHP config array structure into a readable format.
+     *
+     * @param array $config
+     * @param array $array
+     * @param int $indentLevel
+     * @return string
+     */
     protected function processIndented(array $config, array $array, &$indentLevel = 1)
     {
         $arrayString = "";

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -12,6 +12,11 @@ namespace Zend\Config\Writer;
 class PhpArray extends AbstractWriter
 {
     /**
+     * @var string
+     */
+    const INDENT_STRING = '    ';
+
+    /**
      * @var bool
      */
     protected $useBracketArraySyntax = false;
@@ -48,7 +53,7 @@ class PhpArray extends AbstractWriter
         $arrayString = "";
 
         foreach ($config as $key => $value) {
-            $arrayString .= str_repeat('    ', $indentLevel);
+            $arrayString .= str_repeat(self::INDENT_STRING, $indentLevel);
             $arrayString .= (is_int($key) ? $key : "'" . addslashes($key) . "'") . ' => ';
 
             if (is_array($value)) {
@@ -58,7 +63,7 @@ class PhpArray extends AbstractWriter
                     $indentLevel++;
                     $arrayString .= $array['open'] . "\n"
                                   . $this->processIndented($value, $array, $indentLevel)
-                                  . str_repeat('    ', --$indentLevel) . $array['close'] . ",\n";
+                                  . str_repeat(self::INDENT_STRING, --$indentLevel) . $array['close'] . ",\n";
                 }
             } elseif (is_object($value)) {
                 $arrayString .= var_export($value, true) . ",\n";

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -19,9 +19,25 @@ class PhpArray extends AbstractWriter
      */
     public function processConfig(array $config)
     {
-        $arrayString = "<?php\n"
-                     . "return " . var_export($config, true) . ";\n";
+        $arrayString = "<?php\n\n"
+                     . "return";
+        $indentLevel = 0;
 
-        return $arrayString;
+        foreach (explode("\n", var_export($config, true)) as $line) {
+            $line = trim($line);
+
+            if ($line === '),' || $line === ')') {
+                $indentLevel--;
+            } else if (preg_match('/^\s*array \(/', $line)) {
+                $line = 'array(';
+                $indentLevel++;
+                $arrayString .= ' ' . $line;
+                continue;
+            }
+
+            $arrayString .= "\n" . str_repeat('    ', $indentLevel) . $line;
+        }
+
+        return $arrayString . ";\n";
     }
 }

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -176,14 +176,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $result = Factory::toFile($file, $config);
 
         // build string line by line as we are trailing-whitespace sensitive.
-        $expected = "<?php\n";
-        $expected .= "return array (\n";
-        $expected .= "  'test' => 'foo',\n";
-        $expected .= "  'bar' => \n";
-        $expected .= "  array (\n";
-        $expected .= "    0 => 'baz',\n";
-        $expected .= "    1 => 'foo',\n";
-        $expected .= "  ),\n";
+        $expected = "<?php\n\n";
+        $expected .= "return array(\n";
+        $expected .= "    'test' => 'foo',\n";
+        $expected .= "    'bar' => array(\n";
+        $expected .= "        0 => 'baz',\n";
+        $expected .= "        1 => 'foo',\n";
+        $expected .= "    ),\n";
         $expected .= ");\n";
 
         $this->assertEquals(true, $result);

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -176,7 +176,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $result = Factory::toFile($file, $config);
 
         // build string line by line as we are trailing-whitespace sensitive.
-        $expected = "<?php\n\n";
+        $expected = "<?php\n";
         $expected .= "return array(\n";
         $expected .= "    'test' => 'foo',\n";
         $expected .= "    'bar' => array(\n";

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -31,7 +31,10 @@ class PhpArrayTest extends AbstractWriterTestCase
      */
     public function testRender()
     {
-        $config = new Config(array('test' => 'foo', 'bar' => array(0 => 'baz', 1 => 'foo')));
+        $config = new Config(array(
+            'test' => 'foo',
+            'bar' => array(0 => 'baz', 1 => 'foo'),
+            'emptyArray' => array()));
 
         $configString = $this->writer->toString($config);
 
@@ -43,6 +46,7 @@ class PhpArrayTest extends AbstractWriterTestCase
         $expected .= "        0 => 'baz',\n";
         $expected .= "        1 => 'foo',\n";
         $expected .= "    ),\n";
+        $expected .= "    'emptyArray' => array(),\n";
         $expected .= ");\n";
 
         $this->assertEquals($expected, $configString);
@@ -50,7 +54,7 @@ class PhpArrayTest extends AbstractWriterTestCase
 
     public function testRenderWithBracketArraySyntax()
     {
-        $config = new Config(array('test' => 'foo', 'bar' => array(0 => 'baz', 1 => 'foo')));
+        $config = new Config(array('test' => 'foo', 'bar' => array(0 => 'baz', 1 => 'foo'), 'emptyArray' => array()));
 
         $this->writer->setUseBracketArraySyntax(true);
         $configString = $this->writer->toString($config);
@@ -63,6 +67,7 @@ class PhpArrayTest extends AbstractWriterTestCase
         $expected .= "        0 => 'baz',\n";
         $expected .= "        1 => 'foo',\n";
         $expected .= "    ],\n";
+        $expected .= "    'emptyArray' => [],\n";
         $expected .= "];\n";
 
         $this->assertEquals($expected, $configString);

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -72,4 +72,9 @@ class PhpArrayTest extends AbstractWriterTestCase
 
         $this->assertEquals($expected, $configString);
     }
+
+    public function testSetUseBracketArraySyntaxReturnsFluentInterface()
+    {
+        $this->assertSame($this->writer, $this->writer->setUseBracketArraySyntax(true));
+    }
 }

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -31,13 +31,12 @@ class PhpArrayTest extends AbstractWriterTestCase
      */
     public function testRender()
     {
-        $configArray = array(
+        $config = new Config(array(
             'test' => 'foo',
             'bar' => array(0 => 'baz', 1 => 'foo'),
             'emptyArray' => array(),
             'object' => (object) array('foo' => 'bar')
-        );
-        $config = new Config($configArray);
+        ));
 
         $configString = $this->writer->toString($config);
 

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -36,14 +36,13 @@ class PhpArrayTest extends AbstractWriterTestCase
         $configString = $this->writer->toString($config);
 
         // build string line by line as we are trailing-whitespace sensitive.
-        $expected = "<?php\n";
-        $expected .= "return array (\n";
-        $expected .= "  'test' => 'foo',\n";
-        $expected .= "  'bar' => \n";
-        $expected .= "  array (\n";
-        $expected .= "    0 => 'baz',\n";
-        $expected .= "    1 => 'foo',\n";
-        $expected .= "  ),\n";
+        $expected = "<?php\n\n";
+        $expected .= "return array(\n";
+        $expected .= "    'test' => 'foo',\n";
+        $expected .= "    'bar' => array(\n";
+        $expected .= "        0 => 'baz',\n";
+        $expected .= "        1 => 'foo',\n";
+        $expected .= "    ),\n";
         $expected .= ");\n";
 
         $this->assertEquals($expected, $configString);

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -31,10 +31,13 @@ class PhpArrayTest extends AbstractWriterTestCase
      */
     public function testRender()
     {
-        $config = new Config(array(
+        $configArray = array(
             'test' => 'foo',
             'bar' => array(0 => 'baz', 1 => 'foo'),
-            'emptyArray' => array()));
+            'emptyArray' => array(),
+            'object' => (object) array('foo' => 'bar')
+        );
+        $config = new Config($configArray);
 
         $configString = $this->writer->toString($config);
 
@@ -47,6 +50,9 @@ class PhpArrayTest extends AbstractWriterTestCase
         $expected .= "        1 => 'foo',\n";
         $expected .= "    ),\n";
         $expected .= "    'emptyArray' => array(),\n";
+        $expected .= "    'object' => stdClass::__set_state(array(\n";
+        $expected .= "   'foo' => 'bar',\n";
+        $expected .= ")),\n";
         $expected .= ");\n";
 
         $this->assertEquals($expected, $configString);

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -47,4 +47,24 @@ class PhpArrayTest extends AbstractWriterTestCase
 
         $this->assertEquals($expected, $configString);
     }
+
+    public function testRenderWithBracketArraySyntax()
+    {
+        $config = new Config(array('test' => 'foo', 'bar' => array(0 => 'baz', 1 => 'foo')));
+
+        $this->writer->setUseBracketArraySyntax(true);
+        $configString = $this->writer->toString($config);
+
+        // build string line by line as we are trailing-whitespace sensitive.
+        $expected = "<?php\n\n";
+        $expected .= "return [\n";
+        $expected .= "    'test' => 'foo',\n";
+        $expected .= "    'bar' => [\n";
+        $expected .= "        0 => 'baz',\n";
+        $expected .= "        1 => 'foo',\n";
+        $expected .= "    ],\n";
+        $expected .= "];\n";
+
+        $this->assertEquals($expected, $configString);
+    }
 }

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -36,7 +36,7 @@ class PhpArrayTest extends AbstractWriterTestCase
         $configString = $this->writer->toString($config);
 
         // build string line by line as we are trailing-whitespace sensitive.
-        $expected = "<?php\n\n";
+        $expected = "<?php\n";
         $expected .= "return array(\n";
         $expected .= "    'test' => 'foo',\n";
         $expected .= "    'bar' => array(\n";
@@ -56,7 +56,7 @@ class PhpArrayTest extends AbstractWriterTestCase
         $configString = $this->writer->toString($config);
 
         // build string line by line as we are trailing-whitespace sensitive.
-        $expected = "<?php\n\n";
+        $expected = "<?php\n";
         $expected .= "return [\n";
         $expected .= "    'test' => 'foo',\n";
         $expected .= "    'bar' => [\n";


### PR DESCRIPTION
Saw [this Twitter conversation](https://twitter.com/spiffyjr/status/388726534673928192) and agreed.

This PR modified `Zend\Config\Writer\PhpArray` to generate better readable arrays. Specifically, it will (1) indent 4 spaces per level instead of 2 and (2) put the opening `array(` on the same line as the `=>`.

Tests pass, and this "shouldn't" affect BC because it's "just" whitespace.
