### PR TITLE
Zend code method prototype

### DIFF
--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -116,11 +116,12 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
 
         $declaringClass = $this->getDeclaringClass();
         $prototype = array(
-            'namespace' => $declaringClass->getNamespaceName(),
-            'class'     => substr($declaringClass->getName(), strlen($declaringClass->getNamespaceName()) + 1),
-            'name'      => $this->getName(),
-            'return'    => $returnType,
-            'arguments' => array(),
+            'namespace'  => $declaringClass->getNamespaceName(),
+            'class'      => substr($declaringClass->getName(), strlen($declaringClass->getNamespaceName()) + 1),
+            'name'       => $this->getName(),
+            'visibility' => ($this->isPublic() ? 'public' : ($this->isPrivate() ? 'private' : 'protected')),
+            'return'     => $returnType,
+            'arguments'  => array(),
         );
 
         $parameters = $this->getParameters();
@@ -134,7 +135,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         }
 
         if ($format == MethodReflection::PROTOTYPE_AS_STRING) {
-            $line = $prototype['return'] . ' ' . $prototype['name'] . '(';
+            $line = $prototype['visibility'] . ' ' . $prototype['return'] . ' ' . $prototype['name'] . '(';
             $args = array();
             foreach ($prototype['arguments'] as $name => $argument) {
                 $argsLine = ($argument['type'] ? $argument['type'] . ' ' : '') . ($argument['by_ref'] ? '&' : '') . '$' . $name;

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -20,7 +20,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      * Constant use in @MethodReflection to display prototype as an array
      */
     const PROTOTYPE_AS_ARRAY = 'prototype_as_array';
-    
+
     /**
      * Constant use in @MethodReflection to display prototype as a string
      */
@@ -97,10 +97,10 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
 
         return $zendReflection;
     }
-    
+
     /**
      * Get method prototype
-     * 
+     *
      * @return array
      */
     public function getPrototype($format = MethodReflection::PROTOTYPE_AS_ARRAY)
@@ -113,7 +113,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             $returnTypes = $return->getTypes();
             $returnType = count($returnTypes) > 1 ? implode('|', $returnTypes) : $returnTypes[0];
         }
-        
+
         $declaringClass = $this->getDeclaringClass();
         $prototype = array(
             'namespace' => $declaringClass->getNamespaceName(),
@@ -122,9 +122,9 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             'return'    => $returnType,
             'arguments' => array(),
         );
-        
+
         $parameters = $this->getParameters();
-        foreach($parameters as $parameter) {
+        foreach ($parameters as $parameter) {
             $prototype['arguments'][$parameter->getName()] = array(
                 'type'     => $parameter->getType(),
                 'required' => !$parameter->isOptional(),
@@ -132,7 +132,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                 'default'  => $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
             );
         }
-        
+
         if ($format == MethodReflection::PROTOTYPE_AS_STRING) {
             $line = $prototype['return'] . ' ' . $prototype['name'] . '(';
             $args = array();
@@ -145,10 +145,10 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             }
             $line .= implode(', ', $args);
             $line .= ')';
-            
+
             return $line;
         }
-        
+
         return $prototype;
     }
 
@@ -178,7 +178,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     /**
      * Get method contents
      *
-     * @param  bool $includeDocBlock
+     * @param  bool   $includeDocBlock
      * @return string
      */
     public function getContents($includeDocBlock = true)

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -35,4 +35,32 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function6');
         $this->assertInstanceOf('Zend\Code\Reflection\DocBlockReflection', $function->getDocBlock());
     }
+
+    public function testGetPrototypeMethod()
+    {
+        require_once __DIR__ . '/TestAsset/functions.php';
+
+        $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function2');
+        $prototype = array(
+            'namespace' => 'ZendTest\Code\Reflection\TestAsset',
+            'name' => 'function2',
+            'return' => 'string',
+            'arguments' => array(
+                'one' => array(
+                    'type'     => 'string',
+                    'required' => true,
+                    'by_ref'   => false,
+                    'default'  => null,
+                ),
+                'two' => array(
+                    'type'     => 'string',
+                    'required' => false,
+                    'by_ref'   => false,
+                    'default'  => 'two',
+                ),
+            ),
+        );
+        $this->assertEquals($prototype, $function->getPrototype());
+        $this->assertEquals('string function2(string $one, string $two = \'two\')', $function->getPrototype(FunctionReflection::PROTOTYPE_AS_STRING));
+    }
 }

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -59,4 +59,58 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("    {\n\n        return 'mixedValue';\n\n    }\n", $reflectionMethod->getContents(false));
     }
 
+    public function testGetPrototypeMethod()
+    {
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass10', 'doSomethingElse');
+        $prototype = array(
+            'namespace' => 'ZendTest\Code\Reflection\TestAsset',
+            'class' => 'TestSampleClass10',
+            'name' => 'doSomethingElse',
+            'return' => 'int',
+            'arguments' => array(
+                'one' => array(
+                    'type'     => 'int',
+                    'required' => true,
+                    'by_ref'   => false,
+                    'default'  => null,
+                ),
+                'two' => array(
+                    'type'     => 'int',
+                    'required' => false,
+                    'by_ref'   => false,
+                    'default'  => 2,
+                ),
+                'three' => array(
+                    'type'     => 'string',
+                    'required' => false,
+                    'by_ref'   => false,
+                    'default'  => 'three',
+                ),
+            ),
+        );
+        $this->assertEquals($prototype, $reflectionMethod->getPrototype());
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
+        $prototype = array(
+            'namespace' => 'ZendTest\Code\Reflection\TestAsset',
+            'class' => 'TestSampleClass2',
+            'name' => 'getProp2',
+            'return' => '',
+            'arguments' => array(
+                'param1' => array(
+                    'type'     => '',
+                    'required' => true,
+                    'by_ref'   => false,
+                    'default'  => null,
+                ),
+                'param2' => array(
+                    'type'     => 'ZendTest\Code\Reflection\TestAsset\TestSampleClass',
+                    'required' => true,
+                    'by_ref'   => false,
+                    'default'  => null,
+                ),
+            ),
+        );
+        $this->assertEquals($prototype, $reflectionMethod->getPrototype());
+    }
 }

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -66,6 +66,7 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
             'class' => 'TestSampleClass10',
             'name' => 'doSomethingElse',
+            'visibility' => 'public',
             'return' => 'int',
             'arguments' => array(
                 'one' => array(
@@ -89,13 +90,14 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
             ),
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
-        $this->assertEquals('int doSomethingElse(int $one, int $two = 2, string $three = \'three\')', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
+        $this->assertEquals('public int doSomethingElse(int $one, int $two = 2, string $three = \'three\')', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
 
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
         $prototype = array(
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
             'class' => 'TestSampleClass2',
             'name' => 'getProp2',
+            'visibility' => 'public',
             'return' => 'mixed',
             'arguments' => array(
                 'param1' => array(
@@ -113,13 +115,14 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
             ),
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
-        $this->assertEquals('mixed getProp2($param1, ZendTest\Code\Reflection\TestAsset\TestSampleClass $param2)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
+        $this->assertEquals('public mixed getProp2($param1, ZendTest\Code\Reflection\TestAsset\TestSampleClass $param2)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
 
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass12', 'doSomething');
         $prototype = array(
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
             'class' => 'TestSampleClass12',
             'name' => 'doSomething',
+            'visibility' => 'protected',
             'return' => 'string',
             'arguments' => array(
                 'one' => array(
@@ -137,6 +140,6 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
             ),
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
-        $this->assertEquals('string doSomething(int &$one, int $two)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
+        $this->assertEquals('protected string doSomething(int &$one, int $two)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
     }
 }

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -48,6 +48,7 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $body = '        //we need a multi-line method body.
         $assigned = 1;
         $alsoAssigined = 2;
+
         return \'mixedValue\';';
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6', 'doSomething');
         $this->assertEquals($body, $reflectionMethod->getBody());
@@ -90,7 +91,7 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
         $this->assertEquals('int doSomethingElse(int $one, int $two = 2, string $three = \'three\')', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
         $prototype = array(
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
@@ -114,7 +115,7 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
         $this->assertEquals('mixed getProp2($param1, ZendTest\Code\Reflection\TestAsset\TestSampleClass $param2)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
-        
+
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass12', 'doSomething');
         $prototype = array(
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -89,13 +89,14 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
             ),
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
+        $this->assertEquals('int doSomethingElse(int $one, int $two = 2, string $three = \'three\')', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
         
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass2', 'getProp2');
         $prototype = array(
             'namespace' => 'ZendTest\Code\Reflection\TestAsset',
             'class' => 'TestSampleClass2',
             'name' => 'getProp2',
-            'return' => '',
+            'return' => 'mixed',
             'arguments' => array(
                 'param1' => array(
                     'type'     => '',
@@ -112,5 +113,30 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
             ),
         );
         $this->assertEquals($prototype, $reflectionMethod->getPrototype());
+        $this->assertEquals('mixed getProp2($param1, ZendTest\Code\Reflection\TestAsset\TestSampleClass $param2)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
+        
+        $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass12', 'doSomething');
+        $prototype = array(
+            'namespace' => 'ZendTest\Code\Reflection\TestAsset',
+            'class' => 'TestSampleClass12',
+            'name' => 'doSomething',
+            'return' => 'string',
+            'arguments' => array(
+                'one' => array(
+                    'type'     => 'int',
+                    'required' => true,
+                    'by_ref'   => true,
+                    'default'  => null,
+                ),
+                'two' => array(
+                    'type'     => 'int',
+                    'required' => true,
+                    'by_ref'   => false,
+                    'default'  => null,
+                ),
+            ),
+        );
+        $this->assertEquals($prototype, $reflectionMethod->getPrototype());
+        $this->assertEquals('string doSomething(int &$one, int $two)', $reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING));
     }
 }

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -48,7 +48,6 @@ class MethodReflectionTest extends \PHPUnit_Framework_TestCase
         $body = '        //we need a multi-line method body.
         $assigned = 1;
         $alsoAssigined = 2;
-
         return \'mixedValue\';';
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass6', 'doSomething');
         $this->assertEquals($body, $reflectionMethod->getBody());

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass12.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass12.php
@@ -12,12 +12,12 @@ namespace ZendTest\Code\Reflection\TestAsset;
 class TestSampleClass12
 {
     /**
-     * 
-     * @param int $one
-     * @param int $two
+     *
+     * @param  int    $one
+     * @param  int    $two
      * @return string
      */
-    public function doSomething(&$one, $two)
+    protected function doSomething(&$one, $two)
     {
         return 'mixedValue';
     }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass12.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass12.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+class TestSampleClass12
+{
+    /**
+     * 
+     * @param int $one
+     * @param int $two
+     * @return string
+     */
+    public function doSomething(&$one, $two)
+    {
+        return 'mixedValue';
+    }
+}

--- a/tests/ZendTest/Code/Reflection/TestAsset/functions.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/functions.php
@@ -21,8 +21,8 @@ function function1()
  *
  * This is the long description for funciton two
  *
- * @param unknown_type $one
- * @param unknown_type $two
+ * @param string $one
+ * @param string $two
  * @return string
  */
 function function2($one, $two = 'two')


### PR DESCRIPTION
`$reflectionMethod->getPrototype()` will return an array :

``` php
'namespace' => 'ZendTest\Code\Reflection\TestAsset',
'class' => 'TestSampleClass12',
'name' => 'doSomething',
'visibility' => 'public',
'return' => 'string',
'arguments' => array(
    'one' => array(
        'type'     => 'int',
        'required' => true,
        'by_ref'   => true,
        'default'  => null,
    ),
    'two' => array(
        'type'     => 'int',
        'required' => true,
        'by_ref'   => false,
        'default'  => null,
    ),
),
```

`$reflectionMethod->getPrototype(MethodReflection::PROTOTYPE_AS_STRING)` will return an string :

```
public string doSomething(int &$one, int $two)
```
