### PR TITLE
toUrl() & toRoute() statusCode parameter

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
@@ -293,7 +293,7 @@ class FilePostRedirectGet extends AbstractPlugin
      * @return Response
      * @throws \Zend\Mvc\Exception\RuntimeException
      */
-    protected function redirect($redirect, $redirectToUrl, $statusCode = 303)
+    protected function redirect($redirect, $redirectToUrl)
     {
         $controller         = $this->getController();
         $params             = array();
@@ -324,11 +324,13 @@ class FilePostRedirectGet extends AbstractPlugin
         }
 
         if ($redirectToUrl === false) {
-            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams, $statusCode);
+            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams);
+            $response->setStatusCode(303);
             return $response;
         }
 
-        $response = $redirector->toUrl($redirect, $statusCode);
+        $response = $redirector->toUrl($redirect);
+        $response->setStatusCode(303);
 
         return $response;
     }

--- a/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/FilePostRedirectGet.php
@@ -293,7 +293,7 @@ class FilePostRedirectGet extends AbstractPlugin
      * @return Response
      * @throws \Zend\Mvc\Exception\RuntimeException
      */
-    protected function redirect($redirect, $redirectToUrl)
+    protected function redirect($redirect, $redirectToUrl, $statusCode = 303)
     {
         $controller         = $this->getController();
         $params             = array();
@@ -324,13 +324,11 @@ class FilePostRedirectGet extends AbstractPlugin
         }
 
         if ($redirectToUrl === false) {
-            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams);
-            $response->setStatusCode(303);
+            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams, $statusCode);
             return $response;
         }
 
-        $response = $redirector->toUrl($redirect);
-        $response->setStatusCode(303);
+        $response = $redirector->toUrl($redirect, $statusCode);
 
         return $response;
     }

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -91,7 +91,7 @@ class PostRedirectGet extends AbstractPlugin
      * @return \Zend\Http\Response
      * @throws \Zend\Mvc\Exception\RuntimeException
      */
-    protected function redirect($redirect, $redirectToUrl)
+    protected function redirect($redirect, $redirectToUrl, $statusCode = 303)
     {
         $controller         = $this->getController();
         $params             = array();
@@ -122,13 +122,11 @@ class PostRedirectGet extends AbstractPlugin
         }
 
         if ($redirectToUrl === false) {
-            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams);
-            $response->setStatusCode(303);
+            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams, $statusCode);
             return $response;
         }
 
-        $response = $redirector->toUrl($redirect);
-        $response->setStatusCode(303);
+        $response = $redirector->toUrl($redirect, $statusCode);
 
         return $response;
     }

--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -91,7 +91,7 @@ class PostRedirectGet extends AbstractPlugin
      * @return \Zend\Http\Response
      * @throws \Zend\Mvc\Exception\RuntimeException
      */
-    protected function redirect($redirect, $redirectToUrl, $statusCode = 303)
+    protected function redirect($redirect, $redirectToUrl)
     {
         $controller         = $this->getController();
         $params             = array();
@@ -122,11 +122,13 @@ class PostRedirectGet extends AbstractPlugin
         }
 
         if ($redirectToUrl === false) {
-            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams, $statusCode);
+            $response = $redirector->toRoute($redirect, $params, $options, $reuseMatchedParams);
+            $response->setStatusCode(303);
             return $response;
         }
 
-        $response = $redirector->toUrl($redirect, $statusCode);
+        $response = $redirector->toUrl($redirect);
+        $response->setStatusCode(303);
 
         return $response;
     }

--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -33,7 +33,7 @@ class Redirect extends AbstractPlugin
      * @throws Exception\DomainException if composed controller does not implement InjectApplicationEventInterface, or
      *         router cannot be found in controller event
      */
-    public function toRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false)
+    public function toRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false, $statusCode = 302)
     {
         $controller = $this->getController();
         if (!$controller || !method_exists($controller, 'plugin')) {
@@ -48,7 +48,7 @@ class Redirect extends AbstractPlugin
             $url = $urlPlugin->fromRoute($route, $params, $options, $reuseMatchedParams);
         }
 
-        return $this->toUrl($url);
+        return $this->toUrl($url, $statusCode);
     }
 
     /**
@@ -57,11 +57,11 @@ class Redirect extends AbstractPlugin
      * @param  string $url
      * @return Response
      */
-    public function toUrl($url)
+    public function toUrl($url, $statusCode = 302)
     {
         $response = $this->getResponse();
         $response->getHeaders()->addHeaderLine('Location', $url);
-        $response->setStatusCode(302);
+        $response->setStatusCode($statusCode);
         return $response;
     }
 

--- a/library/Zend/Mvc/Controller/Plugin/Redirect.php
+++ b/library/Zend/Mvc/Controller/Plugin/Redirect.php
@@ -33,7 +33,7 @@ class Redirect extends AbstractPlugin
      * @throws Exception\DomainException if composed controller does not implement InjectApplicationEventInterface, or
      *         router cannot be found in controller event
      */
-    public function toRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false, $statusCode = 302)
+    public function toRoute($route = null, $params = array(), $options = array(), $reuseMatchedParams = false)
     {
         $controller = $this->getController();
         if (!$controller || !method_exists($controller, 'plugin')) {
@@ -48,7 +48,7 @@ class Redirect extends AbstractPlugin
             $url = $urlPlugin->fromRoute($route, $params, $options, $reuseMatchedParams);
         }
 
-        return $this->toUrl($url, $statusCode);
+        return $this->toUrl($url);
     }
 
     /**
@@ -57,11 +57,11 @@ class Redirect extends AbstractPlugin
      * @param  string $url
      * @return Response
      */
-    public function toUrl($url, $statusCode = 302)
+    public function toUrl($url)
     {
         $response = $this->getResponse();
         $response->getHeaders()->addHeaderLine('Location', $url);
-        $response->setStatusCode($statusCode);
+        $response->setStatusCode(302);
         return $response;
     }
 


### PR DESCRIPTION
This change sets the statusCode response header as a parameter that the toUrl() accepts, instead of the "302" being a hard coded value inside the method, which requires extra overhead/code of an override when the developer does not want a 302.

example of
$this->redirect()->toUrl( '/sent/to/here' )->setStatusCode(301);
changed to
$this->redirect()->toUrl( '/sent/to/here', 301);
