### PR TITLE
[Form] Implementing __invoke, currently \Zend\Form\View\Helper\AbstractH...

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -150,6 +150,11 @@ abstract class AbstractHelper extends BaseAbstractHelper
     );
 
     /**
+     * Invoke helper as function
+     */
+    abstract public function __invoke();
+
+    /**
      * Set value for doctype
      *
      * @param  string $doctype


### PR DESCRIPTION
...elper

I have error in FormCollection view helper:
Function name must be callable - a string, Closure or class implementing __invoke, currently \Zend\Form\View\Helper\AbstractHelper

Protected function getElementHelper return AbstractHelper, but AbstractHelper dont have __invoke method.
