### PR TITLE
Deprecate ProvidesEvents trait

### DIFF
--- a/library/Zend/EventManager/EventManagerAwareTrait.php
+++ b/library/Zend/EventManager/EventManagerAwareTrait.php
@@ -9,7 +9,7 @@
 
 namespace Zend\EventManager;
 
-use \Zend\EventManager\ProvidesEvents;
+use Traversable;
 
 /**
  * A trait for objects that provide events.
@@ -18,6 +18,8 @@ use \Zend\EventManager\ProvidesEvents;
  * EventManagerAwareInterface, which will make it so the default initializer in
  * a ZF2 MVC application will automatically inject an instance of the
  * EventManager into your object when it is pulled from the ServiceManager.
+ *
+ * @see Zend\Mvc\Service\ServiceManagerConfig
  */
 trait EventManagerAwareTrait
 {

--- a/library/Zend/EventManager/EventManagerAwareTrait.php
+++ b/library/Zend/EventManager/EventManagerAwareTrait.php
@@ -11,6 +11,14 @@ namespace Zend\EventManager;
 
 use \Zend\EventManager\ProvidesEvents;
 
+/**
+ * A trait for objects that provide events.
+ *
+ * If you use this trait in an object, you will probably want to also implement
+ * EventManagerAwareInterface, which will make it so the default initializer in
+ * a ZF2 MVC application will automatically inject an instance of the
+ * EventManager into your object when it is pulled from the ServiceManager.
+ */
 trait EventManagerAwareTrait
 {
     /**
@@ -19,7 +27,11 @@ trait EventManagerAwareTrait
     protected $events;
 
     /**
-     * Set the event manager instance used by this context
+     * Set the event manager instance used by this context.
+     *
+     * For convenience, this method will also set the class name / LSB name as
+     * identifiers, in addition to any string or array of strings set to the
+     * $this->eventIdentifier property.
      *
      * @param  EventManagerInterface $events
      * @return mixed

--- a/library/Zend/EventManager/EventManagerAwareTrait.php
+++ b/library/Zend/EventManager/EventManagerAwareTrait.php
@@ -13,5 +13,51 @@ use \Zend\EventManager\ProvidesEvents;
 
 trait EventManagerAwareTrait
 {
-    use ProvidesEvents;
+    /**
+     * @var EventManagerInterface
+     */
+    protected $events;
+
+    /**
+     * Set the event manager instance used by this context
+     *
+     * @param  EventManagerInterface $events
+     * @return mixed
+     */
+    public function setEventManager(EventManagerInterface $events)
+    {
+        $identifiers = array(__CLASS__, get_class($this));
+        if (isset($this->eventIdentifier)) {
+            if ((is_string($this->eventIdentifier))
+                || (is_array($this->eventIdentifier))
+                || ($this->eventIdentifier instanceof Traversable)
+            ) {
+                $identifiers = array_unique(array_merge($identifiers, (array) $this->eventIdentifier));
+            } elseif (is_object($this->eventIdentifier)) {
+                $identifiers[] = $this->eventIdentifier;
+            }
+            // silently ignore invalid eventIdentifier types
+        }
+        $events->setIdentifiers($identifiers);
+        $this->events = $events;
+        if (method_exists($this, 'attachDefaultListeners')) {
+            $this->attachDefaultListeners();
+        }
+        return $this;
+    }
+
+    /**
+     * Retrieve the event manager
+     *
+     * Lazy-loads an EventManager instance if none registered.
+     *
+     * @return EventManagerInterface
+     */
+    public function getEventManager()
+    {
+        if (!$this->events instanceof EventManagerInterface) {
+            $this->setEventManager(new EventManager());
+        }
+        return $this->events;
+    }
 }

--- a/library/Zend/EventManager/ProvidesEvents.php
+++ b/library/Zend/EventManager/ProvidesEvents.php
@@ -9,12 +9,11 @@
 
 namespace Zend\EventManager;
 
-use Traversable;
-
 /**
- * NOTE: THIS TRAIT IS DEPRECATED! Please use EventManagerAwareTrait instead.
+ * @deprecated Please use EventManagerAwareTrait instead.
+ *
  * This trait exists solely for backwards compatibility in the 2.x branch and
- * willl likely be removed in 3.x.
+ * will likely be removed in 3.x.
  */
 trait ProvidesEvents
 {

--- a/library/Zend/EventManager/ProvidesEvents.php
+++ b/library/Zend/EventManager/ProvidesEvents.php
@@ -12,55 +12,11 @@ namespace Zend\EventManager;
 use Traversable;
 
 /**
- * A trait for objects that provide events
+ * NOTE: THIS TRAIT IS DEPRECATED! Please use EventManagerAwareTrait instead.
+ * This trait exists solely for backwards compatibility in the 2.x branch and
+ * willl likely be removed in 3.x.
  */
 trait ProvidesEvents
 {
-    /**
-     * @var EventManagerInterface
-     */
-    protected $events;
-
-    /**
-     * Set the event manager instance used by this context
-     *
-     * @param  EventManagerInterface $events
-     * @return mixed
-     */
-    public function setEventManager(EventManagerInterface $events)
-    {
-        $identifiers = array(__CLASS__, get_class($this));
-        if (isset($this->eventIdentifier)) {
-            if ((is_string($this->eventIdentifier))
-                || (is_array($this->eventIdentifier))
-                || ($this->eventIdentifier instanceof Traversable)
-            ) {
-                $identifiers = array_unique(array_merge($identifiers, (array) $this->eventIdentifier));
-            } elseif (is_object($this->eventIdentifier)) {
-                $identifiers[] = $this->eventIdentifier;
-            }
-            // silently ignore invalid eventIdentifier types
-        }
-        $events->setIdentifiers($identifiers);
-        $this->events = $events;
-        if (method_exists($this, 'attachDefaultListeners')) {
-            $this->attachDefaultListeners();
-        }
-        return $this;
-    }
-
-    /**
-     * Retrieve the event manager
-     *
-     * Lazy-loads an EventManager instance if none registered.
-     *
-     * @return EventManagerInterface
-     */
-    public function getEventManager()
-    {
-        if (!$this->events instanceof EventManagerInterface) {
-            $this->setEventManager(new EventManager());
-        }
-        return $this->events;
-    }
+    use EventManagerAwareTrait;
 }


### PR DESCRIPTION
This trait was added before we had a naming convention for traits, and
has since been replaced by EventManagerAwareTrait. To help people
understand this, we should have the actual code in the correct trait,
and proxy the old one to the new one with a comment explaining what's
going on.

I also improved the docblocks a little bit while I was in there.
