### PR TITLE
remove zendframework/zend-stdlib from suggest dependency at Zend\Loader\composer.json

### DIFF
--- a/library/Zend/Loader/composer.json
+++ b/library/Zend/Loader/composer.json
@@ -15,9 +15,6 @@
     "require": {
         "php": ">=5.3.3"
     },
-    "suggest": {
-        "zendframework/zend-stdlib": "Zend\\Stdlib component"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.2-dev",


### PR DESCRIPTION
because it not used at this component
