### PR TITLE
fixes #5253

### DIFF
--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -65,9 +65,14 @@ class Headers implements Countable, Iterator
                     $headers->headersKeys[] = static::createKey($current['name']);
                     $headers->headers[]     = $current;
                 }
+
+                // re-assemble header line to fix any spacing issues
+                list($name, $value) = explode(':', $line, 2);
+                $line = trim($name) .": ". trim($value);
+
                 $current = array(
                     'name' => $matches['name'],
-                    'line' => trim($line)
+                    'line' => $line
                 );
             } elseif (preg_match('/^\s+.*$/', $line, $matches)) {
                 // continuation: append to current line

--- a/tests/ZendTest/Http/ResponseTest.php
+++ b/tests/ZendTest/Http/ResponseTest.php
@@ -306,6 +306,21 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = Response::fromString($response_str);
     }
 
+    /**
+     * @group 5253
+     */
+    public function testMultilineHeaderNoSpaces()
+    {
+        $response = Response::fromString($this->readResponse('response_multiline_header_nospace'));
+
+        // Make sure we got the corrent no. of headers
+        $this->assertEquals(6, count($response->getHeaders()), 'Header count is expected to be 6');
+
+        // Check header integrity
+        $this->assertEquals('timeout=15,max=100', $response->getHeaders()->get('keep-alive')->getFieldValue());
+        $this->assertEquals('text/html;charset=iso-8859-1', $response->getHeaders()->get('content-type')->getFieldValue());
+    }
+
     public function testMultilineHeader()
     {
         $response = Response::fromString($this->readResponse('response_multiline_header'));

--- a/tests/ZendTest/Http/_files/response_multiline_header_nospace
+++ b/tests/ZendTest/Http/_files/response_multiline_header_nospace
@@ -1,0 +1,19 @@
+HTTP/1.1 404 Not Found
+Date:Fri, 17 Nov 2006 22:22:40 GMT
+Server:Apache
+Content-Length:272
+Keep-Alive:timeout=15, 
+    max=100
+Connection:Keep-Alive
+Content-Type:text/html; 
+  charset=iso-8859-1
+
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>404 Not Found</title>
+</head><body>
+<h1>Not Found</h1>
+<p>The requested URL /some/wrong/path was not found on this server.</p>
+<hr>
+<address>Apache Server at localhost Port 80</address>
+</body></html>


### PR DESCRIPTION
Issue appears to be valid.

Specification doesn't state that spaces must exist after field-name only that it's preferred they do.
http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html

" Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive. The field value MAY be preceded by any amount of LWS, though a single SP is preferred. "

Perhaps I've misunderstood this, anyways it seems like better form to "fix" improper headers if we can.
