### PR TITLE
[mail] Fixes, criteria unification and optimization.

### DIFF
--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -43,9 +43,7 @@ abstract class AbstractAddressList implements HeaderInterface
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
         // split into name/value
-        list($fieldName, $fieldValue) = explode(':', $decodedLine, 2);
-        $fieldName  = trim($fieldName);
-        $fieldValue = trim($fieldValue);
+        list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($decodedLine);
 
         if (strtolower($fieldName) !== static::$type) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -26,7 +26,7 @@ class ContentType implements HeaderInterface
     public static function fromString($headerLine)
     {
         $headerLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'content-type') {

--- a/library/Zend/Mail/Header/Date.php
+++ b/library/Zend/Mail/Header/Date.php
@@ -21,7 +21,7 @@ class Date implements HeaderInterface
 
     public static function fromString($headerLine)
     {
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'date') {

--- a/library/Zend/Mail/Header/Date.php
+++ b/library/Zend/Mail/Header/Date.php
@@ -28,10 +28,14 @@ class Date implements HeaderInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Date string');
         }
 
-        $header = new static();
-        $header->value= $value;
+        $header = new static($value);
 
         return $header;
+    }
+
+    public function __construct($value)
+    {
+        $this->value = $value;
     }
 
     public function getFieldName()

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -76,7 +76,7 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
         $fieldName = str_replace(' ', '-', ucwords(str_replace(array('_', '-'), ' ', $fieldName)));
 
         // Validate what we have
-        if (!preg_match('/^[\x21-\x39\x3B-\x7E]*$/i', $fieldName)) {
+        if (!preg_match('/^[\x21-\x39\x3B-\x7E]*$/', $fieldName)) {
             throw new Exception\InvalidArgumentException(
                 'Header name must be composed of printable US-ASCII characters, except colon.'
             );

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -31,15 +31,31 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
     public static function fromString($headerLine)
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        $parts = explode(':', $decodedLine, 2);
-        if (count($parts) != 2) {
-            throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
-        }
-        $header = new static($parts[0], ltrim($parts[1]));
+        list($name, $value) = GenericHeader::splitHeaderLine($decodedLine);
+        $header = new static($name, $value);
         if ($decodedLine != $headerLine) {
             $header->setEncoding('UTF-8');
         }
         return $header;
+    }
+
+    /**
+     * Splits the header line in `name` and `value` parts.
+     *
+     * @param string $headerLine
+     * @return string[] `name` in the first index and `value` in the second.
+     * @throws Exception\InvalidArgumentException If header does not match with the format ``name:value``
+     */
+    public static function splitHeaderLine($headerLine)
+    {
+        $parts = explode(':', $headerLine, 2);
+        if (count($parts) !== 2) {
+            throw new Exception\InvalidArgumentException('Header must match with the format "name:value"');
+        }
+
+        $parts[1] = ltrim($parts[1]);
+
+        return $parts;
     }
 
     /**

--- a/library/Zend/Mail/Header/GenericMultiHeader.php
+++ b/library/Zend/Mail/Header/GenericMultiHeader.php
@@ -17,11 +17,7 @@ class GenericMultiHeader extends GenericHeader implements MultipleHeadersInterfa
     public static function fromString($headerLine)
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        $parts = explode(': ', $decodedLine, 2);
-        if (count($parts) != 2) {
-            throw new Exception\InvalidArgumentException('Header must match with the format "name: value"');
-        }
-        list($fieldName, $fieldValue) = $parts;
+        list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($decodedLine);
 
         if (strpos($fieldValue, ',')) {
             $headers = array();

--- a/library/Zend/Mail/Header/HeaderInterface.php
+++ b/library/Zend/Mail/Header/HeaderInterface.php
@@ -31,6 +31,8 @@ interface HeaderInterface
      *
      * @param string $headerLine
      * @return self
+     * @throws Exception\InvalidArgumentException If the header does not match with RFC 2822 definition.
+     * @see http://tools.ietf.org/html/rfc2822#section-2.2
      */
     public static function fromString($headerLine);
 

--- a/library/Zend/Mail/Header/MessageId.php
+++ b/library/Zend/Mail/Header/MessageId.php
@@ -20,7 +20,7 @@ class MessageId implements HeaderInterface
 
     public static function fromString($headerLine)
     {
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'message-id') {

--- a/library/Zend/Mail/Header/MimeVersion.php
+++ b/library/Zend/Mail/Header/MimeVersion.php
@@ -18,7 +18,7 @@ class MimeVersion implements HeaderInterface
 
     public static function fromString($headerLine)
     {
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'mime-version') {

--- a/library/Zend/Mail/Header/MimeVersion.php
+++ b/library/Zend/Mail/Header/MimeVersion.php
@@ -28,7 +28,7 @@ class MimeVersion implements HeaderInterface
         // Check for version, and set if found
         $header = new static();
         if (preg_match('/^(?P<version>\d+\.\d+)$/', $value, $matches)) {
-            $header->version = $matches['version'];
+            $header->setVersion($matches['version']);
         }
 
         return $header;

--- a/library/Zend/Mail/Header/Received.php
+++ b/library/Zend/Mail/Header/Received.php
@@ -30,10 +30,14 @@ class Received implements HeaderInterface, MultipleHeadersInterface
             throw new Exception\InvalidArgumentException('Invalid header line for Received string');
         }
 
-        $header = new static();
-        $header->value= $value;
+        $header = new static($value);
 
         return $header;
+    }
+
+    public function __construct($value = '')
+    {
+        $this->value = $value;
     }
 
     public function getFieldName()

--- a/library/Zend/Mail/Header/Received.php
+++ b/library/Zend/Mail/Header/Received.php
@@ -23,7 +23,7 @@ class Received implements HeaderInterface, MultipleHeadersInterface
 
     public static function fromString($headerLine)
     {
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'received') {

--- a/library/Zend/Mail/Header/Sender.php
+++ b/library/Zend/Mail/Header/Sender.php
@@ -28,7 +28,7 @@ class Sender implements HeaderInterface
     public static function fromString($headerLine)
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        list($name, $value) = explode(': ', $decodedLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($decodedLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'sender') {

--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -26,8 +26,7 @@ class Subject implements UnstructuredInterface
     public static function fromString($headerLine)
     {
         $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        list($name, $value) = explode(':', $decodedLine, 2);
-        $value = ltrim($value);
+        list($name, $value) = GenericHeader::splitHeaderLine($decodedLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'subject') {

--- a/tests/ZendTest/Mail/HeadersTest.php
+++ b/tests/ZendTest/Mail/HeadersTest.php
@@ -138,7 +138,10 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadersAddHeaderLineThrowsExceptionOnMissingFieldValue()
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException', 'Header must match with the format "name: value"');
+        $this->setExpectedException(
+            'Zend\Mail\Header\Exception\InvalidArgumentException',
+            'Header must match with the format "name:value"'
+        );
         $headers = new Mail\Headers();
         $headers->addHeaderLine('Foo');
     }


### PR DESCRIPTION
I've created a new static method in `GenericHeader` for unify the criteria about split a header line in name and value.

This go rid with all issues about to force to have a space after colon (`:`) (RFC 2822 does not say nothing about to have an space)
