### PR TITLE
Fix #5289 (abstract factories return type)

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -591,21 +591,21 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function doCreate($rName, $cName)
     {
-        $instance = false;
+        $instance = null;
 
         if (isset($this->factories[$cName])) {
             $instance = $this->createFromFactory($cName, $rName);
         }
 
-        if ($instance === false && isset($this->invokableClasses[$cName])) {
+        if ($instance === null && isset($this->invokableClasses[$cName])) {
             $instance = $this->createFromInvokable($cName, $rName);
         }
 
-        if ($instance === false && $this->canCreateFromAbstractFactory($cName, $rName)) {
+        if ($instance === null && $this->canCreateFromAbstractFactory($cName, $rName)) {
             $instance = $this->createFromAbstractFactory($cName, $rName);
         }
 
-        if ($instance === false && $this->throwExceptionInCreate) {
+        if ($instance === null && $this->throwExceptionInCreate) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 'No valid instance was found for %s%s',
                 $cName,
@@ -1023,7 +1023,7 @@ class ServiceManager implements ServiceLocatorInterface
                     );
                     unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
                 } else {
-                    $instance = false;
+                    $instance = null;
                 }
             } catch (\Exception $e) {
                 unset($this->pendingAbstractFactoryRequests[get_class($abstractFactory)]);
@@ -1037,12 +1037,10 @@ class ServiceManager implements ServiceLocatorInterface
                     $e
                 );
             }
-            if (is_object($instance)) {
-                break;
+            if ($instance !== null) {
+                return $instance;
             }
         }
-
-        return $instance;
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -14,6 +14,7 @@ use Zend\Di\Di;
 use Zend\Mvc\Service\DiFactory;
 use Zend\ServiceManager\Di\DiAbstractServiceFactory;
 use Zend\ServiceManager\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Config;
 
@@ -809,5 +810,96 @@ class ServiceManagerTest extends TestCase
         $this->assertCount(1, $fooDelegator->instances);
         $this->assertInstanceOf('stdClass', array_shift($fooDelegator->instances));
         $this->assertSame($fooDelegator, array_shift($barDelegator->instances));
+    }
+
+    /**
+     * @dataProvider getServiceOfVariousTypes
+     * @param $service
+     */
+    public function testAbstractFactoriesCanReturnAnyTypeButNull($service)
+    {
+        $abstractFactory = $this->getMock('Zend\ServiceManager\AbstractFactoryInterface');
+        $abstractFactory
+            ->expects($this->any())
+            ->method('canCreateServiceWithName')
+            ->with($this->serviceManager, 'something', 'something')
+            ->will($this->returnValue(true));
+
+        $abstractFactory
+            ->expects($this->any())
+            ->method('createServiceWithName')
+            ->with($this->serviceManager, 'something', 'something')
+            ->will($this->returnValue($service));
+
+        $this->serviceManager->addAbstractFactory($abstractFactory);
+
+        if ($service === null) {
+            try {
+                $this->serviceManager->get('something');
+                $this->fail('ServiceManager::get() successfully returned null');
+            } catch(\Exception $e) {
+                $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceNotCreatedException', $e);
+            }
+        } else {
+            $this->assertSame($service, $this->serviceManager->get('something'));
+        }
+    }
+
+    /**
+     * @dataProvider getServiceOfVariousTypes
+     * @param $service
+     */
+    public function testFactoriesCanReturnAnyTypeButNull($service)
+    {
+        $factory = function () use ($service) {
+            return $service;
+        };
+        $this->serviceManager->setFactory('something', $factory);
+
+        if ($service === null) {
+            try {
+                $this->serviceManager->get('something');
+                $this->fail('ServiceManager::get() successfully returned null');
+            } catch(\Exception $e) {
+                $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceNotCreatedException', $e);
+            }
+        } else {
+            $this->assertSame($service, $this->serviceManager->get('something'));
+        }
+    }
+
+    /**
+     * @dataProvider getServiceOfVariousTypes
+     * @param $service
+     */
+    public function testServicesCanBeOfAnyTypeButNull($service)
+    {
+        $this->serviceManager->setService('something', $service);
+
+        if ($service === null) {
+            try {
+                $this->serviceManager->get('something');
+                $this->fail('ServiceManager::get() successfully returned null');
+            } catch(\Exception $e) {
+                $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceNotFoundException', $e);
+            }
+        } else {
+            $this->assertSame($service, $this->serviceManager->get('something'));
+        }
+    }
+
+    public function getServiceOfVariousTypes()
+    {
+        return array(
+            array(null),
+            array('string'),
+            array(1),
+            array(1.2),
+            array(array()),
+            array(function () {}),
+            array(false),
+            array(new \stdClass()),
+            array(tmpfile())
+        );
     }
 }


### PR DESCRIPTION
Fixes #5289

Just let me know if you consider allowing services to return `bool(false)` as a BC break, because I'm not sure.

In any case, imho it should be allowed.
