### PR TITLE
Update DateFormat.php to fix deprecated method call: PHP >= 5.5.0.

### DIFF
--- a/library/Zend/I18n/View/Helper/DateFormat.php
+++ b/library/Zend/I18n/View/Helper/DateFormat.php
@@ -133,8 +133,11 @@ class DateFormat extends AbstractHelper
     {
         $this->timezone = (string) $timezone;
 
+        // The method setTimeZoneId is deprecated as of PHP 5.5.0
+        $setTimeZoneMethodName = version_compare(PHP_VERSION, '5.5.0', '<') ? 'setTimeZoneId' : 'setTimeZone';
+
         foreach ($this->formatters as $formatter) {
-            $formatter->setTimeZoneId($this->timezone);
+            $formatter->$setTimeZoneMethodName($this->timezone);
         }
 
         return $this;


### PR DESCRIPTION
In versions of PHP >= 5.5.0, the method IntlDateFormatter::setTimeZoneId() is deprecated and IntlDateFormatter::setTimeZone() should be used instead.

This is my first proposed zf fix, so hopefully the ternary + dynamic method name var is acceptable.
