### PR TITLE
[mail] Fix headers cast to string

### DIFF
--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -386,7 +386,7 @@ class Headers implements Countable, Iterator
     public function toString()
     {
         $headers = '';
-        foreach ($this->headers as $header) {
+        foreach ($this as $header) {
             if ($str = $header->toString()) {
                 $headers .= $str . self::EOL;
             }


### PR DESCRIPTION
Due lazy loading of specific headers is not possible a direct access to the headers attribute.
Instead use the own implementation of ArrayAccess allow lazy load through the get method which do lazy loading of headers.

Test case of this is in #5140 
