### PR TITLE
[http] Unify criteria for split name

### DIFF
--- a/library/Zend/Http/Header/Etag.php
+++ b/library/Zend/Http/Header/Etag.php
@@ -20,7 +20,7 @@ class Etag implements HeaderInterface
     {
         $header = new static();
 
-        list($name, $value) = explode(': ', $headerLine, 2);
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'etag') {


### PR DESCRIPTION
Add missing Etag from #5302 c22ec11bf67f7d3f36edcd824ecdb26960c789d5

Supersede #5250
