### PR TITLE
Enable persistent connections for IbmDb2.

### DIFF
--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -166,9 +166,12 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         $connection['database'] = $findParameterValue(array('database', 'db'));
         $connection['username'] = $findParameterValue(array('username', 'uid', 'UID'));
         $connection['password'] = $findParameterValue(array('password', 'pwd', 'PWD'));
+        $connection['persistent'] = $findParameterValue(array('persistent', 'PERSISTENT', 'Persistent'));
         $connection['options']  = (isset($p['driver_options']) ? $p['driver_options'] : array());
 
-        $this->resource = db2_connect(
+        $db2_connect = ($connection['persistent'] ? 'db2_pconnect' : 'db2_connect');
+        
+        $this->resource = $db2_connect(
             $connection['database'],
             $connection['username'],
             $connection['password'],

--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -162,15 +162,15 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             return null;
         };
 
-        $connection             = array();
-        $connection['database'] = $findParameterValue(array('database', 'db'));
-        $connection['username'] = $findParameterValue(array('username', 'uid', 'UID'));
-        $connection['password'] = $findParameterValue(array('password', 'pwd', 'PWD'));
+        $connection               = array();
+        $connection['database']   = $findParameterValue(array('database', 'db'));
+        $connection['username']   = $findParameterValue(array('username', 'uid', 'UID'));
+        $connection['password']   = $findParameterValue(array('password', 'pwd', 'PWD'));
         $connection['persistent'] = $findParameterValue(array('persistent', 'PERSISTENT', 'Persistent'));
-        $connection['options']  = (isset($p['driver_options']) ? $p['driver_options'] : array());
+        $connection['options']    = (isset($p['driver_options']) ? $p['driver_options'] : array());
 
         $db2_connect = ($connection['persistent'] ? 'db2_pconnect' : 'db2_connect');
-        
+
         $this->resource = $db2_connect(
             $connection['database'],
             $connection['username'],


### PR DESCRIPTION
Usage example in global.php:

``` php
return array(
    'db' => array(
        'driver' => 'IbmDb2',
        'database' => '*LOCAL',
        'username' => 'user',
        'password' => 'password',
        'persistent' => true,
        'driver_options' => array(
            'i5_naming' => DB2_I5_NAMING_ON,
            'i5_libl' => 'SOMELIB QGPL'
        ),
        'platform_options' => array(
            'quote_identifiers' => false
        )
    ),

    'service_manager' => array(
        'factories' => array(
            'Zend\Db\Adapter\Adapter' =>
'Zend\Db\Adapter\AdapterServiceFactory'
        )
    )
);
```

Change-Id: I42ff3d52b2f112cefb828432c93eb409d42b2cad
