### PR TITLE
Added Content Security Policy 1.0 header class

### DIFF
--- a/library/Zend/Http/Header/ContentSecurityPolicy.php
+++ b/library/Zend/Http/Header/ContentSecurityPolicy.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Http\Header;
+
+/**
+ * Content Security Policy 1.0 Header
+ *
+ * @link http://www.w3.org/TR/CSP/
+ */
+class ContentSecurityPolicy implements HeaderInterface
+{
+    /**
+     * Valid directive names
+     *
+     * @var array
+     */
+    protected $validDirectiveNames = array(
+        // As per http://www.w3.org/TR/CSP/#directives
+        'default-src',
+        'script-src',
+        'object-src',
+        'style-src',
+        'img-src',
+        'media-src',
+        'frame-src',
+        'font-src',
+        'connect-src',
+        'sandbox',
+        'report-uri',
+    );
+
+    /**
+     * The directives defined for this policy
+     *
+     * @var array
+     */
+    protected $directives = array();
+
+    /**
+     * Get the list of defined directives
+     *
+     * @return array
+     */
+    public function getDirectives()
+    {
+        return $this->directives;
+    }
+
+    /**
+     * Sets the directive to consist of the source list
+     *
+     * Reverses http://www.w3.org/TR/CSP/#parsing-1
+     *
+     * @param string $name The directive name.
+     * @param array $sources The source list.
+     * @return self
+     * @throws Exception\InvalidArgumentException If the name is not a valid directive name.
+     */
+    public function setDirective($name, array $sources)
+    {
+        if (!in_array($name, $this->validDirectiveNames, true)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a valid directive name; received "%s"',
+                __METHOD__,
+                (string) $name
+            ));
+        }
+        if (empty($sources)) {
+            $this->directives[$name] = "'none'";
+        } else {
+            $this->directives[$name] = implode(' ', $sources);
+        }
+        return $this;
+    }
+
+    /**
+     * Create Content Security Policy header from a given header line
+     *
+     * @param string $headerLine The header line to parse.
+     * @return self
+     * @throws Exception\InvalidArgumentException If the name field in the given header line does not match.
+     */
+    public static function fromString($headerLine)
+    {
+        $header = new static();
+        $headerName = $header->getFieldName();
+        list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
+        // Ensure the proper header name
+        if (strcasecmp($name, $headerName) != 0) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid header line for %s string: "%s"',
+                $headerName,
+                $name
+            ));
+        }
+        // As per http://www.w3.org/TR/CSP/#parsing
+        $tokens = explode(';', $value);
+        foreach ($tokens as $token) {
+            $token = trim($token);
+            if ($token) {
+                list($directiveName, $directiveValue) = explode(' ', $token, 2);
+                if (!isset($header->directives[$directiveName])) {
+                    $header->directives[$directiveName] = $directiveValue;
+                }
+            }
+        }
+        return $header;
+    }
+
+    /**
+     * Get the header name
+     *
+     * @return string
+     */
+    public function getFieldName()
+    {
+        return 'Content-Security-Policy';
+    }
+
+    /**
+     * Get the header value
+     *
+     * @return string
+     */
+    public function getFieldValue()
+    {
+        $directives = array();
+        foreach ($this->directives as $name => $value) {
+            $directives[] = sprintf('%s %s;', $name, $value);
+        }
+        return implode(' ', $directives);
+    }
+
+    /**
+     * Return the header as a string
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return sprintf('%s: %s', $this->getFieldName(), $this->getFieldValue());
+    }
+}

--- a/tests/ZendTest/Http/Header/ContentSecurityPolicyTest.php
+++ b/tests/ZendTest/Http/Header/ContentSecurityPolicyTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Http\Header;
+
+use Zend\Http\Header\ContentSecurityPolicy;
+
+class ContentSecurityPolicyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testContentSecurityPolicyFromStringThrowsExceptionIfImproperHeaderNameUsed()
+    {
+        $this->setExpectedException('Zend\Http\Header\Exception\InvalidArgumentException');
+        ContentSecurityPolicy::fromString('X-Content-Security-Policy: default-src *;');
+    }
+
+    public function testContentSecurityPolicyFromStringParsesDirectivesCorrectly()
+    {
+        $csp = ContentSecurityPolicy::fromString(
+            "Content-Security-Policy: default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self';"
+        );
+        $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $csp);
+        $this->assertInstanceOf('Zend\Http\Header\ContentSecurityPolicy', $csp);
+        $directives = array('default-src' => "'none'",
+                            'script-src'  => "'self'",
+                            'img-src'     => "'self'",
+                            'style-src'   => "'self'");
+        $this->assertEquals($directives, $csp->getDirectives());
+    }
+
+    public function testContentSecurityPolicyGetFieldNameReturnsHeaderName()
+    {
+        $csp = new ContentSecurityPolicy();
+        $this->assertEquals('Content-Security-Policy', $csp->getFieldName());
+    }
+
+    public function testContentSecurityPolicyToStringReturnsHeaderFormattedString()
+    {
+        $csp = ContentSecurityPolicy::fromString(
+            "Content-Security-Policy: default-src 'none'; img-src 'self' https://*.gravatar.com;"
+        );
+        $this->assertInstanceOf('Zend\Http\Header\HeaderInterface', $csp);
+        $this->assertInstanceOf('Zend\Http\Header\ContentSecurityPolicy', $csp);
+        $this->assertEquals(
+            "Content-Security-Policy: default-src 'none'; img-src 'self' https://*.gravatar.com;",
+            $csp->toString()
+        );
+    }
+
+    public function testContentSecurityPolicySetDirective()
+    {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective('default-src', array('https://*.google.com', 'http://foo.com'))
+            ->setDirective('img-src', array("'self'"))
+            ->setDirective('script-src', array('https://*.googleapis.com', 'https://*.bar.com'));
+        $header = "Content-Security-Policy: default-src https://*.google.com http://foo.com; "
+                . "img-src 'self'; script-src https://*.googleapis.com https://*.bar.com;";
+        $this->assertEquals($header, $csp->toString());
+    }
+
+    public function testContentSecurityPolicySetDirectiveWithEmptySourcesDefaultsToNone()
+    {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective('default-src', array("'self'"))
+            ->setDirective('img-src', array('*'))
+            ->setDirective('script-src', array());
+        $this->assertEquals(
+            "Content-Security-Policy: default-src 'self'; img-src *; script-src 'none';",
+            $csp->toString()
+        );
+    }
+
+    public function testContentSecurityPolicySetDirectiveThrowsExceptionIfInvalidDirectiveNameGiven()
+    {
+        $this->setExpectedException('Zend\Http\Header\Exception\InvalidArgumentException');
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective('foo', array());
+    }
+
+    public function testContentSecurityPolicyGetFieldValueReturnsProperValue()
+    {
+        $csp = new ContentSecurityPolicy();
+        $csp->setDirective('default-src', array("'self'"))
+            ->setDirective('img-src', array('https://*.github.com'));
+        $this->assertEquals("default-src 'self'; img-src https://*.github.com;", $csp->getFieldValue());
+    }
+}


### PR DESCRIPTION
There seems to not be a Content Security Policy 1.0 Header class in `Zend\Http\Header`, so this is an implementation.

The Candidate Recommendation: http://www.w3.org/TR/CSP/

If this goes through, I can update [the docs](https://github.com/zendframework/zf2-documentation/blob/18ad64234b220b9ac10f7ed3729b5f938964a528/docs/languages/en/modules/zend.http.headers.rst) as needed.
