### PR TITLE
Zend\Db\Predicates - allow use different types of arguments in any position

### DIFF
--- a/library/Zend/Db/Sql/AbstractExpression.php
+++ b/library/Zend/Db/Sql/AbstractExpression.php
@@ -20,6 +20,14 @@ abstract class AbstractExpression implements ExpressionInterface
         self::TYPE_VALUE,
     );
 
+    /**
+     * Normalize Argument
+     *
+     * @param mixed $argument
+     * @param string $defaultType
+     * @return array
+     * @throws Exception\InvalidArgumentException
+     */
     protected function normalizeArgument($argument, $defaultType = self::TYPE_VALUE)
     {
         $argumentType = null;
@@ -62,6 +70,14 @@ abstract class AbstractExpression implements ExpressionInterface
         );
     }
 
+    /**
+     * Push variables from $source to self
+     *
+     * @param mixed $source
+     * @param array $excludeVariables
+     * @return self
+     * @throws Exception\InvalidArgumentException
+     */
     protected function localizeVariablesForDecorator($source, array $excludeVariables = array())
     {
         if (!$this instanceof PlatformDecoratorInterface) {

--- a/library/Zend/Db/Sql/AbstractExpression.php
+++ b/library/Zend/Db/Sql/AbstractExpression.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql;
+
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+
+abstract class AbstractExpression implements ExpressionInterface
+{
+    protected $allowedTypes = array(
+        self::TYPE_IDENTIFIER,
+        self::TYPE_LITERAL,
+        self::TYPE_SELECT,
+        self::TYPE_VALUE,
+    );
+
+    protected function normalizeArgument($argument, $defaultType = self::TYPE_VALUE)
+    {
+        $argumentType = null;
+        if ($argument instanceof ExpressionInterface || $argument instanceof SqlInterface) {
+            $argumentType = self::TYPE_VALUE;
+        } elseif (is_scalar($argument) || $argument === null) {
+            $argumentType = $defaultType;
+        } elseif (is_array($argument)) {
+            $k = key($argument);
+            $v = current($argument);
+            if ($v instanceof ExpressionInterface || $v instanceof SqlInterface) {
+                $argument = $v;
+                $argumentType = self::TYPE_VALUE;
+            } elseif (is_integer($k) && !in_array($v, $this->allowedTypes)) {
+                $argument = $v;
+                $argumentType = $defaultType;
+            } else {
+                $argument = $k;
+                $argumentType = $v;
+            }
+        } else {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '$argument should be %s or %s or %s or %s or %s',
+                'null',
+                'scalar',
+                'array',
+                'Zend\Db\Sql\ExpressionInterface',
+                'Zend\Db\Sql\SqlInterface'
+            ));
+        }
+        if (!in_array($argumentType, $this->allowedTypes)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Argument type should be in array(%s)',
+                implode(',', $this->allowedTypes)
+            ));
+        }
+        return array(
+            $argument,
+            $argumentType,
+        );
+    }
+
+    protected function localizeVariablesForDecorator($source, array $excludeVariables = array())
+    {
+        if (!$this instanceof PlatformDecoratorInterface) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'function AbstractExpression::localizeVariablesForDecorator can only be called for %s.',
+                'Zend\Db\Sql\Platform\PlatformDecoratorInterface'
+            ));
+        }
+        // localize variables
+        foreach (get_object_vars($source) as $name => $value) {
+            if (!in_array($name, $excludeVariables)) {
+                $this->{$name} = $value;
+            }
+        }
+        return $this;
+    }
+}

--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -34,19 +34,14 @@ class Expression extends AbstractExpression
     /**
      * @param string $expression
      * @param string|array $parameters
-     * @param array $types @deprecated
+     * @param array $types @deprecated since version 3.0.0
      */
     public function __construct($expression = '', $parameters = null, array $types = array())
     {
         if ($expression) {
             $this->setExpression($expression);
         }
-        /**
-         * Backward Compatibility
-         * Pass parameter value and type to $parameters is more better way, as sample : $parameters = array(ParameterValue => ParameterType)
-         * But put parameter value to $parameters and it type to $types is allow too for backward compatibility.
-         */
-        if ($types) {
+        if ($types) { // should be deprecated since version 3.0.0
             if (is_array($parameters)) {
                 foreach ($parameters as $i=>$parameter) {
                     $parameters[$i] = array(

--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Sql;
 
-class Expression implements ExpressionInterface
+class Expression extends AbstractExpression
 {
     /**
      * @const
@@ -41,11 +41,23 @@ class Expression implements ExpressionInterface
         if ($expression) {
             $this->setExpression($expression);
         }
+        //BC
+        if ($types) {
+            if (is_array($parameters)) {
+                foreach ($parameters as $i=>$parameter) {
+                    $parameters[$i] = array(
+                        $parameter => isset($types[$i]) ? $types[$i] : self::TYPE_VALUE,
+                    );
+                }
+            } elseif (is_scalar($parameters)) {
+                $parameters = array(
+                    $parameters => $types[0],
+                );
+            }
+        }
+
         if ($parameters) {
             $this->setParameters($parameters);
-        }
-        if ($types) {
-            $this->setTypes($types);
         }
     }
 
@@ -94,6 +106,7 @@ class Expression implements ExpressionInterface
     }
 
     /**
+     * @deprecated
      * @param array $types
      * @return Expression
      */
@@ -104,6 +117,7 @@ class Expression implements ExpressionInterface
     }
 
     /**
+     * @deprecated
      * @return array
      */
     public function getTypes()
@@ -118,35 +132,26 @@ class Expression implements ExpressionInterface
     public function getExpressionData()
     {
         $parameters = (is_scalar($this->parameters)) ? array($this->parameters) : $this->parameters;
-
-        $types = array();
         $parametersCount = count($parameters);
+        $expression = str_replace('%', '%%', $this->expression);
 
-        if ($parametersCount == 0 && strpos($this->expression, self::PLACEHOLDER) !== false) {
-            // if there are no parameters, but there is a placeholder
-            $parametersCount = substr_count($this->expression, self::PLACEHOLDER);
-            $parameters = array_fill(0, $parametersCount, null);
-        }
-
-        for ($i = 0; $i < $parametersCount; $i++) {
-            $types[$i] = (isset($this->types[$i]) && ($this->types[$i] == self::TYPE_IDENTIFIER || $this->types[$i] == self::TYPE_LITERAL))
-                ? $this->types[$i] : self::TYPE_VALUE;
+        if ($parametersCount == 0) {
+            return array(
+                str_ireplace(self::PLACEHOLDER, '', $expression)
+            );
         }
 
         // assign locally, escaping % signs
-        $expression = str_replace('%', '%%', $this->expression);
-
-        if ($parametersCount > 0) {
-            $count = 0;
-            $expression = str_replace(self::PLACEHOLDER, '%s', $expression, $count);
-            if ($count !== $parametersCount) {
-                throw new Exception\RuntimeException('The number of replacements in the expression does not match the number of parameters');
-            }
+        $expression = str_replace(self::PLACEHOLDER, '%s', $expression, $count);
+        if ($count !== $parametersCount) {
+            throw new Exception\RuntimeException('The number of replacements in the expression does not match the number of parameters');
         }
-
+        foreach ($parameters as $parameter) {
+            list($values[], $types[]) = $this->normalizeArgument($parameter, self::TYPE_VALUE);
+        }
         return array(array(
             $expression,
-            $parameters,
+            $values,
             $types
         ));
     }

--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -34,14 +34,18 @@ class Expression extends AbstractExpression
     /**
      * @param string $expression
      * @param string|array $parameters
-     * @param array $types
+     * @param array $types @deprecated
      */
     public function __construct($expression = '', $parameters = null, array $types = array())
     {
         if ($expression) {
             $this->setExpression($expression);
         }
-        //BC
+        /**
+         * Backward Compatibility
+         * Pass parameter value and type to $parameters is more better way, as sample : $parameters = array(ParameterValue => ParameterType)
+         * But put parameter value to $parameters and it type to $types is allow too for backward compatibility.
+         */
         if ($types) {
             if (is_array($parameters)) {
                 foreach ($parameters as $i=>$parameter) {

--- a/library/Zend/Db/Sql/ExpressionInterface.php
+++ b/library/Zend/Db/Sql/ExpressionInterface.php
@@ -14,6 +14,7 @@ interface ExpressionInterface
     const TYPE_IDENTIFIER = 'identifier';
     const TYPE_VALUE = 'value';
     const TYPE_LITERAL = 'literal';
+    const TYPE_SELECT = 'select';
 
     /**
      * @abstract

--- a/library/Zend/Db/Sql/Predicate/Between.php
+++ b/library/Zend/Db/Sql/Predicate/Between.php
@@ -9,7 +9,9 @@
 
 namespace Zend\Db\Sql\Predicate;
 
-class Between implements PredicateInterface
+use Zend\Db\Sql\AbstractExpression;
+
+class Between extends AbstractExpression implements PredicateInterface
 {
     protected $specification = '%1$s BETWEEN %2$s AND %3$s';
     protected $identifier    = null;
@@ -131,11 +133,14 @@ class Between implements PredicateInterface
      */
     public function getExpressionData()
     {
+        list($values[], $types[]) = $this->normalizeArgument($this->identifier, self::TYPE_IDENTIFIER);
+        list($values[], $types[]) = $this->normalizeArgument($this->minValue,   self::TYPE_VALUE);
+        list($values[], $types[]) = $this->normalizeArgument($this->maxValue,   self::TYPE_VALUE);
         return array(
             array(
                 $this->getSpecification(),
-                array($this->identifier, $this->minValue, $this->maxValue),
-                array(self::TYPE_IDENTIFIER, self::TYPE_VALUE, self::TYPE_VALUE),
+                $values,
+                $types,
             ),
         );
     }

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -11,13 +11,16 @@ namespace Zend\Db\Sql\Predicate;
 
 use Zend\Db\Sql\Exception;
 use Zend\Db\Sql\Select;
+use Zend\Db\Sql\AbstractExpression;
 
-class In implements PredicateInterface
+class In extends AbstractExpression implements PredicateInterface
 {
     protected $identifier;
     protected $valueSet;
 
     protected $specification = '%s IN %s';
+
+    protected $valueSpecSpecification = '%%s IN (%s)';
 
     /**
      * Constructor
@@ -116,12 +119,13 @@ class In implements PredicateInterface
             $replacements[] = $values;
             $types[] = self::TYPE_VALUE;
         } else {
+            foreach ($values as $argument) {
+                list($replacements[], $types[]) = $this->normalizeArgument($argument, self::TYPE_VALUE);
+            }
             $specification = vsprintf(
                 $this->specification,
                 array($identifierSpecFragment, '(' . implode(', ', array_fill(0, count($values), '%s')) . ')')
             );
-            $replacements = array_merge($replacements, $values);
-            $types = array_merge($types, array_fill(0, count($values), self::TYPE_VALUE));
         }
 
         return array(array(

--- a/library/Zend/Db/Sql/Predicate/IsNull.php
+++ b/library/Zend/Db/Sql/Predicate/IsNull.php
@@ -9,7 +9,9 @@
 
 namespace Zend\Db\Sql\Predicate;
 
-class IsNull implements PredicateInterface
+use Zend\Db\Sql\AbstractExpression;
+
+class IsNull extends AbstractExpression implements PredicateInterface
 {
 
     /**
@@ -85,10 +87,11 @@ class IsNull implements PredicateInterface
      */
     public function getExpressionData()
     {
+        $identifier = $this->normalizeArgument($this->identifier, self::TYPE_IDENTIFIER);
         return array(array(
             $this->getSpecification(),
-            array($this->identifier),
-            array(self::TYPE_IDENTIFIER),
+            array($identifier[0]),
+            array($identifier[1]),
         ));
     }
 }

--- a/library/Zend/Db/Sql/Predicate/Like.php
+++ b/library/Zend/Db/Sql/Predicate/Like.php
@@ -9,7 +9,9 @@
 
 namespace Zend\Db\Sql\Predicate;
 
-class Like implements PredicateInterface
+use Zend\Db\Sql\AbstractExpression;
+
+class Like extends AbstractExpression implements PredicateInterface
 {
 
     /**
@@ -100,8 +102,14 @@ class Like implements PredicateInterface
      */
     public function getExpressionData()
     {
+        list($values[], $types[]) = $this->normalizeArgument($this->identifier, self::TYPE_IDENTIFIER);
+        list($values[], $types[]) = $this->normalizeArgument($this->like, self::TYPE_VALUE);
         return array(
-            array($this->specification, array($this->identifier, $this->like), array(self::TYPE_IDENTIFIER, self::TYPE_VALUE))
+            array(
+                $this->specification,
+                $values,
+                $types,
+            )
         );
     }
 }

--- a/library/Zend/Db/Sql/Predicate/Operator.php
+++ b/library/Zend/Db/Sql/Predicate/Operator.php
@@ -10,8 +10,9 @@
 namespace Zend\Db\Sql\Predicate;
 
 use Zend\Db\Sql\Exception;
+use Zend\Db\Sql\AbstractExpression;
 
-class Operator implements PredicateInterface
+class Operator extends AbstractExpression implements PredicateInterface
 {
     const OPERATOR_EQUAL_TO                  = '=';
     const OP_EQ                              = '=';
@@ -83,6 +84,10 @@ class Operator implements PredicateInterface
     public function setLeft($left)
     {
         $this->left = $left;
+        if (is_array($left)) {
+            $left = $this->normalizeArgument($left, $this->leftType);
+            $this->leftType = $left[1];
+        }
         return $this;
     }
 
@@ -155,9 +160,13 @@ class Operator implements PredicateInterface
      * @param  int|float|bool|string $value
      * @return Operator
      */
-    public function setRight($value)
+    public function setRight($right)
     {
-        $this->right = $value;
+        $this->right = $right;
+        if (is_array($right)) {
+            $right = $this->normalizeArgument($right, $this->rightType);
+            $this->rightType = $right[1];
+        }
         return $this;
     }
 
@@ -209,10 +218,12 @@ class Operator implements PredicateInterface
      */
     public function getExpressionData()
     {
+        list($values[], $types[]) = $this->normalizeArgument($this->left, $this->leftType);
+        list($values[], $types[]) = $this->normalizeArgument($this->right, $this->rightType);
         return array(array(
             '%s ' . $this->operator . ' %s',
-            array($this->left, $this->right),
-            array($this->leftType, $this->rightType)
+            $values,
+            $types
         ));
     }
 }

--- a/tests/ZendTest/Db/Sql/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/ExpressionTest.php
@@ -124,16 +124,29 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             )),
             $expression->getExpressionData()
         );
+        $expression = new Expression(
+            'X SAME AS ? AND Y = ? BUT LITERALLY ?',
+            array(
+                array('foo'        => Expression::TYPE_IDENTIFIER),
+                array(5            => Expression::TYPE_VALUE),
+                array('FUNC(FF%X)' => Expression::TYPE_LITERAL),
+            )
+        );
+
+        $expected = array(array(
+            'X SAME AS %s AND Y = %s BUT LITERALLY %s',
+            array('foo', 5, 'FUNC(FF%X)'),
+            array(Expression::TYPE_IDENTIFIER, Expression::TYPE_VALUE, Expression::TYPE_LITERAL)
+        ));
+
+        $this->assertEquals($expected, $expression->getExpressionData());
     }
 
     public function testGetExpressionDataWillEscapePercent()
     {
         $expression = new Expression('X LIKE "foo%"');
-        $this->assertEquals(array(array(
-                'X LIKE "foo%%"',
-                array(),
-                array()
-            )),
+        $this->assertEquals(
+            array('X LIKE "foo%%"'),
             $expression->getExpressionData()
         );
     }

--- a/tests/ZendTest/Db/Sql/Predicate/BetweenTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/BetweenTest.php
@@ -125,6 +125,16 @@ class BetweenTest extends TestCase
             array(Between::TYPE_IDENTIFIER, Between::TYPE_VALUE, Between::TYPE_VALUE),
         ));
         $this->assertEquals($expected, $this->between->getExpressionData());
+
+        $this->between->setIdentifier(array(10=>Between::TYPE_VALUE))
+                      ->setMinValue(array('foo.bar'=>Between::TYPE_IDENTIFIER))
+                      ->setMaxValue(array('foo.baz'=>Between::TYPE_IDENTIFIER));
+        $expected = array(array(
+            $this->between->getSpecification(),
+            array(10, 'foo.bar', 'foo.baz'),
+            array(Between::TYPE_VALUE, Between::TYPE_IDENTIFIER, Between::TYPE_IDENTIFIER),
+        ));
+        $this->assertEquals($expected, $this->between->getExpressionData());
     }
 
 }

--- a/tests/ZendTest/Db/Sql/Predicate/InTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/InTest.php
@@ -55,6 +55,20 @@ class InTest extends TestCase
             array(In::TYPE_IDENTIFIER, In::TYPE_VALUE, In::TYPE_VALUE, In::TYPE_VALUE),
         ));
         $this->assertEquals($expected, $in->getExpressionData());
+
+        $in->setIdentifier('foo.bar')
+            ->setValueSet(array(
+                array(1=>In::TYPE_LITERAL),
+                array(2=>In::TYPE_VALUE),
+                array(3=>In::TYPE_LITERAL),
+            ));
+        $expected = array(array(
+            '%s IN (%s, %s, %s)',
+            array('foo.bar', 1, 2, 3),
+            array(In::TYPE_IDENTIFIER, In::TYPE_LITERAL, In::TYPE_VALUE, In::TYPE_LITERAL),
+        ));
+        $qqq = $in->getExpressionData();
+        $this->assertEquals($expected, $in->getExpressionData());
     }
 
     public function testGetExpressionDataWithSubselect()

--- a/tests/ZendTest/Db/Sql/Predicate/LikeTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/LikeTest.php
@@ -48,6 +48,14 @@ class LikeTest extends \PHPUnit_Framework_TestCase
             ),
             $like->getExpressionData()
         );
+
+        $like = new Like(array('Foo%'=>$like::TYPE_VALUE), array('bar'=>$like::TYPE_IDENTIFIER));
+        $this->assertEquals(
+            array(
+                array('%1$s LIKE %2$s', array('Foo%', 'bar'), array($like::TYPE_VALUE, $like::TYPE_IDENTIFIER))
+            ),
+            $like->getExpressionData()
+        );
     }
 
     public function testInstanceOfPerSetters()

--- a/tests/ZendTest/Db/Sql/Predicate/OperatorTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/OperatorTest.php
@@ -39,6 +39,13 @@ class OperatorTest extends TestCase
         $this->assertEquals(Operator::TYPE_VALUE, $operator->getLeftType());
         $this->assertEquals(Operator::TYPE_IDENTIFIER, $operator->getRightType());
 
+        $operator = new Operator(array('bar'=>Operator::TYPE_VALUE), '>=', array('foo.bar'=>Operator::TYPE_IDENTIFIER));
+        $this->assertEquals(Operator::OP_GTE, $operator->getOperator());
+        $this->assertEquals(array('bar'=>Operator::TYPE_VALUE), $operator->getLeft());
+        $this->assertEquals(array('foo.bar'=>Operator::TYPE_IDENTIFIER), $operator->getRight());
+        $this->assertEquals(Operator::TYPE_VALUE, $operator->getLeftType());
+        $this->assertEquals(Operator::TYPE_IDENTIFIER, $operator->getRightType());
+
         $operator = new Operator('bar', '>=', 0);
         $this->assertEquals(0, $operator->getRight());
     }


### PR DESCRIPTION
for more readable methods calls
implements Case predicate to demonstrate the need for these changes
