### PR TITLE
Zend\Db\Adapter alow to use the temporary ResultSetPrototype

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -163,7 +163,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
      * @throws Exception\InvalidArgumentException
      * @return Driver\StatementInterface|ResultSet\ResultSet
      */
-    public function query($sql, $parametersOrQueryMode = self::QUERY_MODE_PREPARE)
+    public function query($sql, $parametersOrQueryMode = self::QUERY_MODE_PREPARE, ResultSet\ResultSetInterface $resultPrototype = null)
     {
         if (is_string($parametersOrQueryMode) && in_array($parametersOrQueryMode, array(self::QUERY_MODE_PREPARE, self::QUERY_MODE_EXECUTE))) {
             $mode = $parametersOrQueryMode;
@@ -190,7 +190,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
         }
 
         if ($result instanceof Driver\ResultInterface && $result->isQueryResult()) {
-            $resultSet = clone $this->queryResultSetPrototype;
+            $resultSet = clone ($resultPrototype ?: $this->queryResultSetPrototype);
             $resultSet->initialize($result);
             return $resultSet;
         }

--- a/tests/ZendTest/Db/Adapter/AdapterTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterTest.php
@@ -272,6 +272,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         $r = $this->adapter->query($sql, Adapter::QUERY_MODE_EXECUTE);
         $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $r);
+
+        $r = $this->adapter->query($sql, Adapter::QUERY_MODE_EXECUTE, new TemporaryResultSet());
+        $this->assertInstanceOf('ZendTest\Db\Adapter\TemporaryResultSet', $r);
     }
 
     /**
@@ -297,4 +300,8 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException', 'Invalid magic');
         $this->adapter->foo;
     }
+}
+
+class TemporaryResultSet extends \Zend\Db\ResultSet\ResultSet
+{
 }

--- a/tests/ZendTest/Log/TestAsset/MockDbAdapter.php
+++ b/tests/ZendTest/Log/TestAsset/MockDbAdapter.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Log\TestAsset;
 
 use Zend\Db\Adapter\Adapter as DbAdapter;
+use Zend\Db\ResultSet\ResultSetInterface;
 
 class MockDbAdapter extends DbAdapter
 {
@@ -29,7 +30,7 @@ class MockDbAdapter extends DbAdapter
         $this->driver = new MockDbDriver;
 
     }
-    public function query($sql, $parametersOrQueryMode = DbAdapter::QUERY_MODE_PREPARE)
+    public function query($sql, $parametersOrQueryMode = DbAdapter::QUERY_MODE_PREPARE, ResultSetInterface $resultPrototype = null)
     {
         $this->calls[__FUNCTION__][] = $sql;
         return $this;


### PR DESCRIPTION
Allow use construction:
    `$adapter->query("SELECT...", Adapter::QUERY_MODE_EXECUTE, new TemporaryResultSet());`
