### PR TITLE
Fixing a bug that causes fatal error when a RowGateway's primary key wer...

### DIFF
--- a/library/Zend/Db/RowGateway/AbstractRowGateway.php
+++ b/library/Zend/Db/RowGateway/AbstractRowGateway.php
@@ -132,12 +132,15 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
 
             $data = $this->data;
             $where = array();
+            $arePrimaryKeysModified = false;
 
             // primary key is always an array even if its a single column
             foreach ($this->primaryKeyColumn as $pkColumn) {
                 $where[$pkColumn] = $this->primaryKeyData[$pkColumn];
                 if ($data[$pkColumn] == $this->primaryKeyData[$pkColumn]) {
                     unset($data[$pkColumn]);
+                } else {
+                    $arePrimaryKeysModified = true;
                 }
             }
 
@@ -146,6 +149,14 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
             $rowsAffected = $result->getAffectedRows();
             unset($statement, $result); // cleanup
 
+            // If one or more primary keys are modified, we update the where clause
+            if ($arePrimaryKeysModified) {
+                foreach ($this->primaryKeyColumn as $pkColumn) {
+                    if ($data[$pkColumn] != $this->primaryKeyData[$pkColumn]) {
+                        $where[$pkColumn] = $data[$pkColumn];
+                    }
+                }
+            }
         } else {
 
             // INSERT

--- a/tests/ZendTest/Db/RowGateway/AbstractRowGatewayTest.php
+++ b/tests/ZendTest/Db/RowGateway/AbstractRowGatewayTest.php
@@ -200,6 +200,33 @@ class AbstractRowGatewayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\RowGateway\RowGateway::save
+     */
+    public function testSaveUpdateChangingPrimaryKey()
+    {
+        $selectMock = $this->getMock('Zend\Db\Sql\Select', array('where'));
+        $selectMock->expects($this->once())
+                   ->method('where')
+                   ->with($this->equalTo(array('id' => 7)))
+                   ->will($this->returnValue($selectMock));
+
+        $sqlMock = $this->getMock('Zend\Db\Sql\Sql', array('select'), array($this->mockAdapter));
+        $sqlMock->expects($this->any())
+                ->method('select')
+                ->will($this->returnValue($selectMock));
+
+        $this->setRowGatewayState(array('sql' => $sqlMock));
+
+        $this->mockResult->expects($this->any())
+                         ->method('current')
+                         ->will($this->returnValue(array('id' => 6, 'name' => 'foo')));
+
+        $this->rowGateway->populate(array('id' => 6, 'name' => 'foo'), true);
+        $this->rowGateway->id = 7;
+        $this->rowGateway->save();
+    }
+
+    /**
      * @covers Zend\Db\RowGateway\RowGateway::delete
      */
     public function testDelete()


### PR DESCRIPTION
...e changed directly : refresh the select's where clause after the update query. Attempting to solve the issue #5232.
