### PR TITLE
Zend\ServiceManager allow to set root service manager

### DIFF
--- a/library/Zend/ServiceManager/ServiceLocatorAwareTrait.php
+++ b/library/Zend/ServiceManager/ServiceLocatorAwareTrait.php
@@ -9,14 +9,17 @@
 
 namespace Zend\ServiceManager;
 
-use Zend\ServiceManager\ServiceLocatorInterface;
-
 trait ServiceLocatorAwareTrait
 {
     /**
      * @var ServiceLocatorInterface
      */
     protected $serviceLocator = null;
+
+    /**
+     * @var bool
+     */
+    protected $useTopServiceLocator = false;
 
     /**
      * Set service locator
@@ -26,7 +29,9 @@ trait ServiceLocatorAwareTrait
      */
     public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $this->useTopServiceLocator
+                ? $this->getTopServiceLocator($serviceLocator)
+                : $serviceLocator;
 
         return $this;
     }
@@ -39,5 +44,19 @@ trait ServiceLocatorAwareTrait
     public function getServiceLocator()
     {
         return $this->serviceLocator;
+    }
+
+    /**
+     * Get top service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return ServiceLocatorInterface
+     */
+    protected function getTopServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        while ($serviceLocator instanceof ServiceLocatorAwareInterface && ($parentLocator = $serviceLocator->getServiceLocator()) != null) {
+            $serviceLocator = $parentLocator;
+        }
+        return $serviceLocator;
     }
 }

--- a/library/Zend/ServiceManager/ServiceManagerAwareTrait.php
+++ b/library/Zend/ServiceManager/ServiceManagerAwareTrait.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+trait ServiceManagerAwareTrait
+{
+    /**
+     * @var ServiceManager
+     */
+    protected $serviceManager = null;
+
+    /**
+     * Set service manager
+     *
+     * @param ServiceManager $serviceManager
+     * @return self
+     */
+    public function setServiceManager(ServiceManager $serviceManager)
+    {
+        $this->serviceManager = $serviceManager;
+        return $this;
+    }
+}

--- a/tests/ZendTest/ServiceManager/ServiceLocatorAwareTraitTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceLocatorAwareTraitTest.php
@@ -43,4 +43,25 @@ class ServiceLocatorAwareTraitTest extends TestCase
 
         $this->assertEquals($serviceLocator, $object->getServiceLocator());
     }
+
+    public function testSetPluginsServiceLocator()
+    {
+        $object = $this->getObjectForTrait('\Zend\ServiceManager\ServiceLocatorAwareTrait');
+
+        $property = new \ReflectionProperty($object, 'useTopServiceLocator');
+        $property->setAccessible(true);
+        $property->setValue($object, true);
+
+        $this->assertAttributeEquals(null, 'serviceLocator', $object);
+
+        $serviceLocator = new ServiceManager;
+        $pluginManager = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
+        $pluginManager->setServiceLocator($serviceLocator);
+
+        $object->setServiceLocator($pluginManager);
+        $this->assertAttributeEquals($serviceLocator, 'serviceLocator', $object);
+
+        $object->setServiceLocator($serviceLocator);
+        $this->assertAttributeEquals($serviceLocator, 'serviceLocator', $object);
+    }
 }

--- a/tests/ZendTest/ServiceManager/ServiceManagerAwareTraitTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerAwareTraitTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+use \Zend\ServiceManager\ServiceManager;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_ServiceManager
+ */
+class ServiceManagerAwareTraitTest extends TestCase
+{
+    public function testSetServiceManager()
+    {
+        $object = $this->getObjectForTrait('\Zend\ServiceManager\ServiceManagerAwareTrait');
+
+        $this->assertAttributeEquals(null, 'serviceManager', $object);
+
+        $serviceManager = new ServiceManager;
+
+        $object->setServiceManager($serviceManager);
+
+        $this->assertAttributeEquals($serviceManager, 'serviceManager', $object);
+    }
+}


### PR DESCRIPTION
Sometime we need get some object via PluginManager, but in this object we need only root ServiceManager and PluginManager will never using.

added ServiceManagerAwareTrait
