### PR TITLE
Wrong PHPDoc

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -126,7 +126,7 @@ abstract class AbstractController implements
     /**
      * Get request object
      *
-     * @return Request
+     * @return HttpRequest
      */
     public function getRequest()
     {


### PR DESCRIPTION
PHPStorm IDE confuses "Zend\Http\Request" AND "Zend\Stdlib\RequestInterface as Request". Returned object must be Zend\Http\Request and not Zend\Stdlib\RequestInterface
