### PR TITLE
change self:: with static:: in call-ing static property/method

### DIFF
--- a/library/Zend/Code/Generator/DocBlockGenerator.php
+++ b/library/Zend/Code/Generator/DocBlockGenerator.php
@@ -101,11 +101,11 @@ class DocBlockGenerator extends AbstractGenerator
 
     protected static function getTagManager()
     {
-        if (!isset(self::$tagManager)) {
-            self::$tagManager = new TagManager();
-            self::$tagManager->initializeDefaultTags();
+        if (!isset(static::$tagManager)) {
+            static::$tagManager = new TagManager();
+            static::$tagManager->initializeDefaultTags();
         }
-        return self::$tagManager;
+        return static::$tagManager;
     }
 
 

--- a/library/Zend/Mail/Header/ContentTransferEncoding.php
+++ b/library/Zend/Mail/Header/ContentTransferEncoding.php
@@ -92,9 +92,9 @@ class ContentTransferEncoding implements HeaderInterface
      */
     public function setTransferEncoding($transferEncoding)
     {
-        if (!in_array($transferEncoding, self::$allowedTransferEncodings)) {
+        if (!in_array($transferEncoding, static::$allowedTransferEncodings)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects one of "'. implode(', ', self::$allowedTransferEncodings) . '"; received "%s"',
+                '%s expects one of "'. implode(', ', static::$allowedTransferEncodings) . '"; received "%s"',
                 __METHOD__,
                 (string) $transferEncoding
             ));

--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -234,8 +234,8 @@ abstract class AbstractPage extends AbstractContainer
             }
         }
 
-        if (self::$factories) {
-            foreach (self::$factories as $factoryCallBack) {
+        if (static::$factories) {
+            foreach (static::$factories as $factoryCallBack) {
                 if (($page = call_user_func($factoryCallBack, $options))) {
                     return $page;
                 }
@@ -264,7 +264,7 @@ abstract class AbstractPage extends AbstractContainer
      */
     public static function addFactory($callback)
     {
-        self::$factories[] = $callback;
+        static::$factories[] = $callback;
     }
 
     /**

--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -78,11 +78,11 @@ final class Version
      */
     public static function getLatest($service = self::VERSION_SERVICE_ZEND, Http\Client $httpClient = null)
     {
-        if (null !== self::$latestVersion) {
-            return self::$latestVersion;
+        if (null !== static::$latestVersion) {
+            return static::$latestVersion;
         }
 
-        self::$latestVersion = 'not available';
+        static::$latestVersion = 'not available';
 
         if (null === $httpClient && !ini_get('allow_url_fopen')) {
             trigger_error(
@@ -96,7 +96,7 @@ final class Version
                 E_USER_WARNING
             );
 
-            return self::$latestVersion;
+            return static::$latestVersion;
         }
 
         $response = false;
@@ -115,10 +115,10 @@ final class Version
         }
 
         if ($response) {
-            self::$latestVersion = $response;
+            static::$latestVersion = $response;
         }
 
-        return self::$latestVersion;
+        return static::$latestVersion;
     }
 
     /**
@@ -130,7 +130,7 @@ final class Version
      */
     public static function isLatest()
     {
-        return self::compareVersion(self::getLatest()) < 1;
+        return static::compareVersion(self::getLatest()) < 1;
     }
 
     /**


### PR DESCRIPTION
some of this change is part of #5136 that I forgot to comment about changing self:: to static:: when calling static property/method that merged to **develop** branch. So I proposed it to be pointed to **develop**
