### PR TITLE
Zend/ServiceManager/AbstractPluginManager - allow to use the top service manager

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -50,6 +50,12 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     protected $serviceLocator;
 
     /**
+     * The top service locator
+     *
+     * @var ServiceLocatorInterface
+     */
+    protected $topLocator = null;
+    /**
      * Constructor
      *
      * Add a default initializer to ensure the plugin is valid after instance
@@ -136,6 +142,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
+        $this->topLocator = null;
         return $this;
     }
 
@@ -147,6 +154,22 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     public function getServiceLocator()
     {
         return $this->serviceLocator;
+    }
+
+    /**
+     * Get top service locator
+     *
+     * @return self|ServiceLocatorInterface
+     */
+    public function getTopLocator()
+    {
+        if (!$this->topLocator && $this->serviceLocator) {
+            $this->topLocator = $this->serviceLocator;
+            while ($this->topLocator instanceof ServiceLocatorAwareInterface && ($parentLocator = $this->topLocator->getServiceLocator()) != null) {
+                $this->topLocator = $parentLocator;
+            }
+        }
+        return $this->topLocator;
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -158,7 +158,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue($delegator));
 
-        $pluginManager->setFactory('foo-service', function() use ($realService) {
+        $pluginManager->setFactory('foo-service', function () use ($realService) {
             return $realService;
         });
         $pluginManager->addDelegator('foo-service', $delegatorFactory);
@@ -191,5 +191,26 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('stdClass', array_shift($fooDelegator->instances));
         $this->assertSame($fooDelegator, array_shift($barDelegator->instances));
 
+    }
+
+    public function testGetTopLocator()
+    {
+        $pluginManager = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
+        // no locator
+        $this->assertNull($pluginManager->getTopLocator());
+        // one level locator
+        $pluginManager->setServiceLocator($this->serviceManager);
+        $this->assertSame($this->serviceManager, $pluginManager->getTopLocator());
+        // set another locator
+        $serviceManager = new ServiceManager;
+        $pluginManager->setServiceLocator($serviceManager);
+        $this->assertSame($serviceManager, $pluginManager->getTopLocator());
+        // set tree of locators
+        $pluginManager2 = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
+        $pluginManager2->setServiceLocator($serviceManager);
+        $pluginManager3 = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
+        $pluginManager3->setServiceLocator($pluginManager2);
+        $pluginManager->setServiceLocator($pluginManager3);
+        $this->assertSame($serviceManager, $pluginManager->getTopLocator());
     }
 }

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -997,12 +997,12 @@ class ServiceManagerTest extends TestCase
         $realService = $this->getMock('stdClass', array(), array(), 'RealService');
         $delegator = $this->getMock('stdClass', array(), array(), 'Delegator');
 
-        $delegatorFactoryCallback = function($serviceManager, $cName, $rName, $callback) use ($delegator) {
+        $delegatorFactoryCallback = function ($serviceManager, $cName, $rName, $callback) use ($delegator) {
             $delegator->real = call_user_func($callback);
             return $delegator;
         };
 
-        $this->serviceManager->setFactory('foo-service', function() use ($realService) { return $realService; } );
+        $this->serviceManager->setFactory('foo-service', function () use ($realService) { return $realService; } );
         $this->serviceManager->addDelegator('foo-service', $delegatorFactoryCallback);
 
         $service = $this->serviceManager->create('foo-service');


### PR DESCRIPTION
Sometime we need get some object via PluginManager, but in this object we need to use root ServiceManager.
(recreate https://github.com/zendframework/zf2/pull/5326)
