### PR TITLE
ZendTest - added tearDown for Netbeans tests

### DIFF
--- a/tests/ZendTest/Config/Reader/XmlTest.php
+++ b/tests/ZendTest/Config/Reader/XmlTest.php
@@ -21,6 +21,11 @@ class XmlTest extends AbstractReaderTestCase
         $this->reader = new Xml();
     }
 
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
+
     /**
      * getTestAssetPath(): defined by AbstractReaderTestCase.
      *

--- a/tests/ZendTest/Console/Prompt/CharTest.php
+++ b/tests/ZendTest/Console/Prompt/CharTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Console\Char;
+namespace ZendTest\Console\Prompt;
 
 use Zend\Console\Prompt\Char;
 use ZendTest\Console\TestAssets\ConsoleAdapter;

--- a/tests/ZendTest/Console/Prompt/ConfirmTest.php
+++ b/tests/ZendTest/Console/Prompt/ConfirmTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Console\Char;
+namespace ZendTest\Console\Prompt;
 
 use Zend\Console\Prompt\Confirm;
 use ZendTest\Console\TestAssets\ConsoleAdapter;

--- a/tests/ZendTest/Console/Prompt/LineTest.php
+++ b/tests/ZendTest/Console/Prompt/LineTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Console\Char;
+namespace ZendTest\Console\Prompt;
 
 use Zend\Console\Prompt\Line;
 use ZendTest\Console\TestAssets\ConsoleAdapter;

--- a/tests/ZendTest/Console/Prompt/NumberTest.php
+++ b/tests/ZendTest/Console/Prompt/NumberTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Console\Char;
+namespace ZendTest\Console\Prompt;
 
 use Zend\Console\Prompt\Number;
 use ZendTest\Console\TestAssets\ConsoleAdapter;

--- a/tests/ZendTest/Console/Prompt/SelectTest.php
+++ b/tests/ZendTest/Console/Prompt/SelectTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Console\Char;
+namespace ZendTest\Console\Prompt;
 
 use Zend\Console\Prompt\Select;
 use ZendTest\Console\TestAssets\ConsoleAdapter;


### PR DESCRIPTION
when running tests for folder error handler is not restored

fix namespaces
