### PR TITLE
[WIP]fix 'Invalid date string provided' because of wrong \DateTime formatting

### DIFF
--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -74,19 +74,16 @@ class DateTimeFormatter extends AbstractFilter
         if ($value === '' || $value === null) {
             return $value;
         } elseif (is_int($value)) {
-            $value = new DateTime('@' . $value);
+            $value           = new DateTime('@' . $value);
             $normalizedValue = $value->format($this->format);
-
         } elseif (!$value instanceof DateTime) {
-            $datetime = new DateTime();
+            $datetime        = new DateTime();
             $normalizedValue = $datetime->createFromFormat($this->format, $value);
-            if(!$normalizedValue)
-            {
-                $value = new DateTime($value);
+            if (!$normalizedValue) {
+                $value           = new DateTime($value);
                 $normalizedValue = $value->format($this->format);
             }
-        }
-        elseif($value instanceof DateTime) {
+        } elseif ($value instanceof DateTime) {
             $normalizedValue = $value->format($this->format);
         }
 

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -74,19 +74,17 @@ class DateTimeFormatter extends AbstractFilter
         if ($value === '' || $value === null) {
             return $value;
         } elseif (is_int($value)) {
-            $value           = new DateTime('@' . $value);
-            $normalizedValue = $value->format($this->format);
+            $value = new DateTime('@' . $value);
         } elseif (!$value instanceof DateTime) {
             $datetime        = new DateTime();
-            $normalizedValue = $datetime->createFromFormat($this->format, $value);
-            if (!$normalizedValue) {
-                $value           = new DateTime($value);
-                $normalizedValue = $value->format($this->format);
+            $fromFormatValue = $datetime->createFromFormat($this->format, $value);
+            if (!$fromFormatValue) {
+                $value = new DateTime($value);
+            } else {
+                $value = $fromFormatValue;
             }
-        } elseif ($value instanceof DateTime) {
-            $normalizedValue = $value->format($this->format);
         }
 
-        return $normalizedValue;
+        return $value->format($this->format);
     }
 }

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -74,11 +74,13 @@ class DateTimeFormatter extends AbstractFilter
         if ($value === '' || $value === null) {
             return $value;
         } elseif (is_int($value)) {
-            $value = new DateTime('@' . $value);
+            $datetimeFromInt = new DateTime('@' . $value);
+            $value = $datetimeFromInt->format($this->format);
         } elseif (!$value instanceof DateTime) {
-            $value = new DateTime($value);
+            $datetime = new DateTime();
+            $value = $datetime->createFromFormat($this->format, $value);
         }
 
-        return $value->format($this->format);
+        return $value;
     }
 }

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -74,13 +74,22 @@ class DateTimeFormatter extends AbstractFilter
         if ($value === '' || $value === null) {
             return $value;
         } elseif (is_int($value)) {
-            $datetimeFromInt = new DateTime('@' . $value);
-            $value = $datetimeFromInt->format($this->format);
+            $value = new DateTime('@' . $value);
+            $normalizedValue = $value->format($this->format);
+
         } elseif (!$value instanceof DateTime) {
             $datetime = new DateTime();
-            $value = $datetime->createFromFormat($this->format, $value);
+            $normalizedValue = $datetime->createFromFormat($this->format, $value);
+            if(!$normalizedValue)
+            {
+                $value = new DateTime($value);
+                $normalizedValue = $value->format($this->format);
+            }
+        }
+        elseif($value instanceof DateTime) {
+            $normalizedValue = $value->format($this->format);
         }
 
-        return $value;
+        return $normalizedValue;
     }
 }


### PR DESCRIPTION
When submitting french formatted dates with a Date form element and so, a custom format (d/m/Y), DateTimeFormatter fails because of wrong date formatting.

example :

``` php
$this->add(
            array(
                'name'       => 'mydate',
                'type'        => 'date',
                'attributes' => array(
                    'id'    => 'mydate',
                ),
                'options'    => array(
                    'format'=>'d/m/Y'
                ),
            )
        );
```

Trying to validate 31/01/2013 fails with 'Invalid date string provided' 

``` php
$value->format($this->format);
```

When the value is a string, we must consider using DateTime::CreateFromFormat() to format the date accordingly to the format that is set in the form element.
When the value is an int (timestamp), the format ->format() method can be used
