### PR TITLE
Remove date filtering on date elements

### DIFF
--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -187,12 +187,6 @@ class DateTime extends Element implements InputProviderInterface
             'required' => true,
             'filters' => array(
                 array('name' => 'Zend\Filter\StringTrim'),
-                array(
-                    'name' => 'Zend\Filter\DateTimeFormatter',
-                    'options' => array(
-                        'format' => $this->getFormat(),
-                    )
-                )
             ),
             'validators' => $this->getValidators(),
         );


### PR DESCRIPTION
According to https://github.com/zendframework/zf2/issues/4889 , this PR removes the date filter on the related form elements.

This can be BC break for those who (can) use this filter on form submission. The validator is still ok according to the format option.
