### PR TITLE
Add Traversable merge capability to Stdlib\ArrayUtils:merge()

### DIFF
--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -257,7 +257,15 @@ abstract class ArrayUtils
     public static function merge(array $a, array $b)
     {
         foreach ($b as $key => $value) {
+            if ($value instanceof Traversable) {
+                $value = static::iteratorToArray($value);
+            }
+
             if (array_key_exists($key, $a)) {
+                if ($a[$key] instanceof Traversable) {
+                    $a[$key] = static::iteratorToArray($a[$key]);
+                }
+
                 if (is_int($key)) {
                     $a[] = $value;
                 } elseif (is_array($value) && is_array($a[$key])) {

--- a/tests/ZendTest/Stdlib/ArrayUtilsTest.php
+++ b/tests/ZendTest/Stdlib/ArrayUtilsTest.php
@@ -191,6 +191,34 @@ class ArrayUtilsTest extends TestCase
                     'bar' => 'bat'
                 )
             ),
+            'merge-iterators' => array(
+                array(
+                    'foo' => array(
+                        'bar'
+                    ),
+                    'bat' => new Config(array(
+                        'man'
+                    ))
+                ),
+                array(
+                    'foo' => new Config(array(
+                        'baz'
+                    )),
+                    'bat' => new Config(array(
+                        'girl'
+                    ))
+                ),
+                array(
+                    'foo' => array(
+                        0 => 'bar',
+                        1 => 'baz'
+                    ),
+                    'bat' => array(
+                        0 => 'man',
+                        1 => 'girl'
+                    ),
+                )
+            ),
         );
     }
 


### PR DESCRIPTION
I don't know if this will be accepted, since reading #880 and #882 it looks like `ArrayUtils::merge()` is only meant to merge plain arrays.

Nevertheless, I've got a use case for this: merging convenience `Config` classes in service locator configurations.

At the moment, trying to do this:

``` php
// inside a module
public function getServiceConfig()
{
    return array(
        // ideally we would instantiate a new custom configuration
        // with callables defined in it
        'factories' => new \Zend\Config\Config(array(
            'foo' => function(){ return 'some service' }
        )),
    );
}
```

will result in a broken service manager configuration, because on `loadModules` event the `factories` key will be overwritten, rather than merged.

I know it would suffice to invoke `Config::toArray()`, but it looks a bit obnoxious imho.

Thoughts?
