### PR TITLE
Fixed Zend\Http\Header\SetCookie docblock

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -434,6 +434,8 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
+     * Set whether the value for this cookie should be quoted
+     *
      * @param  bool $quotedValue
      * @return SetCookie
      */
@@ -501,7 +503,7 @@ class SetCookie implements MultipleHeaderInterface
     }
 
     /**
-     * Check whether the cookie is a session cookie (has no expiry time set)
+     * Check whether the value for this cookie should be quoted
      *
      * @return bool
      */


### PR DESCRIPTION
The docblock for `hasQuoteFieldValue()` was copied from above `isSessionCookie()` and not
changed.
