### PR TITLE
Handle 'disable_html_escape' option in FormButton helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -11,6 +11,7 @@ namespace Zend\Form\View\Helper;
 
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
+use Zend\Form\LabelOptionsAwareInterface;
 
 class FormButton extends FormInput
 {
@@ -92,9 +93,18 @@ class FormButton extends FormInput
             }
         }
 
-        $escape = $this->getEscapeHtmlHelper();
+        $labelOptions = array();
 
-        return $openTag . $escape($buttonContent) . $this->closeTag();
+        if ($element instanceof LabelOptionsAwareInterface) {
+            $labelOptions = $element->getLabelOptions();
+        }
+
+        if (empty($labelOptions) || $labelOptions['disable_html_escape'] == false) {
+            $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+            $buttonContent = $escapeHtmlHelper($buttonContent);
+        }
+
+        return $openTag . $buttonContent . $this->closeTag();
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormButtonTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormButtonTest.php
@@ -292,4 +292,21 @@ class FormButtonTest extends CommonTestCase
         $this->helper->setTranslatorEnabled(false);
         $this->assertFalse($this->helper->isTranslatorEnabled());
     }
+
+    public function testLabelIsEscapedByDefault()
+    {
+        $element = new Element('foo');
+        $element->setLabel('<strong>Click me</strong>');
+        $markup = $this->helper->__invoke($element);
+        $this->assertRegexp('#<button([^>]*)>&lt;strong&gt;Click me&lt;/strong&gt;<\/button>#', $markup);
+    }
+
+    public function testCanDisableLabelHtmlEscape()
+    {
+        $element = new Element('foo');
+        $element->setLabel('<strong>Click me</strong>');
+        $element->setLabelOptions(array('disable_html_escape' => true));
+        $markup = $this->helper->__invoke($element);
+        $this->assertRegexp('#<button([^>]*)><strong>Click me</strong></button>#', $markup);
+    }
 }


### PR DESCRIPTION
As requested in #4677 and #3015 discussions
