### PR TITLE
remove zendframework/zend-stdlib from require dependency when zend-eventmanager/zend-inputfilter already at require

### DIFF
--- a/library/Zend/Cache/composer.json
+++ b/library/Zend/Cache/composer.json
@@ -14,7 +14,6 @@
     "target-dir": "Zend/Cache",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-eventmanager": "self.version"
     },

--- a/library/Zend/Form/composer.json
+++ b/library/Zend/Form/composer.json
@@ -14,8 +14,7 @@
     "target-dir": "Zend/Form",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-inputfilter": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-inputfilter": "self.version"
     },
     "require-dev": {
         "zendframework/zendservice-recaptcha": "*"

--- a/library/Zend/ModuleManager/composer.json
+++ b/library/Zend/ModuleManager/composer.json
@@ -14,8 +14,7 @@
     "target-dir": "Zend/ModuleManager",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-eventmanager": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-eventmanager": "self.version"
     },
     "suggest": {
         "zendframework/zend-config": "Zend\\Config component",

--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-eventmanager": "self.version",
-        "zendframework/zend-servicemanager": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-servicemanager": "self.version"
     },
     "suggest": {
         "zendframework/zend-authentication": "Zend\\Authentication component for Identity plugin",

--- a/library/Zend/Test/composer.json
+++ b/library/Zend/Test/composer.json
@@ -20,7 +20,6 @@
         "zendframework/zend-http": "self.version",
         "zendframework/zend-mvc": "self.version",
         "zendframework/zend-servicemanager": "self.version",
-        "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-uri": "self.version",
         "zendframework/zend-view": "self.version"
     },

--- a/library/Zend/View/composer.json
+++ b/library/Zend/View/composer.json
@@ -15,8 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-eventmanager": "self.version",
-        "zendframework/zend-loader": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-loader": "self.version"
     },
     "suggest": {
         "zendframework/zend-filter": "Zend\\Filter component",


### PR DESCRIPTION
zend-eventmanager and zend-inputfilter already require zend-stdlib
