### PR TITLE
[stdlib] Add guard utils and traits

### DIFF
--- a/library/Zend/Stdlib/Guard/AllGuardsTrait.php
+++ b/library/Zend/Stdlib/Guard/AllGuardsTrait.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * An aggregate for all guard traits
+ */
+trait AllGuardsTrait
+{
+
+    use ArrayOrTraversableGuardTrait;
+    use EmptyGuardTrait;
+    use NullGuardTrait;
+
+}

--- a/library/Zend/Stdlib/Guard/ArrayOrTraversableGuardTrait.php
+++ b/library/Zend/Stdlib/Guard/ArrayOrTraversableGuardTrait.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Provide a guard method for array or Traversable data
+ */
+trait ArrayOrTraversableGuardTrait
+{
+
+    /**
+     * Verifies that the data is an array or Traversable
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    protected function guardForArrayOrTraversable(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
+    ) {
+        if (!is_array($data) && !($data instanceof \Traversable)) {
+            $message = sprintf(
+                "%s must be an array or Traversable, [%s] given",
+                $dataName,
+                is_object($data) ? get_class($data) : gettype($data)
+            );
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Stdlib/Guard/EmptyGuardTrait.php
+++ b/library/Zend/Stdlib/Guard/EmptyGuardTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Provide a guard method against empty data
+ */
+trait EmptyGuardTrait
+{
+
+    /**
+     * Verify that the data is not empty
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    protected function guardAgainstEmpty(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
+    ) {
+        if (empty($data)) {
+            $message = sprintf('%s cannot be empty', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Stdlib/Guard/GuardUtils.php
+++ b/library/Zend/Stdlib/Guard/GuardUtils.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Static guard helper class
+ *
+ * Bridges the gap for allowing refactoring until traits can be used by default.
+ *
+ * @deprecated
+ */
+abstract class GuardUtils
+{
+
+    const DEFAULT_EXCEPTION_CLASS = 'Zend\Stdlib\Exception\InvalidArgumentException';
+
+
+    /**
+     * Verifies that the data is an array or Traversable
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    public static function guardForArrayOrTraversable(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = self::DEFAULT_EXCEPTION_CLASS
+    ) {
+        if (!is_array($data) && !($data instanceof \Traversable)) {
+            $message = sprintf(
+                '%s must be an array or Traversable, [%s] given',
+                $dataName,
+                is_object($data) ? get_class($data) : gettype($data)
+            );
+            throw new $exceptionClass($message);
+        }
+    }
+
+    /**
+     * Verify that the data is not empty
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    public static function guardAgainstEmpty(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = self::DEFAULT_EXCEPTION_CLASS
+    ) {
+        if (empty($data)) {
+            $message = sprintf('%s cannot be empty', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+    /**
+     * Verify that the data is not null
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    public static function guardAgainstNull(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = self::DEFAULT_EXCEPTION_CLASS
+    ) {
+        if (is_null($data)) {
+            $message = sprintf('%s cannot be null', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/library/Zend/Stdlib/Guard/NullGuardTrait.php
+++ b/library/Zend/Stdlib/Guard/NullGuardTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Guard;
+
+/**
+ * Provide a guard method against null data
+ */
+trait NullGuardTrait
+{
+
+    /**
+     * Verify that the data is not null
+     *
+     * @param  mixed  $data           the data to verify
+     * @param  string $dataName       the data name
+     * @param  string $exceptionClass FQCN for the exception
+     * @throws \Exception
+     */
+    protected function guardAgainstNull(
+        $data,
+        $dataName = 'Argument',
+        $exceptionClass = 'Zend\Stdlib\Exception\InvalidArgumentException'
+    ) {
+        if (is_null($data)) {
+            $message = sprintf('%s cannot be null', $dataName);
+            throw new $exceptionClass($message);
+        }
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/ArrayOrTraversableGuardTraitTest.php
+++ b/tests/ZendTest/Stdlib/Guard/ArrayOrTraversableGuardTraitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Stdlib\TestAsset\GuardedObject;
+use Zend\Stdlib\ArrayObject;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\ArrayOrTraversableGuardTrait
+ */
+class ArrayOrTraversableGuardTraitTest extends TestCase
+{
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped('Only valid for php >= 5.4');
+        }
+    }
+
+    public function testGuardForArrayOrTraversableThrowsException()
+    {
+        $object = new GuardedObject;
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument must be an array or Traversable, [string] given'
+        );
+        $object->setArrayOrTraversable('');
+    }
+
+    public function testGuardForArrayOrTraversableAllowsArray()
+    {
+        $object = new GuardedObject;
+        $this->assertNull($object->setArrayOrTraversable(array()));
+    }
+
+    public function testGuardForArrayOrTraversableAllowsTraversable()
+    {
+        $object      = new GuardedObject;
+        $traversable = new ArrayObject;
+        $this->assertNull($object->setArrayOrTraversable($traversable));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/EmptyGuardTraitTest.php
+++ b/tests/ZendTest/Stdlib/Guard/EmptyGuardTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Stdlib\TestAsset\GuardedObject;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\EmptyGuardTrait
+ */
+class EmptyGuardTraitTest extends TestCase
+{
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped('Only valid for php >= 5.4');
+        }
+    }
+
+    public function testGuardAgainstEmptyThrowsException()
+    {
+        $object = new GuardedObject;
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be empty'
+        );
+        $object->setNotEmpty('');
+    }
+
+    public function testGuardAgainstEmptyAllowsNonEmptyString()
+    {
+        $object = new GuardedObject;
+        $this->assertNull($object->setNotEmpty('foo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/GuardUtilsTest.php
+++ b/tests/ZendTest/Stdlib/Guard/GuardUtilsTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Stdlib\Guard\GuardUtils;
+use Zend\Stdlib\ArrayObject;
+
+/**
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\GuardUtils
+ */
+class GuardUtilsTest extends TestCase
+{
+
+    public function testGuardForArrayOrTraversableThrowsException()
+    {
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument must be an array or Traversable, [string] given'
+        );
+        GuardUtils::guardForArrayOrTraversable('');
+    }
+
+    public function testGuardForArrayOrTraversableAllowsArray()
+    {
+        $this->assertNull(GuardUtils::guardForArrayOrTraversable(array()));
+    }
+
+    public function testGuardForArrayOrTraversableAllowsTraversable()
+    {
+        $traversable = new ArrayObject;
+        $this->assertNull(GuardUtils::guardForArrayOrTraversable($traversable));
+    }
+
+    public function testGuardAgainstEmptyThrowsException()
+    {
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be empty'
+        );
+        GuardUtils::guardAgainstEmpty('');
+    }
+
+    public function testGuardAgainstEmptyAllowsNonEmptyString()
+    {
+        $this->assertNull(GuardUtils::guardAgainstEmpty('foo'));
+    }
+
+    public function testGuardAgainstNullThrowsException()
+    {
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be null'
+        );
+        GuardUtils::guardAgainstNull(null);
+    }
+
+    public function testGuardAgainstNullAllowsNonNull()
+    {
+        $this->assertNull(GuardUtils::guardAgainstNull('foo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/Guard/NullGuardTraitTest.php
+++ b/tests/ZendTest/Stdlib/Guard/NullGuardTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Guard;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZendTest\Stdlib\TestAsset\GuardedObject;
+
+/**
+ * @requires PHP 5.4
+ * @group    Zend_StdLib_Guard
+ * @covers   Zend\Stdlib\Guard\NullGuardTrait
+ */
+class NullGuardTraitTest extends TestCase
+{
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped('Only valid for php >= 5.4');
+        }
+    }
+
+    public function testGuardAgainstNullThrowsException()
+    {
+        $object = new GuardedObject;
+        $this->setExpectedException(
+            'Zend\Stdlib\Exception\InvalidArgumentException',
+            'Argument cannot be null'
+        );
+        $object->setNotNull(null);
+    }
+
+    public function testGuardAgainstNullAllowsNonNull()
+    {
+        $object = new GuardedObject;
+        $this->assertNull($object->setNotNull('foo'));
+    }
+
+}

--- a/tests/ZendTest/Stdlib/TestAsset/GuardedObject.php
+++ b/tests/ZendTest/Stdlib/TestAsset/GuardedObject.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\Guard\AllGuardsTrait;
+
+/**
+ * @group Zend_Stdlib_Guard
+ */
+class GuardedObject
+{
+
+    use AllGuardsTrait;
+
+    public function setArrayOrTraversable($value)
+    {
+        $this->guardForArrayOrTraversable($value);
+    }
+
+    public function setNotEmpty($value)
+    {
+        $this->guardAgainstEmpty($value);
+    }
+
+    public function setNotNull($value)
+    {
+        $this->guardAgainstNull($value);
+    }
+
+}


### PR DESCRIPTION
The check for `array` or `Traversable` code is littered throughout the framework.  This is a prime opportunity for a trait.  Included a couple extra traits for good measure.

For example, https://github.com/zendframework/zf2/blob/master/library/Zend/Form/Fieldset.php#L297 could be:

``` php
class Fieldset extends Element implements FieldsetInterface
{
    use \Zend\Stdlib\Guard\ArrayOrTraversableGuardTrait;

    // ...

    public function setMessages($messages)
    {
        // php 5.4
        $this->guardForArrayOrTraversable(
            $messages, 'Messages', 'Zend\Form\Exception\InvalidArgumentException'
        );

        // or php 5.3
        \Zend\Stdlib\Guard\GuardUtils::guardForArrayOrTraversable(
            $messages, 'Messages', 'Zend\Form\Exception\InvalidArgumentException'
        );

        foreach ($messages as $elementName => $elementMessages) {
            $this->get($elementName)->setMessages($elementMessages);
        }

        return $this;
    }

    // ...

}
```

Please see http://verraes.net/2013/09/extract-till-you-drop/
Note: resubmitting to clean up failed rebase.
