### PR TITLE
Avoid SOAP constant error in PHPUnit

### DIFF
--- a/tests/ZendTest/Soap/ClientTest.php
+++ b/tests/ZendTest/Soap/ClientTest.php
@@ -11,6 +11,14 @@ namespace ZendTest\Soap;
 
 require_once __DIR__ . '/TestAsset/commontypes.php';
 
+//if soap exension is not loaded, this will avoid two notices in the test runner suite
+if(!defined('SOAP_ENCODED')){
+    define ('SOAP_ENCODED', 1);
+}
+if(!defined('SOAP_DOCUMENT')){
+    define ('SOAP_DOCUMENT', 2);
+}
+
 use Zend\Soap\AutoDiscover;
 use Zend\Soap\Client;
 use Zend\Soap\Server;


### PR DESCRIPTION
Always had this two issues, because SOAP extension is not loaded. With this patch this is fixed.

```

C:\Data\Zend\Apache2\htdocs\GitHub\zf2\tests>..\vendor\bin\phpunit

Notice: Use of undefined constant SOAP_ENCODED - assumed 'SOAP_ENCODED' in C:\Da
ta\Zend\Apache2\htdocs\GitHub\zf2\tests\ZendTest\Soap\ClientTest.php on line 608


Call Stack:
    0.0020     122224   1. {main}() C:\Data\Zend\Apache2\htdocs\GitHub\zf2\vendo
r\phpunit\phpunit\composer\bin\phpunit:0
    0.0080     284824   2. PHPUnit_TextUI_Command::main() C:\Data\Zend\Apache2\h
tdocs\GitHub\zf2\vendor\phpunit\phpunit\composer\bin\phpunit:63
    0.0080     284960   3. PHPUnit_TextUI_Command->run() C:\Data\Zend\Apache2\ht
docs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\TextUI\Command.php:129
    0.0080     285176   4. PHPUnit_TextUI_Command->handleArguments() C:\Data\Zen
d\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\TextUI\Command.php:13
8
    0.0190     500184   5. PHPUnit_Util_Configuration->getTestSuiteConfiguration
() C:\Data\Zend\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\TextUI\
Command.php:657
    0.0190     500688   6. PHPUnit_Util_Configuration->getTestSuite() C:\Data\Ze
nd\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Util\Configuration.p
hp:789
    1.7432     782168   7. PHPUnit_Framework_TestSuite->addTestFiles() C:\Data\Z
end\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Util\Configuration.
php:873
   18.3148   81518912   8. PHPUnit_Framework_TestSuite->addTestFile() C:\Data\Ze
nd\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.
php:416
   18.3198   81657136   9. PHPUnit_Framework_TestSuite->addTestSuite() C:\Data\Z
end\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite
.php:389
   18.3198   81657264  10. PHPUnit_Framework_TestSuite->__construct() C:\Data\Ze
nd\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.
php:315
   18.3248   81742736  11. PHPUnit_Framework_TestSuite->addTestMethod() C:\Data\
Zend\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuit
e.php:212
   18.3248   81743000  12. PHPUnit_Framework_TestSuite::createTest() C:\Data\Zen
d\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.p
hp:834
   18.3248   81745280  13. PHPUnit_Util_Test::getProvidedData() C:\Data\Zend\Apa
che2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.php:48
1
   18.3248   81747168  14. ReflectionMethod->invoke() C:\Data\Zend\Apache2\htdoc
s\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Util\Test.php:267
   18.3248   81747184  15. ZendTest\Soap\ClientTest->dataProviderForInitSoapClie
ntObjectException() C:\Data\Zend\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpuni
t\PHPUnit\Util\Test.php:267


Notice: Use of undefined constant SOAP_DOCUMENT - assumed 'SOAP_DOCUMENT' in C:\
Data\Zend\Apache2\htdocs\GitHub\zf2\tests\ZendTest\Soap\ClientTest.php on line 6
09

Call Stack:
    0.0020     122224   1. {main}() C:\Data\Zend\Apache2\htdocs\GitHub\zf2\vendo
r\phpunit\phpunit\composer\bin\phpunit:0
    0.0080     284824   2. PHPUnit_TextUI_Command::main() C:\Data\Zend\Apache2\h
tdocs\GitHub\zf2\vendor\phpunit\phpunit\composer\bin\phpunit:63
    0.0080     284960   3. PHPUnit_TextUI_Command->run() C:\Data\Zend\Apache2\ht
docs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\TextUI\Command.php:129
    0.0080     285176   4. PHPUnit_TextUI_Command->handleArguments() C:\Data\Zen
d\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\TextUI\Command.php:13
8
    0.0190     500184   5. PHPUnit_Util_Configuration->getTestSuiteConfiguration
() C:\Data\Zend\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\TextUI\
Command.php:657
    0.0190     500688   6. PHPUnit_Util_Configuration->getTestSuite() C:\Data\Ze
nd\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Util\Configuration.p
hp:789
    1.7432     782168   7. PHPUnit_Framework_TestSuite->addTestFiles() C:\Data\Z
end\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Util\Configuration.
php:873
   18.3148   81518912   8. PHPUnit_Framework_TestSuite->addTestFile() C:\Data\Ze
nd\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.
php:416
   18.3198   81657136   9. PHPUnit_Framework_TestSuite->addTestSuite() C:\Data\Z
end\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite
.php:389
   18.3198   81657264  10. PHPUnit_Framework_TestSuite->__construct() C:\Data\Ze
nd\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.
php:315
   18.3248   81742736  11. PHPUnit_Framework_TestSuite->addTestMethod() C:\Data\
Zend\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuit
e.php:212
   18.3248   81743000  12. PHPUnit_Framework_TestSuite::createTest() C:\Data\Zen
d\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.p
hp:834
   18.3248   81745280  13. PHPUnit_Util_Test::getProvidedData() C:\Data\Zend\Apa
che2\htdocs\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Framework\TestSuite.php:48
1
   18.3248   81747168  14. ReflectionMethod->invoke() C:\Data\Zend\Apache2\htdoc
s\GitHub\zf2\vendor\phpunit\phpunit\PHPUnit\Util\Test.php:267
   18.3248   81747184  15. ZendTest\Soap\ClientTest->dataProviderForInitSoapClie
ntObjectException() C:\Data\Zend\Apache2\htdocs\GitHub\zf2\vendor\phpunit\phpuni
t\PHPUnit\Util\Test.php:267
```
