### PR TITLE
remove zendframework/zend-eventmanager and zendframework/zend-servicemanager dependency from Zend/Test/composer.json

### DIFF
--- a/library/Zend/Test/composer.json
+++ b/library/Zend/Test/composer.json
@@ -16,10 +16,8 @@
         "php": ">=5.3.3",
         "phpunit/PHPUnit": "3.7.*",
         "zendframework/zend-dom": "self.version",
-        "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-http": "self.version",
         "zendframework/zend-mvc": "self.version",
-        "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-uri": "self.version",
         "zendframework/zend-view": "self.version"


### PR DESCRIPTION
because zendframework/zend-mvc already require it
