### PR TITLE
Exception as one of the possible exception for Soap\Server::registerFaultException

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -939,7 +939,7 @@ class Server implements ZendServerServer
                 $this->registerFaultException($row);
             }
 
-        } elseif (is_string($class) && class_exists($class) && is_subclass_of($class, 'Exception')) {
+        } elseif (is_string($class) && class_exists($class) && (is_subclass_of($class, 'Exception') || 'Exception' === $class)) {
             $ref = new ReflectionClass($class);
 
             $this->faultExceptions[] = $ref->getName();

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -710,6 +710,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function dataProviderForRegisterFaultException()
     {
         return array(
+            array('Exception'),
             array('Zend\Soap\Exception\InvalidArgumentException'),
             array('InvalidArgumentException'),
             array('Zend\Server\Exception\RuntimeException'),


### PR DESCRIPTION
I've update to ZF 2.2.4 and found that passing "Exception" to the Soap\Server::registerFaultException wasn't possible anymore.
This PR adds the possibility to pass the generic class Exception as one of those that will be converted to a SoapFault.
