### PR TITLE
Zf hydrator strategy context

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Strategy/ClosureStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/ClosureStrategy.php
@@ -75,26 +75,28 @@ class ClosureStrategy implements StrategyInterface
     /**
      * Converts the given value so that it can be extracted by the hydrator.
      *
-     * @param mixed $value The original value.
+     * @param  mixed $value  The original value.
+     * @param  array $object The object is optionally provided as context.
      * @return mixed Returns the value that should be extracted.
      */
-    public function extract($value)
+    public function extract($value, $object = null)
     {
         $func = $this->extractFunc;
 
-        return $func($value);
+        return $func($value, $object);
     }
 
     /**
      * Converts the given value so that it can be hydrated by the hydrator.
      *
-     * @param mixed $value The original value.
+     * @param  mixed $value The original value.
+     * @param  array $data  The whole data is optionally provided as context.
      * @return mixed Returns the value that should be hydrated.
      */
-    public function hydrate($value)
+    public function hydrate($value, $data = null)
     {
         $func = $this->hydrateFunc;
 
-        return $func($value);
+        return $func($value, $data);
     }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/ClosureStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/ClosureStrategyTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\Strategy;
+
+use Zend\Stdlib\Hydrator\Strategy\ClosureStrategy;
+
+class ClosureStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return array
+     */
+    public function extractDataProvider()
+    {
+        return array(
+            array(
+                function ($value) { return strtoupper($value); },
+                new \ArrayObject(array('foo' => 'foo', 'bar' => 'bar')),
+                array('foo' => 'FOO', 'bar' => 'BAR'),
+            ),
+            array(
+                function ($value, $data) { return isset($data['bar']) ? strtoupper($value) : $value; },
+                new \ArrayObject(array('foo' => 'foo', 'bar' => 'bar')),
+                array('foo' => 'FOO', 'bar' => 'BAR'),
+            ),
+            array(
+                function ($value, $data) { return isset($data['bar']) ? strtoupper($value) : $value; },
+                new \ArrayObject(array('foo' => 'foo', 'baz' => 'baz')),
+                array('foo' => 'foo', 'baz' => 'baz'),
+            ),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function hydrateDataProvider()
+    {
+        return array(
+            array(
+                function ($value) { return strtoupper($value); },
+                array('foo' => 'foo', 'bar' => 'bar'),
+                array('foo' => 'FOO', 'bar' => 'BAR'),
+            ),
+            array(
+                function ($value, $data) { return strtoupper($value); },
+                array('foo' => 'foo', 'bar' => 'bar'),
+                array('foo' => 'FOO', 'bar' => 'BAR'),
+            ),
+            array(
+                function ($value, $data) { return isset($data['bar']) ? strtoupper($value) : $value; },
+                array('foo' => 'foo', 'bar' => 'bar'),
+                array('foo' => 'FOO', 'bar' => 'BAR'),
+            ),
+            array(
+                function ($value, $data) { return isset($data['bar']) ? strtoupper($value) : $value; },
+                array('foo' => 'foo', 'baz' => 'baz'),
+                array('foo' => 'foo', 'baz' => 'baz'),
+            ),
+        );
+    }
+
+    /**
+     * @covers \ZendTest\Stdlib\Hydrator\Strategy\ClosureStrategy::extract()
+     * @dataProvider extractDataProvider
+     *
+     * @param Callable $extractFunc
+     * @param array    $data
+     * @param array    $expected
+     */
+    public function testExtract($extractFunc, $data, $expected)
+    {
+        $strategy = new ClosureStrategy($extractFunc);
+
+        $actual = array();
+        foreach ($data as $k => $value) {
+           $actual[$k] = $strategy->extract($value, $data);
+        }
+
+        $this->assertSame($actual, $expected);
+    }
+
+    /**
+     * @covers \ZendTest\Stdlib\Hydrator\Strategy\ClosureStrategy::hydrate()
+     * @dataProvider hydrateDataProvider
+     *
+     * @param Callable $hydrateFunc
+     * @param array    $data
+     * @param array    $expected
+     */
+    public function testHydrate($hydrateFunc, $data, $expected)
+    {
+        $strategy = new ClosureStrategy(null, $hydrateFunc);
+
+        $actual = array();
+        foreach ($data as $k => $value) {
+           $actual[$k] = $strategy->hydrate($value, $data);
+        }
+
+        $this->assertSame($actual, $expected);
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/ClosureStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/ClosureStrategyTest.php
@@ -67,7 +67,7 @@ class ClosureStrategyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \ZendTest\Stdlib\Hydrator\Strategy\ClosureStrategy::extract()
+     * @covers \Zend\Stdlib\Hydrator\Strategy\ClosureStrategy::extract()
      * @dataProvider extractDataProvider
      *
      * @param Callable $extractFunc
@@ -87,7 +87,7 @@ class ClosureStrategyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \ZendTest\Stdlib\Hydrator\Strategy\ClosureStrategy::hydrate()
+     * @covers \Zend\Stdlib\Hydrator\Strategy\ClosureStrategy::hydrate()
      * @dataProvider hydrateDataProvider
      *
      * @param Callable $hydrateFunc


### PR DESCRIPTION
Since AbstractHydrator::extractValue() and AbstractHydrator::hydrateValue() can provide a context as the 2nd arg when calling ClosureStrategy::extract() and ClosureStrategy::hydrate(), I added support for this context in these methods.
I also provided U.T.
Should be BC.
