### PR TITLE
[Cache] Add adhoc TTL support, fix per-item ttl handling.

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -35,6 +35,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
     /**
      * Event handles of this adapter
+     *
      * @var array
      */
     protected $eventHandles = array();
@@ -127,6 +128,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             $event = new Event('option', $this, new ArrayObject($options->toArray()));
             $this->getEventManager()->trigger($event);
         }
+
         return $this;
     }
 
@@ -141,6 +143,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         if (!$this->options) {
             $this->setOptions(new AdapterOptions());
         }
+
         return $this->options;
     }
 
@@ -156,10 +159,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      */
     public function setCaching($flag)
     {
-        $flag    = (bool) $flag;
+        $flag = (bool)$flag;
         $options = $this->getOptions();
         $options->setWritable($flag);
         $options->setReadable($flag);
+
         return $this;
     }
 
@@ -175,6 +179,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     public function getCaching()
     {
         $options = $this->getOptions();
+
         return ($options->getWritable() && $options->getReadable());
     }
 
@@ -190,13 +195,14 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         if ($this->events === null) {
             $this->events = new EventManager(array(__CLASS__, get_class($this)));
         }
+
         return $this->events;
     }
 
     /**
      * Trigger an pre event and return the event response collection
      *
-     * @param  string $eventName
+     * @param  string      $eventName
      * @param  ArrayObject $args
      * @return \Zend\EventManager\ResponseCollection All handler return values
      */
@@ -216,7 +222,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     protected function triggerPost($eventName, ArrayObject $args, & $result)
     {
         $postEvent = new PostEvent($eventName . '.post', $this, $args, $result);
-        $eventRs   = $this->getEventManager()->trigger($postEvent);
+        $eventRs = $this->getEventManager()->trigger($postEvent);
         if ($eventRs->stopped()) {
             return $eventRs->last();
         }
@@ -234,13 +240,13 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @param  ArrayObject $args
      * @param  mixed       $result
      * @param  \Exception  $exception
-     * @throws Exception\ExceptionInterface
+     * @throws \Exception
      * @return mixed
      */
     protected function triggerException($eventName, ArrayObject $args, & $result, \Exception $exception)
     {
         $exceptionEvent = new ExceptionEvent($eventName . '.exception', $this, $args, $result, $exception);
-        $eventRs        = $this->getEventManager()->trigger($exceptionEvent);
+        $eventRs = $this->getEventManager()->trigger($exceptionEvent);
 
         if ($exceptionEvent->getThrowException()) {
             throw $exceptionEvent->getException();
@@ -262,6 +268,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     public function hasPlugin(Plugin\PluginInterface $plugin)
     {
         $registry = $this->getPluginRegistry();
+
         return $registry->contains($plugin);
     }
 
@@ -303,6 +310,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             $plugin->detach($this->getEventManager());
             $registry->detach($plugin);
         }
+
         return $this;
     }
 
@@ -316,6 +324,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         if (!$this->pluginRegistry instanceof SplObjectStorage) {
             $this->pluginRegistry = new SplObjectStorage();
         }
+
         return $this->pluginRegistry;
     }
 
@@ -324,9 +333,9 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Get an item.
      *
-     * @param  string  $key
-     * @param  bool $success
-     * @param  mixed   $casToken
+     * @param  string $key
+     * @param  bool   $success
+     * @param  mixed  $casToken
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      *
@@ -338,6 +347,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     {
         if (!$this->getOptions()->getReadable()) {
             $success = false;
+
             return null;
         }
 
@@ -368,9 +378,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             } else {
                 $result = $this->internalGetItem($args['key']);
             }
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -378,9 +390,9 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to get an item.
      *
-     * @param  string  $normalizedKey
-     * @param  bool $success
-     * @param  mixed   $casToken
+     * @param  string $normalizedKey
+     * @param  bool   $success
+     * @param  mixed  $casToken
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
@@ -415,9 +427,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalGetItems($args['keys']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array();
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -432,7 +446,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     protected function internalGetItems(array & $normalizedKeys)
     {
         $success = null;
-        $result  = array();
+        $result = array();
         foreach ($normalizedKeys as $normalizedKey) {
             $value = $this->internalGetItem($normalizedKey, $success);
             if ($success) {
@@ -472,9 +486,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalHasItem($args['key']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -490,6 +506,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     {
         $success = null;
         $this->internalGetItem($normalizedKey, $success);
+
         return $success;
     }
 
@@ -522,9 +539,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalHasItems($args['keys']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array();
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -544,6 +563,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 $result[] = $normalizedKey;
             }
         }
+
         return $result;
     }
 
@@ -576,9 +596,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalGetMetadata($args['key']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -628,9 +650,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalGetMetadatas($args['keys']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array();
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -651,6 +675,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 $result[$normalizedKey] = $metadata;
             }
         }
+
         return $result;
     }
 
@@ -659,8 +684,9 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Store an item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -668,7 +694,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers setItem.post(PostEvent)
      * @triggers setItem.exception(ExceptionEvent)
      */
-    public function setItem($key, $value)
+    public function setItem($key, $value, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -678,6 +704,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $args = new ArrayObject(array(
             'key'   => & $key,
             'value' => & $value,
+            'ttl'   => & $ttl,
         ));
 
         try {
@@ -686,10 +713,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalSetItem($args['key'], $args['value']);
+            $result = $this->internalSetItem($args['key'], $args['value'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -697,17 +726,19 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    abstract protected function internalSetItem(& $normalizedKey, & $value);
+    abstract protected function internalSetItem(& $normalizedKey, & $value, $ttl = null);
 
     /**
      * Store multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      *
@@ -715,7 +746,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers setItems.post(PostEvent)
      * @triggers setItems.exception(ExceptionEvent)
      */
-    public function setItems(array $keyValuePairs)
+    public function setItems(array $keyValuePairs, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return array_keys($keyValuePairs);
@@ -724,6 +755,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKeyValuePairs($keyValuePairs);
         $args = new ArrayObject(array(
             'keyValuePairs' => & $keyValuePairs,
+            'ttl'           => & $ttl,
         ));
 
         try {
@@ -732,10 +764,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalSetItems($args['keyValuePairs']);
+            $result = $this->internalSetItems($args['keyValuePairs'], $ttl);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array_keys($keyValuePairs);
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -743,11 +777,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to store multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $failedKeys = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
@@ -755,14 +790,16 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 $failedKeys[] = $normalizedKey;
             }
         }
+
         return $failedKeys;
     }
 
     /**
      * Add an item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -770,7 +807,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers addItem.post(PostEvent)
      * @triggers addItem.exception(ExceptionEvent)
      */
-    public function addItem($key, $value)
+    public function addItem($key, $value, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -780,6 +817,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $args = new ArrayObject(array(
             'key'   => & $key,
             'value' => & $value,
+            'ttl'   => & $ttl,
         ));
 
         try {
@@ -788,10 +826,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalAddItem($args['key'], $args['value']);
+            $result = $this->internalAddItem($args['key'], $args['value'], $ttl);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -799,23 +839,26 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to add an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem(& $normalizedKey, & $value, $ttl = null)
     {
         if ($this->internalHasItem($normalizedKey)) {
             return false;
         }
-        return $this->internalSetItem($normalizedKey, $value);
+
+        return $this->internalSetItem($normalizedKey, $value, $ttl);
     }
 
     /**
      * Add multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      *
@@ -823,7 +866,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers addItems.post(PostEvent)
      * @triggers addItems.exception(ExceptionEvent)
      */
-    public function addItems(array $keyValuePairs)
+    public function addItems(array $keyValuePairs, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return array_keys($keyValuePairs);
@@ -832,6 +875,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKeyValuePairs($keyValuePairs);
         $args = new ArrayObject(array(
             'keyValuePairs' => & $keyValuePairs,
+            'ttl'           => & $ttl,
         ));
 
         try {
@@ -840,10 +884,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalAddItems($args['keyValuePairs']);
+            $result = $this->internalAddItems($args['keyValuePairs'], $ttl);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array_keys($keyValuePairs);
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -851,26 +897,29 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to add multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $result = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            if (!$this->internalAddItem($normalizedKey, $value)) {
+            if (!$this->internalAddItem($normalizedKey, $value, $ttl)) {
                 $result[] = $normalizedKey;
             }
         }
+
         return $result;
     }
 
     /**
      * Replace an existing item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -878,7 +927,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers replaceItem.post(PostEvent)
      * @triggers replaceItem.exception(ExceptionEvent)
      */
-    public function replaceItem($key, $value)
+    public function replaceItem($key, $value, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -888,6 +937,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $args = new ArrayObject(array(
             'key'   => & $key,
             'value' => & $value,
+            'ttl'   => & $ttl,
         ));
 
         try {
@@ -896,10 +946,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalReplaceItem($args['key'], $args['value']);
+            $result = $this->internalReplaceItem($args['key'], $args['value'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -907,24 +959,26 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to replace an existing item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem(& $normalizedKey, & $value, $ttl = null)
     {
         if (!$this->internalhasItem($normalizedKey)) {
             return false;
         }
 
-        return $this->internalSetItem($normalizedKey, $value);
+        return $this->internalSetItem($normalizedKey, $value, $ttl);
     }
 
     /**
      * Replace multiple existing items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      *
@@ -932,7 +986,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers replaceItems.post(PostEvent)
      * @triggers replaceItems.exception(ExceptionEvent)
      */
-    public function replaceItems(array $keyValuePairs)
+    public function replaceItems(array $keyValuePairs, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return array_keys($keyValuePairs);
@@ -941,6 +995,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKeyValuePairs($keyValuePairs);
         $args = new ArrayObject(array(
             'keyValuePairs' => & $keyValuePairs,
+            'ttl'           => & $ttl,
         ));
 
         try {
@@ -949,10 +1004,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalReplaceItems($args['keyValuePairs']);
+            $result = $this->internalReplaceItems($args['keyValuePairs'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array_keys($keyValuePairs);
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -960,18 +1017,20 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to replace multiple existing items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItems(array & $normalizedKeyValuePairs)
+    protected function internalReplaceItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $result = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            if (!$this->internalReplaceItem($normalizedKey, $value)) {
+            if (!$this->internalReplaceItem($normalizedKey, $value, $ttl)) {
                 $result[] = $normalizedKey;
             }
         }
+
         return $result;
     }
 
@@ -981,15 +1040,16 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * It uses the token received from getItem() to check if the item has
      * changed before overwriting it.
      *
-     * @param  mixed  $token
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  mixed    $token
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      * @see    getItem()
      * @see    setItem()
      */
-    public function checkAndSetItem($token, $key, $value)
+    public function checkAndSetItem($token, $key, $value, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -1000,6 +1060,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             'token' => & $token,
             'key'   => & $key,
             'value' => & $value,
+            'ttl'   => & $ttl,
         ));
 
         try {
@@ -1008,10 +1069,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalCheckAndSetItem($args['token'], $args['key'], $args['value']);
+            $result = $this->internalCheckAndSetItem($args['token'], $args['key'], $args['value'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1019,28 +1082,30 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to set an item only if token matches
      *
-     * @param  mixed  $token
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  mixed    $token
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value, $ttl = null)
     {
         $oldValue = $this->internalGetItem($normalizedKey);
         if ($oldValue !== $token) {
             return false;
         }
 
-        return $this->internalSetItem($normalizedKey, $value);
+        return $this->internalSetItem($normalizedKey, $value, $ttl);
     }
 
     /**
      * Reset lifetime of an item
      *
-     * @param  string $key
+     * @param  string   $key
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -1048,7 +1113,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers touchItem.post(PostEvent)
      * @triggers touchItem.exception(ExceptionEvent)
      */
-    public function touchItem($key)
+    public function touchItem($key, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -1057,6 +1122,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKey($key);
         $args = new ArrayObject(array(
             'key' => & $key,
+            'ttl' => & $ttl,
         ));
 
         try {
@@ -1065,10 +1131,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalTouchItem($args['key']);
+            $result = $this->internalTouchItem($args['key'], $ttl);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1076,25 +1144,27 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to reset lifetime of an item
      *
-     * @param  string $normalizedKey
+     * @param  string   $normalizedKey
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItem(& $normalizedKey)
+    protected function internalTouchItem(& $normalizedKey, $ttl = null)
     {
         $success = null;
-        $value   = $this->internalGetItem($normalizedKey, $success);
+        $value = $this->internalGetItem($normalizedKey, $success);
         if (!$success) {
             return false;
         }
 
-        return $this->internalReplaceItem($normalizedKey, $value);
+        return $this->internalReplaceItem($normalizedKey, $value, $ttl);
     }
 
     /**
      * Reset lifetime of multiple items.
      *
-     * @param  array $keys
+     * @param  array    $keys
+     * @param  int|null $ttl
      * @return array Array of not updated keys
      * @throws Exception\ExceptionInterface
      *
@@ -1102,7 +1172,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers touchItems.post(PostEvent)
      * @triggers touchItems.exception(ExceptionEvent)
      */
-    public function touchItems(array $keys)
+    public function touchItems(array $keys, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return $keys;
@@ -1111,6 +1181,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKeys($keys);
         $args = new ArrayObject(array(
             'keys' => & $keys,
+            'ttl'  => & $ttl,
         ));
 
         try {
@@ -1119,7 +1190,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalTouchItems($args['keys']);
+            $result = $this->internalTouchItems($args['keys'], $ttl);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             return $this->triggerException(__FUNCTION__, $args, $keys, $e);
@@ -1129,18 +1201,20 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to reset lifetime of multiple items.
      *
-     * @param  array $normalizedKeys
+     * @param  array    $normalizedKeys
+     * @param  int|null $ttl
      * @return array Array of not updated keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItems(array & $normalizedKeys)
+    protected function internalTouchItems(array & $normalizedKeys, $ttl = null)
     {
         $result = array();
         foreach ($normalizedKeys as $normalizedKey) {
-            if (!$this->internalTouchItem($normalizedKey)) {
+            if (!$this->internalTouchItem($normalizedKey, $ttl)) {
                 $result[] = $normalizedKey;
             }
         }
+
         return $result;
     }
 
@@ -1173,9 +1247,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalRemoveItem($args['key']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1218,6 +1294,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalRemoveItems($args['keys']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             return $this->triggerException(__FUNCTION__, $args, $keys, $e);
@@ -1239,14 +1316,16 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 $result[] = $normalizedKey;
             }
         }
+
         return $result;
     }
 
     /**
      * Increment an item.
      *
-     * @param  string $key
-     * @param  int    $value
+     * @param  string   $key
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      *
@@ -1254,7 +1333,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers incrementItem.post(PostEvent)
      * @triggers incrementItem.exception(ExceptionEvent)
      */
-    public function incrementItem($key, $value)
+    public function incrementItem($key, $value, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -1264,6 +1343,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $args = new ArrayObject(array(
             'key'   => & $key,
             'value' => & $value,
+            'ttl'   => & $ttl,
         ));
 
         try {
@@ -1272,10 +1352,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalIncrementItem($args['key'], $args['value']);
+            $result = $this->internalIncrementItem($args['key'], $args['value'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1283,22 +1365,23 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to increment an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem(& $normalizedKey, & $value, $ttl = null)
     {
-        $success  = null;
-        $value    = (int) $value;
-        $get      = (int) $this->internalGetItem($normalizedKey, $success);
+        $success = null;
+        $value = (int)$value;
+        $get = (int)$this->internalGetItem($normalizedKey, $success);
         $newValue = $get + $value;
 
         if ($success) {
-            $this->internalReplaceItem($normalizedKey, $newValue);
+            $this->internalReplaceItem($normalizedKey, $newValue, $ttl);
         } else {
-            $this->internalAddItem($normalizedKey, $newValue);
+            $this->internalAddItem($normalizedKey, $newValue, $ttl);
         }
 
         return $newValue;
@@ -1307,7 +1390,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Increment multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return array Associative array of keys and new values
      * @throws Exception\ExceptionInterface
      *
@@ -1315,7 +1399,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers incrementItems.post(PostEvent)
      * @triggers incrementItems.exception(ExceptionEvent)
      */
-    public function incrementItems(array $keyValuePairs)
+    public function incrementItems(array $keyValuePairs, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return array();
@@ -1324,6 +1408,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKeyValuePairs($keyValuePairs);
         $args = new ArrayObject(array(
             'keyValuePairs' => & $keyValuePairs,
+            'ttl'           => & $ttl,
         ));
 
         try {
@@ -1332,10 +1417,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalIncrementItems($args['keyValuePairs']);
+            $result = $this->internalIncrementItems($args['keyValuePairs'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array();
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1343,27 +1430,30 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to increment multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Associative array of keys and new values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItems(array & $normalizedKeyValuePairs)
+    protected function internalIncrementItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $result = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            $newValue = $this->internalIncrementItem($normalizedKey, $value);
+            $newValue = $this->internalIncrementItem($normalizedKey, $value, $ttl);
             if ($newValue !== false) {
                 $result[$normalizedKey] = $newValue;
             }
         }
+
         return $result;
     }
 
     /**
      * Decrement an item.
      *
-     * @param  string $key
-     * @param  int    $value
+     * @param  string   $key
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      *
@@ -1371,7 +1461,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers decrementItem.post(PostEvent)
      * @triggers decrementItem.exception(ExceptionEvent)
      */
-    public function decrementItem($key, $value)
+    public function decrementItem($key, $value, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -1381,6 +1471,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $args = new ArrayObject(array(
             'key'   => & $key,
             'value' => & $value,
+            'ttl'   => & $ttl,
         ));
 
         try {
@@ -1389,10 +1480,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalDecrementItem($args['key'], $args['value']);
+            $result = $this->internalDecrementItem($args['key'], $args['value'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1402,20 +1495,21 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      *
      * @param  string $normalizedKey
      * @param  int    $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem(& $normalizedKey, & $value, $ttl = null)
     {
-        $success  = null;
-        $value    = (int) $value;
-        $get      = (int) $this->internalGetItem($normalizedKey, $success);
+        $success = null;
+        $value = (int)$value;
+        $get = (int)$this->internalGetItem($normalizedKey, $success);
         $newValue = $get - $value;
 
         if ($success) {
-            $this->internalReplaceItem($normalizedKey, $newValue);
+            $this->internalReplaceItem($normalizedKey, $newValue, $ttl);
         } else {
-            $this->internalAddItem($normalizedKey, $newValue);
+            $this->internalAddItem($normalizedKey, $newValue, $ttl);
         }
 
         return $newValue;
@@ -1424,7 +1518,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Decrement multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return array Associative array of keys and new values
      * @throws Exception\ExceptionInterface
      *
@@ -1432,7 +1527,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers incrementItems.post(PostEvent)
      * @triggers incrementItems.exception(ExceptionEvent)
      */
-    public function decrementItems(array $keyValuePairs)
+    public function decrementItems(array $keyValuePairs, $ttl = null)
     {
         if (!$this->getOptions()->getWritable()) {
             return array();
@@ -1441,6 +1536,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
         $this->normalizeKeyValuePairs($keyValuePairs);
         $args = new ArrayObject(array(
             'keyValuePairs' => & $keyValuePairs,
+            'ttl'           => & $ttl,
         ));
 
         try {
@@ -1449,10 +1545,12 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 return $eventRs->last();
             }
 
-            $result = $this->internalDecrementItems($args['keyValuePairs']);
+            $result = $this->internalDecrementItems($args['keyValuePairs'], $args['ttl']);
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = array();
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1460,19 +1558,21 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Internal method to decrement multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Associative array of keys and new values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItems(array & $normalizedKeyValuePairs)
+    protected function internalDecrementItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $result = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            $newValue = $this->decrementItem($normalizedKey, $value);
+            $newValue = $this->decrementItem($normalizedKey, $value, $ttl);
             if ($newValue !== false) {
                 $result[$normalizedKey] = $newValue;
             }
         }
+
         return $result;
     }
 
@@ -1497,9 +1597,11 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
 
             $result = $this->internalGetCapabilities();
+
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
             $result = false;
+
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }
@@ -1513,8 +1615,9 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     {
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
-            $this->capabilities     = new Capabilities($this, $this->capabilityMarker);
+            $this->capabilities = new Capabilities($this, $this->capabilityMarker);
         }
+
         return $this->capabilities;
     }
 
@@ -1529,7 +1632,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      */
     protected function normalizeKey(& $key)
     {
-        $key = (string) $key;
+        $key = (string)$key;
 
         if ($key === '') {
             throw new Exception\InvalidArgumentException(

--- a/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
@@ -163,17 +163,23 @@ abstract class AbstractZendServer extends AbstractAdapter
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string  $normalizedKey
+     * @param  mixed   $value
+     * @param int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
+
         $prefix    = ($namespace === '') ? '' : $namespace . self::NAMESPACE_SEPARATOR;
-        $this->zdcStore($prefix . $normalizedKey, $value, $options->getTtl());
+        $this->zdcStore($prefix . $normalizedKey, $value, $ttl);
         return true;
     }
 

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -164,6 +164,7 @@ class Apc extends AbstractAdapter implements
      * Remove items by given namespace
      *
      * @param string $namespace
+     * @throws \Zend\Cache\Exception\InvalidArgumentException
      * @return bool
      */
     public function clearByNamespace($namespace)
@@ -185,6 +186,7 @@ class Apc extends AbstractAdapter implements
      * Remove items matching given prefix
      *
      * @param string $prefix
+     * @throws \Zend\Cache\Exception\InvalidArgumentException
      * @return bool
      */
     public function clearByPrefix($prefix)
@@ -206,9 +208,9 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to get an item.
      *
-     * @param  string  $normalizedKey
-     * @param  bool $success
-     * @param  mixed   $casToken
+     * @param  string $normalizedKey
+     * @param  bool   $success
+     * @param  mixed  $casToken
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
@@ -389,18 +391,22 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         if (!apc_store($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
@@ -415,16 +421,22 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to store multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array        $normalizedKeyValuePairs
+     * @param  integer|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
+
         if ($namespace === '') {
-            return array_keys(apc_store($normalizedKeyValuePairs, null, $options->getTtl()));
+            return array_keys(apc_store($normalizedKeyValuePairs, null, $ttl));
         }
 
         $prefix                = $namespace . $options->getNamespaceSeparator();
@@ -434,7 +446,7 @@ class Apc extends AbstractAdapter implements
             $internalKeyValuePairs[$internalKey] = &$value;
         }
 
-        $failedKeys = apc_store($internalKeyValuePairs, null, $options->getTtl());
+        $failedKeys = apc_store($internalKeyValuePairs, null, $ttl);
         $failedKeys = array_keys($failedKeys);
 
         // remove prefix
@@ -449,18 +461,22 @@ class Apc extends AbstractAdapter implements
     /**
      * Add an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string       $normalizedKey
+     * @param  mixed        $value
+     * @param  integer|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         if (!apc_add($internalKey, $value, $ttl)) {
             if (apc_exists($internalKey)) {
@@ -479,16 +495,22 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to add multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array        $normalizedKeyValuePairs
+     * @param  integer|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
+
         if ($namespace === '') {
-            return array_keys(apc_add($normalizedKeyValuePairs, null, $options->getTtl()));
+            return array_keys(apc_add($normalizedKeyValuePairs, null, $ttl));
         }
 
         $prefix                = $namespace . $options->getNamespaceSeparator();
@@ -498,7 +520,7 @@ class Apc extends AbstractAdapter implements
             $internalKeyValuePairs[$internalKey] = $value;
         }
 
-        $failedKeys = apc_add($internalKeyValuePairs, null, $options->getTtl());
+        $failedKeys = apc_add($internalKeyValuePairs, null, $ttl);
         $failedKeys = array_keys($failedKeys);
 
         // remove prefix
@@ -513,12 +535,13 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to replace an existing item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string       $normalizedKey
+     * @param  mixed        $value
+     * @param  integer|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -529,7 +552,10 @@ class Apc extends AbstractAdapter implements
             return false;
         }
 
-        $ttl = $options->getTtl();
+        if ($ttl === null) {
+            $ttl = $options->getTtl();
+        }
+
         if (!apc_store($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
             throw new Exception\RuntimeException(
@@ -590,25 +616,29 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to increment an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
         $value       = (int) $value;
         $newValue    = apc_inc($internalKey, $value);
 
         // initial value
         if ($newValue === false) {
-            $ttl      = $options->getTtl();
             $newValue = $value;
+
+            if($ttl === null){
+                $ttl = $options->getTtl();
+            }
+
             if (!apc_add($internalKey, $newValue, $ttl)) {
                 throw new Exception\RuntimeException(
                     "apc_add('{$internalKey}', {$newValue}, {$ttl}) failed"
@@ -622,12 +652,13 @@ class Apc extends AbstractAdapter implements
     /**
      * Internal method to decrement an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -638,8 +669,12 @@ class Apc extends AbstractAdapter implements
 
         // initial value
         if ($newValue === false) {
-            $ttl      = $options->getTtl();
             $newValue = -$value;
+
+            if($ttl === null){
+                $ttl = $options->getTtl();
+            }
+
             if (!apc_add($internalKey, $newValue, $ttl)) {
                 throw new Exception\RuntimeException(
                     "apc_add('{$internalKey}', {$newValue}, {$ttl}) failed"

--- a/library/Zend/Cache/Storage/Adapter/Dba.php
+++ b/library/Zend/Cache/Storage/Adapter/Dba.php
@@ -365,12 +365,13 @@ class Dba extends AbstractAdapter implements
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -388,12 +389,13 @@ class Dba extends AbstractAdapter implements
     /**
      * Add an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -39,6 +39,11 @@ class Filesystem extends AbstractAdapter implements
 {
 
     /**
+     * The size (in bytes) of metadata header inside data file
+     */
+    const HEADER_SIZE = 64;
+
+    /**
      * Buffered total space in bytes
      *
      * @var null|int|float
@@ -130,6 +135,7 @@ class Filesystem extends AbstractAdapter implements
     /**
      * Remove expired items
      *
+     * @throws Exception\RuntimeException
      * @return bool
      */
     public function clearExpired()
@@ -174,6 +180,7 @@ class Filesystem extends AbstractAdapter implements
      *
      * @param string $namespace
      * @throws Exception\RuntimeException
+     * @throws Exception\InvalidArgumentException
      * @return bool
      */
     public function clearByNamespace($namespace)
@@ -211,6 +218,7 @@ class Filesystem extends AbstractAdapter implements
      *
      * @param string $prefix
      * @throws Exception\RuntimeException
+     * @throws Exception\InvalidArgumentException
      * @return bool
      */
     public function clearByPrefix($prefix)
@@ -497,11 +505,11 @@ class Filesystem extends AbstractAdapter implements
     /**
      * Internal method to get an item.
      *
-     * @param  string  $normalizedKey
-     * @param  bool $success
-     * @param  mixed   $casToken
+     * @param  string $normalizedKey
+     * @param  bool   $success
+     * @param  mixed  $casToken
      * @return mixed Data on success, null on failure
-     * @throws Exception\ExceptionInterface
+     * @throws BaseException
      */
     protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
     {
@@ -514,13 +522,15 @@ class Filesystem extends AbstractAdapter implements
             $filespec = $this->getFileSpec($normalizedKey);
             $data     = $this->getFileContent($filespec . '.dat');
 
+            // Separate data from header
+            $data = substr($data, static::HEADER_SIZE);
+
             // use filemtime + filesize as CAS token
             if (func_num_args() > 2) {
                 $casToken = filemtime($filespec . '.dat') . filesize($filespec . '.dat');
             }
             $success  = true;
             return $data;
-
         } catch (BaseException $e) {
             $success = false;
             throw $e;
@@ -541,7 +551,7 @@ class Filesystem extends AbstractAdapter implements
         $result  = array();
         while ($keys) {
 
-            // LOCK_NB if more than one items have to read
+            // LOCK_NB if we are about to read multiple items
             $nonBlocking = count($keys) > 1;
             $wouldblock  = null;
 
@@ -554,6 +564,10 @@ class Filesystem extends AbstractAdapter implements
 
                 $filespec = $this->getFileSpec($key);
                 $data     = $this->getFileContent($filespec . '.dat', $nonBlocking, $wouldblock);
+
+                // Separate header from data
+                $data = substr($data, static::HEADER_SIZE);
+
                 if ($nonBlocking && $wouldblock) {
                     continue;
                 } else {
@@ -626,7 +640,9 @@ class Filesystem extends AbstractAdapter implements
             return false;
         }
 
-        $ttl = $this->getOptions()->getTtl();
+        // Load the TTL from data file header
+        $ttl = $this->getFileTtl($file);
+
         if ($ttl) {
             ErrorHandler::start();
             $mtime = filemtime($file);
@@ -750,8 +766,9 @@ class Filesystem extends AbstractAdapter implements
     /**
      * Store an item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -759,19 +776,20 @@ class Filesystem extends AbstractAdapter implements
      * @triggers setItem.post(PostEvent)
      * @triggers setItem.exception(ExceptionEvent)
      */
-    public function setItem($key, $value)
+    public function setItem($key, $value, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
-        return parent::setItem($key, $value);
+        return parent::setItem($key, $value, $ttl);
     }
 
     /**
      * Store multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      *
@@ -779,21 +797,22 @@ class Filesystem extends AbstractAdapter implements
      * @triggers setItems.post(PostEvent)
      * @triggers setItems.exception(ExceptionEvent)
      */
-    public function setItems(array $keyValuePairs)
+    public function setItems(array $keyValuePairs, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::setItems($keyValuePairs);
+        return parent::setItems($keyValuePairs, $ttl);
     }
 
     /**
      * Add an item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -801,20 +820,21 @@ class Filesystem extends AbstractAdapter implements
      * @triggers addItem.post(PostEvent)
      * @triggers addItem.exception(ExceptionEvent)
      */
-    public function addItem($key, $value)
+    public function addItem($key, $value, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::addItem($key, $value);
+        return parent::addItem($key, $value, $ttl);
     }
 
     /**
      * Add multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -822,21 +842,22 @@ class Filesystem extends AbstractAdapter implements
      * @triggers addItems.post(PostEvent)
      * @triggers addItems.exception(ExceptionEvent)
      */
-    public function addItems(array $keyValuePairs)
+    public function addItems(array $keyValuePairs, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::addItems($keyValuePairs);
+        return parent::addItems($keyValuePairs, $ttl);
     }
 
     /**
      * Replace an existing item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -844,20 +865,21 @@ class Filesystem extends AbstractAdapter implements
      * @triggers replaceItem.post(PostEvent)
      * @triggers replaceItem.exception(ExceptionEvent)
      */
-    public function replaceItem($key, $value)
+    public function replaceItem($key, $value, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::replaceItem($key, $value);
+        return parent::replaceItem($key, $value, $ttl);
     }
 
     /**
      * Replace multiple existing items.
      *
-     * @param  array $keyValuePairs
+     * @param  array    $keyValuePairs
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -865,39 +887,47 @@ class Filesystem extends AbstractAdapter implements
      * @triggers replaceItems.post(PostEvent)
      * @triggers replaceItems.exception(ExceptionEvent)
      */
-    public function replaceItems(array $keyValuePairs)
+    public function replaceItems(array $keyValuePairs, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::replaceItems($keyValuePairs);
+        return parent::replaceItems($keyValuePairs, $ttl);
     }
 
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
+        }
+
         $filespec = $this->getFileSpec($normalizedKey);
         $this->prepareDirectoryStructure($filespec);
 
+        // Prepare header containing metadata
+        $header = static::buildHeader($ttl);
+
         // write data in non-blocking mode
         $wouldblock = null;
-        $this->putFileContent($filespec . '.dat', $value, true, $wouldblock);
+        $this->putFileContent($filespec . '.dat', $header . $value, true, $wouldblock);
 
         // delete related tag file (if present)
         $this->unlink($filespec . '.tag');
 
         // Retry writing data in blocking mode if it was blocked before
         if ($wouldblock) {
-            $this->putFileContent($filespec . '.dat', $value);
+            $this->putFileContent($filespec . '.dat', $header . $value);
         }
 
         return true;
@@ -907,12 +937,17 @@ class Filesystem extends AbstractAdapter implements
      * Internal method to store multiple items.
      *
      * @param  array $normalizedKeyValuePairs
+     * @param int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
-        $oldUmask    = null;
+        $oldUmask = null;
+
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
+        }
 
         // create an associated array of files and contents to write
         $contents = array();
@@ -933,7 +968,10 @@ class Filesystem extends AbstractAdapter implements
             $wouldblock  = null;
 
             foreach ($contents as $file => & $content) {
-                $this->putFileContent($file, $content, $nonBlocking, $wouldblock);
+                // Prepare ttl information to the beginning of the file
+                $header = static::buildHeader($ttl);
+
+                $this->putFileContent($file, $header . $content, $nonBlocking, $wouldblock);
                 if (!$nonBlocking || !$wouldblock) {
                     unset($contents[$file]);
                 }
@@ -950,39 +988,45 @@ class Filesystem extends AbstractAdapter implements
      * It uses the token received from getItem() to check if the item has
      * changed before overwriting it.
      *
-     * @param  mixed  $token
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  mixed    $token
+     * @param  string   $key
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      * @see    getItem()
      * @see    setItem()
      */
-    public function checkAndSetItem($token, $key, $value)
+    public function checkAndSetItem($token, $key, $value, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::checkAndSetItem($token, $key, $value);
+        return parent::checkAndSetItem($token, $key, $value, $ttl);
     }
 
     /**
      * Internal method to set an item only if token matches
      *
-     * @param  mixed  $token
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  mixed    $token
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value, $ttl = null)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
+        }
+
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
         }
 
         // use filemtime + filesize as CAS token
@@ -992,13 +1036,14 @@ class Filesystem extends AbstractAdapter implements
             return false;
         }
 
-        return $this->internalSetItem($normalizedKey, $value);
+        return $this->internalSetItem($normalizedKey, $value, $ttl);
     }
 
     /**
      * Reset lifetime of an item
      *
-     * @param  string $key
+     * @param  string   $key
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -1006,20 +1051,21 @@ class Filesystem extends AbstractAdapter implements
      * @triggers touchItem.post(PostEvent)
      * @triggers touchItem.exception(ExceptionEvent)
      */
-    public function touchItem($key)
+    public function touchItem($key, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::touchItem($key);
+        return parent::touchItem($key, $ttl);
     }
 
     /**
      * Reset lifetime of multiple items.
      *
-     * @param  array $keys
+     * @param  array    $keys
+     * @param  int|null $ttl
      * @return array Array of not updated keys
      * @throws Exception\ExceptionInterface
      *
@@ -1027,27 +1073,32 @@ class Filesystem extends AbstractAdapter implements
      * @triggers touchItems.post(PostEvent)
      * @triggers touchItems.exception(ExceptionEvent)
      */
-    public function touchItems(array $keys)
+    public function touchItems(array $keys, $ttl = null)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
 
-        return parent::touchItems($keys);
+        return parent::touchItems($keys, $ttl);
     }
 
     /**
      * Internal method to reset lifetime of an item
      *
-     * @param  string $normalizedKey
+     * @param  string   $normalizedKey
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItem(& $normalizedKey)
+    protected function internalTouchItem(& $normalizedKey, $ttl = null)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
+        }
+
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
         }
 
         $filespec = $this->getFileSpec($normalizedKey);
@@ -1166,7 +1217,7 @@ class Filesystem extends AbstractAdapter implements
                     'maxTtl'             => 0,
                     'staticTtl'          => false,
                     'ttlPrecision'       => 1,
-                    'expiredRead'        => true,
+                    'expiredRead'        => false,
                     'maxKeyLength'       => 251, // 255 - strlen(.dat | .tag)
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $options->getNamespaceSeparator(),
@@ -1380,6 +1431,70 @@ class Filesystem extends AbstractAdapter implements
     }
 
     /**
+     * Retrieve TTL for given file using the first line or 512 bytes.
+     *
+     * @param string $file
+     * @param bool   $nonBlocking
+     * @param null   $wouldblock
+     * @return int
+     * @throws \Zend\Cache\Exception\RuntimeException
+     */
+    protected function getFileTtl($file, $nonBlocking = false, & $wouldblock = null)
+    {
+        $wouldblock = null;
+
+        ErrorHandler::start();
+
+        $fp = fopen($file, 'rb');
+        if ($fp === false) {
+            $err = ErrorHandler::stop();
+            throw new Exception\RuntimeException(
+                "Error opening file '{$file}'", 0, $err
+            );
+        }
+
+        if ($nonBlocking) {
+            $lock = flock($fp, LOCK_SH | LOCK_NB, $wouldblock);
+            if ($wouldblock) {
+                fclose($fp);
+                ErrorHandler::stop();
+                return;
+            }
+        } else {
+            $lock = flock($fp, LOCK_SH);
+        }
+
+        if (!$lock) {
+            fclose($fp);
+            $err = ErrorHandler::stop();
+            throw new Exception\RuntimeException(
+                "Error locking file '{$file}'", 0, $err
+            );
+        }
+
+        $header = fgets($fp, static::HEADER_SIZE);
+        if ($header === false) {
+            flock($fp, LOCK_UN);
+            fclose($fp);
+            $err = ErrorHandler::stop();
+            throw new Exception\RuntimeException(
+                'Error getting stream contents', 0, $err
+            );
+        }
+
+        flock($fp, LOCK_UN);
+        fclose($fp);
+
+        // Parse header and extract TTL
+        $ttl = null;
+        static::parseHeader($header, $ttl);
+
+        ErrorHandler::stop();
+
+        return $ttl;
+    }
+
+    /**
      * Prepares a directory structure for the given file(spec)
      * using the configured directory level.
      *
@@ -1489,14 +1604,15 @@ class Filesystem extends AbstractAdapter implements
     /**
      * Write content to a file
      *
-     * @param  string  $file        File complete path
-     * @param  string  $data        Data to write
-     * @param  bool $nonBlocking Don't block script if file is locked
-     * @param  bool $wouldblock  The optional argument is set to TRUE if the lock would block
+     * @param  string $file        File complete path
+     * @param  string $data        Data to write
+     * @param  bool   $nonBlocking Don't block script if file is locked
+     * @param  bool   $wouldblock  The optional argument is set to TRUE if the lock would block
+     * @throws \Zend\Cache\Exception\RuntimeException
+     * @internal param string $metadata Metadata to store
      * @return void
-     * @throws Exception\RuntimeException
      */
-    protected function putFileContent($file, $data, $nonBlocking = false, & $wouldblock = null)
+    protected function putFileContent($file, $data, $nonBlocking = false, &$wouldblock = null)
     {
         $options     = $this->getOptions();
         $locking     = $options->getFileLocking();
@@ -1600,7 +1716,7 @@ class Filesystem extends AbstractAdapter implements
      *
      * @param string $file
      * @return void
-     * @throws RuntimeException
+     * @throws Exception\RuntimeException
      */
     protected function unlink($file)
     {
@@ -1614,5 +1730,32 @@ class Filesystem extends AbstractAdapter implements
                 "Error unlinking file '{$file}'; file still exists", 0, $err
             );
         }
+    }
+
+    /**
+     * Build header string by pack()ing metadata
+     *
+     * @param int $ttl
+     * @return string
+     */
+    protected static function buildHeader($ttl = 0)
+    {
+        $highMap = 0xffffffff00000000;
+        $lowMap = 0x00000000ffffffff;
+        $higher = ($ttl & $highMap) >>32;
+        $lower = $ttl & $lowMap;
+        return pack('NN@' . static::HEADER_SIZE, $higher, $lower);
+    }
+
+    /**
+     * Process the header string and extract TTL value
+     *
+     * @param string $header
+     * @param string $ttl
+     */
+    protected static function parseHeader($header, &$ttl)
+    {
+        list($higher, $lower) = array_values(unpack('N2', $header));
+        $ttl = $higher << 32 | $lower;
     }
 }

--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -12,9 +12,8 @@ namespace Zend\Cache\Storage\Adapter;
 use Redis as RedisResource;
 use RedisException as RedisResourceException;
 use stdClass;
-use Zend\Cache\Storage\Adapter\AbstractAdapter;
+use Traversable;
 use Zend\Cache\Exception;
-use Zend\Cache\Storage\AvailableSpaceCapableInterface;
 use Zend\Cache\Storage\Capabilities;
 use Zend\Cache\Storage\FlushableInterface;
 use Zend\Cache\Storage\TotalSpaceCapableInterface;
@@ -56,6 +55,7 @@ class Redis extends AbstractAdapter implements
      * Create new Adapter for redis storage
      *
      * @param null|array|Traversable|RedisOptions $options
+     * @throws Exception\ExtensionNotLoadedException
      * @see \Zend\Cache\Storage\Adapter\Abstract
      */
     public function __construct($options = null)
@@ -213,16 +213,20 @@ class Redis extends AbstractAdapter implements
     /**
      * Internal method to store an item.
      *
-     * @param string &$normalizedKey Key in Redis under which value will be saved
-     * @param mixed  &$value         Value to store under cache key
+     * @param string   &$normalizedKey Key in Redis under which value will be saved
+     * @param mixed    &$value         Value to store under cache key
+     * @param int|null $ttl
      *
-     * @return bool
      * @throws Exception\RuntimeException
+     * @throws Exception\UnsupportedMethodCallException
+     * @return bool
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $redis = $this->getRedisResource();
-        $ttl = $this->getOptions()->getTtl();
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
+        }
 
         try {
             if ($ttl) {
@@ -240,18 +244,23 @@ class Redis extends AbstractAdapter implements
         return $success;
     }
 
-     /**
+    /**
      * Internal method to store multiple items.
      *
-     * @param array &$normalizedKeyValuePairs An array of normalized key/value pairs
+     * @param array    &$normalizedKeyValuePairs An array of normalized key/value pairs
+     * @param int|null $ttl
      *
-     * @return array Array of not stored keys
      * @throws Exception\RuntimeException
+     * @throws Exception\UnsupportedMethodCallException
+     * @return array Array of not stored keys
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $redis = $this->getRedisResource();
-        $ttl   = $this->getOptions()->getTtl();
+
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
+        }
 
         $namespacedKeyValuePairs = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => & $value) {
@@ -286,16 +295,34 @@ class Redis extends AbstractAdapter implements
     /**
      * Add an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\RuntimeException
+     * @throws Exception\UnsupportedMethodCallException
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem(& $normalizedKey, & $value, $ttl = null)
     {
         $redis = $this->getRedisResource();
+
+        if($ttl === null){
+            $ttl = $this->getOptions()->getTtl();
+        }
+
         try {
-            return $redis->setnx($this->namespacePrefix . $normalizedKey, $value);
+            if ($ttl) {
+                if ($this->resourceManager->getMajorVersion($this->resourceId) < 2) {
+                    throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");
+                }
+
+                if($redis->get($this->namespacePrefix . $normalizedKey) !== false){
+                    return false; // value already exists
+                }
+                return $redis->setex($this->namespacePrefix . $normalizedKey, $ttl, $value);
+            } else {
+                return $redis->setnx($this->namespacePrefix . $normalizedKey, $value);
+            }
         } catch (RedisResourceException $e) {
             throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
         }
@@ -322,12 +349,13 @@ class Redis extends AbstractAdapter implements
     /**
      * Internal method to increment an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\RuntimeException
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $redis = $this->getRedisResource();
         try {
@@ -340,12 +368,13 @@ class Redis extends AbstractAdapter implements
     /**
      * Internal method to decrement an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\RuntimeException
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $redis = $this->getRedisResource();
         try {

--- a/library/Zend/Cache/Storage/Adapter/Session.php
+++ b/library/Zend/Cache/Storage/Adapter/Session.php
@@ -56,6 +56,7 @@ class Session extends AbstractAdapter implements
     /**
      * Get the session container
      *
+     * @throws Exception\RuntimeException
      * @return SessionContainer
      */
     protected function getSessionContainer()
@@ -107,6 +108,7 @@ class Session extends AbstractAdapter implements
      * Remove items matching given prefix
      *
      * @param string $prefix
+     * @throws Exception\InvalidArgumentException
      * @return bool
      */
     public function clearByPrefix($prefix)
@@ -261,10 +263,11 @@ class Session extends AbstractAdapter implements
      *
      * @param  string $normalizedKey
      * @param  mixed  $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -277,11 +280,12 @@ class Session extends AbstractAdapter implements
     /**
      * Internal method to store multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -299,12 +303,13 @@ class Session extends AbstractAdapter implements
     /**
      * Add an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem(& $normalizedKey, & $value, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -328,11 +333,12 @@ class Session extends AbstractAdapter implements
     /**
      * Internal method to add multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -359,12 +365,13 @@ class Session extends AbstractAdapter implements
     /**
      * Internal method to replace an existing item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem(& $normalizedKey, & $value, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -386,11 +393,12 @@ class Session extends AbstractAdapter implements
     /**
      * Internal method to replace multiple existing items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItems(array & $normalizedKeyValuePairs)
+    protected function internalReplaceItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -447,12 +455,13 @@ class Session extends AbstractAdapter implements
     /**
      * Internal method to increment an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -479,12 +488,13 @@ class Session extends AbstractAdapter implements
     /**
      * Internal method to decrement an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -224,18 +224,22 @@ class WinCache extends AbstractAdapter implements
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         if (!wincache_ucache_set($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
@@ -250,16 +254,22 @@ class WinCache extends AbstractAdapter implements
     /**
      * Internal method to store multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
+
         if ($namespace === '') {
-            return wincache_ucache_set($normalizedKeyValuePairs, null, $options->getTtl());
+            return wincache_ucache_set($normalizedKeyValuePairs, null, $ttl);
         }
 
         $prefix                = $namespace . $options->getNamespaceSeparator();
@@ -269,9 +279,9 @@ class WinCache extends AbstractAdapter implements
             $internalKeyValuePairs[$internalKey] = & $value;
         }
 
-        $result = wincache_ucache_set($internalKeyValuePairs, null, $options->getTtl());
+        $result = wincache_ucache_set($internalKeyValuePairs, null, $ttl);
 
-        // remove key prefic
+        // remove key prefix
         $prefixL = strlen($prefix);
         foreach ($result as & $key) {
             $key = substr($key, $prefixL);
@@ -283,18 +293,22 @@ class WinCache extends AbstractAdapter implements
     /**
      * Add an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         if (!wincache_ucache_add($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
@@ -309,16 +323,22 @@ class WinCache extends AbstractAdapter implements
     /**
      * Internal method to add multiple items.
      *
-     * @param  array $normalizedKeyValuePairs
+     * @param  array    $normalizedKeyValuePairs
+     * @param  int|null $ttl
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array & $normalizedKeyValuePairs, $ttl = null)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
+
         if ($namespace === '') {
-            return wincache_ucache_add($normalizedKeyValuePairs, null, $options->getTtl());
+            return wincache_ucache_add($normalizedKeyValuePairs, null, $ttl);
         }
 
         $prefix                = $namespace . $options->getNamespaceSeparator();
@@ -328,7 +348,7 @@ class WinCache extends AbstractAdapter implements
             $internalKeyValuePairs[$internalKey] = $value;
         }
 
-        $result = wincache_ucache_add($internalKeyValuePairs, null, $options->getTtl());
+        $result = wincache_ucache_add($internalKeyValuePairs, null, $ttl);
 
         // remove key prefic
         $prefixL = strlen($prefix);
@@ -342,12 +362,13 @@ class WinCache extends AbstractAdapter implements
     /**
      * Internal method to replace an existing item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -357,7 +378,10 @@ class WinCache extends AbstractAdapter implements
             return false;
         }
 
-        $ttl = $options->getTtl();
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
+
         if (!wincache_ucache_set($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
             throw new Exception\RuntimeException(
@@ -425,10 +449,11 @@ class WinCache extends AbstractAdapter implements
      *
      * @param  string $normalizedKey
      * @param  int    $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -440,12 +465,13 @@ class WinCache extends AbstractAdapter implements
     /**
      * Internal method to decrement an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/XCache.php
+++ b/library/Zend/Cache/Storage/Adapter/XCache.php
@@ -337,18 +337,22 @@ class XCache extends AbstractAdapter implements
     /**
      * Internal method to store an item.
      *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  string   $normalizedKey
+     * @param  mixed    $value
+     * @param  int|null $ttl
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($options === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         if (!xcache_set($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
@@ -380,19 +384,23 @@ class XCache extends AbstractAdapter implements
     /**
      * Internal method to increment an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
         $value       = (int) $value;
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         return xcache_inc($internalKey, $value, $ttl);
     }
@@ -400,19 +408,23 @@ class XCache extends AbstractAdapter implements
     /**
      * Internal method to decrement an item.
      *
-     * @param  string $normalizedKey
-     * @param  int    $value
+     * @param  string   $normalizedKey
+     * @param  int      $value
+     * @param  int|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem(& $normalizedKey, & $value, $ttl = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
         $value       = (int) $value;
+
+        if($ttl === null){
+            $ttl = $options->getTtl();
+        }
 
         return xcache_dec($internalKey, $value, $ttl);
     }

--- a/library/Zend/Cache/Storage/StorageInterface.php
+++ b/library/Zend/Cache/Storage/StorageInterface.php
@@ -33,9 +33,9 @@ interface StorageInterface
     /**
      * Get an item.
      *
-     * @param  string  $key
-     * @param  bool $success
-     * @param  mixed   $casToken
+     * @param  string $key
+     * @param  bool   $success
+     * @param  mixed  $casToken
      * @return mixed Data on success, null on failure
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
@@ -91,59 +91,64 @@ interface StorageInterface
     /**
      * Store an item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string       $key
+     * @param  mixed        $value
+     * @param  integer|null $ttl
      * @return bool
-     * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function setItem($key, $value);
+    public function setItem($key, $value, $ttl = null);
 
     /**
      * Store multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array        $keyValuePairs
+     * @param  integer|null $ttl
      * @return array Array of not stored keys
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function setItems(array $keyValuePairs);
+    public function setItems(array $keyValuePairs, $ttl = null);
 
     /**
      * Add an item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string       $key
+     * @param  mixed        $value
+     * @param  integer|null $ttl
      * @return bool
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function addItem($key, $value);
+    public function addItem($key, $value, $ttl = null);
 
     /**
      * Add multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array        $keyValuePairs
+     * @param  integer|null $ttl
      * @return array Array of not stored keys
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function addItems(array $keyValuePairs);
+    public function addItems(array $keyValuePairs, $ttl = null);
 
     /**
      * Replace an existing item.
      *
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  string       $key
+     * @param  mixed        $value
+     * @param  integer|null $ttl
      * @return bool
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function replaceItem($key, $value);
+    public function replaceItem($key, $value, $ttl = null);
 
     /**
      * Replace multiple existing items.
      *
-     * @param  array $keyValuePairs
+     * @param  array        $keyValuePairs
+     * @param  integer|null $ttl
      * @return array Array of not stored keys
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function replaceItems(array $keyValuePairs);
+    public function replaceItems(array $keyValuePairs, $ttl = null);
 
     /**
      * Set an item only if token matches
@@ -151,33 +156,36 @@ interface StorageInterface
      * It uses the token received from getItem() to check if the item has
      * changed before overwriting it.
      *
-     * @param  mixed  $token
-     * @param  string $key
-     * @param  mixed  $value
+     * @param  mixed        $token
+     * @param  string       $key
+     * @param  mixed        $value
+     * @param  integer|null $ttl
      * @return bool
      * @throws \Zend\Cache\Exception\ExceptionInterface
      * @see    getItem()
      * @see    setItem()
      */
-    public function checkAndSetItem($token, $key, $value);
+    public function checkAndSetItem($token, $key, $value, $ttl = null);
 
     /**
      * Reset lifetime of an item
      *
-     * @param  string $key
+     * @param  string       $key
+     * @param  integer|null $ttl
      * @return bool
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function touchItem($key);
+    public function touchItem($key, $ttl = null);
 
     /**
      * Reset lifetime of multiple items.
      *
-     * @param  array $keys
+     * @param  array        $keys
+     * @param  integer|null $ttl
      * @return array Array of not updated keys
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function touchItems(array $keys);
+    public function touchItems(array $keys, $ttl = null);
 
     /**
      * Remove an item.
@@ -200,40 +208,44 @@ interface StorageInterface
     /**
      * Increment an item.
      *
-     * @param  string $key
-     * @param  int    $value
+     * @param  string       $key
+     * @param  int          $value
+     * @param  integer|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function incrementItem($key, $value);
+    public function incrementItem($key, $value, $ttl = null);
 
     /**
      * Increment multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array        $keyValuePairs
+     * @param  integer|null $ttl
      * @return array Associative array of keys and new values
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function incrementItems(array $keyValuePairs);
+    public function incrementItems(array $keyValuePairs, $ttl = null);
 
     /**
      * Decrement an item.
      *
-     * @param  string $key
-     * @param  int    $value
+     * @param  string       $key
+     * @param  int          $value
+     * @param  integer|null $ttl
      * @return int|bool The new value on success, false on failure
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function decrementItem($key, $value);
+    public function decrementItem($key, $value, $ttl = null);
 
     /**
      * Decrement multiple items.
      *
-     * @param  array $keyValuePairs
+     * @param  array        $keyValuePairs
+     * @param  integer|null $ttl
      * @return array Associative array of keys and new values
      * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function decrementItems(array $keyValuePairs);
+    public function decrementItems(array $keyValuePairs, $ttl = null);
 
     /* status */
 

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -622,7 +622,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
 
         $ttl = $capabilities->getTtlPrecision();
         $this->_storage->setItem('key1', 'value1', $ttl);
-        $this->_storage->setItem('key2', 'value2', $ttl*3);
+        $this->_storage->setItem('key2', 'value2', $ttl * 100);
 
         // wait until the first item expired
         usleep($ttl * 2000000);
@@ -631,6 +631,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
             // Can't test much more if the request time will be used
             $this->assertEquals('value1', $this->_storage->getItem('key1'));
             $this->assertEquals('value2', $this->_storage->getItem('key2'));
+
             return;
         }
 

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -622,11 +622,10 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
 
         $ttl = $capabilities->getTtlPrecision();
         $this->_storage->setItem('key1', 'value1', $ttl);
-        $this->_storage->setItem('key2', 'value2', $ttl*2);
+        $this->_storage->setItem('key2', 'value2', $ttl*3);
 
-        // wait until expired
-        $wait = $ttl + $capabilities->getTtlPrecision();
-        usleep($wait * 2000000);
+        // wait until the first item expired
+        usleep($ttl * 2000000);
 
         if ($capabilities->getUseRequestTime()) {
             // Can't test much more if the request time will be used

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -310,6 +310,28 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->_storage->getItem('key'));
     }
 
+    public function testGetItemReturnsNullOnExpiredItemAdhoc()
+    {
+        $capabilities = $this->_storage->getCapabilities();
+
+        if ($capabilities->getMinTtl() === 0) {
+            $this->markTestSkipped("Adapter doesn't support item expiration");
+        }
+
+        if ($capabilities->getUseRequestTime()) {
+            $this->markTestSkipped("Can't test get expired item if request time will be used");
+        }
+
+        $ttl = $capabilities->getTtlPrecision();
+        $this->_storage->setItem('key', 'value', $ttl);
+
+        // wait until expired
+        $wait = $ttl + $capabilities->getTtlPrecision();
+        usleep($wait * 2000000);
+
+        $this->assertNull($this->_storage->getItem('key'));
+    }
+
     public function testGetItemReturnsNullIfNonReadable()
     {
         $this->_options->setReadable(false);
@@ -566,6 +588,30 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testSetAndGetExpiredItemAdhoc()
+    {
+        $capabilities = $this->_storage->getCapabilities();
+
+        if ($capabilities->getMinTtl() === 0) {
+            $this->markTestSkipped("Adapter doesn't support item expiration");
+        }
+
+        $ttl = $capabilities->getTtlPrecision();
+        $this->_storage->setItem('key', 'value', $ttl);
+
+        // wait until expired
+        $wait = $ttl + $capabilities->getTtlPrecision();
+        usleep($wait * 2000000);
+
+        if ($capabilities->getUseRequestTime()) {
+            // Can't test much more if the request time will be used
+            $this->assertEquals('value', $this->_storage->getItem('key'));
+            return;
+        }
+
+        $this->assertNull($this->_storage->getItem('key'));
+    }
+
     public function testSetAndGetExpiredItems()
     {
         $capabilities = $this->_storage->getCapabilities();
@@ -599,6 +645,36 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         $this->_options->setTtl(0);
         if ($capabilities->getExpiredRead()) {
             $rs = $this->_storage->getItems(array_keys($items));
+            ksort($rs);
+            $this->assertEquals($items, $rs);
+        }
+    }
+
+    public function testSetAndGetExpiredItemsAdhoc()
+    {
+        $capabilities = $this->_storage->getCapabilities();
+
+        if ($capabilities->getMinTtl() === 0) {
+            $this->markTestSkipped("Adapter doesn't support item expiration");
+        }
+
+        $ttl = $capabilities->getTtlPrecision();
+
+        $items = array(
+            'key1' => 'value1',
+            'key2' => 'value2',
+            'key3' => 'value3'
+        );
+        $this->assertSame(array(), $this->_storage->setItems($items, $ttl));
+
+        // wait until expired
+        $wait = $ttl + $capabilities->getTtlPrecision();
+        usleep($wait * 2000000);
+
+        $rs = $this->_storage->getItems(array_keys($items));
+        if (!$capabilities->getUseRequestTime()) {
+            $this->assertEquals(array(), $rs);
+        } else {
             ksort($rs);
             $this->assertEquals($items, $rs);
         }

--- a/tests/ZendTest/Cache/Storage/TestAsset/MockAdapter.php
+++ b/tests/ZendTest/Cache/Storage/TestAsset/MockAdapter.php
@@ -18,7 +18,7 @@ class MockAdapter extends AbstractAdapter
     {
     }
 
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = null)
     {
     }
 


### PR DESCRIPTION
### Why can't I specify TTL ?

Since I remember working with code-level cache solutions there was always an easy method to specify TTL on per-item basis. It is a [common](http://us3.php.net/apc_store) [feature](http://us3.php.net/manual/en/function.wincache-ucache-add.php) [among](http://www.php.net/manual/en/memcache.add.php) most well-known libraries and extensions and was present in [ZF1 Zend_Cache](https://github.com/zendframework/zf1/blob/master/library/Zend/Cache/Backend/File.php#L243). Sadly, zf2 is missing this.

``` php
// APC
apc_store ( string $key , mixed $var [, int $ttl = 0 ] );

// Memcache
Memcache::add( string $key , mixed $var [, int $flag [, int $expire ]] );

// Wincache
wincache_ucache_add ( string $key , mixed $value [, int $ttl = 0 ] );

// Zend Server
zend_shm_cache_store($internalKey, $value, $ttl);

// Zend_Cache
Zend_Cache_Backend_File::save($data, $id, $tags = array(), $specificLifetime = false);

// etc.
```
### Problem 1

ZF2 Cache Storage does not allow to store items with specific TTL.

The first problem was missing `$ttl` parameter in all [Cache\StorageInterface](https://github.com/zendframework/zf2/blob/master/library/Zend/Cache/Storage/StorageInterface.php#L99) write methods (i.e. `setItem()`, `replaceItem()` etc.). Without this, the only way to set an item with a specific TTL was:

``` php
/* @var $cache StorageInterface */
$oldTtl = $cache->getOptions()->getTtl();
$cache->getOptions()->setTtl(60); // set to 1 minute
$cache->setItem('foo','bar'); // store the item
$cache->getOptions()->setTtl($oldTtl); // restore previous ttl
// *phew*
```
### Problem 2

Unfortunately, the above code does not work properly. This is because many ZF2 adapters do not support or understand item-level TTL, unless it is handled internally by the backend (i.e. `apc_store()` natively supports TTL and it's getting fed with the one from options).

For example,  `Storage\Memory` and `Storage\Filesystem` would exhibit unexpected behavior when discarding old items or fetching items if we tried to manipulate ttl:

``` php
/* @var $cache StorageInterface */
$cache = new \Zend\Cache\Storage\Adapter\Memory();
$cache->getOptions()->setTtl(3600); // set TTL to 1 hour
$cache->setItem('foo',1); // store an item

$cache->getOptions()->setTtl(60); // set TTL to 1 minute
$cache->setItem('bar',1); // store another item

sleep(61);

var_dump($cache->hasItem('bar'));  // false
var_dump($cache->hasItem('foo'));  // false
// *poof*   "foo" item disappeared but should live for an hour
```
### The goal

``` php
/* @var $cache StorageInterface */
$cache->setItem('foo','1', 60); // store the item for 60s
$cache->setItem('bar','2', 3600); // store the item for 1 hour

// store the item with default TTL setting from the storage
$cache->setItem('bar','2'); 

// replace multiple items and set their TTL to 60s
$cache->replaceItems(['foo'=>10,'bar'=>20], 60); 

// increment item by 5 and make it live for 1h
$cache->incrementItem('foo', 5, 3600);
```
### Solution
- [x] Add `$ttl` support to StorageInterface.
- [x] Refactor `Cache\Storage\Adapter\AbstractAdapter` to handle $ttl in write operations.
- [x] Pass on `$ttl` to listeners (plugins).
- [x] Refactor all `Adapter\*` classes to use per-item `$ttl` and pass it on to underlying backend.
- [x] Refactor `Adapter\Memory` to support per-item TTL.
- [x] Refactor `Adapter\Filesystem` to support per-item TTL.
- [x] Add TTL tests that work with ad-hoc ttl setting.
- [x] Add overlapping temporal per-item ttl tests.
