### PR TITLE
Zend\Log\Writer\Db via config throws exception

### DIFF
--- a/tests/ZendTest/Log/LoggerAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Log/LoggerAbstractServiceFactoryTest.php
@@ -9,8 +9,9 @@
 
 namespace ZendTest\Log;
 
-use Zend\ServiceManager\ServiceManager;
+use Zend\Log\Writer\Db as DbWriter;
 use Zend\Mvc\Service\ServiceManagerConfig;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * @group      Zend_Log
@@ -82,5 +83,49 @@ class LoggerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
     public function testInvalidLoggerService($service)
     {
         $actual = $this->serviceManager->get($service);
+    }
+
+    /**
+     * @group 5254
+     */
+    public function testRetrievesDatabaseServiceFromServiceManagerWhenEncounteringDbWriter()
+    {
+        $db = $this->getMockBuilder('Zend\Db\Adapter\Adapter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $serviceManager = new ServiceManager(new ServiceManagerConfig(array(
+            'abstract_factories' => array('Zend\Log\LoggerAbstractServiceFactory'),
+        )));
+        $serviceManager->setService('Db\Logger', $db);
+        $serviceManager->setService('Config', array(
+            'log' => array(
+                'Application\Log' => array(
+                    'writers' => array(
+                        array(
+                            'name'     => 'db',
+                            'priority' => 1,
+                            'options'  => array(
+                                'separator' => '_',
+                                'column'    => array(),
+                                'table'     => 'applicationlog',
+                                'db'        => 'Db\Logger',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ));
+        $logger = $serviceManager->get('Application\Log');
+        $this->assertInstanceOf('Zend\Log\Logger', $logger);
+        $writers = $logger->getWriters();
+        $found   = false;
+        foreach ($writers as $writer) {
+            if ($writer instanceof DbWriter) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'Did not find expected DB writer');
+        $this->assertAttributeSame($db, 'db', $writer);
     }
 }


### PR DESCRIPTION
I use this config to create a logger:

```
'log' => array(
    'Application\Log' => array(
        'writers' => array(
            array(
                'name'     => 'db',
                'priority' => 1,
                'options'  => array(
                    'separator' => '_',
                    'column'    => array(),
                    'table'     => 'applicationlog',
                    'db'        => 'Zend\Db\Adapter\Adapter',
                ),
            ),
        ),
        #'exceptionhandler' => true,
        #'errorhandler'     => true,
    ),
),
```

With this config I can get the logger via the service manager:

``` php
$serviceManager->get('Application\Log');
```

This results in the following exception:

> Zend\Log\Exception\InvalidArgumentException: You must pass a valid Zend\Db\Adapter\Adapter in [...]\vendor\zendframework\zendframework\library\Zend\Log\Writer\Db.php on line 74

`Zend\Log\Writer\Db` expects an instance of `Zend\Db\Adapter\Adapter` for the option key `db`.

Suggested fixes:
- If `db` is a string, use the service manager to get the class by the name provided in the `db` option key.
- If `db` is a closure, get the result of the closure.

When the string possibility and the closure possibility is checked and processed there can be checked if this results in a valid instance of `Zend\Db\Adapter\Adapter`.
