### PR TITLE
Add identity interface for Rbac

### DIFF
--- a/library/Zend/Permissions/IdentityInterface.php
+++ b/library/Zend/Permissions/IdentityInterface.php
@@ -7,14 +7,17 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace Zend\Permissions\Rbac;
+namespace Zend\Permissions;
 
+/**
+ * Common identity interface for RBAC and ACL models
+ */
 interface IdentityInterface 
 {
     /**
      * Get the list of roles of this identity
      *
-     * @return string|RoleInterface|RoleInterface[]
+     * @return mixed
      */
     public function getRoles();
 }

--- a/library/Zend/Permissions/IdentityInterface.php
+++ b/library/Zend/Permissions/IdentityInterface.php
@@ -17,7 +17,7 @@ interface IdentityInterface
     /**
      * Get the list of roles of this identity
      *
-     * @return mixed
+     * @return string|array|\Zend\Permissions\Acl\Role\RoleInterface|\Zend\Permissions\Rbac\RoleInterface
      */
     public function getRoles();
 }

--- a/library/Zend/Permissions/Rbac/IdentityInterface.php
+++ b/library/Zend/Permissions/Rbac/IdentityInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Permissions\Rbac;
+
+interface IdentityInterface 
+{
+    /**
+     * Get the list of roles of this identity
+     * 
+     * @return string|RoleInterface|RoleInterface[]
+     */
+    public function getRoles();
+} 

--- a/library/Zend/Permissions/Rbac/IdentityInterface.php
+++ b/library/Zend/Permissions/Rbac/IdentityInterface.php
@@ -17,4 +17,4 @@ interface IdentityInterface
      * @return string|RoleInterface|RoleInterface[]
      */
     public function getRoles();
-} 
+}

--- a/library/Zend/Permissions/Rbac/IdentityInterface.php
+++ b/library/Zend/Permissions/Rbac/IdentityInterface.php
@@ -13,7 +13,7 @@ interface IdentityInterface
 {
     /**
      * Get the list of roles of this identity
-     * 
+     *
      * @return string|RoleInterface|RoleInterface[]
      */
     public function getRoles();


### PR DESCRIPTION
The documentation of Rbac talks about the Identity (http://framework.zend.com/manual/2.2/en/modules/zend.permissions.rbac.intro.html).

However, there is no such interface in Rbac code. It makes things easier for modules that can type hint on this.

ping @spiffyjr

(Note : I made the PR against develop as I'm not sure if this is considered as a new feature or not)

EDIT : usage:

The use of this is mainly to have a common interface for authorization module (MvcAuth, BjyAuthorize, ZfcRbac...). Entity that represent "identities" (like users) could simply implement this interface:

``` php
class User implements IdentityInterface
{
     public function getRoles()
     {
          return 'admin'; // simplest use case
     }
}
```
