### PR TITLE
[Form] addAttribute function

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -172,6 +172,30 @@ class Element implements
     }
 
     /**
+     * Add a single element attribute
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return Element|ElementInterface
+     */
+    public function addAttribute($key, $value)
+    {
+        if ($this->hasAttribute($key)) {
+            $attribute = $this->getAttribute($key);
+            $array = explode(' ', $attribute);
+            if(!in_array($value, $array)) {
+                array_push($array, $value);
+            }
+            $attribute = implode(' ', $array);
+        } else {
+            $attribute = $value;
+        }
+        $this->setAttribute($key, $attribute);
+
+        return $this;
+    }
+
+    /**
      * Retrieve a single element attribute
      *
      * @param  $key

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -111,6 +111,23 @@ class ElementTest extends TestCase
         $this->assertEquals('foo', $element->getName());
     }
 
+    public function testAddAttribute()
+    {
+        $element = new Element();
+        $attributes = array(
+            'type'     => 'text',
+            'class'    => 'text-element',
+            'data-foo' => 'bar',
+        );
+        $element->addAttribute('class', 'baz');
+        $expected = array(
+            'type'     => 'text',
+            'class'    => 'text-element baz',
+            'data-foo' => 'bar',
+        );
+        $this->assertEquals($expected, $element->getAttributes());
+    }
+
     public function testCanPassNameToConstructor()
     {
         $element = new Element('foo');


### PR DESCRIPTION
Often have to do so:

<pre>
if ($form->hasAttribute('class')) {
    $form->setAttribute('class', $form->getAttribute('class') . ' form-horizontal');
} else {
    $form->setAttribute('class', 'form-horizontal');
}
</pre>

But it is much easier:

<pre>
$form->addAttribute('class', 'form-horizontal');
</pre>
