### PR TITLE
Added isset check for REMOTE_ADDR

### DIFF
--- a/library/Zend/Http/PhpEnvironment/RemoteAddress.php
+++ b/library/Zend/Http/PhpEnvironment/RemoteAddress.php
@@ -119,7 +119,7 @@ class RemoteAddress
     protected function getIpAddressFromProxy()
     {
         if (!$this->useProxy
-            || !in_array($_SERVER['REMOTE_ADDR'], $this->trustedProxies)
+            || (isset($_SERVER['REMOTE_ADDR']) && !in_array($_SERVER['REMOTE_ADDR'], $this->trustedProxies))
         ) {
             return false;
         }

--- a/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
@@ -137,12 +137,17 @@ class RemoteAddressTest extends TestCase
      */
     public function testGetIpAddressReturnsEmptyStringOnNoRemoteAddr()
     {
-        $ipAddress = $_SERVER['REMOTE_ADDR'];
-        unset($_SERVER['REMOTE_ADDR']);
+        // Store the set IP address for later use
+        if (isset($_SERVER['REMOTE_ADDR'])) {
+            $ipAddress = $_SERVER['REMOTE_ADDR'];
+            unset($_SERVER['REMOTE_ADDR']);
+        }
 
         $this->remoteAddress->setUseProxy(true);
         $this->assertEquals('', $this->remoteAddress->getIpAddress());
 
-        $_SERVER['REMOTE_ADDR'] = $ipAddress;
+        if (isset($ipAddress)) {
+            $_SERVER['REMOTE_ADDR'] = $ipAddress;
+        }
     }
 }

--- a/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
@@ -65,7 +65,7 @@ class RemoteAddressTest extends TestCase
         $this->remoteAddress->setUseProxy(false);
         $this->assertFalse($this->remoteAddress->getUseProxy());
     }
-
+    
     public function testSetGetDefaultUseProxy()
     {
         $this->remoteAddress->setUseProxy();
@@ -83,7 +83,7 @@ class RemoteAddressTest extends TestCase
     public function testGetIpAddress()
     {
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-        $this->assertEquals('127.0.0.1', $this->remoteAddress->getIpAddress());
+        $this->assertEquals('127.0.0.1', $this->remoteAddress->getIpAddress()); 
     }
 
     public function testGetIpAddressFromProxy()
@@ -122,9 +122,27 @@ class RemoteAddressTest extends TestCase
             '192.168.0.10', '10.0.0.1', '10.0.0.2'
         ));
         $_SERVER['REMOTE_ADDR'] = '192.168.0.10';
-        // 1.1.1.1 is the first IP address from the right not representing a known proxy server; as such, we
+        // 1.1.1.1 is the first IP address from the right not representing a known proxy server; as such, we 
         // must treat it as a client IP.
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8, 10.0.0.2, 1.1.1.1, 10.0.0.1';
         $this->assertEquals('1.1.1.1', $this->remoteAddress->getIpAddress());
+    }
+
+    /**
+     * Tests if an empty string is returned if the server variable
+     * REMOTE_ADDR is not set.
+     *
+     * This happens when you run a local unit test, or a PHP script with
+     * PHP from the command line.
+     */
+    public function testGetIpAddressReturnsEmptyStringOnNoRemoteAddr()
+    {
+        $ipAddress = $_SERVER['REMOTE_ADDR'];
+        unset($_SERVER['REMOTE_ADDR']);
+
+        $this->remoteAddress->setUseProxy(true);
+        $this->assertEquals('', $this->remoteAddress->getIpAddress());
+
+        $_SERVER['REMOTE_ADDR'] = $ipAddress;
     }
 }

--- a/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
@@ -65,7 +65,7 @@ class RemoteAddressTest extends TestCase
         $this->remoteAddress->setUseProxy(false);
         $this->assertFalse($this->remoteAddress->getUseProxy());
     }
-    
+
     public function testSetGetDefaultUseProxy()
     {
         $this->remoteAddress->setUseProxy();
@@ -83,7 +83,7 @@ class RemoteAddressTest extends TestCase
     public function testGetIpAddress()
     {
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-        $this->assertEquals('127.0.0.1', $this->remoteAddress->getIpAddress()); 
+        $this->assertEquals('127.0.0.1', $this->remoteAddress->getIpAddress());
     }
 
     public function testGetIpAddressFromProxy()
@@ -122,7 +122,7 @@ class RemoteAddressTest extends TestCase
             '192.168.0.10', '10.0.0.1', '10.0.0.2'
         ));
         $_SERVER['REMOTE_ADDR'] = '192.168.0.10';
-        // 1.1.1.1 is the first IP address from the right not representing a known proxy server; as such, we 
+        // 1.1.1.1 is the first IP address from the right not representing a known proxy server; as such, we
         // must treat it as a client IP.
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8, 10.0.0.2, 1.1.1.1, 10.0.0.1';
         $this->assertEquals('1.1.1.1', $this->remoteAddress->getIpAddress());


### PR DESCRIPTION
getIpAddressFromProxy failed while unit-testing, because there is no REMOTE_ADDR set. Now there is a check to see if it is set before trying to check if it is in the trustedProxies array.
