### PR TITLE
fix typo & wording

### DIFF
--- a/library/Zend/Cache/PatternPluginManager.php
+++ b/library/Zend/Cache/PatternPluginManager.php
@@ -14,7 +14,7 @@ use Zend\ServiceManager\AbstractPluginManager;
 /**
  * Plugin manager implementation for cache pattern adapters
  *
- * Enforces that adapters retrieved are instances of
+ * Enforces that retrieved adapters are instances of
  * Pattern\PatternInterface. Additionally, it registers a number of default
  * patterns available.
  */

--- a/library/Zend/Cache/PatternPluginManager.php
+++ b/library/Zend/Cache/PatternPluginManager.php
@@ -14,7 +14,7 @@ use Zend\ServiceManager\AbstractPluginManager;
 /**
  * Plugin manager implementation for cache pattern adapters
  *
- * Enforces that adatpers retrieved are instances of
+ * Enforces that adapters retrieved are instances of
  * Pattern\PatternInterface. Additionally, it registers a number of default
  * patterns available.
  */


### PR DESCRIPTION
first, "adatpers" should be typed "adapters", second, "adatpers retrieved" should be "retrieved adapters"
