### PR TITLE
Fix emails that contain lines that start with periods

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -282,6 +282,11 @@ class Smtp extends AbstractProtocol
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
+        // Ensure newlines are CRLF (\r\n)
+        if (PHP_EOL === "\n") {
+            $data = str_replace("\n", "\r\n", str_replace("\r", '', $data));
+        }
+
         foreach (explode(self::EOL, $data) as $line) {
             if (strpos($line, '.') === 0) {
                 // Escape lines prefixed with a '.'

--- a/tests/ZendTest/Mail/Protocol/SmtpTest.php
+++ b/tests/ZendTest/Mail/Protocol/SmtpTest.php
@@ -57,6 +57,34 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedMessage, $this->connection->getLog());
     }
 
+    public function testSendEscapedEmail()
+    {
+        $headers = new Headers();
+        $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
+        $message = new Message();
+        $message
+            ->setHeaders($headers)
+            ->setSender('ralph.schindler@zend.com', 'Ralph Schindler')
+            ->setBody("This is a test\n.")
+            ->addTo('zf-devteam@zend.com', 'ZF DevTeam')
+        ;
+        $expectedMessage = "EHLO localhost\r\n"
+            . "MAIL FROM:<ralph.schindler@zend.com>\r\n"
+            . "DATA\r\n"
+            . "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"
+            . "Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n"
+            . "To: ZF DevTeam <zf-devteam@zend.com>\r\n"
+            . "\r\n"
+            . "This is a test\r\n"
+            . "..\r\n"
+            . ".\r\n";
+
+        $this->transport->send($message);
+
+        $this->assertEquals($expectedMessage, $this->connection->getLog());
+
+    }
+
     public function testDisconnectCallsQuit()
     {
         $this->connection->disconnect();


### PR DESCRIPTION
This pull request contains a unit test (which fails under the current master) and patch for the following problem:

When sending an email via SMTP that has a line in the message body that starts with a period character ("."), the message body gets chopped off at that line and the remote SMTP server closes the connection.

Although escaping code exists in Zend\Mail\Protocol\Smtp's data() method, it doesn't work since it splits the string on "\r\n" but the MimeMessage class uses "\n" for newlines.

Lines 285-291 of Mail/Protocol/Smtp.php:

```
foreach (explode(self::EOL, $data) as $line) {
    if (strpos($line, '.') === 0) {
        // Escape lines prefixed with a '.'
        $line = '.' . $line;
    }
    $this->_send($line);
```

}

https://github.com/zendframework/zf2/blob/master/library/Zend/Mail/Protocol/Smtp.php#L285-L290

Since $data is delimited on "\n" the period escaping never happens, so the message ends prematurely.
