### PR TITLE
Zend\Http\Header\SetCookie not compatible with older versions of pcre (and therefore CentOS)

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -97,7 +97,6 @@ class SetCookie implements MultipleHeaderInterface
      */
     public static function fromString($headerLine, $bypassHeaderFieldName = false)
     {
-        /* @var $setCookieProcessor Closure */
         static $setCookieProcessor = null;
 
         if ($setCookieProcessor === null) {
@@ -107,7 +106,7 @@ class SetCookie implements MultipleHeaderInterface
                 $keyValuePairs = preg_split('#;\s*#', $headerLine);
 
                 foreach ($keyValuePairs as $keyValue) {
-                    if (preg_match('#^(?<headerKey>[^=]+)=\s*("?)(?<headerValue>[^"]+)\2#',$keyValue,$matches)) {
+                    if (preg_match('#^(?P<headerKey>[^=]+)=\s*("?)(?P<headerValue>[^"]+)\2#', $keyValue, $matches)) {
                         $headerKey  = $matches['headerKey'];
                         $headerValue= $matches['headerValue'];
                     } else {


### PR DESCRIPTION
SetCookie no longer compiles with older versions of PCRE as of 2.2.5.

This appears to be the same issue addressed in the Console Router in an earlier version.

https://github.com/zendframework/zf2/issues/4134

---

Version 6.x of PCRE does not recognize ?< as a valid preg_match command.

It DOES recognize ?P<

From http://php.net/manual/en/function.preg-match.php:
"Named subpatterns now accept the syntax (?) and (?'name') as well as (?P). Previous versions accepted only (?P)."
