### PR TITLE
[WIP] Zend\Filter harmonization (Issue 5119)

### DIFF
--- a/library/Zend/Filter/BaseName.php
+++ b/library/Zend/Filter/BaseName.php
@@ -17,29 +17,17 @@ class BaseName extends AbstractFilter
      * Returns basename($value).
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return string|mixed
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
+        $value = (string) $value;
 
-        return basename((string) $value);
+        return basename($value);
     }
 }

--- a/library/Zend/Filter/Callback.php
+++ b/library/Zend/Filter/Callback.php
@@ -67,7 +67,7 @@ class Callback extends AbstractFilter
     /**
      * Sets parameters for the callback
      *
-     * @param  mixed $params
+     * @param  array $params
      * @return self
      */
     public function setCallbackParams($params)

--- a/library/Zend/Filter/Compress.php
+++ b/library/Zend/Filter/Compress.php
@@ -204,7 +204,7 @@ class Compress extends AbstractFilter
         if (!is_string($value)) {
             return $value;
         }
-        
+
         return $this->getAdapter()->compress($value);
     }
 }

--- a/library/Zend/Filter/Compress.php
+++ b/library/Zend/Filter/Compress.php
@@ -201,6 +201,10 @@ class Compress extends AbstractFilter
      */
     public function filter($value)
     {
+        if (!is_string($value)) {
+            return $value;
+        }
+        
         return $this->getAdapter()->compress($value);
     }
 }

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -59,7 +59,7 @@ class DateTimeFormatter extends AbstractFilter
             // DateTime threw an exception, an invalid date string was provided
             throw new Exception\InvalidArgumentException('Invalid date string provided', $e->getCode(), $e);
         }
-        
+
         if($result === false){
             return $value;
         }
@@ -78,11 +78,11 @@ class DateTimeFormatter extends AbstractFilter
         if ($value === '' || $value === null) {
             return $value;
         }
-        
+
         if(!is_string($value) && !is_int($value) && !$value instanceof DateTime){
             return $value;
         }
-        
+
         if (is_int($value)) {
             //timestamp
             $value = new DateTime('@' . $value);

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -41,6 +41,7 @@ class DateTimeFormatter extends AbstractFilter
     public function setFormat($format)
     {
         $this->format = $format;
+
         return $this;
     }
 
@@ -60,7 +61,7 @@ class DateTimeFormatter extends AbstractFilter
             throw new Exception\InvalidArgumentException('Invalid date string provided', $e->getCode(), $e);
         }
 
-        if($result === false){
+        if ($result === false) {
             return $value;
         }
 
@@ -79,7 +80,7 @@ class DateTimeFormatter extends AbstractFilter
             return $value;
         }
 
-        if(!is_string($value) && !is_int($value) && !$value instanceof DateTime){
+        if (!is_string($value) && !is_int($value) && !$value instanceof DateTime) {
             return $value;
         }
 

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -47,7 +47,7 @@ class DateTimeFormatter extends AbstractFilter
     /**
      * Filter a datetime string by normalizing it to the filters specified format
      *
-     * @param  string $value
+     * @param  DateTime|string|integer $value
      * @throws Exception\InvalidArgumentException
      * @return string
      */
@@ -58,6 +58,10 @@ class DateTimeFormatter extends AbstractFilter
         } catch (\Exception $e) {
             // DateTime threw an exception, an invalid date string was provided
             throw new Exception\InvalidArgumentException('Invalid date string provided', $e->getCode(), $e);
+        }
+        
+        if($result === false){
+            return $value;
         }
 
         return $result;
@@ -73,7 +77,14 @@ class DateTimeFormatter extends AbstractFilter
     {
         if ($value === '' || $value === null) {
             return $value;
-        } elseif (is_int($value)) {
+        }
+        
+        if(!is_string($value) && !is_int($value) && !$value instanceof DateTime){
+            return $value;
+        }
+        
+        if (is_int($value)) {
+            //timestamp
             $value = new DateTime('@' . $value);
         } elseif (!$value instanceof DateTime) {
             $value = new DateTime($value);

--- a/library/Zend/Filter/Decompress.php
+++ b/library/Zend/Filter/Decompress.php
@@ -37,6 +37,10 @@ class Decompress extends Compress
      */
     public function filter($value)
     {
+        if (!is_string($value)) {
+            return $value;
+        }
+        
         return $this->getAdapter()->decompress($value);
     }
 }

--- a/library/Zend/Filter/Decompress.php
+++ b/library/Zend/Filter/Decompress.php
@@ -24,7 +24,7 @@ class Decompress extends Compress
      */
     public function __invoke($value)
     {
-        return $this->getAdapter()->decompress($value);
+        return $this->filter($value);
     }
 
     /**

--- a/library/Zend/Filter/Decompress.php
+++ b/library/Zend/Filter/Decompress.php
@@ -40,7 +40,7 @@ class Decompress extends Compress
         if (!is_string($value)) {
             return $value;
         }
-        
+
         return $this->getAdapter()->decompress($value);
     }
 }

--- a/library/Zend/Filter/Decompress.php
+++ b/library/Zend/Filter/Decompress.php
@@ -37,7 +37,7 @@ class Decompress extends Compress
      */
     public function filter($value)
     {
-        if (!is_string($value)) {
+        if (!is_string($value) && $value !== null) {
             return $value;
         }
 

--- a/library/Zend/Filter/Decrypt.php
+++ b/library/Zend/Filter/Decrypt.php
@@ -24,7 +24,7 @@ class Decrypt extends Encrypt
      */
     public function filter($value)
     {
-        if(!is_string($value)){
+        if (!is_string($value)) {
             return $value;
         }
 

--- a/library/Zend/Filter/Decrypt.php
+++ b/library/Zend/Filter/Decrypt.php
@@ -27,7 +27,7 @@ class Decrypt extends Encrypt
         if(!is_string($value)){
             return $value;
         }
-        
+
         return $this->adapter->decrypt($value);
     }
 }

--- a/library/Zend/Filter/Decrypt.php
+++ b/library/Zend/Filter/Decrypt.php
@@ -24,6 +24,10 @@ class Decrypt extends Encrypt
      */
     public function filter($value)
     {
+        if(!is_string($value)){
+            return $value;
+        }
+        
         return $this->adapter->decrypt($value);
     }
 }

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -19,28 +19,16 @@ class Digits extends AbstractFilter
      * Returns the string $value, removing all but digit characters
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return string|mixed
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
+        $value = (string) $value;
 
         if (!StringUtils::hasPcreUnicodeSupport()) {
             // POSIX named classes are not supported, use alternative 0-9 match
@@ -53,6 +41,6 @@ class Digits extends AbstractFilter
             $pattern = '/[\p{^N}]/';
         }
 
-        return preg_replace($pattern, '', (string) $value);
+        return preg_replace($pattern, '', $value);
     }
 }

--- a/library/Zend/Filter/Dir.php
+++ b/library/Zend/Filter/Dir.php
@@ -25,7 +25,7 @@ class Dir extends AbstractFilter
             return $value;
         }
         $value = (string) $value;
-        
+
         return dirname($value);
     }
 }

--- a/library/Zend/Filter/Dir.php
+++ b/library/Zend/Filter/Dir.php
@@ -21,6 +21,11 @@ class Dir extends AbstractFilter
      */
     public function filter($value)
     {
-        return dirname((string) $value);
+        if (!is_scalar($value)) {
+            return $value;
+        }
+        $value = (string) $value;
+        
+        return dirname($value);
     }
 }

--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -19,6 +19,8 @@ class Encrypt extends AbstractFilter
 {
     /**
      * Encryption adapter
+     * 
+     * @param Encrypt\EncryptionAlgorithmInterface
      */
     protected $adapter;
 

--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -41,7 +41,7 @@ class Encrypt extends AbstractFilter
     /**
      * Returns the name of the set adapter
      * @todo inconsitent: get adapter should return the adapter and not the name
-     * 
+     *
      * @return string
      */
     public function getAdapter()
@@ -123,7 +123,7 @@ class Encrypt extends AbstractFilter
         if(!is_string($value)){
             return $value;
         }
-        
+
         return $this->adapter->encrypt($value);
     }
 }

--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -19,7 +19,7 @@ class Encrypt extends AbstractFilter
 {
     /**
      * Encryption adapter
-     * 
+     *
      * @param Encrypt\EncryptionAlgorithmInterface
      */
     protected $adapter;

--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -120,7 +120,7 @@ class Encrypt extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_string($value)){
+        if (!is_string($value)) {
             return $value;
         }
 

--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -40,7 +40,8 @@ class Encrypt extends AbstractFilter
 
     /**
      * Returns the name of the set adapter
-     *
+     * @todo inconsitent: get adapter should return the adapter and not the name
+     * 
      * @return string
      */
     public function getAdapter()
@@ -119,6 +120,10 @@ class Encrypt extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_string($value)){
+            return $value;
+        }
+        
         return $this->adapter->encrypt($value);
     }
 }

--- a/library/Zend/Filter/File/Decrypt.php
+++ b/library/Zend/Filter/File/Decrypt.php
@@ -58,12 +58,22 @@ class Decrypt extends Filter\Decrypt
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
-        if ($isFileUpload) {
+        $isFileUpload = false;
+        if(is_array($value)){
+            if(!isset($value['tmp_name'])){
+                return $value;
+            }
+            
+            $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }
+        
 
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");

--- a/library/Zend/Filter/File/Decrypt.php
+++ b/library/Zend/Filter/File/Decrypt.php
@@ -64,8 +64,8 @@ class Decrypt extends Filter\Decrypt
 
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
-        if(is_array($value)){
-            if(!isset($value['tmp_name'])){
+        if (is_array($value)) {
+            if (!isset($value['tmp_name'])) {
                 return $value;
             }
 

--- a/library/Zend/Filter/File/Decrypt.php
+++ b/library/Zend/Filter/File/Decrypt.php
@@ -61,19 +61,19 @@ class Decrypt extends Filter\Decrypt
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
         if(is_array($value)){
             if(!isset($value['tmp_name'])){
                 return $value;
             }
-            
+
             $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }
-        
+
 
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");

--- a/library/Zend/Filter/File/Encrypt.php
+++ b/library/Zend/Filter/File/Encrypt.php
@@ -58,9 +58,18 @@ class Encrypt extends Filter\Encrypt
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
-        if ($isFileUpload) {
+        $isFileUpload = false;
+        if(is_array($value)){
+            if(!isset($value['tmp_name'])){
+                return $value;
+            }
+        
+            $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }

--- a/library/Zend/Filter/File/Encrypt.php
+++ b/library/Zend/Filter/File/Encrypt.php
@@ -64,8 +64,8 @@ class Encrypt extends Filter\Encrypt
 
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
-        if(is_array($value)){
-            if(!isset($value['tmp_name'])){
+        if (is_array($value)) {
+            if (!isset($value['tmp_name'])) {
                 return $value;
             }
 

--- a/library/Zend/Filter/File/Encrypt.php
+++ b/library/Zend/Filter/File/Encrypt.php
@@ -61,14 +61,14 @@ class Encrypt extends Filter\Encrypt
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
         if(is_array($value)){
             if(!isset($value['tmp_name'])){
                 return $value;
             }
-        
+
             $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];

--- a/library/Zend/Filter/File/LowerCase.php
+++ b/library/Zend/Filter/File/LowerCase.php
@@ -32,8 +32,8 @@ class LowerCase extends StringToLower
 
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
-        if(is_array($value)){
-            if(!isset($value['tmp_name'])){
+        if (is_array($value)) {
+            if (!isset($value['tmp_name'])) {
                 return $value;
             }
 

--- a/library/Zend/Filter/File/LowerCase.php
+++ b/library/Zend/Filter/File/LowerCase.php
@@ -26,13 +26,22 @@ class LowerCase extends StringToLower
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
-        if ($isFileUpload) {
+        $isFileUpload = false;
+        if(is_array($value)){
+            if(!isset($value['tmp_name'])){
+                return $value;
+            }
+        
+            $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }
-
+        
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");
         }

--- a/library/Zend/Filter/File/LowerCase.php
+++ b/library/Zend/Filter/File/LowerCase.php
@@ -29,19 +29,19 @@ class LowerCase extends StringToLower
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
         if(is_array($value)){
             if(!isset($value['tmp_name'])){
                 return $value;
             }
-        
+
             $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }
-        
+
         if (!file_exists($value)) {
             throw new Exception\InvalidArgumentException("File '$value' not found");
         }

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -163,14 +163,14 @@ class Rename extends Filter\AbstractFilter
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
         if(is_array($value)){
             if(!isset($value['tmp_name'])){
                 return $value;
             }
-        
+
             $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -160,9 +160,18 @@ class Rename extends Filter\AbstractFilter
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
-        if ($isFileUpload) {
+        $isFileUpload = false;
+        if(is_array($value)){
+            if(!isset($value['tmp_name'])){
+                return $value;
+            }
+        
+            $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }

--- a/library/Zend/Filter/File/Rename.php
+++ b/library/Zend/Filter/File/Rename.php
@@ -166,8 +166,8 @@ class Rename extends Filter\AbstractFilter
 
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
-        if(is_array($value)){
-            if(!isset($value['tmp_name'])){
+        if (is_array($value)) {
+            if (!isset($value['tmp_name'])) {
                 return $value;
             }
 

--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -165,8 +165,8 @@ class RenameUpload extends AbstractFilter
 
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
-        if(is_array($value)){
-            if(!isset($value['tmp_name'])){
+        if (is_array($value)) {
+            if (!isset($value['tmp_name'])) {
                 return $value;
             }
 

--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -159,12 +159,21 @@ class RenameUpload extends AbstractFilter
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
-        if ($isFileUpload) {
+        $isFileUpload = false;
+        if(is_array($value)){
+            if(!isset($value['tmp_name'])){
+                return $value;
+            }
+        
+            $isFileUpload = true;
             $uploadData = $value;
             $sourceFile = $value['tmp_name'];
-        } else {
+        } else{
             $uploadData = array(
                 'tmp_name' => $value,
                 'name'     => $value,

--- a/library/Zend/Filter/File/RenameUpload.php
+++ b/library/Zend/Filter/File/RenameUpload.php
@@ -162,14 +162,14 @@ class RenameUpload extends AbstractFilter
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
         if(is_array($value)){
             if(!isset($value['tmp_name'])){
                 return $value;
             }
-        
+
             $isFileUpload = true;
             $uploadData = $value;
             $sourceFile = $value['tmp_name'];

--- a/library/Zend/Filter/File/UpperCase.php
+++ b/library/Zend/Filter/File/UpperCase.php
@@ -32,8 +32,8 @@ class UpperCase extends StringToUpper
 
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
-        if(is_array($value)){
-            if(!isset($value['tmp_name'])){
+        if (is_array($value)) {
+            if (!isset($value['tmp_name'])) {
                 return $value;
             }
 

--- a/library/Zend/Filter/File/UpperCase.php
+++ b/library/Zend/Filter/File/UpperCase.php
@@ -29,14 +29,14 @@ class UpperCase extends StringToUpper
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // An uploaded file? Retrieve the 'tmp_name'
         $isFileUpload = false;
         if(is_array($value)){
             if(!isset($value['tmp_name'])){
                 return $value;
             }
-        
+
             $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];

--- a/library/Zend/Filter/File/UpperCase.php
+++ b/library/Zend/Filter/File/UpperCase.php
@@ -26,9 +26,18 @@ class UpperCase extends StringToUpper
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = (is_array($value) && isset($value['tmp_name']));
-        if ($isFileUpload) {
+        $isFileUpload = false;
+        if(is_array($value)){
+            if(!isset($value['tmp_name'])){
+                return $value;
+            }
+        
+            $isFileUpload = true;
             $uploadData = $value;
             $value      = $value['tmp_name'];
         }

--- a/library/Zend/Filter/HtmlEntities.php
+++ b/library/Zend/Filter/HtmlEntities.php
@@ -174,7 +174,6 @@ class HtmlEntities extends AbstractFilter
      * equivalents where they exist
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return string|mixed
@@ -182,29 +181,18 @@ class HtmlEntities extends AbstractFilter
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
+        $value = (string) $value;
 
-        $filtered = htmlentities((string) $value, $this->getQuoteStyle(), $this->getEncoding(), $this->getDoubleQuote());
-        if (strlen((string) $value) && !strlen($filtered)) {
+        $filtered = htmlentities($value, $this->getQuoteStyle(), $this->getEncoding(), $this->getDoubleQuote());
+        if (strlen($value) && !strlen($filtered)) {
             if (!function_exists('iconv')) {
                 throw new Exception\DomainException('Encoding mismatch has resulted in htmlentities errors');
             }
             $enc      = $this->getEncoding();
-            $value    = iconv('', $this->getEncoding() . '//IGNORE', (string) $value);
+            $value    = iconv('', $this->getEncoding() . '//IGNORE', $value);
             $filtered = htmlentities($value, $this->getQuoteStyle(), $enc, $this->getDoubleQuote());
             if (!strlen($filtered)) {
                 throw new Exception\DomainException('Encoding mismatch has resulted in htmlentities errors');

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -17,29 +17,17 @@ class Int extends AbstractFilter
      * Returns (int) $value
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return int|mixed
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
-
-        return (int) ((string) $value);
+        $value = (string) $value;
+        
+        return (int) $value;
     }
 }

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -27,7 +27,7 @@ class Int extends AbstractFilter
             return $value;
         }
         $value = (string) $value;
-        
+
         return (int) $value;
     }
 }

--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -129,7 +129,7 @@ class PregReplace extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value) && !is_array($value)){
+        if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
 

--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -132,7 +132,7 @@ class PregReplace extends AbstractFilter
         if(!is_scalar($value) && !is_array($value)){
             return $value;
         }
-        
+
         if ($this->options['pattern'] === null) {
             throw new Exception\RuntimeException(sprintf(
                 'Filter %s does not have a valid pattern set',

--- a/library/Zend/Filter/PregReplace.php
+++ b/library/Zend/Filter/PregReplace.php
@@ -129,6 +129,10 @@ class PregReplace extends AbstractFilter
      */
     public function filter($value)
     {
+        if(!is_scalar($value) && !is_array($value)){
+            return $value;
+        }
+        
         if ($this->options['pattern'] === null) {
             throw new Exception\RuntimeException(sprintf(
                 'Filter %s does not have a valid pattern set',

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -67,30 +67,17 @@ class RealPath extends AbstractFilter
      * Returns realpath($value)
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return string|mixed
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
-        if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
+        if(!is_string($value)){
             return $value;
         }
-
         $path = (string) $value;
+
         if ($this->options['exists']) {
             return realpath($path);
         }

--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -42,33 +42,21 @@ class StringToLower extends AbstractUnicode
      * Returns the string $value, converting characters to lowercase as necessary
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return string|mixed
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
+        $value = (string) $value;
 
         if ($this->options['encoding'] !== null) {
-            return mb_strtolower((string) $value,  $this->options['encoding']);
+            return mb_strtolower($value,  $this->options['encoding']);
         }
 
-        return strtolower((string) $value);
+        return strtolower($value);
     }
 }

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -42,33 +42,21 @@ class StringToUpper extends AbstractUnicode
      * Returns the string $value, converting characters to uppercase as necessary
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @param  string $value
      * @return string|mixed
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
+        $value = (string) $value;
 
         if ($this->options['encoding'] !== null) {
-            return mb_strtoupper((string) $value,  $this->options['encoding']);
+            return mb_strtoupper($value,  $this->options['encoding']);
         }
 
-        return strtoupper((string) $value);
+        return strtoupper($value);
     }
 }

--- a/library/Zend/Filter/StringTrim.php
+++ b/library/Zend/Filter/StringTrim.php
@@ -73,16 +73,16 @@ class StringTrim extends AbstractFilter
      */
     public function filter($value)
     {
-        // Do not filter non-string values
         if (!is_string($value)) {
             return $value;
         }
+        $value = (string) $value;
 
         if (null === $this->options['charlist']) {
-            return $this->unicodeTrim((string) $value);
+            return $this->unicodeTrim($value);
         }
 
-        return $this->unicodeTrim((string) $value, $this->options['charlist']);
+        return $this->unicodeTrim($value, $this->options['charlist']);
     }
 
     /**

--- a/library/Zend/Filter/StripNewlines.php
+++ b/library/Zend/Filter/StripNewlines.php
@@ -22,7 +22,7 @@ class StripNewlines extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_scalar($value) && !is_array($value)){
+        if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
         return str_replace(array("\n", "\r"), '', $value);

--- a/library/Zend/Filter/StripNewlines.php
+++ b/library/Zend/Filter/StripNewlines.php
@@ -17,11 +17,14 @@ class StripNewlines extends AbstractFilter
      *
      * Returns $value without newline control characters
      *
-     * @param  string $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if(!is_scalar($value) && !is_array($value)){
+            return $value;
+        }
         return str_replace(array("\n", "\r"), '', $value);
     }
 }

--- a/library/Zend/Filter/StripTags.php
+++ b/library/Zend/Filter/StripTags.php
@@ -167,7 +167,6 @@ class StripTags extends AbstractFilter
      * Defined by Zend\Filter\FilterInterface
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     * and an E_USER_WARNING will be raised indicating it's unfilterable.
      *
      * @todo   improve docblock descriptions
      * @param  string $value
@@ -175,22 +174,9 @@ class StripTags extends AbstractFilter
      */
     public function filter($value)
     {
-        if (null === $value) {
-            return null;
-        }
-
         if (!is_scalar($value)) {
-            trigger_error(
-                sprintf(
-                    '%s expects parameter to be scalar, "%s" given; cannot filter',
-                    __METHOD__,
-                    (is_object($value) ? get_class($value) : gettype($value))
-                ),
-                E_USER_WARNING
-            );
             return $value;
         }
-
         $value = (string) $value;
 
         // Strip HTML comments first

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -90,7 +90,7 @@ class UriNormalize extends AbstractFilter
             return $value;
         }
         $value = (string) $value;
-        
+
         $defaultScheme = $this->defaultScheme ?: $this->enforcedScheme;
 
         // Reset default scheme if it is not a known scheme

--- a/library/Zend/Filter/UriNormalize.php
+++ b/library/Zend/Filter/UriNormalize.php
@@ -86,6 +86,11 @@ class UriNormalize extends AbstractFilter
      */
     public function filter($value)
     {
+        if (!is_scalar($value)) {
+            return $value;
+        }
+        $value = (string) $value;
+        
         $defaultScheme = $this->defaultScheme ?: $this->enforcedScheme;
 
         // Reset default scheme if it is not a known scheme

--- a/library/Zend/Filter/Word/CamelCaseToSeparator.php
+++ b/library/Zend/Filter/Word/CamelCaseToSeparator.php
@@ -16,11 +16,15 @@ class CamelCaseToSeparator extends AbstractSeparator
     /**
      * Defined by Zend\Filter\Filter
      *
-     * @param  string $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         if (StringUtils::hasPcreUnicodeSupport()) {
             $pattern     = array('#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#');
             $replacement = array($this->separator . '\1', $this->separator . '\1');

--- a/library/Zend/Filter/Word/CamelCaseToSeparator.php
+++ b/library/Zend/Filter/Word/CamelCaseToSeparator.php
@@ -24,7 +24,7 @@ class CamelCaseToSeparator extends AbstractSeparator
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         if (StringUtils::hasPcreUnicodeSupport()) {
             $pattern     = array('#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#');
             $replacement = array($this->separator . '\1', $this->separator . '\1');

--- a/library/Zend/Filter/Word/DashToSeparator.php
+++ b/library/Zend/Filter/Word/DashToSeparator.php
@@ -14,11 +14,15 @@ class DashToSeparator extends AbstractSeparator
     /**
      * Defined by Zend\Filter\Filter
      *
-     * @param  string $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         return preg_replace('#-#', $this->separator, $value);
     }
 }

--- a/library/Zend/Filter/Word/DashToSeparator.php
+++ b/library/Zend/Filter/Word/DashToSeparator.php
@@ -22,7 +22,7 @@ class DashToSeparator extends AbstractSeparator
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         return preg_replace('#-#', $this->separator, $value);
     }
 }

--- a/library/Zend/Filter/Word/SeparatorToCamelCase.php
+++ b/library/Zend/Filter/Word/SeparatorToCamelCase.php
@@ -24,7 +24,7 @@ class SeparatorToCamelCase extends AbstractSeparator
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         // a unicode safe way of converting characters to \x00\x00 notation
         $pregQuotedSeparator = preg_quote($this->separator, '#');
 

--- a/library/Zend/Filter/Word/SeparatorToCamelCase.php
+++ b/library/Zend/Filter/Word/SeparatorToCamelCase.php
@@ -16,11 +16,15 @@ class SeparatorToCamelCase extends AbstractSeparator
     /**
      * Defined by Zend\Filter\Filter
      *
-     * @param  string $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         // a unicode safe way of converting characters to \x00\x00 notation
         $pregQuotedSeparator = preg_quote($this->separator, '#');
 

--- a/library/Zend/Filter/Word/SeparatorToSeparator.php
+++ b/library/Zend/Filter/Word/SeparatorToSeparator.php
@@ -78,11 +78,15 @@ class SeparatorToSeparator extends AbstractFilter
      *
      * Returns the string $value, replacing the searched separators with the defined ones
      *
-     * @param  string $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if (!is_scalar($value) && !is_array($value)) {
+            return $value;
+        }
+        
         if ($this->searchSeparator == null) {
             throw new Exception\RuntimeException('You must provide a search separator for this filter to work.');
         }

--- a/library/Zend/Filter/Word/SeparatorToSeparator.php
+++ b/library/Zend/Filter/Word/SeparatorToSeparator.php
@@ -86,7 +86,7 @@ class SeparatorToSeparator extends AbstractFilter
         if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
-        
+
         if ($this->searchSeparator == null) {
             throw new Exception\RuntimeException('You must provide a search separator for this filter to work.');
         }

--- a/library/Zend/I18n/Filter/Alnum.php
+++ b/library/Zend/I18n/Filter/Alnum.php
@@ -76,7 +76,7 @@ class Alnum extends AbstractLocale
         if(!is_scalar($value) && !is_array($value)){
             return $value;
         }
-        
+
         $whiteSpace = $this->options['allow_white_space'] ? '\s' : '';
         $language   = Locale::getPrimaryLanguage($this->getLocale());
 

--- a/library/Zend/I18n/Filter/Alnum.php
+++ b/library/Zend/I18n/Filter/Alnum.php
@@ -68,11 +68,15 @@ class Alnum extends AbstractLocale
      *
      * Returns $value as string with all non-alphanumeric characters removed
      *
-     * @param  mixed $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if(!is_scalar($value) && !is_array($value)){
+            return $value;
+        }
+        
         $whiteSpace = $this->options['allow_white_space'] ? '\s' : '';
         $language   = Locale::getPrimaryLanguage($this->getLocale());
 
@@ -87,6 +91,6 @@ class Alnum extends AbstractLocale
             $pattern = '/[^\p{L}\p{N}' . $whiteSpace . ']/u';
         }
 
-        return preg_replace($pattern, '', (string) $value);
+        return preg_replace($pattern, '', $value);
     }
 }

--- a/library/Zend/I18n/Filter/Alnum.php
+++ b/library/Zend/I18n/Filter/Alnum.php
@@ -73,7 +73,7 @@ class Alnum extends AbstractLocale
      */
     public function filter($value)
     {
-        if(!is_scalar($value) && !is_array($value)){
+        if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
 

--- a/library/Zend/I18n/Filter/Alpha.php
+++ b/library/Zend/I18n/Filter/Alpha.php
@@ -23,7 +23,7 @@ class Alpha extends Alnum
      */
     public function filter($value)
     {
-        if(!is_scalar($value) && !is_array($value)){
+        if (!is_scalar($value) && !is_array($value)) {
             return $value;
         }
 

--- a/library/Zend/I18n/Filter/Alpha.php
+++ b/library/Zend/I18n/Filter/Alpha.php
@@ -26,7 +26,7 @@ class Alpha extends Alnum
         if(!is_scalar($value) && !is_array($value)){
             return $value;
         }
-        
+
         $whiteSpace = $this->options['allow_white_space'] ? '\s' : '';
         $language   = Locale::getPrimaryLanguage($this->getLocale());
 

--- a/library/Zend/I18n/Filter/Alpha.php
+++ b/library/Zend/I18n/Filter/Alpha.php
@@ -18,11 +18,15 @@ class Alpha extends Alnum
      *
      * Returns the string $value, removing all but alphabetic characters
      *
-     * @param  string $value
-     * @return string
+     * @param  string|array $value
+     * @return string|array
      */
     public function filter($value)
     {
+        if(!is_scalar($value) && !is_array($value)){
+            return $value;
+        }
+        
         $whiteSpace = $this->options['allow_white_space'] ? '\s' : '';
         $language   = Locale::getPrimaryLanguage($this->getLocale());
 
@@ -37,6 +41,6 @@ class Alpha extends Alnum
             $pattern = '/[^\p{L}' . $whiteSpace . ']/u';
         }
 
-        return preg_replace($pattern, '', (string) $value);
+        return preg_replace($pattern, '', $value);
     }
 }

--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -140,6 +140,10 @@ class NumberFormat extends AbstractLocale
      */
     public function filter($value)
     {
+        if(!is_scalar($value)){
+            return $value;
+        }
+        
         $formatter = $this->getFormatter();
         $type      = $this->getType();
 

--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -143,7 +143,7 @@ class NumberFormat extends AbstractLocale
         if(!is_scalar($value)){
             return $value;
         }
-        
+
         $formatter = $this->getFormatter();
         $type      = $this->getType();
 

--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -140,7 +140,7 @@ class NumberFormat extends AbstractLocale
      */
     public function filter($value)
     {
-        if(!is_scalar($value)){
+        if (!is_scalar($value)) {
             return $value;
         }
 

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -6,17 +6,17 @@
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace ZendTest\Filter;
 
 use Zend\Filter\BaseName as BaseNameFilter;
 use Zend\Stdlib\ErrorHandler;
 
 /**
- * @group      Zend_Filter
+ * @group Zend_Filter
  */
 class BaseNameTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
      * Ensures that the filter follows expected behavior
      *
@@ -26,40 +26,32 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new BaseNameFilter();
         $valuesExpected = array(
-            '/path/to/filename'     => 'filename',
+            '/path/to/filename' => 'filename',
             '/path/to/filename.ext' => 'filename.ext'
-            );
+        );
         foreach ($valuesExpected as $input => $output) {
             $this->assertEquals($output, $filter($input));
         }
     }
 
     /**
-     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
         $filter = new BaseNameFilter();
-        $input = array('/path/to/filename', '/path/to/filename.ext');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filter   = new BaseNameFilter();
-        $filtered = $filter->filter(null);
-        $this->assertNull($filtered);
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                '/path/to/filename',
+                '/path/to/filename.ext'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -41,7 +41,7 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
     public function testReturnUnfiltered()
     {
         $filter = new BaseNameFilter();
-        
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -34,7 +34,8 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -44,7 +45,7 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -34,24 +34,25 @@ class BaseNameTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                '/path/to/filename',
+                '/path/to/filename.ext'
+            ))
+        );
+    }
+    
     /**
-     *
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new BaseNameFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                '/path/to/filename',
-                '/path/to/filename.ext'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/Compress/TarLoadArchiveTarTest.php
+++ b/tests/ZendTest/Filter/Compress/TarLoadArchiveTarTest.php
@@ -15,7 +15,7 @@ use Zend\Filter\Exception\ExtensionNotLoadedException;
 /**
  * @group      Zend_Filter
  */
-class TarLoadArchveTarTest extends \PHPUnit_Framework_TestCase
+class TarLoadArchiveTarTest extends \PHPUnit_Framework_TestCase
 {
     public function testArchiveTarNotLoaded()
     {

--- a/tests/ZendTest/Filter/CompressTest.php
+++ b/tests/ZendTest/Filter/CompressTest.php
@@ -228,7 +228,8 @@ class CompressTest extends \PHPUnit_Framework_TestCase
         $filter->invalidMethod();
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -238,7 +239,7 @@ class CompressTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/CompressTest.php
+++ b/tests/ZendTest/Filter/CompressTest.php
@@ -228,23 +228,25 @@ class CompressTest extends \PHPUnit_Framework_TestCase
         $filter->invalidMethod();
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                'compress me',
+                'compress me too, please'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter  = new CompressFilter('bz2');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                'compress me',
-                'compress me too, please'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/CompressTest.php
+++ b/tests/ZendTest/Filter/CompressTest.php
@@ -234,7 +234,7 @@ class CompressTest extends \PHPUnit_Framework_TestCase
     public function testReturnUnfiltered()
     {
         $filter  = new CompressFilter('bz2');
-        
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/CompressTest.php
+++ b/tests/ZendTest/Filter/CompressTest.php
@@ -227,4 +227,24 @@ class CompressTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Zend\Filter\Exception\BadMethodCallException', 'Unknown method');
         $filter->invalidMethod();
     }
+
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter  = new CompressFilter('bz2');
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'compress me',
+                'compress me too, please'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -29,28 +29,30 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         date_default_timezone_set($this->defaultTimezone);
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(''),
+            array(new \stdClass()),
+            array(array(
+                '1',
+                -1
+            )),
+            array(0.53)
+        );
+    }
+    
     /**
-     * Values which are skipped by the formatter
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
 
-        $valuesExpected = array(
-            null,
-            '',
-            new \stdClass(),
-            array(
-                '1',
-                -1
-            ),
-            0.53
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 
     public function testFormatterFormatsZero()

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -29,7 +29,8 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
         date_default_timezone_set($this->defaultTimezone);
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(''),
@@ -41,7 +42,7 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
             array(0.53)
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -28,16 +28,16 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
     {
         date_default_timezone_set($this->defaultTimezone);
     }
-    
+
     /**
      * Values which are skipped by the formatter
      */
     public function testReturnUnfiltered()
     {
         date_default_timezone_set('UTC');
-        
+
         $filter = new DateTimeFormatter();
-    
+
         $valuesExpected = array(
             null,
             '',

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Filter;
 
-use DateTime;
 use Zend\Filter\DateTimeFormatter;
+use DateTime;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/DateTimeFormatterTest.php
+++ b/tests/ZendTest/Filter/DateTimeFormatterTest.php
@@ -28,21 +28,29 @@ class DateTimeFormatterTest extends \PHPUnit_Framework_TestCase
     {
         date_default_timezone_set($this->defaultTimezone);
     }
-
-    public function testFormatterDoesNotFormatAnEmptyString()
+    
+    /**
+     * Values which are skipped by the formatter
+     */
+    public function testReturnUnfiltered()
     {
         date_default_timezone_set('UTC');
-
+        
         $filter = new DateTimeFormatter();
-        $result = $filter->filter('');
-        $this->assertEquals('', $result);
-    }
-
-    public function testFormatterDoesNotFormatNull()
-    {
-        $filter = new DateTimeFormatter();
-        $result = $filter->filter(null);
-        $this->assertEquals(null, $result);
+    
+        $valuesExpected = array(
+            null,
+            '',
+            new \stdClass(),
+            array(
+                '1',
+                -1
+            ),
+            0.53
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
     }
 
     public function testFormatterFormatsZero()

--- a/tests/ZendTest/Filter/DecompressTest.php
+++ b/tests/ZendTest/Filter/DecompressTest.php
@@ -107,14 +107,14 @@ class DecompressTest extends \PHPUnit_Framework_TestCase
         $content2 = $filter2->filter($archive);
         $this->assertEquals('compress me', $content2);
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new DecompressFilter('bz2');
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/DecompressTest.php
+++ b/tests/ZendTest/Filter/DecompressTest.php
@@ -107,4 +107,24 @@ class DecompressTest extends \PHPUnit_Framework_TestCase
         $content2 = $filter2->filter($archive);
         $this->assertEquals('compress me', $content2);
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new DecompressFilter('bz2');
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'decompress me',
+                'decompress me too, please'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/DecompressTest.php
+++ b/tests/ZendTest/Filter/DecompressTest.php
@@ -108,7 +108,8 @@ class DecompressTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('compress me', $content2);
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -118,7 +119,7 @@ class DecompressTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/DecompressTest.php
+++ b/tests/ZendTest/Filter/DecompressTest.php
@@ -108,23 +108,25 @@ class DecompressTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('compress me', $content2);
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                'decompress me',
+                'decompress me too, please'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new DecompressFilter('bz2');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                'decompress me',
-                'decompress me too, please'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/DecryptTest.php
+++ b/tests/ZendTest/Filter/DecryptTest.php
@@ -138,10 +138,22 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter->getUnknownMethod();
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=',
+                'decrypt me too, please'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         if (!extension_loaded('mcrypt')) {
             $this->markTestSkipped('Mcrypt extension not installed');
@@ -150,19 +162,8 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $decrypt = new DecryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
         $decrypt->setVector('1234567890123456890');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=',
-                'decrypt me too, please'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $decrypted = $decrypt->filter($input);
-
-            $this->assertEquals($input, $decrypted);
-        }
+        $decrypted = $decrypt->filter($input);
+        $this->assertEquals($input, $decrypted);
     }
 }
 

--- a/tests/ZendTest/Filter/DecryptTest.php
+++ b/tests/ZendTest/Filter/DecryptTest.php
@@ -138,7 +138,8 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter->getUnknownMethod();
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -148,7 +149,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/DecryptTest.php
+++ b/tests/ZendTest/Filter/DecryptTest.php
@@ -137,6 +137,33 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter = new DecryptFilter();
         $filter->getUnknownMethod();
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        if (!extension_loaded('mcrypt')) {
+            $this->markTestSkipped('Mcrypt extension not installed');
+        }
+
+        $decrypt = new DecryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
+        $decrypt->setVector('1234567890123456890');
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=',
+                'decrypt me too, please'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $decrypted = $decrypt->filter($input);
+            
+            $this->assertEquals($input, $decrypted);
+        }
+    }
 }
 
 class TestAdapter

--- a/tests/ZendTest/Filter/DecryptTest.php
+++ b/tests/ZendTest/Filter/DecryptTest.php
@@ -137,7 +137,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter = new DecryptFilter();
         $filter->getUnknownMethod();
     }
-    
+
     /**
      * @return void
      */
@@ -149,7 +149,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
         $decrypt = new DecryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
         $decrypt->setVector('1234567890123456890');
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),
@@ -160,7 +160,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         );
         foreach ($valuesExpected as $input) {
             $decrypted = $decrypt->filter($input);
-            
+
             $this->assertEquals($input, $decrypted);
         }
     }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -89,7 +89,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     public function testReturnUnfiltered()
     {
         $filter = new DigitsFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -83,7 +83,8 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -93,7 +94,7 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -84,31 +84,22 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that an error is raised if array is used
-     *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
         $filter = new DigitsFilter();
-        $input = array('abc123', 'abc 123');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filter   = new DigitsFilter();
-        $filtered = $filter->filter(null);
-        $this->assertNull($filtered);
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'abc123',
+                'abc 123'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -83,23 +83,25 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                'abc123',
+                'abc 123'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new DigitsFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                'abc123',
-                'abc 123'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/DirTest.php
+++ b/tests/ZendTest/Filter/DirTest.php
@@ -34,23 +34,25 @@ class DirTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                '/path/to/filename',
+                '/path/to/filename.ext'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new DirFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                '/path/to/filename',
-                '/path/to/filename.ext'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/DirTest.php
+++ b/tests/ZendTest/Filter/DirTest.php
@@ -33,14 +33,14 @@ class DirTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($output, $filter($input));
         }
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new DirFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/DirTest.php
+++ b/tests/ZendTest/Filter/DirTest.php
@@ -34,7 +34,8 @@ class DirTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -44,7 +45,7 @@ class DirTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/DirTest.php
+++ b/tests/ZendTest/Filter/DirTest.php
@@ -33,4 +33,24 @@ class DirTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($output, $filter($input));
         }
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new DirFilter();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                '/path/to/filename',
+                '/path/to/filename.ext'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/EncryptTest.php
+++ b/tests/ZendTest/Filter/EncryptTest.php
@@ -143,6 +143,33 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter = new EncryptFilter();
         $filter->getUnknownMethod();
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        if (!extension_loaded('mcrypt')) {
+            $this->markTestSkipped('Mcrypt extension not installed');
+        }
+    
+        $encrypt = new EncryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
+        $encrypt->setVector('1234567890123456890');
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'encrypt me',
+                'encrypt me too, please'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $encrypted = $encrypt->filter($input);
+                
+            $this->assertEquals($input, $encrypted);
+        }
+    }
 }
 
 class TestAdapter2

--- a/tests/ZendTest/Filter/EncryptTest.php
+++ b/tests/ZendTest/Filter/EncryptTest.php
@@ -143,7 +143,7 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter = new EncryptFilter();
         $filter->getUnknownMethod();
     }
-    
+
     /**
      * @return void
      */
@@ -152,10 +152,10 @@ PIDs9E7uuizAKDhRRRvho8BS
         if (!extension_loaded('mcrypt')) {
             $this->markTestSkipped('Mcrypt extension not installed');
         }
-    
+
         $encrypt = new EncryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
         $encrypt->setVector('1234567890123456890');
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),
@@ -166,7 +166,7 @@ PIDs9E7uuizAKDhRRRvho8BS
         );
         foreach ($valuesExpected as $input) {
             $encrypted = $encrypt->filter($input);
-                
+
             $this->assertEquals($input, $encrypted);
         }
     }

--- a/tests/ZendTest/Filter/EncryptTest.php
+++ b/tests/ZendTest/Filter/EncryptTest.php
@@ -144,10 +144,23 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter->getUnknownMethod();
     }
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                'encrypt me',
+                'encrypt me too, please'
+            ))
+        );
+    }
+
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         if (!extension_loaded('mcrypt')) {
             $this->markTestSkipped('Mcrypt extension not installed');
@@ -156,19 +169,8 @@ PIDs9E7uuizAKDhRRRvho8BS
         $encrypt = new EncryptFilter(array('adapter' => 'BlockCipher', 'key' => 'testkey'));
         $encrypt->setVector('1234567890123456890');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                'encrypt me',
-                'encrypt me too, please'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $encrypted = $encrypt->filter($input);
-
-            $this->assertEquals($input, $encrypted);
-        }
+        $encrypted = $encrypt->filter($input);
+        $this->assertEquals($input, $encrypted);
     }
 }
 

--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -115,4 +115,26 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'not found');
         $filter->filter(dirname(__DIR__).'/_files/nofile.txt');
     }
+    
+
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new FileDecrypt();
+        $filter->setKey('1234567890123456');
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                dirname(__DIR__).'/_files/nofile.txt',
+                dirname(__DIR__).'/_files/nofile2.txt'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -115,7 +115,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'not found');
         $filter->filter(dirname(__DIR__).'/_files/nofile.txt');
     }
-    
+
 
     /**
      * @return void
@@ -124,7 +124,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -116,25 +116,26 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
         $filter->filter(dirname(__DIR__).'/_files/nofile.txt');
     }
 
-
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                dirname(__DIR__).'/_files/nofile.txt',
+                dirname(__DIR__).'/_files/nofile2.txt'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                dirname(__DIR__).'/_files/nofile.txt',
-                dirname(__DIR__).'/_files/nofile2.txt'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/File/DecryptTest.php
+++ b/tests/ZendTest/Filter/File/DecryptTest.php
@@ -116,7 +116,8 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
         $filter->filter(dirname(__DIR__).'/_files/nofile.txt');
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -126,7 +127,7 @@ class DecryptTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/File/EncryptTest.php
+++ b/tests/ZendTest/Filter/File/EncryptTest.php
@@ -22,7 +22,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
         if (! extension_loaded('mcrypt')) {
             $this->markTestSkipped('This filter needs the mcrypt extension');
         }
-        
+
         if (file_exists(dirname(__DIR__) . '/_files/newencryption.txt')) {
             unlink(dirname(__DIR__) . '/_files/newencryption.txt');
         }
@@ -44,14 +44,14 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileEncrypt();
         $filter->setFilename(dirname(__DIR__) . '/_files/newencryption.txt');
-        
+
         $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $filter->getFilename());
-        
+
         $filter->setKey('1234567890123456');
         $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $filter->filter(dirname(__DIR__) . '/_files/encryption.txt'));
-        
+
         $this->assertEquals('Encryption', file_get_contents(dirname(__DIR__) . '/_files/encryption.txt'));
-        
+
         $this->assertNotEquals('Encryption', file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt'));
     }
 
@@ -61,14 +61,14 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
         $filter->setFilename(dirname(__DIR__) . '/_files/newencryption.txt');
         $filter->setKey('1234567890123456');
         $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $filter->filter(dirname(__DIR__) . '/_files/encryption.txt'));
-        
+
         $this->assertNotEquals('Encryption', file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt'));
-        
+
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
         $input = $filter->filter(dirname(__DIR__) . '/_files/newencryption.txt');
         $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $input);
-        
+
         $this->assertEquals('Encryption', trim(file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt')));
     }
 
@@ -80,7 +80,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
-        
+
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'not found');
         echo $filter->filter(dirname(__DIR__) . '/_files/nofile.txt');
     }
@@ -93,10 +93,10 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
-        
+
         copy(dirname(__DIR__) . '/_files/encryption.txt', dirname(__DIR__) . '/_files/newencryption.txt');
         $filter->filter(dirname(__DIR__) . '/_files/newencryption.txt');
-        
+
         $this->assertNotEquals('Encryption', trim(file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt')));
     }
 
@@ -108,7 +108,7 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
-        
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/File/EncryptTest.php
+++ b/tests/ZendTest/Filter/File/EncryptTest.php
@@ -100,25 +100,27 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals('Encryption', trim(file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt')));
     }
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                dirname(__DIR__) . '/_files/nofile.txt',
+                dirname(__DIR__) . '/_files/nofile2.txt'
+            ))
+        );
+    }
+
     /**
-     *
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                dirname(__DIR__) . '/_files/nofile.txt',
-                dirname(__DIR__) . '/_files/nofile2.txt'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/File/EncryptTest.php
+++ b/tests/ZendTest/Filter/File/EncryptTest.php
@@ -6,32 +6,32 @@
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace ZendTest\Filter\File;
 
 use Zend\Filter\File\Encrypt as FileEncrypt;
 use Zend\Filter\File\Decrypt as FileDecrypt;
 
 /**
- * @group      Zend_Filter
+ * @group Zend_Filter
  */
 class EncryptTest extends \PHPUnit_Framework_TestCase
 {
+
     public function setUp()
     {
-        if (!extension_loaded('mcrypt')) {
+        if (! extension_loaded('mcrypt')) {
             $this->markTestSkipped('This filter needs the mcrypt extension');
         }
-
-        if (file_exists(dirname(__DIR__).'/_files/newencryption.txt')) {
-            unlink(dirname(__DIR__).'/_files/newencryption.txt');
+        
+        if (file_exists(dirname(__DIR__) . '/_files/newencryption.txt')) {
+            unlink(dirname(__DIR__) . '/_files/newencryption.txt');
         }
     }
 
     public function tearDown()
     {
-        if (file_exists(dirname(__DIR__).'/_files/newencryption.txt')) {
-            unlink(dirname(__DIR__).'/_files/newencryption.txt');
+        if (file_exists(dirname(__DIR__) . '/_files/newencryption.txt')) {
+            unlink(dirname(__DIR__) . '/_files/newencryption.txt');
         }
     }
 
@@ -43,72 +43,82 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
     public function testBasic()
     {
         $filter = new FileEncrypt();
-        $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
-
-        $this->assertEquals(
-            dirname(__DIR__).'/_files/newencryption.txt',
-            $filter->getFilename());
-
+        $filter->setFilename(dirname(__DIR__) . '/_files/newencryption.txt');
+        
+        $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $filter->getFilename());
+        
         $filter->setKey('1234567890123456');
-        $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt',
-            $filter->filter(dirname(__DIR__).'/_files/encryption.txt'));
-
-        $this->assertEquals(
-            'Encryption',
-            file_get_contents(dirname(__DIR__).'/_files/encryption.txt'));
-
-        $this->assertNotEquals(
-            'Encryption',
-            file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
+        $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $filter->filter(dirname(__DIR__) . '/_files/encryption.txt'));
+        
+        $this->assertEquals('Encryption', file_get_contents(dirname(__DIR__) . '/_files/encryption.txt'));
+        
+        $this->assertNotEquals('Encryption', file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt'));
     }
 
     public function testEncryptionWithDecryption()
     {
         $filter = new FileEncrypt();
-        $filter->setFilename(dirname(__DIR__).'/_files/newencryption.txt');
+        $filter->setFilename(dirname(__DIR__) . '/_files/newencryption.txt');
         $filter->setKey('1234567890123456');
-        $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt',
-            $filter->filter(dirname(__DIR__).'/_files/encryption.txt'));
-
-        $this->assertNotEquals(
-            'Encryption',
-            file_get_contents(dirname(__DIR__).'/_files/newencryption.txt'));
-
+        $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $filter->filter(dirname(__DIR__) . '/_files/encryption.txt'));
+        
+        $this->assertNotEquals('Encryption', file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt'));
+        
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
-        $input = $filter->filter(dirname(__DIR__).'/_files/newencryption.txt');
-        $this->assertEquals(dirname(__DIR__).'/_files/newencryption.txt', $input);
-
-        $this->assertEquals(
-            'Encryption',
-            trim(file_get_contents(dirname(__DIR__).'/_files/newencryption.txt')));
+        $input = $filter->filter(dirname(__DIR__) . '/_files/newencryption.txt');
+        $this->assertEquals(dirname(__DIR__) . '/_files/newencryption.txt', $input);
+        
+        $this->assertEquals('Encryption', trim(file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt')));
     }
 
     /**
+     *
      * @return void
      */
     public function testNonExistingFile()
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
-
+        
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'not found');
-        echo $filter->filter(dirname(__DIR__).'/_files/nofile.txt');
+        echo $filter->filter(dirname(__DIR__) . '/_files/nofile.txt');
     }
 
     /**
+     *
      * @return void
      */
     public function testEncryptionInSameFile()
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
+        
+        copy(dirname(__DIR__) . '/_files/encryption.txt', dirname(__DIR__) . '/_files/newencryption.txt');
+        $filter->filter(dirname(__DIR__) . '/_files/newencryption.txt');
+        
+        $this->assertNotEquals('Encryption', trim(file_get_contents(dirname(__DIR__) . '/_files/newencryption.txt')));
+    }
 
-        copy(dirname(__DIR__).'/_files/encryption.txt', dirname(__DIR__).'/_files/newencryption.txt');
-        $filter->filter(dirname(__DIR__).'/_files/newencryption.txt');
-
-        $this->assertNotEquals(
-            'Encryption',
-            trim(file_get_contents(dirname(__DIR__).'/_files/newencryption.txt')));
+    /**
+     *
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new FileEncrypt();
+        $filter->setKey('1234567890123456');
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                dirname(__DIR__) . '/_files/nofile.txt',
+                dirname(__DIR__) . '/_files/nofile2.txt'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/File/LowerCaseTest.php
+++ b/tests/ZendTest/Filter/File/LowerCaseTest.php
@@ -128,23 +128,25 @@ class LowerCaseTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                dirname(__DIR__).'/_files/nofile.txt',
+                dirname(__DIR__).'/_files/nofile2.txt'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new FileLowerCase();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                dirname(__DIR__).'/_files/nofile.txt',
-                dirname(__DIR__).'/_files/nofile2.txt'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/File/LowerCaseTest.php
+++ b/tests/ZendTest/Filter/File/LowerCaseTest.php
@@ -127,14 +127,14 @@ class LowerCaseTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('mbstring is required', $e->getMessage());
         }
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new FileLowerCase();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/File/LowerCaseTest.php
+++ b/tests/ZendTest/Filter/File/LowerCaseTest.php
@@ -128,7 +128,8 @@ class LowerCaseTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -138,7 +139,7 @@ class LowerCaseTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/File/LowerCaseTest.php
+++ b/tests/ZendTest/Filter/File/LowerCaseTest.php
@@ -127,4 +127,24 @@ class LowerCaseTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('mbstring is required', $e->getMessage());
         }
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new FileLowerCase();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                dirname(__DIR__).'/_files/nofile.txt',
+                dirname(__DIR__).'/_files/nofile2.txt'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/File/RenameTest.php
+++ b/tests/ZendTest/Filter/File/RenameTest.php
@@ -557,4 +557,24 @@ class RenameTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Invalid options');
         $filter = new FileRename(1234);
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new FileRename($this->_newFile);
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                $this->_oldFile,
+                $this->_origFile
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/File/RenameTest.php
+++ b/tests/ZendTest/Filter/File/RenameTest.php
@@ -558,23 +558,26 @@ class RenameTest extends \PHPUnit_Framework_TestCase
         $filter = new FileRename(1234);
     }
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                $this->_oldFile,
+                $this->_origFile
+            ))
+        );
+    }
+
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new FileRename($this->_newFile);
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                $this->_oldFile,
-                $this->_origFile
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/File/RenameTest.php
+++ b/tests/ZendTest/Filter/File/RenameTest.php
@@ -557,14 +557,14 @@ class RenameTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Invalid options');
         $filter = new FileRename(1234);
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new FileRename($this->_newFile);
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -329,7 +329,7 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($firstResult, $secondResult);
     }
-    
+
 
     /**
      * @return void
@@ -340,7 +340,7 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
             'target'          => $this->_newFile,
             'randomize'       => true,
         ));
-        
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -331,26 +331,29 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
     }
 
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                $this->_oldFile,
+                'something invalid'
+            ))
+        );
+    }
+
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new RenameUploadMock(array(
             'target'          => $this->_newFile,
             'randomize'       => true,
         ));
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                $this->_oldFile,
-                'something invalid'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/File/RenameUploadTest.php
+++ b/tests/ZendTest/Filter/File/RenameUploadTest.php
@@ -329,4 +329,28 @@ class RenameUploadTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($firstResult, $secondResult);
     }
+    
+
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new RenameUploadMock(array(
+            'target'          => $this->_newFile,
+            'randomize'       => true,
+        ));
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                $this->_oldFile,
+                'something invalid'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/File/UpperCaseTest.php
+++ b/tests/ZendTest/Filter/File/UpperCaseTest.php
@@ -139,7 +139,7 @@ class UpperCaseTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/File/UpperCaseTest.php
+++ b/tests/ZendTest/Filter/File/UpperCaseTest.php
@@ -128,25 +128,27 @@ class UpperCaseTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                $this->_newFile,
+                'something invalid'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new FileUpperCase();
         $filter->setEncoding('ISO-8859-1');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                $this->_newFile,
-                'something invalid'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/File/UpperCaseTest.php
+++ b/tests/ZendTest/Filter/File/UpperCaseTest.php
@@ -136,7 +136,7 @@ class UpperCaseTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FileUpperCase();
         $filter->setEncoding('ISO-8859-1');
-        
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/File/UpperCaseTest.php
+++ b/tests/ZendTest/Filter/File/UpperCaseTest.php
@@ -127,4 +127,26 @@ class UpperCaseTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('mbstring is required', $e->getMessage());
         }
     }
+
+
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new FileUpperCase();
+        $filter->setEncoding('ISO-8859-1');
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                $this->_newFile,
+                'something invalid'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -256,30 +256,21 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that a warning is raised if array is used
-     *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
-        $input = array('<', '>');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $this->_filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filtered = $this->_filter->filter(null);
-        $this->assertNull($filtered);
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                '<',
+                '>'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $this->_filter->filter($input));
+        }
     }
 
     /**

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -255,22 +255,24 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testReturnUnfiltered()
-    {
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
                 '<',
                 '>'
-            )
+            ))
         );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $this->_filter->filter($input));
-        }
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
+    {
+        $this->assertEquals($input, $this->_filter->filter($input));
     }
 
     /**

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -255,7 +255,8 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -265,7 +266,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -25,7 +25,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
     public function testBasic()
     {
         $filter = new IntFilter();
-        
+
         $valuesExpected = array(
             'string' => 0,
             '1'      => 1,
@@ -46,7 +46,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
     public function testReturnUnfiltered()
     {
         $filter = new IntFilter();
-        
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -40,23 +40,25 @@ class IntTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                '1',
+                -1
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new IntFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                '1',
-                -1
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -40,7 +40,8 @@ class IntTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -50,7 +51,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -25,6 +25,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
     public function testBasic()
     {
         $filter = new IntFilter();
+        
         $valuesExpected = array(
             'string' => 0,
             '1'      => 1,
@@ -40,31 +41,22 @@ class IntTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that a warning is raised if array is used
-     *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
         $filter = new IntFilter();
-        $input = array('123 test', '456 test');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filter   = new IntFilter();
-        $filtered = $filter->filter(null);
-        $this->assertNull($filtered);
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                '1',
+                -1
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/PregReplaceTest.php
+++ b/tests/ZendTest/Filter/PregReplaceTest.php
@@ -119,21 +119,22 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
         $filter->setPattern('/foo/e');
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
     /**
-     *
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter->filter($input));
-        }
+        $this->assertEquals($input, $filter->filter($input));
     }
 }

--- a/tests/ZendTest/Filter/PregReplaceTest.php
+++ b/tests/ZendTest/Filter/PregReplaceTest.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace ZendTest\Filter;
 
 use Zend\Filter\PregReplace as PregReplaceFilter;
@@ -14,11 +13,13 @@ use Zend\Filter\PregReplace as PregReplaceFilter;
 /**
  * Test class for Zend_Filter_PregReplace.
  *
- * @group      Zend_Filter
+ * @group Zend_Filter
  */
 class PregReplaceTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
+     *
      * @var PregReplaceFilter
      */
     protected $filter;
@@ -37,14 +38,14 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
     public function testPassingPatternToConstructorSetsPattern()
     {
         $pattern = '#^controller/(?P<action>[a-z_-]+)#';
-        $filter  = new PregReplaceFilter($pattern);
+        $filter = new PregReplaceFilter($pattern);
         $this->assertEquals($pattern, $filter->getPattern());
     }
 
     public function testPassingReplacementToConstructorSetsReplacement()
     {
         $replace = 'foo/bar';
-        $filter  = new PregReplaceFilter(null, $replace);
+        $filter = new PregReplaceFilter(null, $replace);
         $this->assertEquals($replace, $filter->getReplacement());
     }
 
@@ -76,12 +77,30 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
     public function testFilterPerformsRegexReplacement()
     {
         $filter = $this->filter;
+        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        
         $string = 'controller/action';
-        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')
-               ->setReplacement('foo/bar');
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('foo/bar', $filtered);
+    }
+
+    public function testFilterPerformsRegexReplacementWithArray()
+    {
+        $filter = $this->filter;
+        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        
+        $input = array(
+            'controller/action',
+            'This should stay the same'
+        );
+        
+        $filtered = $filter($input);
+        $this->assertNotEquals($input, $filtered);
+        $this->assertEquals(array(
+            'foo/bar',
+            'This should stay the same'
+        ), $filtered);
     }
 
     public function testFilterThrowsExceptionWhenNoMatchPatternPresent()
@@ -89,8 +108,7 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
         $filter = $this->filter;
         $string = 'controller/action';
         $filter->setReplacement('foo/bar');
-        $this->setExpectedException('Zend\Filter\Exception\RuntimeException',
-                                    'does not have a valid pattern set');
+        $this->setExpectedException('Zend\Filter\Exception\RuntimeException', 'does not have a valid pattern set');
         $filtered = $filter($string);
     }
 
@@ -99,5 +117,23 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
         $filter = new PregReplaceFilter();
         $this->setExpectedException('Zend\Filter\Exception\InvalidArgumentException', '"e" pattern modifier');
         $filter->setPattern('/foo/e');
+    }
+
+    /**
+     *
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = $this->filter;
+        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter->filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/PregReplaceTest.php
+++ b/tests/ZendTest/Filter/PregReplaceTest.php
@@ -78,7 +78,7 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
-        
+
         $string = 'controller/action';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
@@ -89,12 +89,12 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
-        
+
         $input = array(
             'controller/action',
             'This should stay the same'
         );
-        
+
         $filtered = $filter($input);
         $this->assertNotEquals($input, $filtered);
         $this->assertEquals(array(
@@ -127,7 +127,7 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
-        
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/Filter/PregReplaceTest.php
+++ b/tests/ZendTest/Filter/PregReplaceTest.php
@@ -119,13 +119,14 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
         $filter->setPattern('/foo/e');
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -104,7 +104,8 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($path, $filter($path3));
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -116,7 +117,7 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -104,21 +104,25 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($path, $filter($path3));
     }
 
-    /**
-     * @return void
-     */
-    public function testReturnUnfiltered()
-    {
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
             array(
-                $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
-                $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
+                array(
+                    $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
+                    $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
+                )
             )
         );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $this->_filter->filter($input));
-        }
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
+    {
+        $this->assertEquals($input, $this->_filter->filter($input));
     }
 }

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -105,33 +105,20 @@ class RealPathTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that a warning is raised if array is used
-     *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
-        $filter   = $this->_filter;
-        $input = array(
-            $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
-            $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
+                $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2'
+            )
         );
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filtered = $this->_filter->filter(null);
-        $this->assertNull($filtered);
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $this->_filter->filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -156,7 +156,8 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass()),
@@ -168,7 +169,7 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -156,21 +156,25 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
-    /**
-     * @return void
-     */
-    public function testReturnUnfiltered()
-    {
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass()),
             array(
-                'UPPER CASE WRITTEN',
-                'This should stay the same'
+                array(
+                    'UPPER CASE WRITTEN',
+                    'This should stay the same'
+                )
             )
         );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $this->_filter->filter($input));
-        }
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
+    {
+        $this->assertEquals($input, $this->_filter->filter($input));
     }
 }

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -157,29 +157,20 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that a warning is raised if array is used
-     *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
-        $input = array('ABC', 'DEF');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $this->_filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filtered = $this->_filter->filter(null);
-        $this->assertNull($filtered);
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'UPPER CASE WRITTEN',
+                'This should stay the same'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $this->_filter->filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -156,21 +156,24 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
-    /**
-     * @return void
-     */
-    public function testReturnUnfiltered()
+    public function returnUnfilteredDataProvider()
     {
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
                 'lower case written',
                 'This should stay the same'
-            )
+            ))
         );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $this->_filter->filter($input));
-        }
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
+    {
+        $this->assertEquals($input, $this->_filter->filter($input));
     }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -167,7 +167,7 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -157,29 +157,20 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that a warning is raised if array is used
-     *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
-        $input = array('abc', 'def');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $this->_filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filtered = $this->_filter->filter(null);
-        $this->assertNull($filtered);
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'lower case written',
+                'This should stay the same'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $this->_filter->filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/StringTrimTest.php
+++ b/tests/ZendTest/Filter/StringTrimTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Filter;
 
-use stdClass;
 use Zend\Filter\StringTrim;
+use stdClass;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/StripNewlinesTest.php
+++ b/tests/ZendTest/Filter/StripNewlinesTest.php
@@ -53,20 +53,22 @@ class StripNewlinesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array_values($expected), $filter(array_keys($expected)));
     }
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
     /**
-     *
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new StripNewLinesFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/StripNewlinesTest.php
+++ b/tests/ZendTest/Filter/StripNewlinesTest.php
@@ -6,16 +6,16 @@
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace ZendTest\Filter;
 
 use Zend\Filter\StripNewlines as StripNewlinesFilter;
 
 /**
- * @group      Zend_Filter
+ * @group Zend_Filter
  */
 class StripNewlinesTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
      * Ensures that the filter follows expected behavior
      *
@@ -36,6 +36,37 @@ class StripNewlinesTest extends \PHPUnit_Framework_TestCase
         );
         foreach ($valuesExpected as $input => $output) {
             $this->assertEquals($output, $filter($input));
+        }
+    }
+
+    /**
+     *
+     * @return void
+     */
+    public function testArrayValues()
+    {
+        $filter = new StripNewLinesFilter();
+        $expected = array(
+            "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
+            "Some text\n" => 'Some text'
+        );
+        $this->assertEquals(array_values($expected), $filter(array_keys($expected)));
+    }
+
+    /**
+     *
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new StripNewLinesFilter();
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
         }
     }
 }

--- a/tests/ZendTest/Filter/StripNewlinesTest.php
+++ b/tests/ZendTest/Filter/StripNewlinesTest.php
@@ -60,7 +60,7 @@ class StripNewlinesTest extends \PHPUnit_Framework_TestCase
     public function testReturnUnfiltered()
     {
         $filter = new StripNewLinesFilter();
-        
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/Filter/StripNewlinesTest.php
+++ b/tests/ZendTest/Filter/StripNewlinesTest.php
@@ -60,7 +60,7 @@ class StripNewlinesTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -536,22 +536,24 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->_filter->filter($input));
     }
 
-    /**
-     *
-     * @return void
-     */
-    public function testReturnUnfiltered()
+    public function returnUnfilteredDataProvider()
     {
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
                 '<li data-name="Test User" data-id="11223"></li>',
                 '<li data-name="Test User 2" data-id="456789"></li>'
-            )
+            ))
         );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $this->_filter->filter($input));
-        }
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
+    {
+        $this->assertEquals($input, $this->_filter->filter($input));
     }
 }

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -547,7 +547,7 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -537,29 +537,21 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensures that a warning is raised if array is used
      *
      * @return void
      */
-    public function testWarningIsRaisedIfArrayUsed()
+    public function testReturnUnfiltered()
     {
-        $input = array('<li data-name="Test User" data-id="11223"></li>', '<li data-name="Test User 2" data-id="456789"></li>');
-
-        ErrorHandler::start(E_USER_WARNING);
-        $filtered = $this->_filter->filter($input);
-        $err = ErrorHandler::stop();
-
-        $this->assertEquals($input, $filtered);
-        $this->assertInstanceOf('ErrorException', $err);
-        $this->assertContains('cannot filter', $err->getMessage());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnsNullIfNullIsUsed()
-    {
-        $filtered = $this->_filter->filter(null);
-        $this->assertNull($filtered);
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                '<li data-name="Test User" data-id="11223"></li>',
+                '<li data-name="Test User 2" data-id="456789"></li>'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $this->_filter->filter($input));
+        }
     }
 }

--- a/tests/ZendTest/Filter/UriNormalizeTest.php
+++ b/tests/ZendTest/Filter/UriNormalizeTest.php
@@ -63,4 +63,24 @@ class UriNormalizeTest extends \PHPUnit_Framework_TestCase
             array('http', '/just/a/path', '/just/a/path') // cannot be enforced, no host
         );
     }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new UriNormalize();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                'http://www.example.com',
+                'file:///home/shahar/secret/../../otherguy/secret'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/UriNormalizeTest.php
+++ b/tests/ZendTest/Filter/UriNormalizeTest.php
@@ -75,7 +75,7 @@ class UriNormalizeTest extends \PHPUnit_Framework_TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/UriNormalizeTest.php
+++ b/tests/ZendTest/Filter/UriNormalizeTest.php
@@ -64,23 +64,26 @@ class UriNormalizeTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
+                'http://www.example.com',
+                'file:///home/shahar/secret/../../otherguy/secret'
+            ))
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new UriNormalize();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
-                'http://www.example.com',
-                'file:///home/shahar/secret/../../otherguy/secret'
-            )
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/UriNormalizeTest.php
+++ b/tests/ZendTest/Filter/UriNormalizeTest.php
@@ -63,14 +63,14 @@ class UriNormalizeTest extends \PHPUnit_Framework_TestCase
             array('http', '/just/a/path', '/just/a/path') // cannot be enforced, no host
         );
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new UriNormalize();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
@@ -47,4 +47,37 @@ class CamelCaseToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('These_Are_SOME_Camel_CASED_Words', $filtered);
     }
+    
+    /**
+     * @return void
+     */
+    public function testFilterSupportArray(){
+        $filter = new CamelCaseToSeparatorFilter();
+    
+        $input = array(
+            'CamelCasedWords',
+            'somethingDifferent'
+        );
+    
+        $filtered = $filter($input);
+    
+        $this->assertNotEquals($input, $filtered);
+        $this->assertEquals(array('Camel Cased Words', 'something Different'), $filtered);
+    }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new CamelCaseToSeparatorFilter();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
@@ -73,7 +73,7 @@ class CamelCaseToSeparatorTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
@@ -47,31 +47,32 @@ class CamelCaseToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('These_Are_SOME_Camel_CASED_Words', $filtered);
     }
-    
+
     /**
      * @return void
      */
-    public function testFilterSupportArray(){
+    public function testFilterSupportArray()
+    {
         $filter = new CamelCaseToSeparatorFilter();
-    
+
         $input = array(
             'CamelCasedWords',
             'somethingDifferent'
         );
-    
+
         $filtered = $filter($input);
-    
+
         $this->assertNotEquals($input, $filtered);
         $this->assertEquals(array('Camel Cased Words', 'something Different'), $filtered);
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new CamelCaseToSeparatorFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/CamelCaseToSeparatorTest.php
@@ -66,19 +66,22 @@ class CamelCaseToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('Camel Cased Words', 'something Different'), $filtered);
     }
 
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new CamelCaseToSeparatorFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
@@ -57,13 +57,14 @@ class DashToSeparatorTest extends \PHPUnit_Framework_TestCase
     }
 
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
@@ -37,32 +37,33 @@ class DashToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('dash:-:separated:-:words', $filtered);
     }
-    
+
     /**
      * @return void
      */
-    public function testFilterSupportArray(){
+    public function testFilterSupportArray()
+    {
         $filter = new DashToSeparatorFilter();
-    
+
         $input = array(
             'dash-separated-words',
             'something-different'
         );
-    
+
         $filtered = $filter($input);
-    
+
         $this->assertNotEquals($input, $filtered);
         $this->assertEquals(array('dash separated words', 'something different'), $filtered);
     }
-    
-    
+
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new DashToSeparatorFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
@@ -57,20 +57,22 @@ class DashToSeparatorTest extends \PHPUnit_Framework_TestCase
     }
 
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new DashToSeparatorFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 
 }

--- a/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/DashToSeparatorTest.php
@@ -37,5 +37,39 @@ class DashToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('dash:-:separated:-:words', $filtered);
     }
+    
+    /**
+     * @return void
+     */
+    public function testFilterSupportArray(){
+        $filter = new DashToSeparatorFilter();
+    
+        $input = array(
+            'dash-separated-words',
+            'something-different'
+        );
+    
+        $filtered = $filter($input);
+    
+        $this->assertNotEquals($input, $filtered);
+        $this->assertEquals(array('dash separated words', 'something different'), $filtered);
+    }
+    
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new DashToSeparatorFilter();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 
 }

--- a/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
@@ -90,19 +90,21 @@ class SeparatorToCamelCaseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('CamelCasedWords', 'SomethingDifferent'), $filtered);
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new SeparatorToCamelCaseFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
@@ -71,4 +71,37 @@ class SeparatorToCamelCaseTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('TestŠuma', $filtered);
     }
+    
+    /**
+     * @return void
+     */
+    public function testFilterSupportArray(){
+        $filter = new SeparatorToCamelCaseFilter();
+        
+        $input = array(
+            'camel cased words',
+            'something different'
+        );
+        
+        $filtered = $filter($input);
+        
+        $this->assertNotEquals($input, $filtered);
+        $this->assertEquals(array('CamelCasedWords', 'SomethingDifferent'), $filtered);
+    }
+    
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new SeparatorToCamelCaseFilter();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
@@ -71,31 +71,32 @@ class SeparatorToCamelCaseTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('TestŠuma', $filtered);
     }
-    
+
     /**
      * @return void
      */
-    public function testFilterSupportArray(){
+    public function testFilterSupportArray()
+    {
         $filter = new SeparatorToCamelCaseFilter();
-        
+
         $input = array(
             'camel cased words',
             'something different'
         );
-        
+
         $filtered = $filter($input);
-        
+
         $this->assertNotEquals($input, $filtered);
         $this->assertEquals(array('CamelCasedWords', 'SomethingDifferent'), $filtered);
     }
-    
+
     /**
      * @return void
      */
     public function testReturnUnfiltered()
     {
         $filter = new SeparatorToCamelCaseFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
@@ -90,13 +90,14 @@ class SeparatorToCamelCaseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('CamelCasedWords', 'SomethingDifferent'), $filtered);
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
@@ -65,13 +65,14 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('dash?separated?words', $filtered);
     }
 
-    public function returnUnfilteredDataProvider(){
+    public function returnUnfilteredDataProvider()
+    {
         return array(
             array(null),
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
@@ -65,19 +65,21 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('dash?separated?words', $filtered);
     }
 
+    public function returnUnfilteredDataProvider(){
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
     /**
+     * @dataProvider returnUnfilteredDataProvider
      * @return void
      */
-    public function testReturnUnfiltered()
+    public function testReturnUnfiltered($input)
     {
         $filter = new SeparatorToSeparatorFilter('=', '?');
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input, $filter($input));
-        }
+        $this->assertEquals($input, $filter($input));
     }
 }

--- a/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
@@ -27,17 +27,17 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('dash-separated-words', $filtered);
     }
-    
+
     public function testFilterSupportArray()
     {
         $filter   = new SeparatorToSeparatorFilter();
-        
+
         $input = array(
             'dash separated words',
             '=test something'
         );
         $filtered = $filter($input);
-    
+
         $this->assertNotEquals($input, $filtered);
         $this->assertEquals(array(
             'dash-separated-words',
@@ -71,7 +71,7 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
     public function testReturnUnfiltered()
     {
         $filter = new SeparatorToSeparatorFilter('=', '?');
-        
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
@@ -27,6 +27,23 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($string, $filtered);
         $this->assertEquals('dash-separated-words', $filtered);
     }
+    
+    public function testFilterSupportArray()
+    {
+        $filter   = new SeparatorToSeparatorFilter();
+        
+        $input = array(
+            'dash separated words',
+            '=test something'
+        );
+        $filtered = $filter($input);
+    
+        $this->assertNotEquals($input, $filtered);
+        $this->assertEquals(array(
+            'dash-separated-words',
+            '=test-something'
+        ), $filtered);
+    }
 
     public function testFilterSeparatesWordsWithSearchSpecified()
     {
@@ -48,4 +65,19 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('dash?separated?words', $filtered);
     }
 
+    /**
+     * @return void
+     */
+    public function testReturnUnfiltered()
+    {
+        $filter = new SeparatorToSeparatorFilter('=', '?');
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input, $filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/I18n/Filter/AlnumTest.php
+++ b/tests/ZendTest/I18n/Filter/AlnumTest.php
@@ -158,4 +158,34 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expected, $actual);
         }
     }
+    
+    public function testFilterSupportArray()
+    {
+        $filter = new AlnumFilter();
+        
+        $values = array(
+            'abc123'  => 'abc123',
+            'abc 123' => 'abc123',
+            'abcxyz'  => 'abcxyz',
+            'AZ@#4.3' => 'AZ43',
+            ''        => ''
+        );
+        
+        $actual = $filter->filter(array_keys($values));
+        
+        $this->assertEquals(array_values($values), $actual);
+    }
+    
+    public function testReturnUnfiltered()
+    {
+        $filter = new AlnumFilter();
+        
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input,  $filter->filter($input));
+        }
+    }
 }

--- a/tests/ZendTest/I18n/Filter/AlnumTest.php
+++ b/tests/ZendTest/I18n/Filter/AlnumTest.php
@@ -183,7 +183,7 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/I18n/Filter/AlnumTest.php
+++ b/tests/ZendTest/I18n/Filter/AlnumTest.php
@@ -158,11 +158,11 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expected, $actual);
         }
     }
-    
+
     public function testFilterSupportArray()
     {
         $filter = new AlnumFilter();
-        
+
         $values = array(
             'abc123'  => 'abc123',
             'abc 123' => 'abc123',
@@ -170,16 +170,16 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
             'AZ@#4.3' => 'AZ43',
             ''        => ''
         );
-        
+
         $actual = $filter->filter(array_keys($values));
-        
+
         $this->assertEquals(array_values($values), $actual);
     }
-    
+
     public function testReturnUnfiltered()
     {
         $filter = new AlnumFilter();
-        
+
         $valuesExpected = array(
             null,
             new \stdClass()

--- a/tests/ZendTest/I18n/Filter/AlnumTest.php
+++ b/tests/ZendTest/I18n/Filter/AlnumTest.php
@@ -176,16 +176,22 @@ class AlnumTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array_values($values), $actual);
     }
 
-    public function testReturnUnfiltered()
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
     {
         $filter = new AlnumFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input,  $filter->filter($input));
-        }
+        $this->assertEquals($input,  $filter->filter($input));
     }
 }

--- a/tests/ZendTest/I18n/Filter/AlphaTest.php
+++ b/tests/ZendTest/I18n/Filter/AlphaTest.php
@@ -186,7 +186,7 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass())
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/I18n/Filter/AlphaTest.php
+++ b/tests/ZendTest/I18n/Filter/AlphaTest.php
@@ -179,17 +179,23 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array_values($values), $actual);
     }
 
-    public function testReturnUnfiltered()
+    public function returnUnfilteredDataProvider()
+    {
+        return array(
+            array(null),
+            array(new \stdClass())
+        );
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
     {
         $filter = new AlphaFilter();
 
-        $valuesExpected = array(
-            null,
-            new \stdClass()
-        );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input,  $filter->filter($input));
-        }
+        $this->assertEquals($input,  $filter->filter($input));
     }
 
 }

--- a/tests/ZendTest/I18n/Filter/AlphaTest.php
+++ b/tests/ZendTest/I18n/Filter/AlphaTest.php
@@ -162,27 +162,27 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expected, $actual);
         }
     }
-    
+
     public function testFilterSupportArray()
     {
         $filter = new AlphaFilter();
-    
+
         $values = array(
             'abc123'        => 'abc',
             'abc 123'       => 'abc',
             'abcxyz'        => 'abcxyz',
             ''              => ''
         );
-    
+
         $actual = $filter->filter(array_keys($values));
-    
+
         $this->assertEquals(array_values($values), $actual);
     }
-    
+
     public function testReturnUnfiltered()
     {
         $filter = new AlphaFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass()
@@ -191,5 +191,5 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($input,  $filter->filter($input));
         }
     }
-    
+
 }

--- a/tests/ZendTest/I18n/Filter/AlphaTest.php
+++ b/tests/ZendTest/I18n/Filter/AlphaTest.php
@@ -162,4 +162,34 @@ class AlphaTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expected, $actual);
         }
     }
+    
+    public function testFilterSupportArray()
+    {
+        $filter = new AlphaFilter();
+    
+        $values = array(
+            'abc123'        => 'abc',
+            'abc 123'       => 'abc',
+            'abcxyz'        => 'abcxyz',
+            ''              => ''
+        );
+    
+        $actual = $filter->filter(array_keys($values));
+    
+        $this->assertEquals(array_values($values), $actual);
+    }
+    
+    public function testReturnUnfiltered()
+    {
+        $filter = new AlphaFilter();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass()
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input,  $filter->filter($input));
+        }
+    }
+    
 }

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -139,15 +139,15 @@ class NumberFormatTest extends TestCase
             ),
         );
     }
-    
-    
+
+
     public function testReturnUnfiltered()
     {
         $filter = new NumberFormatFilter('de_AT', NumberFormatter::DEFAULT_STYLE, NumberFormatter::TYPE_DOUBLE);
         $this->assertEquals($expected, $filter->filter($value));
-        
+
         $filter = new AlphaFilter();
-    
+
         $valuesExpected = array(
             null,
             new \stdClass(),

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -152,7 +152,7 @@ class NumberFormatTest extends TestCase
             ))
         );
     }
-    
+
     /**
      * @dataProvider returnUnfilteredDataProvider
      * @return void

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -141,23 +141,26 @@ class NumberFormatTest extends TestCase
     }
 
 
-    public function testReturnUnfiltered()
+    public function returnUnfilteredDataProvider()
     {
-        $filter = new NumberFormatFilter('de_AT', NumberFormatter::DEFAULT_STYLE, NumberFormatter::TYPE_DOUBLE);
-        $this->assertEquals($expected, $filter->filter($value));
-
-        $filter = new AlphaFilter();
-
-        $valuesExpected = array(
-            null,
-            new \stdClass(),
-            array(
+        return array(
+            array(null),
+            array(new \stdClass()),
+            array(array(
                 '1.234.567,891',
                 '1.567,891'
-            )
+            ))
         );
-        foreach ($valuesExpected as $input) {
-            $this->assertEquals($input,  $filter->filter($input));
-        }
+    }
+    
+    /**
+     * @dataProvider returnUnfilteredDataProvider
+     * @return void
+     */
+    public function testReturnUnfiltered($input)
+    {
+        $filter = new NumberFormatFilter('de_AT', NumberFormatter::DEFAULT_STYLE, NumberFormatter::TYPE_DOUBLE);
+
+        $this->assertEquals($input,  $filter->filter($input));
     }
 }

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -139,4 +139,25 @@ class NumberFormatTest extends TestCase
             ),
         );
     }
+    
+    
+    public function testReturnUnfiltered()
+    {
+        $filter = new NumberFormatFilter('de_AT', NumberFormatter::DEFAULT_STYLE, NumberFormatter::TYPE_DOUBLE);
+        $this->assertEquals($expected, $filter->filter($value));
+        
+        $filter = new AlphaFilter();
+    
+        $valuesExpected = array(
+            null,
+            new \stdClass(),
+            array(
+                '1.234.567,891',
+                '1.567,891'
+            )
+        );
+        foreach ($valuesExpected as $input) {
+            $this->assertEquals($input,  $filter->filter($input));
+        }
+    }
 }

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./Bootstrap.php" colors="true">
+<phpunit bootstrap="./Bootstrap.php" colors="false">
     <testsuites>
         <testsuite name="Zend Framework Test Suite">
             <directory>./ZendTest</directory>

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./Bootstrap.php" colors="false">
+<phpunit bootstrap="./Bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="Zend Framework Test Suite">
             <directory>./ZendTest</directory>


### PR DESCRIPTION
Filters have currently different behaviours, like:
- return on wrong input value
- trigger errors
- throw exceptions

See issue here: https://github.com/zendframework/zf2/issues/5119#issuecomment-27853158

this PR should harmoize to one behaviour.

Todo list
- [x] Zend\Filter\\* - except the list bellow
  - Zend\Filter\Callback - `not possible to check?` as a user defined function is awaited (could be everything)
  - Zend\Filter\Compress - commit missing + travis check
  - Zend\Filter\DateTimeFormatter - commit missing + travis check
  - Zend\Filter\Decompress - commit missing + travis check
  - Zend\Filter\Decrypt - commit missing + travis check
  - Zend\Filter\Encrypt - commit missing + travis check
  - Zend\Filter\Inflector - `not possible to check?`
- [x] Zend\Filter\File\*
- [x] Zend\Filter\Word\*
- [ ] Zend\I18n\Filter\\* - commit missing + travis check
