### PR TITLE
Fixing issue with ModuleAutoloader on Windows

### DIFF
--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -185,9 +185,9 @@ class ModuleAutoloader implements SplAutoloader
         foreach ($this->paths as $path) {
             $path = $path . $moduleClassPath;
 
-	        if ($path == '.' || substr($path, 0, 2) == './' || substr($path, 0, 2) == '.\\') {
-		        $path = realpath('.').substr($path, 1);
-	        }
+            if ($path == '.' || substr($path, 0, 2) == './' || substr($path, 0, 2) == '.\\') {
+                $path = realpath('.').substr($path, 1);
+            }
 
             $classLoaded = $this->loadModuleFromDir($path, $class);
             if ($classLoaded) {

--- a/library/Zend/Loader/ModuleAutoloader.php
+++ b/library/Zend/Loader/ModuleAutoloader.php
@@ -185,6 +185,10 @@ class ModuleAutoloader implements SplAutoloader
         foreach ($this->paths as $path) {
             $path = $path . $moduleClassPath;
 
+	        if ($path == '.' || substr($path, 0, 2) == './' || substr($path, 0, 2) == '.\\') {
+		        $path = realpath('.').substr($path, 1);
+	        }
+
             $classLoaded = $this->loadModuleFromDir($path, $class);
             if ($classLoaded) {
                 return $classLoaded;


### PR DESCRIPTION
On Windows _ModuleAutoloader_ can't load my module, `./module/MyModule.tar`, because GlobIterator returns an empty array for the path `./module/MyModule.*`. This issue is spoken of in this [SO](http://stackoverflow.com/questions/16396334/why-does-globiterator-produce-a-different-output-than-the-glob-function).

Strangely it just worked on my dev machine (a Mac) without this change. This change works on both my dev and test machine.
