### PR TITLE
Di circular dependancies

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -42,6 +42,13 @@ class Di implements DependencyInjectionInterface
     protected $currentDependencies = array();
 
     /**
+     * All the dependenent aliases
+     *
+     * @var array
+     */
+    protected $currentAliasDependenencies = array();
+
+    /**
      * All the class references [dependency][source]
      *
      * @var array
@@ -767,13 +774,21 @@ class Di implements DependencyInjectionInterface
                 $resolvedParams[$index] = $computedParams['value'][$fqParamPos];
             } elseif (isset($computedParams['retrieval'][$fqParamPos])) {
                 // detect circular dependencies! (they can only happen in instantiators)
-                if ($isInstantiator && in_array($computedParams['retrieval'][$fqParamPos][1], $this->currentDependencies)) {
-                    throw new Exception\CircularDependencyException(
-                        "Circular dependency detected: $class depends on {$value[1]} and viceversa"
-                    );
+                if ($isInstantiator && in_array($computedParams['retrieval'][$fqParamPos][1], $this->currentDependencies)
+                    && (!isset($alias) || in_array($iConfig['thisAlias']['parameters'][$name], $this->currentAliasDependenencies))
+                ) {
+                    $msg = "Circular dependency detected: $class depends on {$value[1]} and viceversa";
+                    if (isset($alias)) {
+                        $msg .= " (Aliased as $alias)";
+                    }
+                    throw new Exception\CircularDependencyException($msg);
                 }
 
                 array_push($this->currentDependencies, $class);
+                if(isset($alias)) {
+                    array_push($this->currentAliasDependenencies, $alias);
+                }
+
                 $dConfig = $this->instanceManager->getConfig($computedParams['retrieval'][$fqParamPos][0]);
 
                 try {
@@ -786,6 +801,9 @@ class Di implements DependencyInjectionInterface
                     if ($methodRequirementType & self::RESOLVE_STRICT) {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
+                        if(isset($alias)) {
+                            array_pop($this->currentAliasDependenencies);
+                        }
                         // if this item was marked strict,
                         // plus it cannot be resolve, and no value exist, bail out
                         throw new Exception\MissingPropertyException(sprintf(
@@ -797,6 +815,9 @@ class Di implements DependencyInjectionInterface
                     } else {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
+                        if(isset($alias)) {
+                            array_pop($this->currentAliasDependenencies);
+                        }
                         return false;
                     }
                 } catch (ServiceManagerException $e) {
@@ -804,6 +825,9 @@ class Di implements DependencyInjectionInterface
                     if ($methodRequirementType & self::RESOLVE_STRICT) {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
+                        if(isset($alias)) {
+                            array_pop($this->currentAliasDependenencies);
+                        }
                         // if this item was marked strict,
                         // plus it cannot be resolve, and no value exist, bail out
                         throw new Exception\MissingPropertyException(sprintf(
@@ -815,10 +839,16 @@ class Di implements DependencyInjectionInterface
                     } else {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
+                        if(isset($alias)) {
+                            array_pop($this->currentAliasDependenencies);
+                        }
                         return false;
                     }
                 }
                 array_pop($this->currentDependencies);
+                if(isset($alias)) {
+                    array_pop($this->currentAliasDependenencies);
+                }
             } elseif (!array_key_exists($fqParamPos, $computedParams['optional'])) {
                 if ($methodRequirementType & self::RESOLVE_STRICT) {
                     // if this item was not marked as optional,

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -775,7 +775,7 @@ class Di implements DependencyInjectionInterface
             } elseif (isset($computedParams['retrieval'][$fqParamPos])) {
                 // detect circular dependencies! (they can only happen in instantiators)
                 if ($isInstantiator && in_array($computedParams['retrieval'][$fqParamPos][1], $this->currentDependencies)
-                    && (!isset($alias) || in_array($iConfig['thisAlias']['parameters'][$name], $this->currentAliasDependenencies))
+                    && (!isset($alias) || in_array($computedParams['retrieval'][$fqParamPos][0], $this->currentAliasDependenencies))
                 ) {
                     $msg = "Circular dependency detected: $class depends on {$value[1]} and viceversa";
                     if (isset($alias)) {

--- a/tests/ZendTest/Di/DiTest.php
+++ b/tests/ZendTest/Di/DiTest.php
@@ -447,6 +447,44 @@ class DiTest extends \PHPUnit_Framework_TestCase
         $di->newInstance('ZendTest\Di\TestAsset\CircularClasses\D');
     }
 
+    protected function configureNoneCircularDependencyTests()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->addAlias('YA', 'ZendTest\Di\TestAsset\CircularClasses\Y');
+        $di->instanceManager()->addAlias('YB', 'ZendTest\Di\TestAsset\CircularClasses\Y', array('y' => 'YA'));
+        $di->instanceManager()->addAlias('YC', 'ZendTest\Di\TestAsset\CircularClasses\Y', array('y' => 'YB'));
+
+        return $di;
+    }
+
+    /**
+     * Test for correctly identifying no Circular Dependencies (case 1)
+     *
+     * YC -> YB, YB -> YA
+     * @group CircularDependencyCheck
+     */
+    public function testNoCircularDependencyDetectedIfWeGetIntermediaryClass()
+    {
+        $di = $this->configureNoneCircularDependencyTests();
+
+        $di->get('YB');
+        $di->get('YC');
+    }
+
+    /**
+     * Test for correctly identifying no Circular Dependencies (case 2)
+     *
+     * YC -> YB, YB -> YA
+     * @group CircularDependencyCheck
+     */
+    public function testNoCircularDependencyDetectedIfWeDontGetIntermediaryClass()
+    {
+        $di = $this->configureNoneCircularDependencyTests();
+
+        $di->get('YC');
+    }
+
     /**
      * Fix for PHP bug in is_subclass_of
      *

--- a/tests/ZendTest/Di/DiTest.php
+++ b/tests/ZendTest/Di/DiTest.php
@@ -468,8 +468,10 @@ class DiTest extends \PHPUnit_Framework_TestCase
     {
         $di = $this->configureNoneCircularDependencyTests();
 
-        $di->get('YB');
-        $di->get('YC');
+        $yb = $di->get('YB');
+        $this->assertInstanceOf('ZendTest\Di\TestAsset\CircularClasses\Y', $yb);
+        $yc = $di->get('YC');
+        $this->assertInstanceOf('ZendTest\Di\TestAsset\CircularClasses\Y', $yc);
     }
 
     /**
@@ -482,7 +484,30 @@ class DiTest extends \PHPUnit_Framework_TestCase
     {
         $di = $this->configureNoneCircularDependencyTests();
 
-        $di->get('YC');
+        $yc = $di->get('YC');
+        $this->assertInstanceOf('ZendTest\Di\TestAsset\CircularClasses\Y', $yc);
+    }
+
+    /**
+     * Test for correctly identifying a Circular Dependency in aliases (case 3)
+     *
+     * YA -> YB, YB -> YA
+     * @group CircularDependencyCheck
+     */
+    public function testCircularDependencyDetectedInAliases()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->addAlias('YA', 'ZendTest\Di\TestAsset\CircularClasses\Y', array('y' => 'YC'));
+        $di->instanceManager()->addAlias('YB', 'ZendTest\Di\TestAsset\CircularClasses\Y', array('y' => 'YA'));
+        $di->instanceManager()->addAlias('YC', 'ZendTest\Di\TestAsset\CircularClasses\Y', array('y' => 'YB'));
+
+        $this->setExpectedException(
+            'Zend\Di\Exception\CircularDependencyException',
+            'Circular dependency detected: ZendTest\Di\TestAsset\CircularClasses\Y depends on ZendTest\Di\TestAsset\CircularClasses\Y and viceversa (Aliased as YA)'
+        );
+
+        $yc = $di->get('YC');
     }
 
     /**

--- a/tests/ZendTest/Di/DiTest.php
+++ b/tests/ZendTest/Di/DiTest.php
@@ -511,6 +511,54 @@ class DiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test for correctly identifying a Circular Dependency with a self referencing alias
+     *
+     * YA -> YA
+     * @group CircularDependencyCheck
+     */
+    public function testCircularDependencyDetectedInSelfReferencingAlias()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->addAlias(
+            'YA',
+            'ZendTest\Di\TestAsset\CircularClasses\Y',
+            array('y' => 'YA')
+        );
+
+        $this->setExpectedException(
+            'Zend\Di\Exception\CircularDependencyException',
+            'Circular dependency detected: ZendTest\Di\TestAsset\CircularClasses\Y depends on ZendTest\Di\TestAsset\CircularClasses\Y and viceversa (Aliased as YA)'
+        );
+
+        $y = $di->get('YA');
+    }
+
+    /**
+     * Test for correctly identifying a Circular Dependency with mixture of classes and aliases
+     *
+     * Y -> YA, YA -> Y
+     * @group CircularDependencyCheck
+     */
+    public function testCircularDependencyDetectedInMixtureOfAliasesAndClasses()
+    {
+        $di = new Di();
+
+        $di->instanceManager()->addAlias(
+            'YA',
+            'ZendTest\Di\TestAsset\CircularClasses\Y',
+            array('y' => 'ZendTest\Di\TestAsset\CircularClasses\Y')
+        );
+
+        $this->setExpectedException(
+            'Zend\Di\Exception\CircularDependencyException',
+            'Circular dependency detected: ZendTest\Di\TestAsset\CircularClasses\Y depends on ZendTest\Di\TestAsset\CircularClasses\Y and viceversa (Aliased as YA)'
+        );
+
+        $y = $di->get('ZendTest\Di\TestAsset\CircularClasses\Y', array('y' => 'YA'));
+    }
+
+    /**
      * Fix for PHP bug in is_subclass_of
      *
      * @see https://bugs.php.net/bug.php?id=53727

--- a/tests/ZendTest/Di/TestAsset/CircularClasses/Y.php
+++ b/tests/ZendTest/Di/TestAsset/CircularClasses/Y.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/tests/ZendTest/Di/TestAsset/CircularClasses/Y.php
+++ b/tests/ZendTest/Di/TestAsset/CircularClasses/Y.php
@@ -5,7 +5,6 @@
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
  * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- * @package   Zend_Di
  */
 
 namespace ZendTest\Di\TestAsset\CircularClasses;

--- a/tests/ZendTest/Di/TestAsset/CircularClasses/Y.php
+++ b/tests/ZendTest/Di/TestAsset/CircularClasses/Y.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Di
+ */
+
+namespace ZendTest\Di\TestAsset\CircularClasses;
+
+class Y
+{
+    public function __construct(Y $y = null)
+    {
+
+    }
+}


### PR DESCRIPTION
I've noticed a situation where dependencies are sometimes incorrectly identified as circular when they're not.

If we a class and use the alias as parameters in other aliases multiple times for the same class we get the following exception:

```
Zend\Di\Exception\CircularDependencyException: Circular dependency detected: ZendTest\Di\TestAsset\CircularClasses\Y depends on ZendTest\Di\TestAsset\CircularClasses\Y and viceversa
```

If we get an instance of the all of the required aliased classes first, we don't get this exception. To help resolve this I've written a couple of tests that succinctly show the problem. We're currently working round this by instantiating the intermediary classes, which is not ideal, so a fix to this would be much appreciated. Please let me know if there's anything else I can do to help debug.
