### PR TITLE
Remove duplicate: zend-stdlib is already required

### DIFF
--- a/library/Zend/Filter/composer.json
+++ b/library/Zend/Filter/composer.json
@@ -23,8 +23,7 @@
         "zendframework/zend-i18n": "Zend\\I18n component",
         "zendframework/zend-uri": "Zend\\Uri component for UriNormalize filter",
         "zendframework/zend-validator": "Zend\\Validator component",
-        "zendframework/zend-crypt": "Zend\\Crypt component",
-        "zendframework/zend-stdlib": "Zend\\Stdlib component"
+        "zendframework/zend-crypt": "Zend\\Crypt component"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
zend-stdlib is required, so suggest is not needed
