### PR TITLE
[Validator] Refactor Date

### DIFF
--- a/library/Zend/Validator/Date.php
+++ b/library/Zend/Validator/Date.php
@@ -12,11 +12,23 @@ namespace Zend\Validator;
 use DateTime;
 use Traversable;
 
+/**
+ * Validates that a given value is a DateTime instance or can be converted into one.
+ */
 class Date extends AbstractValidator
 {
+    /**#@+
+     * Validity constant
+     * @var string
+     */
     const INVALID        = 'dateInvalid';
     const INVALID_DATE   = 'dateInvalidDate';
     const FALSEFORMAT    = 'dateFalseFormat';
+    /**
+     * Default format
+     */
+    const FORMAT_DEFAULT = 'Y-m-d';
+    /**#@-*/
 
     /**
      * Validation failure message template definitions
@@ -24,24 +36,21 @@ class Date extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID        => "Invalid type given. String, integer, array or DateTime expected",
-        self::INVALID_DATE   => "The input does not appear to be a valid date",
-        self::FALSEFORMAT    => "The input does not fit the date format '%format%'",
+        self::INVALID      => "Invalid type given. String, integer, array or DateTime expected",
+        self::INVALID_DATE => "The input does not appear to be a valid date",
+        self::FALSEFORMAT  => "The input does not fit the date format '%format%'",
     );
 
     /**
      * @var array
      */
-    protected $messageVariables = array(
-        'format'  => 'format'
-    );
+    protected $messageVariables = array('format' => 'format');
 
     /**
-     * Optional format
-     *
-     * @var string|null
+     * @var string
      */
-    protected $format;
+    protected $format = self::FORMAT_DEFAULT;
+
 
     /**
      * Sets validator options
@@ -56,10 +65,6 @@ class Date extends AbstractValidator
             $options = func_get_args();
             $temp['format'] = array_shift($options);
             $options = $temp;
-        }
-
-        if (array_key_exists('format', $options)) {
-            $this->setFormat($options['format']);
         }
 
         parent::__construct($options);
@@ -78,79 +83,103 @@ class Date extends AbstractValidator
     /**
      * Sets the format option
      *
+     * Format cannot be null.  It will always default to 'Y-m-d', even
+     * if null is provided.
+     *
      * @param  string $format
      * @return Date provides a fluent interface
+     * @todo   validate the format
      */
-    public function setFormat($format = null)
+    public function setFormat($format = self::FORMAT_DEFAULT)
     {
-        $this->format = $format;
+        $this->format = (empty($format)) ? self::FORMAT_DEFAULT : $format;
         return $this;
     }
 
     /**
-     * Returns true if $value is a valid date of the format YYYY-MM-DD
-     * If optional $format is set the date format is checked
-     * according to DateTime
+     * Returns true if $value is a DateTime instance or can be converted into one.
      *
      * @param  string|array|int|DateTime $value
      * @return bool
      */
     public function isValid($value)
     {
-        if (!is_string($value)
-            && !is_array($value)
-            && !is_int($value)
-            && !($value instanceof DateTime)
-        ) {
-            $this->error(self::INVALID);
+        $this->setValue($value);
+
+        if (!$this->convertToDateTime($value)) {
+            $this->error(self::INVALID_DATE);
             return false;
         }
 
-        $this->setValue($value);
+        return true;
+    }
 
-        $format = $this->getFormat();
-
-        if ($value instanceof DateTime) {
-            return true;
-        } elseif (is_int($value)
-            || (is_string($value) && null !== $format)
-        ) {
-            $date = (is_int($value))
-                    ? date_create("@$value") // from timestamp
-                    : DateTime::createFromFormat($format, $value);
-
-            // Invalid dates can show up as warnings (ie. "2007-02-99")
-            // and still return a DateTime object
-            $errors = DateTime::getLastErrors();
-
-            if ($errors['warning_count'] > 0) {
-                $this->error(self::INVALID_DATE);
-                return false;
-            }
-            if ($date === false) {
-                $this->error(self::INVALID_DATE);
-                return false;
-            }
-        } else {
-            if (is_array($value)) {
-                $value = implode('-', $value);
-            }
-
-            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
-                $this->format = 'Y-m-d';
-                $this->error(self::FALSEFORMAT);
-                $this->format = null;
-                return false;
-            }
-
-            list($year, $month, $day) = sscanf($value, '%d-%d-%d');
-
-            if (!checkdate($month, $day, $year)) {
-                $this->error(self::INVALID_DATE);
-                return false;
-            }
+    /**
+     * Attempts to convert an int, string, or array to a DateTime object
+     *
+     * @param  string|int|array $param
+     * @param  bool             $addErrors
+     * @return bool|DateTime
+     */
+    protected function convertToDateTime($param, $addErrors = true)
+    {
+        if ($param instanceof DateTime) {
+            return $param;
         }
 
-        return true;
+        $type = gettype($param);
+        if (!in_array($type, array('string', 'integer', 'array'))) {
+            if ($addErrors) $this->error(self::INVALID);
+            return false;
+        }
+
+        $convertMethod = 'convert' . ucfirst($type);
+        return $this->{$convertMethod}($param, $addErrors);
+    }
+
+    /**
+     * Attempts to convert an integer into a DateTime object
+     *
+     * @param  integer $value
+     * @return bool|DateTime
+     */
+    protected function convertInteger($value)
+    {
+        return date_create("@$value");
+    }
+
+    /**
+     * Attempts to convert a string into a DateTime object
+     *
+     * @param  string $value
+     * @param  bool   $addErrors
+     * @return bool|DateTime
+     */
+    protected function convertString($value, $addErrors = true)
+    {
+        $date = DateTime::createFromFormat($this->format, $value);
+
+        // Invalid dates can show up as warnings (ie. "2007-02-99")
+        // and still return a DateTime object.
+        $errors = DateTime::getLastErrors();
+        if ($errors['warning_count'] > 0) {
+            if ($addErrors) $this->error(self::FALSEFORMAT);
+            return false;
+        }
+
+        return $date;
+    }
+
+    /**
+     * Implodes the array into a string and proxies to {@link convertString()}.
+     *
+     * @param  array $value
+     * @param  bool  $addErrors
+     * @return bool|DateTime
+     * @todo   enhance the implosion
+     */
+    protected function convertArray(array $value, $addErrors = true)
+    {
+        return $this->convertString(implode('-', $value), $addErrors);
     }
 }

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -18,7 +18,9 @@ use Zend\Validator\Exception;
 
 class DateStep extends Date
 {
-    const NOT_STEP     = 'dateStepNotStep';
+    const NOT_STEP       = 'dateStepNotStep';
+
+    const FORMAT_DEFAULT = DateTime::ISO8601;
 
     /**
      * @var array
@@ -41,13 +43,6 @@ class DateStep extends Date
      * @var DateInterval
      */
     protected $step;
-
-    /**
-     * Format to use for parsing date strings
-     *
-     * @var string
-     */
-    protected $format = DateTime::ISO8601;
 
     /**
      * Optional timezone to be used when the baseValue
@@ -82,21 +77,11 @@ class DateStep extends Date
             $options = $temp;
         }
 
-        if (isset($options['baseValue'])) {
-            $this->setBaseValue($options['baseValue']);
+        if (!isset($options['step'])) {
+            $options['step'] = new DateInterval('P1D');
         }
-        if (isset($options['step'])) {
-            $this->setStep($options['step']);
-        } else {
-            $this->setStep(new DateInterval('P1D'));
-        }
-        if (array_key_exists('format', $options)) {
-            $this->setFormat($options['format']);
-        }
-        if (isset($options['timezone'])) {
-            $this->setTimezone($options['timezone']);
-        } else {
-            $this->setTimezone(new DateTimeZone(date_default_timezone_get()));
+        if (!isset($options['timezone'])) {
+            $options['timezone'] = new DateTimeZone(date_default_timezone_get());
         }
 
         parent::__construct($options);
@@ -169,36 +154,32 @@ class DateStep extends Date
     }
 
     /**
-     * Converts an int or string to a DateTime object
+     * Supports formats with ISO week (W) definitions
      *
-     * @param  string|int|\DateTime $param
-     * @return \DateTime
-     * @throws Exception\InvalidArgumentException
+     * @see Date::convertString()
      */
-    protected function convertToDateTime($param)
+    protected function convertString($value, $addErrors = true)
     {
-        $dateObj = $param;
-        if (is_int($param)) {
-            // Convert from timestamp
-            $dateObj = date_create("@$param");
-        } elseif (is_string($param)) {
-            // Custom week format support
-            if (strpos($this->getFormat(), 'Y-\WW') === 0
-                && preg_match('/^([0-9]{4})\-W([0-9]{2})/', $param, $matches)
-            ) {
-                $dateObj = new DateTime();
-                $dateObj->setISODate($matches[1], $matches[2]);
-            } else {
-                $dateObj = DateTime::createFromFormat(
-                    $this->getFormat(), $param, $this->getTimezone()
-                );
-            }
-        }
-        if (!($dateObj instanceof DateTime)) {
-            throw new Exception\InvalidArgumentException('Invalid date param given');
+        // Custom week format support
+        if (
+            strpos($this->format, 'Y-\WW') === 0
+            && preg_match('/^([0-9]{4})\-W([0-9]{2})/', $value, $matches)
+        ) {
+            $date = new DateTime;
+            $date->setISODate($matches[1], $matches[2]);
+        } else {
+            $date = DateTime::createFromFormat($this->format, $value, $this->timezone);
         }
 
-        return $dateObj;
+        // Invalid dates can show up as warnings (ie. "2007-02-99")
+        // and still return a DateTime object.
+        $errors = DateTime::getLastErrors();
+        if ($errors['warning_count'] > 0) {
+            if ($addErrors) $this->error(self::FALSE_FORMAT);
+            return false;
+        }
+
+        return $date;
     }
 
     /**
@@ -210,19 +191,13 @@ class DateStep extends Date
      */
     public function isValid($value)
     {
-        parent::isValid($value);
-
-        $this->setValue($value);
-
-        $baseDate = $this->convertToDateTime($this->getBaseValue());
-        $step     = $this->getStep();
-
-        // Parse the date
-        try {
-            $valueDate = $this->convertToDateTime($value);
-        } catch (Exception\InvalidArgumentException $ex) {
+        if (!parent::isValid($value)) {
             return false;
         }
+
+        $valueDate = $this->convertToDateTime($value, false); // avoid duplicate errors
+        $baseDate  = $this->convertToDateTime($this->baseValue, false);
+        $step      = $this->getStep();
 
         // Same date?
         if ($valueDate == $baseDate) {

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -310,7 +310,7 @@ class FormRowTest extends TestCase
     {
         $element = new  Element\Date('birth');
         $element->setFormat('Y-m-d');
-        $element->setValue('2010-13-13');
+        $element->setValue('2010.13');
 
         $validator = new \Zend\Validator\Date();
         $validator->isValid($element->getValue());

--- a/tests/ZendTest/Validator/DateStepTest.php
+++ b/tests/ZendTest/Validator/DateStepTest.php
@@ -119,6 +119,6 @@ class DateStepTest extends \PHPUnit_Framework_TestCase
             'step' => new DateInterval("P10D"),
         ));
 
-        $this->assertFalse($validator->isValid('2012-13-13'));
+        $this->assertFalse($validator->isValid('2012-02-23'));
     }
 }

--- a/tests/ZendTest/Validator/DateTest.php
+++ b/tests/ZendTest/Validator/DateTest.php
@@ -37,6 +37,12 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->validator = new Validator\Date();
     }
 
+    public function testSetFormatIgnoresNull()
+    {
+        $this->validator->setFormat(null);
+        $this->assertEquals(Validator\Date::FORMAT_DEFAULT, $this->validator->getFormat());
+    }
+
     public function datesDataProvider()
     {
         return array(
@@ -72,7 +78,9 @@ class DateTest extends \PHPUnit_Framework_TestCase
             // array(999999999999,              null,              true),
             // array
             array(array('2012', '06', '25'), null,              true),
-            array(array('12', '06', '25'),   null,              false),
+            // 0012-06-25 is a valid date, if you want 2012, use 'y' instead of 'Y'
+            array(array('12', '06', '25'),   null,              true),
+            array(array('2012', '06', '33'), null,              false),
             array(array(1 => 1),             null,              false),
             // DateTime
             array(new DateTime(),            null,              true),
@@ -90,7 +98,6 @@ class DateTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->setFormat($format);
         $this->assertEquals($result, $this->validator->isValid($input));
-        $this->assertEquals($format, $this->validator->getFormat());
     }
 
     /**


### PR DESCRIPTION
The `Date` validator converts `string`, `array`, and `int` values into `DateTime` instances, or tries to, as part of the validation process.  But, `DateStep` also uses a conversion process for helper dates.  So, the conversion process was synchronized with `Date` and refactored out into separate methods to allow extending classes to reuse the functionality and to reduce the complexity of the validation method.
