### PR TITLE
fix docblock and exception that still use "Zend_" prefix

### DIFF
--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -37,7 +37,7 @@ namespace Zend\Console;
  * - Automatic generation of a helpful usage message.
  * - Signal end of options with '--'; subsequent arguments are treated
  *   as non-option arguments, even if they begin with '-'.
- * - Raise exception Zend_Console_Getopt_Exception in several cases
+ * - Raise exception Zend\Console\Exception\* in several cases
  *   when invalid flags or parameters are given.  Usage message is
  *   returned in the exception object.
  *
@@ -213,7 +213,7 @@ class Getopt
         if (!isset($_SERVER['argv'])) {
             $errorDescription = (ini_get('register_argc_argv') == false)
                 ? "argv is not available, because ini option 'register_argc_argv' is set Off"
-                : '$_SERVER["argv"] is not set, but Zend_Console_Getopt cannot work without this information.';
+                : '$_SERVER["argv"] is not set, but Zend\Console\Getopt cannot work without this information.';
             throw new Exception\InvalidArgumentException($errorDescription);
         }
 

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -33,7 +33,7 @@ class SqlServer implements PlatformInterface
      */
     public function setDriver($driver)
     {
-        // handle Zend_Db drivers
+        // handle Zend\Db drivers
         if (($driver instanceof Pdo\Pdo && in_array($driver->getDatabasePlatformName(), array('Sqlsrv', 'Dblib')))
             || (($driver instanceof \PDO && in_array($driver->getAttribute(\PDO::ATTR_DRIVER_NAME), array('sqlsrv', 'dblib'))))
         ) {

--- a/library/Zend/Debug/Debug.php
+++ b/library/Zend/Debug/Debug.php
@@ -42,7 +42,7 @@ class Debug
 
     /**
      * Set the debug output environment.
-     * Setting a value of null causes Zend_Debug to use PHP_SAPI.
+     * Setting a value of null causes Zend\Debug\Debug to use PHP_SAPI.
      *
      * @param string $sapi
      * @return void;

--- a/library/Zend/View/Helper/DeclareVars.php
+++ b/library/Zend/View/Helper/DeclareVars.php
@@ -24,7 +24,7 @@ class DeclareVars extends AbstractHelper
     /**
      * Declare template vars to set default values and avoid notices when using strictVars
      *
-     * Primarily for use when using {@link Zend_View_Abstract::strictVars() Zend_View strictVars()},
+     * Primarily for use when using {@link Zend\View\Variables::setStrictVars()},
      * this helper can be used to declare template variables that may or may
      * not already be set in the view object, as well as to set default values.
      * Arrays passed as arguments to the method will be used to set default

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -230,7 +230,7 @@ class Links extends AbstractHelper
      *
      * The form of the returned array:
      * <code>
-     * // $page denotes an instance of Zend_Navigation_Page
+     * // $page denotes an instance of Zend\Navigation\Page\AbstractPage
      * $returned = array(
      *     'rel' => array(
      *         'alternate' => array($page, $page, $page),

--- a/library/Zend/View/Renderer/ConsoleRenderer.php
+++ b/library/Zend/View/Renderer/ConsoleRenderer.php
@@ -60,7 +60,7 @@ class ConsoleRenderer implements RendererInterface, TreeRendererInterface
     }
 
     /**
-     * Allow custom object initialization when extending ConsoleRenderer or
+     * Allow custom object initialization when extending ConsoleRenderer
      *
      * Triggered by {@link __construct() the constructor} as its final action.
      *

--- a/library/Zend/View/Renderer/ConsoleRenderer.php
+++ b/library/Zend/View/Renderer/ConsoleRenderer.php
@@ -14,7 +14,7 @@ use Zend\View\Model\ModelInterface;
 use Zend\View\Resolver\ResolverInterface;
 
 /**
- * Abstract class for Zend_View to help enforce private constructs.
+ * Class for Zend\View\Model\ConsoleModel to help enforce private constructs.
  *
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict
@@ -60,8 +60,7 @@ class ConsoleRenderer implements RendererInterface, TreeRendererInterface
     }
 
     /**
-     * Allow custom object initialization when extending Zend_View_Abstract or
-     * Zend_View
+     * Allow custom object initialization when extending ConsoleRenderer or
      *
      * Triggered by {@link __construct() the constructor} as its final action.
      *

--- a/library/Zend/View/Renderer/FeedRenderer.php
+++ b/library/Zend/View/Renderer/FeedRenderer.php
@@ -15,7 +15,7 @@ use Zend\View\Model\ModelInterface as Model;
 use Zend\View\Resolver\ResolverInterface as Resolver;
 
 /**
- * Interface class for Zend_View compatible template engine implementations
+ * Class for Zend\View\Strategy\FeedStrategy compatible template engine implementations
  */
 class FeedRenderer implements RendererInterface
 {

--- a/library/Zend/View/Renderer/PhpRenderer.php
+++ b/library/Zend/View/Renderer/PhpRenderer.php
@@ -22,7 +22,7 @@ use Zend\View\Resolver\TemplatePathStack;
 use Zend\View\Variables;
 
 /**
- * Class for Zend\View to help enforce private constructs.
+ * Class for Zend\View\Strategy\PhpRendererStrategy to help enforce private constructs.
  *
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict

--- a/library/Zend/View/Renderer/PhpRenderer.php
+++ b/library/Zend/View/Renderer/PhpRenderer.php
@@ -164,7 +164,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     }
 
     /**
-     * Allow custom object initialization when extending PhpRenderer or
+     * Allow custom object initialization when extending PhpRenderer
      *
      * Triggered by {@link __construct() the constructor} as its final action.
      *

--- a/library/Zend/View/Renderer/PhpRenderer.php
+++ b/library/Zend/View/Renderer/PhpRenderer.php
@@ -22,7 +22,7 @@ use Zend\View\Resolver\TemplatePathStack;
 use Zend\View\Variables;
 
 /**
- * Abstract class for Zend_View to help enforce private constructs.
+ * Class for Zend\View to help enforce private constructs.
  *
  * Note: all private variables in this class are prefixed with "__". This is to
  * mark them as part of the internal implementation, and thus prevent conflict
@@ -164,8 +164,7 @@ class PhpRenderer implements Renderer, TreeRendererInterface
     }
 
     /**
-     * Allow custom object initialization when extending Zend_View_Abstract or
-     * Zend_View
+     * Allow custom object initialization when extending PhpRenderer or
      *
      * Triggered by {@link __construct() the constructor} as its final action.
      *

--- a/library/Zend/View/Renderer/RendererInterface.php
+++ b/library/Zend/View/Renderer/RendererInterface.php
@@ -13,7 +13,7 @@ use Zend\View\Model\ModelInterface;
 use Zend\View\Resolver\ResolverInterface;
 
 /**
- * Interface class for Zend_View compatible template engine implementations
+ * Interface class for Zend\View\Renderer\* compatible template engine implementations
  */
 interface RendererInterface
 {

--- a/library/Zend/View/Variables.php
+++ b/library/Zend/View/Variables.php
@@ -12,7 +12,7 @@ namespace Zend\View;
 use ArrayObject;
 
 /**
- * Abstract class for Zend_View to help enforce private constructs.
+ * Class for Zend\View\Renderer\PhpRenderer to help enforce private constructs.
  *
  * @todo       Allow specifying string names for manager, filter chain, variables
  * @todo       Move escaping into variables object


### PR DESCRIPTION
I point it to develop because it include exception change.
