### PR TITLE
Problem with Forward Plugin

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -179,7 +179,7 @@ class Forward extends AbstractPlugin
 
                     // If we have an array, grab the object
                     if (is_array($currentCallback)) {
-                        $currentCallback = $currentCallback[0];
+                        $currentCallback = array_shift($currentCallback);
                     }
 
                     // This routine is only valid for object callbacks

--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -178,8 +178,8 @@ class Forward extends AbstractPlugin
                     $currentCallback = $currentEvent->getCallback();
 
                     // Testing against object callbacks
-                    if (!is_object($currentCallback) 
-                        || !is_array($currentCallback) 
+                    if (!is_object($currentCallback)
+                        || !is_array($currentCallback)
                         || !isset($currentCallback[0])
                     ) {
                         continue;

--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -177,17 +177,14 @@ class Forward extends AbstractPlugin
                 foreach ($events as $currentEvent) {
                     $currentCallback = $currentEvent->getCallback();
 
-                    // Testing against object callbacks
-                    if (!is_object($currentCallback)
-                        || !is_array($currentCallback)
-                        || !isset($currentCallback[0])
-                    ) {
-                        continue;
-                    }
-
                     // If we have an array, grab the object
                     if (is_array($currentCallback)) {
                         $currentCallback = $currentCallback[0];
+                    }
+
+                    // This routine is only valid for object callbacks
+                    if (!is_object($currentCallback)) {
+                        continue;
                     }
 
                     foreach ($classArray as $class) {

--- a/library/Zend/Mvc/Controller/Plugin/Forward.php
+++ b/library/Zend/Mvc/Controller/Plugin/Forward.php
@@ -176,11 +176,22 @@ class Forward extends AbstractPlugin
                 $events = $sharedEvents->getListeners($id, $eventName);
                 foreach ($events as $currentEvent) {
                     $currentCallback = $currentEvent->getCallback();
-                    if (!isset($currentCallback[0])) {
+
+                    // Testing against object callbacks
+                    if (!is_object($currentCallback) 
+                        || !is_array($currentCallback) 
+                        || !isset($currentCallback[0])
+                    ) {
                         continue;
                     }
+
+                    // If we have an array, grab the object
+                    if (is_array($currentCallback)) {
+                        $currentCallback = $currentCallback[0];
+                    }
+
                     foreach ($classArray as $class) {
-                        if (is_a($currentCallback[0], $class)) {
+                        if (is_a($currentCallback, $class)) {
                             $sharedEvents->detach($id, $currentEvent);
                             $results[$id][$eventName][] = $currentEvent;
                         }

--- a/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/ForwardTest.php
@@ -19,6 +19,7 @@ use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\Controller\Plugin\Forward as ForwardPlugin;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\Stdlib\CallbackHandler;
 use ZendTest\Mvc\Controller\TestAsset\ForwardController;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
 use ZendTest\Mvc\Controller\TestAsset\UneventfulController;
@@ -123,6 +124,29 @@ class ForwardTest extends TestCase
 
     public function testPluginDispatchsRequestedControllerWhenFound()
     {
+        $result = $this->plugin->dispatch('forward');
+        $this->assertInternalType('array', $result);
+        $this->assertEquals(array('content' => 'ZendTest\Mvc\Controller\TestAsset\ForwardController::testAction'), $result);
+    }
+
+    /**
+     * @group 5432
+     */
+    public function testNonArrayListenerDoesNotRaiseErrorWhenPluginDispatchsRequestedController()
+    {
+        $services = $this->plugins->getServiceLocator();
+        $events   = $services->get('EventManager');
+        $sharedEvents = $this->getMock('Zend\EventManager\SharedEventManagerInterface');
+        $sharedEvents->expects($this->any())->method('getListeners')->will($this->returnValue(array(
+            new CallbackHandler(function ($e) {})
+        )));
+        $events = $this->getMock('Zend\EventManager\EventManagerInterface');
+        $events->expects($this->any())->method('getSharedManager')->will($this->returnValue($sharedEvents));
+        $application = $this->getMock('Zend\Mvc\ApplicationInterface');
+        $application->expects($this->any())->method('getEventManager')->will($this->returnValue($events));
+        $event = $this->controller->getEvent();
+        $event->setApplication($application);
+
         $result = $this->plugin->dispatch('forward');
         $this->assertInternalType('array', $result);
         $this->assertEquals(array('content' => 'ZendTest\Mvc\Controller\TestAsset\ForwardController::testAction'), $result);


### PR DESCRIPTION
Hi!

I'm playing with apigility and trying to use it with one of my project. But when i try to login in the system i receive the error:

```
Fatal error: Cannot use object of type ZF\ContentNegotiation\AcceptListener as array in xxx/vendor/zendframework/zendframework/library/Zend/Mvc/Controller/Plugin/Forward.php on line 179
```

the error occurs inside detachProblemListeners.

If i comment the attacing listener inside the onBootstrap (zfcampus/zf-content-negotiation/src/ZF/ContentNegotiation/Module.php:122) i can login but the api stops working (as expected).

Maybe Forward.php should check if the callback is in fact an array on line 179 (ZF2 2.2.5)? Something like:

``` php
if (!is_array($currentCallback) || !isset($currentCallback[0])) {
```

Thanks,
Leandro Silva
