### PR TITLE
Fix typehint for getServiceLocator().

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -142,7 +142,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     /**
      * Get the main plugin manager. Useful for fetching dependencies from within factories.
      *
-     * @return mixed
+     * @return ServiceLocatorInterface
      */
     public function getServiceLocator()
     {


### PR DESCRIPTION
It's always `ServiceLocatorInterface` because:
- getServiceLocator() returns the contents of $this->serviceLocator 
- which is set by setServiceLocator(ServiceLocatorInterface $sl).
- setter has a specific type hint
