### PR TITLE
Add element input filters before form input filters

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -756,13 +756,20 @@ class Form extends Fieldset implements FormInterface
                         continue;
                     }
                     // Create a new empty default input for this element
-                    $spec = array('name' => $name, 'required' => false);
+                    $spec  = array('name' => $name, 'required' => false);
+                    $input = $inputFactory->createInput($spec);
                 } else {
                     // Create an input based on the specification returned from the element
                     $spec  = $element->getInputSpecification();
+                    $input = $inputFactory->createInput($spec);
+
+                    if ($inputFilter->has($name)) {
+                        $input->merge($inputFilter->get($name));
+                        $inputFilter->replace($input, $name);
+                        continue;
+                    }
                 }
 
-                $input = $inputFactory->createInput($spec);
                 $inputFilter->add($input, $name);
             }
 

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -18,6 +18,7 @@ use Zend\InputFilter\InputFilterAwareInterface;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\InputFilter\InputFilterProviderInterface;
 use Zend\InputFilter\InputProviderInterface;
+use Zend\InputFilter\ReplaceableInputInterface;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Hydrator\HydratorInterface;
 
@@ -778,7 +779,7 @@ class Form extends Fieldset implements FormInterface
                     $spec  = $element->getInputSpecification();
                     $input = $inputFactory->createInput($spec);
 
-                    if ($inputFilter->has($name)) {
+                    if ($inputFilter->has($name) && $inputFilter instanceof ReplaceableInputInterface) {
                         $input->merge($inputFilter->get($name));
                         $inputFilter->replace($input, $name);
                         continue;

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -109,6 +109,13 @@ class Form extends Fieldset implements FormInterface
     protected $preferFormInputFilter = true;
 
     /**
+     * Has preferFormInputFilter been set with setPreferFormInputFilter?
+     *
+     * @var bool
+     */
+    protected $hasSetPreferFormInputFilter = false;
+
+    /**
      * Are the form elements/fieldsets wrapped by the form name ?
      *
      * @var bool
@@ -643,6 +650,13 @@ class Form extends Fieldset implements FormInterface
         $this->hasValidated                = false;
         $this->hasAddedInputFilterDefaults = false;
         $this->filter                      = $inputFilter;
+
+        // TODO: Remove the statement below and all self::$hasSetPreferFormInputFilter occurrences
+        // if self::$preferFormInputFilter default value is set to false
+        if (false === $this->hasSetPreferFormInputFilter) {
+            $this->preferFormInputFilter = false;
+        }
+
         return $this;
     }
 
@@ -712,6 +726,7 @@ class Form extends Fieldset implements FormInterface
     public function setPreferFormInputFilter($preferFormInputFilter)
     {
         $this->preferFormInputFilter = (bool) $preferFormInputFilter;
+        $this->hasSetPreferFormInputFilter = true;
         return $this;
     }
 

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -90,7 +90,7 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
      * @param  InputInterface|InputFilterInterface $input
      * @param  string                              $name Name of the input to replace
      * @throws Exception\InvalidArgumentException
-     * @return InputFilterInterface
+     * @return self
      */
     public function replace($input, $name)
     {

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -87,7 +87,9 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
     /**
      * Replace a named input
      *
-     * @param  string $name
+     * @param  InputInterface|InputFilterInterface $input
+     * @param  string                              $name Name of the input to replace
+     * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
     public function replace($input, $name)

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -85,6 +85,36 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
     }
 
     /**
+     * Replace a named input
+     *
+     * @param  string $name
+     * @return InputFilterInterface
+     */
+    public function replace($input, $name)
+    {
+        if (!$input instanceof InputInterface && !$input instanceof InputFilterInterface) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an instance of %s or %s as its first argument; received "%s"',
+                __METHOD__,
+                'Zend\InputFilter\InputInterface',
+                'Zend\InputFilter\InputFilterInterface',
+                (is_object($input) ? get_class($input) : gettype($input))
+            ));
+        }
+
+        if (!array_key_exists($name, $this->inputs)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: no input found matching "%s"',
+                __METHOD__,
+                $name
+            ));
+        }
+
+        $this->inputs[$name] = $input;
+        return $this;
+    }
+
+    /**
      * Retrieve a named input
      *
      * @param  string $name

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -18,7 +18,11 @@ use Zend\Stdlib\InitializableInterface;
  * @todo       How should we deal with required input when data is missing?
  *             should a message be returned? if so, what message?
  */
-class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInterface, InitializableInterface
+class BaseInputFilter implements
+    InputFilterInterface,
+    UnknownInputsCapableInterface,
+    InitializableInterface,
+    ReplaceableInputInterface
 {
     protected $data;
     protected $inputs = array();

--- a/library/Zend/InputFilter/ReplaceableInputInterface.php
+++ b/library/Zend/InputFilter/ReplaceableInputInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+interface ReplaceableInputInterface
+{
+    public function replace($input, $name);
+}

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1730,8 +1730,6 @@ class FormTest extends TestCase
 
     public function testFormElementValidatorsMergeIntoAppliedInputFilter()
     {
-        $this->form->setPreferFormInputFilter(false);
-
         $this->form->add(array(
             'name' => 'importance',
             'type'  => 'Zend\Form\Element\Select',

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1727,4 +1727,42 @@ class FormTest extends TestCase
         $filters = $form->getInputFilter()->get('fieldset')->get('foo')->getFilterChain();
         $this->assertEquals(1, $filters->count());
     }
+
+    public function testFormElementValidatorsMergeIntoAppliedInputFilter()
+    {
+        $this->form->setPreferFormInputFilter(false);
+
+        $this->form->add(array(
+            'name' => 'importance',
+            'type'  => 'Zend\Form\Element\Select',
+            'options' => array(
+                'label' => 'Importance',
+                'empty_option' => '',
+                'value_options' => array(
+                    'normal' => 'Normal',
+                    'important' => 'Important'
+                ),
+            ),
+        ));
+
+        $inputFilter = new \Zend\InputFilter\BaseInputFilter();
+        $factory     = new \Zend\InputFilter\Factory();
+        $inputFilter->add($factory->createInput(array(
+            'name'     => 'importance',
+            'required' => false,
+        )));
+
+        $data = array(
+            'importance' => 'unimporant'
+        );
+
+        $this->form->setInputFilter($inputFilter);
+        $this->form->setData($data);
+        $this->assertFalse($this->form->isValid());
+
+        $data = array();
+
+        $this->form->setData($data);
+        $this->assertTrue($this->form->isValid());
+    }
 }


### PR DESCRIPTION
When preferFormInputFilter is set to false, input filters returned by the elements implementing InputProviderInterface are added to inputFilter before the form input filters. This way the inputs are validated as expected, e.g.: using email element, the email is validated before an user specified RecordExists runs.
