### PR TITLE
Fix translate text domain on form view helper

### DIFF
--- a/library/Zend/Form/View/Helper/Form.php
+++ b/library/Zend/Form/View/Helper/Form.php
@@ -64,9 +64,9 @@ class Form extends AbstractHelper
 
         foreach ($form as $element) {
             if ($element instanceof FieldsetInterface) {
-                $formContent.= $this->getView()->formCollection($element);
+                $formContent.= $this->getView()->formCollection()->setTranslatorTextDomain($this->translatorTextDomain)->render($element);
             } else {
-                $formContent.= $this->getView()->formRow($element);
+                $formContent.= $this->getView()->formRow()->setTranslatorTextDomain($this->translatorTextDomain)->render($element);
             }
         }
 


### PR DESCRIPTION
The form view helper does not use the correct translator text domain when rendering elements
