### PR TITLE
Add setOption (singular) to Zend\Form\Element to supplement setOptions

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -154,6 +154,19 @@ class Element implements
     }
 
     /**
+     * Set a single option for an element
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return ElementInterface
+     */
+    public function setOption($key, $value)
+    {
+        $this->options[$key] = $value;
+        return $this;
+    }
+
+    /**
      * Set a single element attribute
      *
      * @param  string $key

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -158,7 +158,7 @@ class Element implements
      *
      * @param  string $key
      * @param  mixed $value
-     * @return ElementInterface
+     * @return self
      */
     public function setOption($key, $value)
     {

--- a/library/Zend/Form/ElementInterface.php
+++ b/library/Zend/Form/ElementInterface.php
@@ -38,6 +38,15 @@ interface ElementInterface
     public function setOptions($options);
 
     /**
+     * Set a single option for an element
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return ElementInterface
+     */
+    public function setOption($key, $value);
+
+    /**
      * get the defined options
      *
      * @return array

--- a/library/Zend/Form/ElementInterface.php
+++ b/library/Zend/Form/ElementInterface.php
@@ -42,7 +42,7 @@ interface ElementInterface
      *
      * @param  string $key
      * @param  mixed $value
-     * @return ElementInterface
+     * @return self
      */
     public function setOption($key, $value);
 

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -161,6 +161,14 @@ class ElementTest extends TestCase
         $this->assertEquals(array('bar' => 'baz'), $option);
     }
 
+    public function testCanSetSingleOptionForLabel()
+    {
+        $element = new Element('foo');
+        $element->setOption('label', 'foo');
+        $option = $element->getOption('label');
+        $this->assertEquals('foo', $option);
+    }
+
     public function testSetOptionsWrongInputRaisesException()
     {
         $element = new Element('foo');


### PR DESCRIPTION
There's currently setAttributes/setAttribute for setting attributes on form elements dynamically; but only setOptions for options. This makes it slightly painful to set things like labels on-the-fly: $element->setOptions(array('label' => '...') + $element->getOptions());

I don't see any reason we can't have a setOption($key, $value) as a singular way of setting an option to make it easier for when this behavior is necessary.

Test Results (ZendTest/Form/ElementTest.php):

ZendTest\Form\Element
 [x] Can set single option for label
