### PR TITLE
Db\Sql\Update add sortable set list

### DIFF
--- a/library/Zend/Mvc/Router/Http/Chain.php
+++ b/library/Zend/Mvc/Router/Http/Chain.php
@@ -12,7 +12,7 @@ namespace Zend\Mvc\Router\Http;
 use ArrayObject;
 use Traversable;
 use Zend\Mvc\Router\Exception;
-use Zend\Mvc\Router\PriorityList;
+use Zend\Stdlib\PriorityList;
 use Zend\Mvc\Router\RoutePluginManager;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\RequestInterface as Request;

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -12,7 +12,7 @@ namespace Zend\Mvc\Router\Http;
 use ArrayObject;
 use Traversable;
 use Zend\Mvc\Router\Exception;
-use Zend\Mvc\Router\PriorityList;
+use Zend\Stdlib\PriorityList;
 use Zend\Mvc\Router\RoutePluginManager;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\RequestInterface as Request;

--- a/library/Zend/Mvc/Router/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/SimpleRouteStack.php
@@ -12,6 +12,7 @@ namespace Zend\Mvc\Router;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\RequestInterface as Request;
+use Zend\Stdlib\PriorityList;
 
 /**
  * Simple route stack implementation.

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -68,7 +68,28 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
     public function testSet()
     {
         $this->update->set(array('foo' => 'bar'));
-        $this->assertEquals(array('foo' => 'bar'), $this->readAttribute($this->update, 'set'));
+        $this->assertEquals(array('foo' => 'bar'), $this->readAttribute($this->update, 'set')->toArray());
+    }
+
+    /**
+     * @covers Zend\Db\Sql\Update::set
+     */
+    public function testSortableSet()
+    {
+        $this->update->set(array(
+            'two'   => 'с_two',
+            'three' => 'с_three',
+        ));
+        $this->update->set(array('one' => 'с_one'), 10);
+
+        $this->assertEquals(
+            array(
+                'one'   => 'с_one',
+                'two'   => 'с_two',
+                'three' => 'с_three',
+            ),
+            $this->readAttribute($this->update, 'set')->toArray()
+        );
     }
 
     /**

--- a/tests/ZendTest/Stdlib/PriorityListTest.php
+++ b/tests/ZendTest/Stdlib/PriorityListTest.php
@@ -7,9 +7,9 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Mvc\Router;
+namespace ZendTest\Stdlib;
 
-use Zend\Mvc\Router\PriorityList;
+use Zend\Stdlib\PriorityList;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -29,7 +29,7 @@ class PriorityListTest extends TestCase
 
     public function testInsert()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), 0);
+        $this->list->insert('foo', new \stdClass(), 0);
 
         $this->assertEquals(1, count($this->list));
 
@@ -40,8 +40,8 @@ class PriorityListTest extends TestCase
 
     public function testRemove()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('bar', new TestAsset\DummyRoute(), 0);
+        $this->list->insert('foo', new \stdClass(), 0);
+        $this->list->insert('bar', new \stdClass(), 0);
 
         $this->assertEquals(2, count($this->list));
 
@@ -57,8 +57,8 @@ class PriorityListTest extends TestCase
 
     public function testClear()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('bar', new TestAsset\DummyRoute(), 0);
+        $this->list->insert('foo', new \stdClass(), 0);
+        $this->list->insert('bar', new \stdClass(), 0);
 
         $this->assertEquals(2, count($this->list));
 
@@ -70,7 +70,7 @@ class PriorityListTest extends TestCase
 
     public function testGet()
     {
-        $route = new TestAsset\DummyRoute();
+        $route = new \stdClass();
 
         $this->list->insert('foo', $route, 0);
 
@@ -80,9 +80,9 @@ class PriorityListTest extends TestCase
 
     public function testLIFOOnly()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('bar', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('baz', new TestAsset\DummyRoute(), 0);
+        $this->list->insert('foo', new \stdClass(), 0);
+        $this->list->insert('bar', new \stdClass(), 0);
+        $this->list->insert('baz', new \stdClass(), 0);
 
         $order = array();
 
@@ -95,9 +95,9 @@ class PriorityListTest extends TestCase
 
     public function testPriorityOnly()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), 1);
-        $this->list->insert('bar', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('baz', new TestAsset\DummyRoute(), 2);
+        $this->list->insert('foo', new \stdClass(), 1);
+        $this->list->insert('bar', new \stdClass(), 0);
+        $this->list->insert('baz', new \stdClass(), 2);
 
         $order = array();
 
@@ -110,11 +110,11 @@ class PriorityListTest extends TestCase
 
     public function testLIFOWithPriority()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('bar', new TestAsset\DummyRoute(), 0);
-        $this->list->insert('baz', new TestAsset\DummyRoute(), 1);
+        $this->list->insert('foo', new \stdClass(), 0);
+        $this->list->insert('bar', new \stdClass(), 0);
+        $this->list->insert('baz', new \stdClass(), 1);
 
-        $order = array();
+        $orders = array();
 
         foreach ($this->list as $key => $value) {
             $orders[] = $key;
@@ -123,11 +123,27 @@ class PriorityListTest extends TestCase
         $this->assertEquals(array('baz', 'bar', 'foo'), $orders);
     }
 
+    public function testFIFOWithPriority()
+    {
+        $this->list->isLIFO(false);
+        $this->list->insert('foo', new \stdClass(), 0);
+        $this->list->insert('bar', new \stdClass(), 0);
+        $this->list->insert('baz', new \stdClass(), 1);
+
+        $order = array();
+
+        foreach ($this->list as $key => $value) {
+            $orders[] = $key;
+        }
+
+        $this->assertEquals(array('baz', 'foo', 'bar'), $orders);
+    }
+
     public function testPriorityWithNegativesAndNull()
     {
-        $this->list->insert('foo', new TestAsset\DummyRoute(), null);
-        $this->list->insert('bar', new TestAsset\DummyRoute(), 1);
-        $this->list->insert('baz', new TestAsset\DummyRoute(), -1);
+        $this->list->insert('foo', new \stdClass(), null);
+        $this->list->insert('bar', new \stdClass(), 1);
+        $this->list->insert('baz', new \stdClass(), -1);
 
         $order = array();
 
@@ -136,5 +152,30 @@ class PriorityListTest extends TestCase
         }
 
         $this->assertEquals(array('bar', 'foo', 'baz'), $orders);
+    }
+
+    public function testToArray()
+    {
+        $this->list->insert('foo', 'foo_value', null);
+        $this->list->insert('bar', 'bar_value', 1);
+        $this->list->insert('baz', 'baz_value', -1);
+
+        $this->assertEquals(
+            array(
+                'bar' => 'bar_value',
+                'foo' => 'foo_value',
+                'baz' => 'baz_value'
+            ),
+            $this->list->toArray()
+        );
+
+        $this->assertEquals(
+            array(
+                'bar' => array('value' => 'bar_value', 'priority' =>  1, 'serial' => 1),
+                'foo' => array('value' => 'foo_value', 'priority' =>  0, 'serial' => 0),
+                'baz' => array('value' => 'baz_value', 'priority' => -1, 'serial' => 2),
+            ),
+            $this->list->toArray(true)
+        );
     }
 }


### PR DESCRIPTION
for compatibility with http://dev.mysql.com/doc/refman/5.0/en/ansi-diff-update.html.
Because sometime set list should be reordable.

Moved `Zend\Mvc\Router\PriorityList` to `Zend\Stdlib\PriorityList` because `Db\Sql\Update` require it and StdLib is more logical location.
