### PR TITLE
Db\Sql move where functionality to PredicateSet

### DIFF
--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -103,47 +103,8 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         if ($predicate instanceof Where) {
             $this->where = $predicate;
-        } elseif ($predicate instanceof \Closure) {
-            $predicate($this->where);
         } else {
-
-            if (is_string($predicate)) {
-                // String $predicate should be passed as an expression
-                $predicate = new Predicate\Expression($predicate);
-                $this->where->addPredicate($predicate, $combination);
-            } elseif (is_array($predicate)) {
-
-                foreach ($predicate as $pkey => $pvalue) {
-                    // loop through predicates
-
-                    if (is_string($pkey) && strpos($pkey, '?') !== false) {
-                        // First, process strings that the abstraction replacement character ?
-                        // as an Expression predicate
-                        $predicate = new Predicate\Expression($pkey, $pvalue);
-
-                    } elseif (is_string($pkey)) {
-                        // Otherwise, if still a string, do something intelligent with the PHP type provided
-
-                        if ($pvalue === null) {
-                            // map PHP null to SQL IS NULL expression
-                            $predicate = new Predicate\IsNull($pkey, $pvalue);
-                        } elseif (is_array($pvalue)) {
-                            // if the value is an array, assume IN() is desired
-                            $predicate = new Predicate\In($pkey, $pvalue);
-                        } else {
-                            // otherwise assume that array('foo' => 'bar') means "foo" = 'bar'
-                            $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
-                        }
-                    } elseif ($pvalue instanceof Predicate\PredicateInterface) {
-                        // Predicate type is ok
-                        $predicate = $pvalue;
-                    } else {
-                        // must be an array of expressions (with int-indexed array)
-                        $predicate = new Predicate\Expression($pvalue);
-                    }
-                    $this->where->addPredicate($predicate, $combination);
-                }
-            }
+            $this->where->addPredicates($predicate, $combination);
         }
         return $this;
     }

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -101,10 +101,6 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
-        if (is_string($predicate)) {
-            // BC
-            $predicate = new Predicate\Expression($predicate);
-        }
         if ($predicate instanceof Where) {
             $this->where = $predicate;
         } else {

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -101,6 +101,10 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
+        if (is_string($predicate)) {
+            // BC
+            $predicate = new Predicate\Expression($predicate);
+        }
         if ($predicate instanceof Where) {
             $this->where = $predicate;
         } else {

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -279,55 +279,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         if ($predicate instanceof Where) {
             $this->where = $predicate;
-        } elseif ($predicate instanceof Predicate\PredicateInterface) {
-            $this->where->addPredicate($predicate, $combination);
-        } elseif ($predicate instanceof \Closure) {
-            $predicate($this->where);
         } else {
-            if (is_string($predicate)) {
-                // String $predicate should be passed as an expression
-                $predicate = (strpos($predicate, Expression::PLACEHOLDER) !== false)
-                    ? new Predicate\Expression($predicate) : new Predicate\Literal($predicate);
-                $this->where->addPredicate($predicate, $combination);
-            } elseif (is_array($predicate)) {
-
-                foreach ($predicate as $pkey => $pvalue) {
-                    // loop through predicates
-
-                    if (is_string($pkey) && strpos($pkey, '?') !== false) {
-                        // First, process strings that the abstraction replacement character ?
-                        // as an Expression predicate
-                        $predicate = new Predicate\Expression($pkey, $pvalue);
-
-                    } elseif (is_string($pkey)) {
-                        // Otherwise, if still a string, do something intelligent with the PHP type provided
-
-                        if ($pvalue === null) {
-                            // map PHP null to SQL IS NULL expression
-                            $predicate = new Predicate\IsNull($pkey, $pvalue);
-                        } elseif (is_array($pvalue)) {
-                            // if the value is an array, assume IN() is desired
-                            $predicate = new Predicate\In($pkey, $pvalue);
-                        } elseif ($pvalue instanceof Predicate\PredicateInterface) {
-                            //
-                            throw new Exception\InvalidArgumentException(
-                                'Using Predicate must not use string keys'
-                            );
-                        } else {
-                            // otherwise assume that array('foo' => 'bar') means "foo" = 'bar'
-                            $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
-                        }
-                    } elseif ($pvalue instanceof Predicate\PredicateInterface) {
-                        // Predicate type is ok
-                        $predicate = $pvalue;
-                    } else {
-                        // must be an array of expressions (with int-indexed array)
-                        $predicate = (strpos($pvalue, Expression::PLACEHOLDER) !== false)
-                            ? new Predicate\Expression($pvalue) : new Predicate\Literal($pvalue);
-                    }
-                    $this->where->addPredicate($predicate, $combination);
-                }
-            }
+            $this->where->addPredicates($predicate, $combination);
         }
         return $this;
     }
@@ -353,26 +306,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function having($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
-        if ($predicate instanceof Having) {
+        if ($predicate instanceof Where) {
             $this->having = $predicate;
-        } elseif ($predicate instanceof \Closure) {
-            $predicate($this->having);
         } else {
-            if (is_string($predicate)) {
-                $predicate = new Predicate\Expression($predicate);
-                $this->having->addPredicate($predicate, $combination);
-            } elseif (is_array($predicate)) {
-                foreach ($predicate as $pkey => $pvalue) {
-                    if (is_string($pkey) && strpos($pkey, '?') !== false) {
-                        $predicate = new Predicate\Expression($pkey, $pvalue);
-                    } elseif (is_string($pkey)) {
-                        $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
-                    } else {
-                        $predicate = new Predicate\Expression($pvalue);
-                    }
-                    $this->having->addPredicate($predicate, $combination);
-                }
-            }
+            $this->having->addPredicates($predicate, $combination);
         }
         return $this;
     }

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -306,7 +306,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function having($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
-        if ($predicate instanceof Where) {
+        if ($predicate instanceof Having) {
             $this->having = $predicate;
         } else {
             $this->having->addPredicates($predicate, $combination);

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -119,52 +119,10 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
-        if ($predicate === null) {
-            throw new Exception\InvalidArgumentException('Predicate cannot be null');
-        }
-
         if ($predicate instanceof Where) {
             $this->where = $predicate;
-        } elseif ($predicate instanceof \Closure) {
-            $predicate($this->where);
         } else {
-            if (is_string($predicate)) {
-                // String $predicate should be passed as an expression
-                $predicate = new Predicate\Expression($predicate);
-                $this->where->addPredicate($predicate, $combination);
-            } elseif (is_array($predicate)) {
-
-                foreach ($predicate as $pkey => $pvalue) {
-                    // loop through predicates
-
-                    if (is_string($pkey) && strpos($pkey, '?') !== false) {
-                        // First, process strings that the abstraction replacement character ?
-                        // as an Expression predicate
-                        $predicate = new Predicate\Expression($pkey, $pvalue);
-
-                    } elseif (is_string($pkey)) {
-                        // Otherwise, if still a string, do something intelligent with the PHP type provided
-
-                        if ($pvalue === null) {
-                            // map PHP null to SQL IS NULL expression
-                            $predicate = new Predicate\IsNull($pkey, $pvalue);
-                        } elseif (is_array($pvalue)) {
-                            // if the value is an array, assume IN() is desired
-                            $predicate = new Predicate\In($pkey, $pvalue);
-                        } else {
-                            // otherwise assume that array('foo' => 'bar') means "foo" = 'bar'
-                            $predicate = new Predicate\Operator($pkey, Predicate\Operator::OP_EQ, $pvalue);
-                        }
-                    } elseif ($pvalue instanceof Predicate\PredicateInterface) {
-                        // Predicate type is ok
-                        $predicate = $pvalue;
-                    } else {
-                        // must be an array of expressions (with int-indexed array)
-                        $predicate = new Predicate\Expression($pvalue);
-                    }
-                    $this->where->addPredicate($predicate, $combination);
-                }
-            }
+            $this->where->addPredicates($predicate, $combination);
         }
         return $this;
     }

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -119,6 +119,10 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
+        if (is_string($predicate)) {
+            // BC
+            $predicate = new Predicate\Expression($predicate);
+        }
         if ($predicate instanceof Where) {
             $this->where = $predicate;
         } else {

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -119,10 +119,6 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
-        if (is_string($predicate)) {
-            // BC
-            $predicate = new Predicate\Expression($predicate);
-        }
         if ($predicate instanceof Where) {
             $this->where = $predicate;
         } else {

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -65,7 +65,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
 
         $predicates = $this->readAttribute($where, 'predicates');
         $this->assertEquals('AND', $predicates[0][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
 
         $this->assertEquals('AND', $predicates[1][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[1][1]);
@@ -74,7 +74,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Operator', $predicates[2][1]);
 
         $this->assertEquals('OR', $predicates[3][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[3][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[3][1]);
 
         $this->assertEquals('AND', $predicates[4][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\IsNull', $predicates[4][1]);

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -65,7 +65,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
 
         $predicates = $this->readAttribute($where, 'predicates');
         $this->assertEquals('AND', $predicates[0][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
 
         $this->assertEquals('AND', $predicates[1][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[1][1]);

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -65,7 +65,7 @@ class DeleteTest extends \PHPUnit_Framework_TestCase
 
         $predicates = $this->readAttribute($where, 'predicates');
         $this->assertEquals('AND', $predicates[0][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
 
         $this->assertEquals('AND', $predicates[1][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[1][1]);

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Db\Sql;
 use Zend\Db\Sql\Select;
 use Zend\Db\Sql\Expression;
 use Zend\Db\Sql\Where;
+use Zend\Db\Sql\Having;
 use Zend\Db\Sql\Predicate;
 use Zend\Db\Sql\TableIdentifier;
 use Zend\Db\Adapter\ParameterContainer;
@@ -464,6 +465,21 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select = new Select;
         $return = $select->having(array('x = ?' => 5));
         $this->assertSame($select, $return);
+
+        return $return;
+    }
+
+    /**
+     * @testdox unit test: Test having() returns same Select object (is chainable)
+     * @covers Zend\Db\Sql\Select::having
+     */
+    public function testHavingArgument1IsHavingObject()
+    {
+        $select = new Select;
+        $having = new Having();
+        $return = $select->having($having);
+        $this->assertSame($select, $return);
+        $this->assertSame($having, $select->getRawState('having'));
 
         return $return;
     }

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -87,7 +87,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
 
         $predicates = $this->readAttribute($where, 'predicates');
         $this->assertEquals('AND', $predicates[0][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
 
         $this->assertEquals('AND', $predicates[1][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[1][1]);

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -87,7 +87,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
 
         $predicates = $this->readAttribute($where, 'predicates');
         $this->assertEquals('AND', $predicates[0][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
 
         $this->assertEquals('AND', $predicates[1][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[1][1]);
@@ -96,7 +96,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Operator', $predicates[2][1]);
 
         $this->assertEquals('OR', $predicates[3][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[3][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[3][1]);
 
         $this->assertEquals('AND', $predicates[4][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\IsNull', $predicates[4][1]);

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -87,7 +87,7 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
 
         $predicates = $this->readAttribute($where, 'predicates');
         $this->assertEquals('AND', $predicates[0][0]);
-        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Literal', $predicates[0][1]);
+        $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[0][1]);
 
         $this->assertEquals('AND', $predicates[1][0]);
         $this->assertInstanceOf('Zend\Db\Sql\Predicate\Expression', $predicates[1][1]);


### PR DESCRIPTION
`Delete::where`, `Select::where`, `Select::having`, `Update::where` methods use the same functionality.
This is the copy&past pattern.
Because this PR is created.
