### PR TITLE
[ZF3] EventManager

### DIFF
--- a/library/Zend/EventManager/CallbackListener.php
+++ b/library/Zend/EventManager/CallbackListener.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\EventManager;
+
+class CallbackListener extends Listener implements CallbackListenerInterface
+{
+    /**
+     * @var callback
+     */
+    protected $callback;
+
+    /**
+     * @param $callback
+     * @param $event
+     * @param $target
+     * @param $priority
+     */
+    public function __construct($callback, $event = null, $target = null, $priority = null)
+    {
+        $this->setCallback($callback);
+
+        if (null !== $event) {
+            $this->setEventName($event);
+        }
+
+        if (null !== $target) {
+            $this->setTarget($target);
+        }
+
+        if (null !== $priority) {
+            $this->setPriority($priority);
+        }
+    }
+
+    /**
+     * @param $callback
+     */
+    public function setCallback($callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getCallback()
+    {
+        return $this->callback;
+    }
+
+    /**
+     * @param $event
+     * @return mixed
+     */
+    public function __invoke($event)
+    {
+        return call_user_func($this->callback, $event);
+    }
+}

--- a/library/Zend/EventManager/CallbackListener.php
+++ b/library/Zend/EventManager/CallbackListener.php
@@ -26,17 +26,7 @@ class CallbackListener extends Listener implements CallbackListenerInterface
     {
         $this->setCallback($callback);
 
-        if (null !== $event) {
-            $this->setEventName($event);
-        }
-
-        if (null !== $target) {
-            $this->setTarget($target);
-        }
-
-        if (null !== $priority) {
-            $this->setPriority($priority);
-        }
+        parent::__construct($event, $target, $priority);
     }
 
     /**

--- a/library/Zend/EventManager/CallbackListenerInterface.php
+++ b/library/Zend/EventManager/CallbackListenerInterface.php
@@ -9,10 +9,8 @@
 
 namespace Zend\EventManager;
 
-use ArrayAccess;
-
 /**
- * Representation of an listener
+ * Representation of a callback listener
  */
 interface CallbackListenerInterface extends ListenerInterface
 {

--- a/library/Zend/EventManager/CallbackListenerInterface.php
+++ b/library/Zend/EventManager/CallbackListenerInterface.php
@@ -9,13 +9,18 @@
 
 namespace Zend\EventManager;
 
+use ArrayAccess;
+
 /**
- * Interface for messengers
+ * Representation of an listener
  */
-interface EventManagerInterface
+interface CallbackListenerInterface extends ListenerInterface
 {
     /**
-     * @param $listener
+     * Callback used for this listener
+     *
+     * @param $callback
+     * @return void
      */
-    public function attach($listener);
+    public function setCallback($callback);
 }

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -203,7 +203,7 @@ class Event implements EventInterface
         }
 
         if ($this->callback) {
-            return (bool) ${$this->callback}($this, $listener, $response);
+            return (bool) call_user_func($this->callback, $this, $listener, $response);
         }
 
         return false;

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -20,11 +20,6 @@ use ArrayAccess;
 class Event implements EventInterface
 {
     /**
-     * Name of wildcard event name
-     */
-    const WILDCARD_NAME = '*';
-
-    /**
      * @var string Event name
      */
     protected $name = self::WILDCARD_NAME;
@@ -37,7 +32,7 @@ class Event implements EventInterface
     /**
      * @var string|object The event target
      */
-    protected $target = Listener::WILDCARD_TARGET_NAME;
+    protected $target = self::WILDCARD_NAME;
 
     /**
      * @var bool Whether or not to stop propagation
@@ -45,18 +40,14 @@ class Event implements EventInterface
     protected $stopPropagation = false;
 
     /**
-     * @var callable Is called when the event's propogation has not been stopped by the listener
+     * @var callable called when the event's propogation has not been stopped by the listener
      */
     protected $callback;
 
     /**
-     * Constructor
-     *
-     * Accept a target and its parameters.
-     *
-     * @param  string $name Event name
-     * @param  string|object $target
-     * @param  array|ArrayAccess $params
+     * @param string $name
+     * @param mixed $target
+     * @param callback $callback
      */
     public function __construct($name = null, $target = null, $callback = null)
     {
@@ -197,9 +188,9 @@ class Event implements EventInterface
 
     /**
      * Invokes listener with this event passed as its only argument.
-     * Returns true if this event's propagation has been stopped by the invoked listener.
+     * The invoke method returns true if this event's propagation has been stopped by the invoked listener.
      * Otherwise, if it exists, returns true if the callback wants to stop this event's propagation.
-     * Otherwise, return false.
+     * Otherwise, it will not stop the event's propagation and returns false.
      *
      * @param $listener
      * @return bool

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -9,8 +9,6 @@
 
 namespace Zend\EventManager;
 
-use ArrayAccess;
-
 /**
  * Representation of an event
  *
@@ -22,7 +20,7 @@ class Event implements EventInterface
     /**
      * @var string Event name
      */
-    protected $name = self::WILDCARD_NAME;
+    protected $name = self::WILDCARD;
 
     /**
      * @var array
@@ -32,7 +30,7 @@ class Event implements EventInterface
     /**
      * @var string|object The event target
      */
-    protected $target = self::WILDCARD_NAME;
+    protected $target = self::WILDCARD;
 
     /**
      * @var bool Whether or not to stop propagation
@@ -59,17 +57,32 @@ class Event implements EventInterface
             $this->setTarget($target);
         }
 
-        if (null !== $callback) {
-            $this->setCallback($callback);
+        if (null === $callback) {
+            $callback = $this->getDefaultCallback();
         }
+
+        $this->setCallback($callback);
     }
 
     /**
-     * @param Callable $callback
+     * @param $callback
+     * @return $this
      */
     public function setCallback($callback)
     {
         $this->callback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getDefaultCallback()
+    {
+        return function($event, $listener, $response) {
+            return $event->propagationIsStopped();
+        };
     }
 
     /**
@@ -91,6 +104,7 @@ class Event implements EventInterface
     public function setName($name)
     {
         $this->name = (string) $name;
+
         return $this;
     }
 
@@ -104,10 +118,13 @@ class Event implements EventInterface
 
     /**
      * @param array $listeners
+     * @return Event
      */
     public function setListeners($listeners)
     {
        $this->listeners = $listeners;
+
+       return $this;
     }
 
     /**
@@ -119,6 +136,7 @@ class Event implements EventInterface
     public function setTarget($target)
     {
         $this->target = $target;
+
         return $this;
     }
 
@@ -150,11 +168,13 @@ class Event implements EventInterface
      * Stop further event propagation
      *
      * @param  bool $flag
-     * @return void
+     * @return Event
      */
     public function stopPropagation($flag = true)
     {
         $this->stopPropagation = (bool) $flag;
+
+        return $this;
     }
 
     /**
@@ -171,10 +191,13 @@ class Event implements EventInterface
      * Determines whether this event should stop propagating (does not set $stopPropagation)
      *
      * @param $callback
+     * @return Event
      */
     public function setPropagtionCallback($callback)
     {
         $this->callback = $callback;
+
+        return $this;
     }
 
     /**
@@ -183,7 +206,6 @@ class Event implements EventInterface
     public function getEventResponses()
     {
         return $this->eventResponses;
-
     }
 
     /**
@@ -201,14 +223,6 @@ class Event implements EventInterface
 
         //$this->eventResponses[] = $response;
 
-        if ($this->stopPropagation) {
-            return true;
-        }
-
-        if ($this->callback) {
-            return (bool) call_user_func($this->callback, $this, $listener, $response);
-        }
-
-        return false;
+        return (bool) call_user_func($this->callback, $this, $listener, $response);
     }
 }

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -203,7 +203,7 @@ class Event implements EventInterface
         }
 
         if ($this->callback) {
-            return (bool) call_user_func($this->callback, $this, $listener, $response);
+            return (bool) ${$this->callback}($this, $listener, $response);
         }
 
         return false;

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -188,19 +188,6 @@ class Event implements EventInterface
     }
 
     /**
-     * Determines whether this event should stop propagating (does not set $stopPropagation)
-     *
-     * @param $callback
-     * @return Event
-     */
-    public function setPropagtionCallback($callback)
-    {
-        $this->callback = $callback;
-
-        return $this;
-    }
-
-    /**
      * @return array The responses of each listener
      */
     public function getEventResponses()
@@ -210,9 +197,6 @@ class Event implements EventInterface
 
     /**
      * Invokes listener with this event passed as its only argument.
-     * The invoke method returns true if this event's propagation has been stopped by the invoked listener.
-     * Otherwise, if it exists, returns true if the callback wants to stop this event's propagation.
-     * Otherwise, it will not stop the event's propagation and returns false.
      *
      * @param $listener
      * @return bool
@@ -223,6 +207,10 @@ class Event implements EventInterface
 
         //$this->eventResponses[] = $response;
 
-        return (bool) call_user_func($this->callback, $this, $listener, $response);
+        if (!$this->callback) {
+            return false;
+        }
+
+        return call_user_func($this->callback, $this, $listener, $response);
     }
 }

--- a/library/Zend/EventManager/Event.php
+++ b/library/Zend/EventManager/Event.php
@@ -144,6 +144,18 @@ class Event implements EventInterface
     }
 
     /**
+     * @return array
+     */
+    public function getTargets()
+    {
+        if (is_array($this->target)) {
+            return $this->target;
+        }
+
+        return [$this->target];
+    }
+
+    /**
      * Stop further event propagation
      *
      * @param  bool $flag

--- a/library/Zend/EventManager/EventInterface.php
+++ b/library/Zend/EventManager/EventInterface.php
@@ -17,6 +17,11 @@ use ArrayAccess;
 interface EventInterface
 {
     /**
+     * Name of wildcard event name
+     */
+    const WILDCARD_NAME = '*';
+
+    /**
      * Callable used to determine if event propagation should stop
      *
      * @param $callback
@@ -67,6 +72,13 @@ interface EventInterface
      * @return void
      */
     public function setTarget($target);
+
+    /**
+     * Array of target/context from which event was triggered
+     *
+     * @return array
+     */
+    public function getTargets();
 
     /**
      * Indicate whether or not the parent EventManagerInterface should stop propagating events

--- a/library/Zend/EventManager/EventInterface.php
+++ b/library/Zend/EventManager/EventInterface.php
@@ -9,8 +9,6 @@
 
 namespace Zend\EventManager;
 
-use ArrayAccess;
-
 /**
  * Representation of an event
  */
@@ -19,12 +17,13 @@ interface EventInterface
     /**
      * Name of wildcard event name
      */
-    const WILDCARD_NAME = '*';
+    const WILDCARD = '*';
 
     /**
      * Callable used to determine if event propagation should stop
      *
      * @param $callback
+     * @return Event
      */
     public function setCallback($callback);
 
@@ -39,14 +38,14 @@ interface EventInterface
      * Set the event name
      *
      * @param  string $name
-     * @return void
+     * @return Event
      */
     public function setName($name);
 
     /**
      * Get listeners
      *
-     * @return null|string|object
+     * @return array|Traversable
      */
     public function getListeners();
 
@@ -54,7 +53,7 @@ interface EventInterface
      * Set listeners
      *
      * @param  null|string|object $target
-     * @return void
+     * @return Event
      */
     public function setListeners($listeners);
 
@@ -69,7 +68,7 @@ interface EventInterface
      * Set the event target/context
      *
      * @param  null|string|object $target
-     * @return void
+     * @return Event
      */
     public function setTarget($target);
 
@@ -84,7 +83,7 @@ interface EventInterface
      * Indicate whether or not the parent EventManagerInterface should stop propagating events
      *
      * @param  bool $flag
-     * @return void
+     * @return Event
      */
     public function stopPropagation($flag = true);
 

--- a/library/Zend/EventManager/EventInterface.php
+++ b/library/Zend/EventManager/EventInterface.php
@@ -17,34 +17,18 @@ use ArrayAccess;
 interface EventInterface
 {
     /**
+     * Callable used to determine if event propagation should stop
+     *
+     * @param $callback
+     */
+    public function setCallback($callback);
+
+    /**
      * Get event name
      *
      * @return string
      */
     public function getName();
-
-    /**
-     * Get target/context from which event was triggered
-     *
-     * @return null|string|object
-     */
-    public function getTarget();
-
-    /**
-     * Get parameters passed to the event
-     *
-     * @return array|ArrayAccess
-     */
-    public function getParams();
-
-    /**
-     * Get a single parameter by name
-     *
-     * @param  string $name
-     * @param  mixed $default Default value to return if parameter does not exist
-     * @return mixed
-     */
-    public function getParam($name, $default = null);
 
     /**
      * Set the event name
@@ -55,29 +39,34 @@ interface EventInterface
     public function setName($name);
 
     /**
+     * Get listeners
+     *
+     * @return null|string|object
+     */
+    public function getListeners();
+
+    /**
+     * Set listeners
+     *
+     * @param  null|string|object $target
+     * @return void
+     */
+    public function setListeners($listeners);
+
+    /**
+     * Get target/context from which event was triggered
+     *
+     * @return null|string|object
+     */
+    public function getTarget();
+
+    /**
      * Set the event target/context
      *
      * @param  null|string|object $target
      * @return void
      */
     public function setTarget($target);
-
-    /**
-     * Set event parameters
-     *
-     * @param  string $params
-     * @return void
-     */
-    public function setParams($params);
-
-    /**
-     * Set a single parameter by key
-     *
-     * @param  string $name
-     * @param  mixed $value
-     * @return void
-     */
-    public function setParam($name, $value);
 
     /**
      * Indicate whether or not the parent EventManagerInterface should stop propagating events
@@ -93,4 +82,12 @@ interface EventInterface
      * @return bool
      */
     public function propagationIsStopped();
+
+    /**
+     * Invokes listener
+     *
+     * @param $listener
+     * @return mixed
+     */
+    public function __invoke($listener);
 }

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -94,18 +94,7 @@ class EventManager extends Listener implements EventManagerInterface
 
         foreach($this->shared as $shared) {
             foreach($shared->getEventListeners($event) as $listener) {
-                foreach($listener->getTargets() as $lt) {
-                    if (Listener::WILDCARD === $lt) {
-                        $listeners->insert($listener, $listener->getPriority());
-                        continue;
-                    }
-                    foreach($targets as $t) {
-                        if ($t === $lt || $lt instanceof $t) {
-                            $listeners->insert($listener, $listener->getPriority());
-                            continue 2;
-                        }
-                    }
-                }
+                $listeners->insert($listener, $listener->getPriority());
             }
         }
 

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -92,7 +92,7 @@ class EventManager extends Listener implements EventManagerInterface
         foreach($this->shared as $shared) {
             foreach($shared->getEventListeners($event) as $listener) {
                 foreach($listener->getTargets() as $lt) {
-                    if ('*' === $lt) {
+                    if (Listener::WILDCARD === $lt) {
                         $listeners->insert($listener, $listener->getPriority());
                         continue;
                     }
@@ -106,7 +106,7 @@ class EventManager extends Listener implements EventManagerInterface
             }
         }
 
-        $names = '*' == $name ? [$name] : ['*', $name];
+        $names = Event::WILDCARD == $name ? [$name] : [Event::WILDCARD, $name];
 
         foreach($names as $name) {
             if (!isset($this->listeners[$name])) {
@@ -115,7 +115,7 @@ class EventManager extends Listener implements EventManagerInterface
 
             foreach($this->listeners[$name] as $listener) {
                 foreach($listener->getTargets() as $lt) {
-                    if ('*' === $lt) {
+                    if (Listener::WILDCARD === $lt) {
                         $listeners->insert($listener, $listener->getPriority());
                         continue;
                     }
@@ -141,7 +141,7 @@ class EventManager extends Listener implements EventManagerInterface
      */
     public function trigger($event)
     {
-        $event->setTarget($this->getTarget());
+        $event->setTarget($this->target);
 
         // Initial value of stop propagation flag should be false
         $event->stopPropagation(false);

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -10,7 +10,7 @@
 namespace Zend\EventManager;
 
 use Traversable;
-use SplPriorityQueue;
+use SplPriorityQueue as PriorityQueue;
 
 /**
  * Event manager: notification system
@@ -35,7 +35,9 @@ class EventManager extends Listener implements EventManagerInterface
      */
     public function __construct($target = null)
     {
-        $this->setTarget($target);
+        if (null !== $target) {
+            $this->setTarget($target);
+        }
     }
 
     /**
@@ -57,16 +59,12 @@ class EventManager extends Listener implements EventManagerInterface
             return;
         }
 
-        $event    = $listener->getEventName();
+        $event    = $listener->getEventNames();
         $priority = $listener->getPriority();
-
-        if (!is_array($event)) {
-            $event = [$event];
-        }
 
         foreach($event as $name) {
             if (!isset($this->listeners[$name])) {
-                $this->listeners[$name] = new SplPriorityQueue();
+                $this->listeners[$name] = new PriorityQueue();
             }
             $this->listeners[$name]->insert($listener, $priority);
         }
@@ -86,7 +84,7 @@ class EventManager extends Listener implements EventManagerInterface
      */
     public function getEventListeners($event)
     {
-        $listeners = new SplPriorityQueue();
+        $listeners = new PriorityQueue();
 
         $name    = $event->getName();
         $targets = $event->getTargets();

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -26,9 +26,9 @@ class EventManager extends Listener implements EventManagerInterface
     protected $listeners = [];
 
     /**
-     * @var array
+     * @var array EventManager
      */
-    protected $shared_listeners = [];
+    protected $shared = [];
 
     /**
      * @param  mixed $target
@@ -46,7 +46,7 @@ class EventManager extends Listener implements EventManagerInterface
     public function attach($listener)
     {
         if ($listener instanceof EventManagerInterface) {
-            $this->shared_listeners[] = $listener;
+            $this->shared[] = $listener;
             return;
         }
 
@@ -91,7 +91,7 @@ class EventManager extends Listener implements EventManagerInterface
         $name    = $event->getName();
         $targets = $event->getTargets();
 
-        foreach($this->shared_listeners as $shared) {
+        foreach($this->shared as $shared) {
             foreach($shared->getEventListeners($event) as $listener) {
                 foreach($listener->getTargets() as $lt) {
                     if ('*' === $lt) {
@@ -143,9 +143,7 @@ class EventManager extends Listener implements EventManagerInterface
      */
     public function trigger($event)
     {
-        if ($this->target) {
-            $event->setTarget($this->getTarget());
-        }
+        $event->setTarget($this->getTarget());
 
         // Initial value of stop propagation flag should be false
         $event->stopPropagation(false);

--- a/library/Zend/EventManager/EventManagerInterface.php
+++ b/library/Zend/EventManager/EventManagerInterface.php
@@ -15,7 +15,23 @@ namespace Zend\EventManager;
 interface EventManagerInterface
 {
     /**
-     * @param $listener
+     * @param ListenerInterface $listener
      */
     public function attach($listener);
+
+    /**
+     * @param ListenerInterface $listener
+     */
+    public function detach($listener);
+
+    /**
+     * @param EventInterface $event
+     * @return array|Traversable
+     */
+    public function getEventListeners($event);
+
+    /**
+     * @param EventInterface $event
+     */
+    public function __invoke($event);
 }

--- a/library/Zend/EventManager/Listener.php
+++ b/library/Zend/EventManager/Listener.php
@@ -49,7 +49,6 @@ class Listener implements ListenerInterface
      */
     public function __construct($event = null, $target = null, $priority = null)
     {
-        var_dump($event, $target, $priority);
         if (null !== $event) {
             $this->setEventName($event);
         }

--- a/library/Zend/EventManager/Listener.php
+++ b/library/Zend/EventManager/Listener.php
@@ -30,7 +30,7 @@ class Listener implements ListenerInterface
      *
      * @var mixed
      */
-    protected $target = self::WILDCARD_NAME;
+    protected $target = self::WILDCARD;
 
     /**
      * @param $event
@@ -54,10 +54,13 @@ class Listener implements ListenerInterface
 
     /**
      * @param $name string|array
+     * @return Listener
      */
     public function setEventName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -82,10 +85,13 @@ class Listener implements ListenerInterface
 
     /**
      * @param $priority
+     * @return Listener
      */
     public function setPriority($priority)
     {
         $this->priority = $priority;
+
+        return $this;
     }
 
     /**
@@ -98,11 +104,13 @@ class Listener implements ListenerInterface
 
     /**
      * @param $target
-     * @return mixed
+     * @return Listener
      */
     public function setTarget($target)
     {
         $this->target = $target;
+
+        return $this;
     }
 
     /**

--- a/library/Zend/EventManager/Listener.php
+++ b/library/Zend/EventManager/Listener.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\EventManager;
+
+class Listener implements ListenerInterface
+{
+    /**
+     *
+     */
+    const WILDCARD_TARGET_NAME = '*';
+
+    /**
+     *
+     */
+    const DEFAULT_PRIORITY = 1;
+
+    /**
+     * Name(s) of events to listener for
+     *
+     * @var string|array
+     */
+    protected $name;
+
+    /**
+     * Priority of listener
+     *
+     * @var int
+     */
+    protected $priority = self::DEFAULT_PRIORITY;
+
+    /**
+     * Target (identifiers) of the events to listen for
+     *
+     * @var mixed
+     */
+    protected $target = self::WILDCARD_TARGET_NAME;
+
+    /**
+     * @param $event
+     * @param $target
+     * @param $priority
+     */
+    public function __construct($event = null, $target = null, $priority = null)
+    {
+        if (null !== $event) {
+            $this->setEventName($event);
+        }
+
+        if (null !== $target) {
+            $this->setTarget($target);
+        }
+
+        if (null !== $priority) {
+            $this->setPriority($priority);
+        }
+    }
+
+    /**
+     * @param $name string|array
+     */
+    public function setEventName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string|array
+     */
+    public function getEventName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param $priority
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @param $target
+     * @return mixed
+     */
+    public function setTarget($target)
+    {
+        $this->target = $target;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * @param $event
+     * @return mixed
+     */
+    public function __invoke($event)
+    {
+    }
+}

--- a/library/Zend/EventManager/Listener.php
+++ b/library/Zend/EventManager/Listener.php
@@ -49,6 +49,7 @@ class Listener implements ListenerInterface
      */
     public function __construct($event = null, $target = null, $priority = null)
     {
+        var_dump($event, $target, $priority);
         if (null !== $event) {
             $this->setEventName($event);
         }
@@ -76,6 +77,18 @@ class Listener implements ListenerInterface
     public function getEventName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return string|array
+     */
+    public function getEventNames()
+    {
+        if (is_array($this->name)) {
+            return $this->name;
+        }
+
+        return [$this->name];
     }
 
     /**
@@ -109,6 +122,18 @@ class Listener implements ListenerInterface
     public function getTarget()
     {
         return $this->target;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTargets()
+    {
+        if (is_array($this->target)) {
+            return $this->target;
+        }
+
+        return [$this->target];
     }
 
     /**

--- a/library/Zend/EventManager/Listener.php
+++ b/library/Zend/EventManager/Listener.php
@@ -12,16 +12,6 @@ namespace Zend\EventManager;
 class Listener implements ListenerInterface
 {
     /**
-     *
-     */
-    const WILDCARD_TARGET_NAME = '*';
-
-    /**
-     *
-     */
-    const DEFAULT_PRIORITY = 1;
-
-    /**
      * Name(s) of events to listener for
      *
      * @var string|array
@@ -40,7 +30,7 @@ class Listener implements ListenerInterface
      *
      * @var mixed
      */
-    protected $target = self::WILDCARD_TARGET_NAME;
+    protected $target = self::WILDCARD_NAME;
 
     /**
      * @param $event

--- a/library/Zend/EventManager/ListenerInterface.php
+++ b/library/Zend/EventManager/ListenerInterface.php
@@ -16,6 +16,15 @@ use ArrayAccess;
  */
 interface ListenerInterface
 {
+    /**
+     *
+     */
+    const WILDCARD_NAME = '*';
+
+    /**
+     *
+     */
+    const DEFAULT_PRIORITY = 1;
 
     /**
      * Name(s) of event to listener for
@@ -30,6 +39,13 @@ interface ListenerInterface
      * @return mixed
      */
     public function setEventName($name);
+
+    /**
+     * Array of name(s) of event to listener for
+     *
+     * @return array
+     */
+    public function getEventNames();
 
     /**
      * Priority of listener
@@ -58,6 +74,13 @@ interface ListenerInterface
      * @return mixed
      */
     public function setTarget($target);
+
+    /**
+     * Array of target (identifiers) to listener for
+     *
+     * @return array
+     */
+    public function getTargets();
 
     /**
      * Invokes listener with the event

--- a/library/Zend/EventManager/ListenerInterface.php
+++ b/library/Zend/EventManager/ListenerInterface.php
@@ -9,8 +9,6 @@
 
 namespace Zend\EventManager;
 
-use ArrayAccess;
-
 /**
  * Representation of an listener
  */
@@ -19,7 +17,7 @@ interface ListenerInterface
     /**
      *
      */
-    const WILDCARD_NAME = '*';
+    const WILDCARD = '*';
 
     /**
      *
@@ -36,7 +34,7 @@ interface ListenerInterface
     /**
      * Name(s) of event to listener for
      *
-     * @return mixed
+     * @return Listener
      */
     public function setEventName($name);
 
@@ -57,7 +55,7 @@ interface ListenerInterface
     /**
      * Priority of listener
      *
-     * @return mixed
+     * @return Listener
      */
     public function setPriority($priority);
 
@@ -71,7 +69,7 @@ interface ListenerInterface
     /**
      * Target (identifiers) to listener for
      *
-     * @return mixed
+     * @return Listener
      */
     public function setTarget($target);
 

--- a/library/Zend/EventManager/ListenerInterface.php
+++ b/library/Zend/EventManager/ListenerInterface.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\EventManager;
+
+use ArrayAccess;
+
+/**
+ * Representation of an listener
+ */
+interface ListenerInterface
+{
+
+    /**
+     * Name(s) of event to listener for
+     *
+     * @return mixed
+     */
+    public function getEventName();
+
+    /**
+     * Name(s) of event to listener for
+     *
+     * @return mixed
+     */
+    public function setEventName($name);
+
+    /**
+     * Priority of listener
+     *
+     * @return mixed
+     */
+    public function getPriority();
+
+    /**
+     * Priority of listener
+     *
+     * @return mixed
+     */
+    public function setPriority($priority);
+
+    /**
+     * Target (identifiers) to listener for
+     *
+     * @return mixed
+     */
+    public function getTarget();
+
+    /**
+     * Target (identifiers) to listener for
+     *
+     * @return mixed
+     */
+    public function setTarget($target);
+
+    /**
+     * Invokes listener with the event
+     *
+     * @param $event
+     * @return mixed
+     */
+    public function __invoke($event);
+}


### PR DESCRIPTION
The primary goal of this changeset is to have a unified interface between the SharedEventManager and EventManager, which can be achieved by having single argument API methods. And consequently would allow replacing the SharedEventManager with an EventManager instead.

```
$em = new Zend\EventManager\EventManager();

$em2 = new Zend\EventManager\EventManager();

$em->attach($em2)
```

Now that the EventManager is itself a Listener and implements the EventManagerInterface; when an EM is attached to another EM, instead of immediately pulling in all of the listeners from the EM it is instead internally assigned to a list of shared listeners. Conceptually this means multiple EMs can be assigned to a single EM; and when getListeners() is called on that EM it will also pull in the listeners from the EMs in its shared listeners list.

I also tried to keep the current notion of being able to assign listeners to an EM without specifying targets, and decided that if no target was specified then it should default to the wildcard target name '*'. In either case, if the EM has been set with targets these are used regardless of what targets the listener may of been configured with. Here, the term _target_ replaces _identifiers_; I switched to it because it seemed easier to grasp and also I wanted to check that object comparisons could be achieved (which may of already been possible).

All listeners implement the ListenerInterface, which contains, the event name(s), priority, target(s) and an invoke method. The CallbackListenerInterface extends the ListenerInterface by allowing a callback method to be assigned which the invoke method would call.

Since the EventManager is also a listener (basically we're only interested in the target(s) and invoke method), the EventManager's invoke method is a proxy to its trigger method. The trigger method then iterates through it listeners invoking the Event object with each listener

```
foreach($listeners as $listener) {
    if ($event($listener)) {
        break;
    }
}
```

The invoke method of the event object actually then invokes the listener

```
public function __invoke($listener)
{
    $response = $listener($this);

    //$this->eventResponses[] = $response;

    if (!$this->callback) {
        return false;
    }

    return call_user_func($this->callback, $this, $listener, $response);
}
```

This allows the event object to determine how to handle responses from the listener and how to determine if its propagation should stop. At which point the Event object is becoming more than just a container, it can also manage its own propagation (e.g how should it handle its responses).

Its my impression that having single argument API methods allows it to be a lot more flexible, in the sense it doesn't care how the single argument objects are created as long as they implement the respective interfaces. It also allows for various strategies to be used in controlling the propagation of an event, e.g. should both isPropagationStopped and the callback be true?

In this initial changeset, I've (hopefully) only been concerned with the core API methods and functionality. Other methods and functionality (e.g. get listeners by identifier) were taken out, but can be (selectively) put back.

I used the bench-evm.php by @bakura10 to get a rough comparison as to any performance improvements gained.

```
------
ZF2 master
------
Attach 10 listeners:
     time=0.000378, mem=44280

Triggers 100 events:
     time=0.000019, mem=0

Attach 10 shared listeners:
     time=0.000358, mem=22976

Triggers 100 events:
     time=0.042357, mem=24432

Total: time=0.043404, mem=1048576 

---------------------
Proposed
---------------------
Attach 10 listeners:
     time=0.000371, mem=20784

Triggers 100 events:
     time=0.018757, mem=824

Attach 10 shared listeners:
     time=0.000097, mem=8648

Triggers 100 events:
     time=0.017926, mem=304000

Total: time=0.037637, mem=786432
```

This gist has the two scripts https://gist.github.com/devosc/7532693

This is the bit of code that I was trying out

```

$em = new Zend\EventManager\EventManager();

$event = new Zend\EventManager\Event();

$listener = new Zend\EventManager\CallbackListener(
    function($e) { var_dump(__LINE__.' '.__FILE__); }, 
    'edit', 
    $event->getTarget(), 
    10
);

$listener2 = new Zend\EventManager\CallbackListener(
    function($e) { var_dump(__LINE__.' '.__FILE__); }, 
    'edit', 
    null, 
    null
);

$event->setName('edit');

$bem = new Zend\EventManager\EventManager();

$blistener = new Zend\EventManager\CallbackListener(
    function($e) { var_dump(__LINE__.' '.__FILE__); }, 
    'edit', 
    $event->getTarget(), 
    11
);

$blistener2 = new Zend\EventManager\CallbackListener(
    function($e) { var_dump(__LINE__.' '.__FILE__); }, 
    'edit', 
    null, 
    null
);

$bem->attach(array($blistener, $blistener2));

$em->attach(array($listener, $listener2, $bem));

$em->trigger($event);
```
