### PR TITLE
Hotfix/5488

### DIFF
--- a/library/Zend/Db/TableGateway/Feature/SequenceFeature.php
+++ b/library/Zend/Db/TableGateway/Feature/SequenceFeature.php
@@ -81,7 +81,7 @@ class SequenceFeature extends AbstractFeature
 
         switch ($platformName) {
             case 'Oracle':
-                $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.NEXTVAL FROM dual';
+                $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.NEXTVAL as "nextval" FROM dual';
                 break;
             case 'PostgreSQL':
                 $sql = 'SELECT NEXTVAL(\'' . $this->sequenceName . '\')';
@@ -109,7 +109,7 @@ class SequenceFeature extends AbstractFeature
 
         switch ($platformName) {
             case 'Oracle':
-                $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.CURRVAL FROM dual';
+                $sql = 'SELECT ' . $platform->quoteIdentifier($this->sequenceName) . '.CURRVAL as "currval" FROM dual';
                 break;
             case 'PostgreSQL':
                 $sql = 'SELECT CURRVAL(\'' . $this->sequenceName . '\')';


### PR DESCRIPTION
There is a hotfix for getting CURRVAL and NEXTVAL from oracle sequences.

Oracle delivers "CURRVAL" and "NEXTVAL" in capital letters but they are accessed as small letters in the result array.
