### PR TITLE
Fixed usage of imported namespace.

### DIFF
--- a/library/Zend/Stdlib/Parameters.php
+++ b/library/Zend/Stdlib/Parameters.php
@@ -26,7 +26,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
         if (null === $values) {
             $values = array();
         }
-        parent::__construct($values, ArrayObject::ARRAY_AS_PROPS);
+        parent::__construct($values, PhpArrayObject::ARRAY_AS_PROPS);
     }
 
     /**


### PR DESCRIPTION
The use statement imports \ArrayObject as PhpArrayObject so we need to use it here. In other case it will use of undefined constant.
