### PR TITLE
Specify correct return type for `Pdo\Connection::getLastGeneratedValue`

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -419,7 +419,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      * Get last generated id
      *
      * @param string $name
-     * @return int|null|false
+     * @return string|null|false
      */
     public function getLastGeneratedValue($name = null)
     {


### PR DESCRIPTION
See http://php.net/manual/en/pdo.lastinsertid.php for reference that it returns `sting` instead of `int`.

TODO: change type of `$lastInsertValue` property and `getLastInsertValue` method in `Zend/Db/TableGateway/AbstractTableGateway.php` accordingly.
