### PR TITLE
fix for #4365 - if constructor received InputFilterManager via arguments...

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -38,12 +38,12 @@ class Factory
      */
     public function __construct(InputFilterPluginManager $inputFilterManager = null)
     {
+	    $this->defaultFilterChain    = new FilterChain();
+	    $this->defaultValidatorChain = new ValidatorChain();
+
         if ($inputFilterManager) {
             $this->setInputFilterManager($inputFilterManager);
         }
-
-        $this->defaultFilterChain    = new FilterChain();
-        $this->defaultValidatorChain = new ValidatorChain();
     }
 
     /**

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -38,8 +38,8 @@ class Factory
      */
     public function __construct(InputFilterPluginManager $inputFilterManager = null)
     {
-	    $this->defaultFilterChain    = new FilterChain();
-	    $this->defaultValidatorChain = new ValidatorChain();
+        $this->defaultFilterChain    = new FilterChain();
+        $this->defaultValidatorChain = new ValidatorChain();
 
         if ($inputFilterManager) {
             $this->setInputFilterManager($inputFilterManager);


### PR DESCRIPTION
fix for #4365 - if constructor received InputFilterManager via arguments, it called setInputFilterManager. setInputFilterManager assumed default filter/validator chains were initialized if serviceLocator was present, which is not the case, as defaultFilter/Validator are not set until later in the constructor.
