### PR TITLE
Update Http.php

### DIFF
--- a/library/Zend/File/Transfer/Adapter/Http.php
+++ b/library/Zend/File/Transfer/Adapter/Http.php
@@ -410,9 +410,9 @@ class Http extends AbstractAdapter
      *
      * @return Http
      */
-    protected function prepareFiles()
+    protected function prepareFiles($files = array())
     {
-        $this->files = array();
+        $this->files = $files;
         foreach ($_FILES as $form => $content) {
             if (is_array($content['name'])) {
                 foreach ($content as $param => $file) {


### PR DESCRIPTION
Simply for the reason that within the fieltset $request->getFiles()->toArray(); comes from a messy way and we could edit the files by sending the same files correctly, or perhaps a setFile() method like, excuse my bad english

I had the same problem that is described in this link
http://stackoverflow.com/questions/18473407/zf2-form-collection-fieldset-with-files
