### PR TITLE
fix Db/Adapter/Driver/Pdo/StatementIntegrationTest.php : should still use array() syntax

### DIFF
--- a/tests/ZendTest/Db/Adapter/Driver/Pdo/StatementIntegrationTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pdo/StatementIntegrationTest.php
@@ -51,7 +51,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase
             $this->equalTo(false),
             $this->equalTo(\PDO::PARAM_BOOL)
         );
-        $this->statement->execute(['foo' => false]);
+        $this->statement->execute(array('foo' => false));
     }
 
     public function testStatementExecuteWillUsePdoStrByDefaultWhenBinding()
@@ -61,7 +61,7 @@ class StatementTest extends \PHPUnit_Framework_TestCase
             $this->equalTo('bar'),
             $this->equalTo(\PDO::PARAM_STR)
         );
-        $this->statement->execute(['foo' => 'bar']);
+        $this->statement->execute(array('foo' => 'bar'));
     }
 
 }


### PR DESCRIPTION
instead of []. ping @ralphschindler . it comes from commit https://github.com/zendframework/zf2/commit/6904db5f11d8f660d1be582ec2c278ad3445016a  in #4490 
