### PR TITLE
[SM] Fix AbstractServiceFactories with aliased services.

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -220,12 +220,13 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * @param  callable $callable
      * @param  string   $cName
      * @param  string   $rName
+     * @param  string   $oName
      * @throws Exception\ServiceNotCreatedException
      * @throws Exception\ServiceNotFoundException
      * @throws Exception\CircularDependencyFoundException
      * @return object
      */
-    protected function createServiceViaCallback($callable, $cName, $rName)
+    protected function createServiceViaCallback($callable, $cName, $rName, $oName = null)
     {
         if (is_object($callable)) {
             $factory = $callable;
@@ -242,6 +243,6 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
             $factory->setCreationOptions($this->creationOptions);
         }
 
-        return parent::createServiceViaCallback($callable, $cName, $rName);
+        return parent::createServiceViaCallback($callable, $cName, $rName, $oName);
     }
 }

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -882,12 +882,13 @@ class ServiceManager implements ServiceLocatorInterface
      * @param  callable $callable
      * @param  string   $cName
      * @param  string   $rName
+     * @param  string   $oName
      * @throws Exception\ServiceNotCreatedException
      * @throws Exception\ServiceNotFoundException
      * @throws Exception\CircularDependencyFoundException
      * @return object
      */
-    protected function createServiceViaCallback($callable, $cName, $rName)
+    protected function createServiceViaCallback($callable, $cName, $rName, $oName = null)
     {
         static $circularDependencyResolver = array();
         $depKey = spl_object_hash($this) . '-' . $cName;
@@ -899,7 +900,7 @@ class ServiceManager implements ServiceLocatorInterface
 
         try {
             $circularDependencyResolver[$depKey] = true;
-            $instance = call_user_func($callable, $this, $cName, $rName);
+            $instance = call_user_func($callable, $this, $cName, $rName, $oName);
             unset($circularDependencyResolver[$depKey]);
         } catch (Exception\ServiceNotFoundException $e) {
             unset($circularDependencyResolver[$depKey]);

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -453,7 +453,7 @@ class ServiceManager implements ServiceLocatorInterface
             list($cName, $oName) = $this->aliases[$cName];
         }
 
-        return [$cName, $oName];
+        return array($cName, $oName);
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -855,9 +855,9 @@ class ServiceManagerTest extends TestCase
         // simulate an inconsistent state of $servicemanager->aliases as it could be
         // caused by derived classes
         $cyclicAliases = array(
-            'fooalias' => array('bazalias', null),
-            'baralias' => array('fooalias', null),
-            'bazalias' => array('baralias', null)
+            'fooalias' => 'bazalias',
+            'baralias' => 'fooalias',
+            'bazalias' => 'baralias',
         );
 
         $reflection = new \ReflectionObject($this->serviceManager);

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -729,8 +729,8 @@ class ServiceManagerTest extends TestCase
         $this->serviceManager->setShareByDefault(true);
         $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAliasedAbstractFactory');
         $this->serviceManager->setAlias('some\alias','app\foo');
-        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('app\foo'));
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('some\alias'));
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('app\foo'));
         $this->assertSame($this->serviceManager->get('app\foo'), $this->serviceManager->get('some\alias'));
     }
 

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -721,6 +721,21 @@ class ServiceManagerTest extends TestCase
     }
 
     /**
+     * @covers Zend\ServiceManager\ServiceManager::get
+     */
+    public function testAbstractFactoryWithServiceAlias()
+    {
+        $this->serviceManager->setAllowOverride(true);
+        $this->serviceManager->setShareByDefault(true);
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAliasedAbstractFactory');
+        $this->serviceManager->setAlias('some\alias','app\foo');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('app\foo'));
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('some\alias'));
+        $this->assertSame($this->serviceManager->get('app\foo'), $this->serviceManager->get('some\alias'));
+    }
+
+
+    /**
      * @covers Zend\ServiceManager\ServiceManager::setService
      * @covers Zend\ServiceManager\ServiceManager::get
      * @covers Zend\ServiceManager\ServiceManager::retrieveFromPeeringManagerFirst
@@ -840,9 +855,9 @@ class ServiceManagerTest extends TestCase
         // simulate an inconsistent state of $servicemanager->aliases as it could be
         // caused by derived classes
         $cyclicAliases = array(
-            'fooalias' => 'bazalias',
-            'baralias' => 'fooalias',
-            'bazalias' => 'baralias'
+            'fooalias' => array('bazalias', null),
+            'baralias' => array('fooalias', null),
+            'bazalias' => array('baralias', null)
         );
 
         $reflection = new \ReflectionObject($this->serviceManager);

--- a/tests/ZendTest/ServiceManager/TestAsset/FooAliasedAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooAliasedAbstractFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooAliasedAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $originalName = null)
+    {
+        if ($requestedName == 'app\foo' || $originalName == 'app\foo') {
+            return true;
+        }
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $originalName = null)
+    {
+        if ($requestedName == 'app\foo' || $originalName == 'app\foo') {
+            return new Foo;
+        } else {
+            throw new ServiceNotCreatedException("I don't know how to create service $requestedName");
+        }
+    }
+}


### PR DESCRIPTION
The point of **AbstractFactories** is to delegate creation of plethora of different services to a single factory. They receive the following arguments (per interface):

``` php
interface AbstractFactoryInterface
{
    public function canCreateServiceWithName(
        ServiceLocatorInterface $serviceLocator, 
        $name, 
        $requestedName
    );
    public function createServiceWithName(
        ServiceLocatorInterface $serviceLocator, 
        $name, 
        $requestedName
    );
}
```

Those arguments are used to determine what to create and return from the factory. For example, [DoctrineModule](https://github.com/doctrine/DoctrineModule) uses an [abstract factory to construct all doctrine namepaced components](https://github.com/doctrine/DoctrineModule/blob/master/src/DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory.php#L68) by regex-parsing the name of the service. 

The problem surfaces when trying to use **Aliases on services created by abstract factory**. 
### Example

We have 3 service classes associated with service names:

| Service Name | Real class name |
| --- | --- |
| service-foo | Application\Class\Foo |
| service-bar | Application\Class\Bar |
| service-baz | Application\Class\Baz |

.. and the following abstract factory

``` php
class FooAliasedAbstractFactory implements AbstractFactoryInterface
{
    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $originalName = null)
    {
        $segments = explode('-', $requestedName);
        if ($segments[0] != 'service') {
            return false; // only
        }
        return class_exists('Application\Class\\' . $segments[1]);

    }

    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $originalName = null)
    {
        $segments = explode('-', $requestedName);
        $className = 'Application\Class\\' . $segments[1];

        return new $className();
    }
}
```

Now when we try to retrieve a service with `$sm->get()` we will receive the following arguments:

| Service Name | $name | $requestedName |
| --- | --- | --- |
| service-foo | servicefoo | service-foo |
| service-bar | servicebar | service-bar |
| service-baz | servicebaz | service-baz |
### What happens when we use aliases

Now let's add some aliases

``` php
[
    'aliases' => [
        'Alias\Foo' => 'service-foo',
        'Alias\Bar' => 'service-bar',
        'Alias\Baz' => 'service-baz'
    ]
]
```

this will result in the following parameter values:

| Service Name | $name | $requestedName |
| --- | --- | --- |
| Alias\Foo | servicefoo | Alias\Foo |
| Alias\Bar | servicebar | Alias\Bar |
| Alias\Baz | servicebaz | Alias\Baz |

The `$requestedName` now contains the name of the requested alias. This is not a bug per se, because we could use it to create branching factories on alias names, however our abstract factory will stop working.
### Solution

I've modified ServiceManager to pass `$originalName` to the abstract factory methods, so that we know the name of the original class before aliasing and canonization. 

This is one of the ways we could use this in our factory:

``` php
class FooAliasedAbstractFactory implements AbstractFactoryInterface
{
    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $originalName = null)
    {
        if($originalName !== null){
            $requestedName = $originalName;
        }

        $segments = explode('-', $requestedName);
        if ($segments[0] != 'service') {
            return false; // only handle service-*
        }
        return class_exists('Application\Class\\' . $segments[1]);

    }

    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $originalName = null)
    {
        if($originalName !== null){
            $requestedName = $originalName;
        }

        $segments = explode('-', $requestedName);
        $className = 'Application\Class\\' . $segments[1];

        return new $className();
    }
}
```

And parameter values will become:

| Service Name | $name | $requestedName | $originalName |
| --- | --- | --- | --- |
| Alias\Foo | servicefoo | Alias\Foo | service-foo |
| Alias\Bar | servicebar | Alias\Bar | service-bar |
| Alias\Baz | servicebaz | Alias\Baz | service-baz |
### What's changed

The PR is fully backward compatible. I have not modified `AbstractFactoryInterface` and the extra parameter is considered as optional for all internal SM methods. Existing factories work the same and require no changes.

We will probably deprecate name canonization in ZF3 so this will no longer be needed, however for 2.\* there is full BC and allow for smarter abstract factories while remaining fully compatible with aliasing.
