### PR TITLE
[Http] Checks and uses $config['adapter'] when current adapter is not usable

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -163,6 +163,11 @@ class Client implements Stdlib\DispatchableInterface
         // Pass configuration options to the adapter if it exists
         if ($this->adapter instanceof Client\Adapter\AdapterInterface) {
             $this->adapter->setOptions($options);
+        } elseif (isset($this->config['adapter'])) {
+            // If the adapter is not an instance of Client\Adapter\AdapterInterface
+            // check the configuration options for a specific HTTP client instance to use and set it.
+            // The ->setAdapter() method also calls ->setOptions()
+            $this->setAdapter($this->config['adapter']);
         }
 
         return $this;


### PR DESCRIPTION
I'm followind the [Authentication](http://zf2.readthedocs.org/en/latest/modules/zendservice.twitter.html#authentication) and the [Seach Methods](http://zf2.readthedocs.org/en/latest/modules/zendservice.twitter.html#search-methods) documentation for `ZendService\Twitter`.

Using the following configuration and running the `PHP` script at the bottom I get this error:

```
PHP Fatal error:  Call to a member function connect() on a non-object in /Users/me/test/vendor/zendframework/zend-http/Zend/Http/Client.php on line 1358
```

The `composer.json`:

```
{
    "require":
    {
        "zendframework/zendservice-twitter": "dev-master"
    }
}
```

Running `composer.phar update`

```
Loading composer repositories with package information
Installing dependencies (including require-dev)
  - Installing zendframework/zend-stdlib (2.2.5)
    Loading from cache

  - Installing zendframework/zend-validator (2.2.5)
    Loading from cache

  - Installing zendframework/zend-escaper (2.2.5)
    Loading from cache

  - Installing zendframework/zend-uri (2.2.5)
    Loading from cache

  - Installing zendframework/zend-math (2.2.5)
    Loading from cache

  - Installing zendframework/zend-i18n (2.2.5)
    Loading from cache

  - Installing zendframework/zend-loader (2.2.5)
    Loading from cache

  - Installing zendframework/zend-http (2.2.5)
    Loading from cache

  - Installing zendframework/zend-servicemanager (2.2.5)
    Loading from cache

  - Installing zendframework/zend-crypt (2.2.5)
    Loading from cache

  - Installing zendframework/zend-config (2.2.5)
    Loading from cache

  - Installing zendframework/zendoauth (2.0.2)
    Loading from cache

  - Installing zendframework/zend-json (2.2.5)
    Loading from cache

  - Installing zendframework/zend-feed (2.2.5)
    Loading from cache

  - Installing zendframework/zendservice-twitter (dev-master f20c772)
    Cloning f20c772e791015aef9f89411f61131465b918337

zendframework/zend-stdlib suggests installing zendframework/zend-eventmanager (To support aggregate hydrator usage)
zendframework/zend-validator suggests installing zendframework/zend-db (Zend\Db component)
zendframework/zend-validator suggests installing zendframework/zend-filter (Zend\Filter component, required by the Digits validator)
zendframework/zend-validator suggests installing zendframework/zend-resources (Translations of validator messages)
zendframework/zend-math suggests installing ircmaxell/random-lib (Fallback random byte generator for Zend\Math\Rand if OpenSSL/Mcrypt extensions are unavailable)
zendframework/zend-i18n suggests installing ext-intl (Required for most features of Zend\I18n; included in default builds of PHP)
zendframework/zend-i18n suggests installing zendframework/zend-eventmanager (You should install this package to use the events in the translator)
zendframework/zend-i18n suggests installing zendframework/zend-filter (You should install this package to use the provided filters)
zendframework/zend-i18n suggests installing zendframework/zend-view (You should install this package to use the provided view helpers)
zendframework/zend-i18n suggests installing zendframework/zend-resources (Translation resources)
zendframework/zend-servicemanager suggests installing zendframework/zend-di (Zend\Di component)
zendframework/zend-json suggests installing zendframework/zend-server (Zend\Server component)
Writing lock file
Generating autoload files
```

The `PHP` file using `ZendService\Twitter`:

```
<?php
include "vendor/autoload.php";

$config = array(
    'access_token' => array(
        'token'  => 'TWITTER_TOKEN',
        'secret' => 'TWITTER_SECRET',
    ),
    'oauth_options' => array(
        'consumerKey' => 'TWITTER_CONSUMER_KEY',
        'consumerSecret' => 'TWITTER_CONSUMER_SECRET',
    ),
    'http_client_options' => array(
        'adapter' => 'Zend\Http\Client\Adapter\Curl',
    ),
);

$twitter = new \ZendService\Twitter\Twitter($config);

$response = $twitter->search->tweets('#zf2');
$tweets = $response->statuses;
var_dump($tweets);
```
