### PR TITLE
add 'disable_html_escape' label option support to FormCollection helper

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -14,6 +14,7 @@ use Zend\Form\Element;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\Collection as CollectionElement;
 use Zend\Form\FieldsetInterface;
+use Zend\Form\LabelOptionsAwareInterface;
 use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
 
 class FormCollection extends AbstractHelper
@@ -82,7 +83,6 @@ class FormCollection extends AbstractHelper
 
         $markup           = '';
         $templateMarkup   = '';
-        $escapeHtmlHelper = $this->getEscapeHtmlHelper();
         $elementHelper    = $this->getElementHelper();
         $fieldsetHelper   = $this->getFieldsetHelper();
 
@@ -121,7 +121,16 @@ class FormCollection extends AbstractHelper
                     );
                 }
 
-                $label = $escapeHtmlHelper($label);
+                $labelOptions = array();
+
+                if ($element instanceof LabelOptionsAwareInterface) {
+                    $labelOptions = $element->getLabelOptions();
+                }
+
+                if (empty($labelOptions) || $labelOptions['disable_html_escape'] == false) {
+                    $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+                    $label = $escapeHtmlHelper($label);
+                }
 
                 $labelMarkup = sprintf('<legend>%s</legend>', $label);
             } else {

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -199,4 +199,23 @@ class FormCollectionTest extends TestCase
         $markup = $this->helper->render($collection);
         $this->assertContains(' id="some-identifier"', $markup);
     }
+
+    public function testLabelIsEscapedByDefault()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('<strong>Some label</strong>');
+        $markup = $this->helper->render($collection);
+        $this->assertRegexp('#<fieldset(.*?)><legend>&lt;strong&gt;Some label&lt;/strong&gt;<\/legend>(.*?)<\/fieldset>#', $markup);
+    }
+
+    public function testCanDisableLabelHtmlEscape()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('<strong>Some label</strong>');
+        $collection->setLabelOptions(array('disable_html_escape' => true));
+        $markup = $this->helper->render($collection);
+        $this->assertRegexp('#<fieldset(.*?)><legend><strong>Some label</strong><\/legend>(.*?)<\/fieldset>#', $markup);
+    }
 }


### PR DESCRIPTION
see #4677 for more details.

closing due to #5533 which will change how `labelOptions` will be retrieved.
