### PR TITLE
Add driver options to the Oci8 Db adapter

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Oci8/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Oci8/Connection.php
@@ -184,17 +184,18 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         $password = $findParameterValue(array('password'));
         $connectionString = $findParameterValue(array('connection_string', 'connectionstring', 'connection', 'hostname', 'instance'));
         $characterSet = $findParameterValue(array('character_set', 'charset', 'encoding'));
+        $sessionMode = $findParameterValue(array('session_mode', 'driver_options'));
 
         // connection modifiers
         $isUnique = $findParameterValue(array('unique'));
         $isPersistent = $findParameterValue(array('persistent'));
 
         if ($isUnique == true) {
-            $this->resource = oci_new_connect($username, $password, $connectionString, $characterSet);
+            $this->resource = oci_new_connect($username, $password, $connectionString, $characterSet, $sessionMode);
         } elseif ($isPersistent == true) {
-            $this->resource = oci_pconnect($username, $password, $connectionString, $characterSet);
+            $this->resource = oci_pconnect($username, $password, $connectionString, $characterSet, $sessionMode);
         } else {
-            $this->resource = oci_connect($username, $password, $connectionString, $characterSet);
+            $this->resource = oci_connect($username, $password, $connectionString, $characterSet, $sessionMode);
         }
 
         if (!$this->resource) {


### PR DESCRIPTION
For some reason the driver options support is missing from the Oci8 driver rendering it unusable for our Oracle setup.  This simple patch adds support for those options into Zend\Db.
