### PR TITLE
[Hotfix] Validator\File classes behaviour with empty value

### DIFF
--- a/library/Zend/Validator/File/Crc32.php
+++ b/library/Zend/Validator/File/Crc32.php
@@ -104,7 +104,7 @@ class Crc32 extends Hash
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/ExcludeExtension.php
+++ b/library/Zend/Validator/File/ExcludeExtension.php
@@ -59,7 +59,7 @@ class ExcludeExtension extends Extension
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/ExcludeMimeType.php
+++ b/library/Zend/Validator/File/ExcludeMimeType.php
@@ -54,7 +54,7 @@ class ExcludeMimeType extends MimeType
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_READABLE);
             return false;
         }

--- a/library/Zend/Validator/File/Extension.php
+++ b/library/Zend/Validator/File/Extension.php
@@ -195,7 +195,7 @@ class Extension extends AbstractValidator
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/FilesSize.php
+++ b/library/Zend/Validator/File/FilesSize.php
@@ -96,7 +96,7 @@ class FilesSize extends Size
         $size = $this->getSize();
         foreach ($value as $files) {
             // Is file readable ?
-            if (false === stream_resolve_include_path($files)) {
+            if (empty($files) || false === stream_resolve_include_path($files)) {
                 $this->throwError($file, self::NOT_READABLE);
                 continue;
             }

--- a/library/Zend/Validator/File/Hash.php
+++ b/library/Zend/Validator/File/Hash.php
@@ -148,7 +148,7 @@ class Hash extends AbstractValidator
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/ImageSize.php
+++ b/library/Zend/Validator/File/ImageSize.php
@@ -343,7 +343,7 @@ class ImageSize extends AbstractValidator
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_READABLE);
             return false;
         }

--- a/library/Zend/Validator/File/Md5.php
+++ b/library/Zend/Validator/File/Md5.php
@@ -104,7 +104,7 @@ class Md5 extends Hash
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/MimeType.php
+++ b/library/Zend/Validator/File/MimeType.php
@@ -368,7 +368,7 @@ class MimeType extends AbstractValidator
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(static::NOT_READABLE);
             return false;
         }

--- a/library/Zend/Validator/File/Sha1.php
+++ b/library/Zend/Validator/File/Sha1.php
@@ -104,7 +104,7 @@ class Sha1 extends Hash
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/Size.php
+++ b/library/Zend/Validator/File/Size.php
@@ -253,7 +253,7 @@ class Size extends AbstractValidator
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/UploadFile.php
+++ b/library/Zend/Validator/File/UploadFile.php
@@ -72,7 +72,7 @@ class UploadFile extends AbstractValidator
         }
         $this->setValue($filename);
 
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::FILE_NOT_FOUND);
             return false;
         }

--- a/library/Zend/Validator/File/WordCount.php
+++ b/library/Zend/Validator/File/WordCount.php
@@ -191,7 +191,7 @@ class WordCount extends AbstractValidator
         $this->setValue($filename);
 
         // Is file readable ?
-        if (false === stream_resolve_include_path($file)) {
+        if (empty($file) || false === stream_resolve_include_path($file)) {
             $this->error(self::NOT_FOUND);
             return false;
         }

--- a/tests/ZendTest/Validator/File/Crc32Test.php
+++ b/tests/ZendTest/Validator/File/Crc32Test.php
@@ -185,4 +185,23 @@ class Crc32Test extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileCrc32NotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggeringError()
+    {
+        $validator = new File\Crc32('12345');
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Crc32::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Crc32::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/Crc32Test.php
+++ b/tests/ZendTest/Validator/File/Crc32Test.php
@@ -186,9 +186,9 @@ class Crc32Test extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggeringError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
-        $validator = new File\Crc32('12345');
+        $validator = new File\Crc32();
 
         $this->assertFalse($validator->isValid(''));
         $this->assertArrayHasKey(File\Crc32::NOT_FOUND, $validator->getMessages());

--- a/tests/ZendTest/Validator/File/ExcludeExtensionTest.php
+++ b/tests/ZendTest/Validator/File/ExcludeExtensionTest.php
@@ -161,4 +161,23 @@ class ExcludeExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileExcludeExtensionNotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalse()
+    {
+        $validator = new File\ExcludeExtension('12345');
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\ExcludeExtension::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\ExcludeExtension::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/ExcludeExtensionTest.php
+++ b/tests/ZendTest/Validator/File/ExcludeExtensionTest.php
@@ -162,7 +162,7 @@ class ExcludeExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalse()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\ExcludeExtension('12345');
 

--- a/tests/ZendTest/Validator/File/ExcludeMimeTypeTest.php
+++ b/tests/ZendTest/Validator/File/ExcludeMimeTypeTest.php
@@ -130,4 +130,23 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('image/gif,text,jpg,to,zip,ti', $validator->getMimeType());
         $this->assertEquals(array('image/gif', 'text', 'jpg', 'to', 'zip', 'ti'), $validator->getMimeType(true));
     }
+
+    public function testEmptyFileArrayShouldReturnFalse()
+    {
+        $validator = new ExcludeMimeType('image/gif');
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(ExcludeMimeType::NOT_READABLE, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(ExcludeMimeType::NOT_READABLE, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/ExcludeMimeTypeTest.php
+++ b/tests/ZendTest/Validator/File/ExcludeMimeTypeTest.php
@@ -131,9 +131,9 @@ class ExcludeMimeTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('image/gif', 'text', 'jpg', 'to', 'zip', 'ti'), $validator->getMimeType(true));
     }
 
-    public function testEmptyFileArrayShouldReturnFalse()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
-        $validator = new ExcludeMimeType('image/gif');
+        $validator = new ExcludeMimeType();
 
         $this->assertFalse($validator->isValid(''));
         $this->assertArrayHasKey(ExcludeMimeType::NOT_READABLE, $validator->getMessages());

--- a/tests/ZendTest/Validator/File/ExistsTest.php
+++ b/tests/ZendTest/Validator/File/ExistsTest.php
@@ -137,4 +137,23 @@ class ExistsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileExistsDoesNotExist', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalse()
+    {
+        $validator = new File\Exists();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Exists::DOES_NOT_EXIST, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Exists::DOES_NOT_EXIST, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/ExtensionTest.php
+++ b/tests/ZendTest/Validator/File/ExtensionTest.php
@@ -165,7 +165,7 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalse()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\Extension('foo');
 

--- a/tests/ZendTest/Validator/File/ExtensionTest.php
+++ b/tests/ZendTest/Validator/File/ExtensionTest.php
@@ -164,4 +164,23 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileExtensionNotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalse()
+    {
+        $validator = new File\Extension('foo');
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Extension::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Extension::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/FilesSizeTest.php
+++ b/tests/ZendTest/Validator/File/FilesSizeTest.php
@@ -183,4 +183,23 @@ class FilesSizeTest extends \PHPUnit_Framework_TestCase
             $this->multipleOptionsDetected = true;
         }
     }
+
+    public function testEmptyFileArrayShouldReturnFalse()
+    {
+        $validator = new File\FilesSize(array('min' => 0, 'max' => 2));
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\FilesSize::NOT_READABLE, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\FilesSize::NOT_READABLE, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/FilesSizeTest.php
+++ b/tests/ZendTest/Validator/File/FilesSizeTest.php
@@ -184,7 +184,7 @@ class FilesSizeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testEmptyFileArrayShouldReturnFalse()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\FilesSize(0);
 

--- a/tests/ZendTest/Validator/File/FilesSizeTest.php
+++ b/tests/ZendTest/Validator/File/FilesSizeTest.php
@@ -186,7 +186,7 @@ class FilesSizeTest extends \PHPUnit_Framework_TestCase
 
     public function testEmptyFileArrayShouldReturnFalse()
     {
-        $validator = new File\FilesSize(array('min' => 0, 'max' => 2));
+        $validator = new File\FilesSize(0);
 
         $this->assertFalse($validator->isValid(''));
         $this->assertArrayHasKey(File\FilesSize::NOT_READABLE, $validator->getMessages());

--- a/tests/ZendTest/Validator/File/HashTest.php
+++ b/tests/ZendTest/Validator/File/HashTest.php
@@ -159,4 +159,23 @@ class HashTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileHashNotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    {
+        $validator = new File\Hash();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Hash::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Hash::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/HashTest.php
+++ b/tests/ZendTest/Validator/File/HashTest.php
@@ -160,7 +160,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\Hash();
 

--- a/tests/ZendTest/Validator/File/ImageSizeTest.php
+++ b/tests/ZendTest/Validator/File/ImageSizeTest.php
@@ -263,4 +263,23 @@ class ImageSizeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileImageSizeNotReadable', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    {
+        $validator = new File\ImageSize();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\ImageSize::NOT_READABLE, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\ImageSize::NOT_READABLE, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/ImageSizeTest.php
+++ b/tests/ZendTest/Validator/File/ImageSizeTest.php
@@ -264,7 +264,7 @@ class ImageSizeTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\ImageSize();
 

--- a/tests/ZendTest/Validator/File/Md5Test.php
+++ b/tests/ZendTest/Validator/File/Md5Test.php
@@ -199,4 +199,23 @@ class Md5Test extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileMd5NotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    {
+        $validator = new File\Md5();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Md5::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Md5::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/Md5Test.php
+++ b/tests/ZendTest/Validator/File/Md5Test.php
@@ -200,7 +200,7 @@ class Md5Test extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\Md5();
 

--- a/tests/ZendTest/Validator/File/MimeTypeTest.php
+++ b/tests/ZendTest/Validator/File/MimeTypeTest.php
@@ -221,4 +221,22 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
         $validator = new File\MimeType($files);
         $this->assertFalse($validator->getMagicFile());
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggeringFinfoWarning()
+    {
+        if (! extension_loaded('fileinfo')) {
+            $this->markTestSkipped('This PHP Version has no finfo installed');
+        }
+
+        $files = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $validator = new File\MimeType($files);
+        $this->assertFalse($validator->isValid($files));
+    }
 }

--- a/tests/ZendTest/Validator/File/MimeTypeTest.php
+++ b/tests/ZendTest/Validator/File/MimeTypeTest.php
@@ -222,7 +222,7 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($validator->getMagicFile());
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggeringFinfoWarning()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         if (! extension_loaded('fileinfo')) {
             $this->markTestSkipped('This PHP Version has no finfo installed');

--- a/tests/ZendTest/Validator/File/MimeTypeTest.php
+++ b/tests/ZendTest/Validator/File/MimeTypeTest.php
@@ -228,7 +228,11 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('This PHP Version has no finfo installed');
         }
 
-        $files = array(
+        $validator = new File\MimeType();
+
+        $this->assertFalse($validator->isValid(''));
+
+        $filesArray = array(
             'name'      => '',
             'size'      => 0,
             'tmp_name'  => '',
@@ -236,7 +240,6 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
             'type'      => '',
         );
 
-        $validator = new File\MimeType($files);
-        $this->assertFalse($validator->isValid($files));
+        $this->assertFalse($validator->isValid($filesArray));
     }
 }

--- a/tests/ZendTest/Validator/File/Sha1Test.php
+++ b/tests/ZendTest/Validator/File/Sha1Test.php
@@ -187,9 +187,9 @@ class Sha1Test extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggeringError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
-        $validator = new File\Sha1('foo');
+        $validator = new File\Sha1();
 
         $this->assertFalse($validator->isValid(''));
         $this->assertArrayHasKey(File\Sha1::NOT_FOUND, $validator->getMessages());

--- a/tests/ZendTest/Validator/File/Sha1Test.php
+++ b/tests/ZendTest/Validator/File/Sha1Test.php
@@ -186,4 +186,23 @@ class Sha1Test extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileSha1NotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggeringError()
+    {
+        $validator = new File\Sha1('foo');
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Sha1::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Sha1::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/SizeTest.php
+++ b/tests/ZendTest/Validator/File/SizeTest.php
@@ -204,7 +204,7 @@ class SizeTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\Size();
 

--- a/tests/ZendTest/Validator/File/SizeTest.php
+++ b/tests/ZendTest/Validator/File/SizeTest.php
@@ -203,4 +203,23 @@ class SizeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileSizeNotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    {
+        $validator = new File\Size();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\Size::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\Size::NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/UploadFileTest.php
+++ b/tests/ZendTest/Validator/File/UploadFileTest.php
@@ -83,4 +83,23 @@ class UploadFileTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileUploadFileErrorFileNotFound', $validator->getMessages()));
         $this->assertContains("not found", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    {
+        $validator = new File\UploadFile();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\UploadFile::FILE_NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\UploadFile::FILE_NOT_FOUND, $validator->getMessages());
+    }
 }

--- a/tests/ZendTest/Validator/File/UploadFileTest.php
+++ b/tests/ZendTest/Validator/File/UploadFileTest.php
@@ -84,7 +84,7 @@ class UploadFileTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("not found", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\UploadFile();
 

--- a/tests/ZendTest/Validator/File/WordCountTest.php
+++ b/tests/ZendTest/Validator/File/WordCountTest.php
@@ -137,7 +137,7 @@ class WordCountTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 
-    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage()
     {
         $validator = new File\WordCount();
 

--- a/tests/ZendTest/Validator/File/WordCountTest.php
+++ b/tests/ZendTest/Validator/File/WordCountTest.php
@@ -136,4 +136,23 @@ class WordCountTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileWordCountNotFound', $validator->getMessages()));
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
+
+    public function testEmptyFileArrayShouldReturnFalseRatherThanTriggerError()
+    {
+        $validator = new File\WordCount();
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertArrayHasKey(File\WordCount::NOT_FOUND, $validator->getMessages());
+
+        $filesArray = array(
+            'name'      => '',
+            'size'      => 0,
+            'tmp_name'  => '',
+            'error'     => UPLOAD_ERR_NO_FILE,
+            'type'      => '',
+        );
+
+        $this->assertFalse($validator->isValid($filesArray));
+        $this->assertArrayHasKey(File\WordCount::NOT_FOUND, $validator->getMessages());
+    }
 }


### PR DESCRIPTION
an empty `$_FILES` array would be passed to file validators under some circumstances, e.g. trying to upload a file that exceeds the php.ini `upload_max_filesize` value.

`stream_resolve_include_path()` is used in place of `file_exists()` across the whole `Validator\File` package and, while being faster, it actually returns the current working directory when called with an empty argument.

this PR prevents the subsequent inconsistent behaviour of all the validators using `stream_resolve_include_path()` when trying to validate an empty value. (triggering errors/warnings, displaying wrong failed validation message, etc)
## Done/To-do
- [x] Crc32
- [x] ExcludeExtension
- [x] ExcludeMimeType
- [x] Extension
- [x] FileSize 
- [x] Hash
- [x] ImageSize
- [x] Md5
- [x] MimeType
- [x] Size
- [x] UploadFile
- [x] WordCount
