### PR TITLE
fix for improvement/issue #5559

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -911,18 +911,26 @@ class ServiceManager implements ServiceLocatorInterface
     }
 
     /**
-     * Retrieve a keyed list of all registered services. Handy for debugging!
+     * Retrieve a list of registered services or specific
+     * service type. Handy for debugging!
      *
+     * @param  string $type Index of specific service type
      * @return array
      */
-    public function getRegisteredServices()
+    public function getRegisteredServices($type = null)
     {
-        return array(
+        $services = array(
             'invokableClasses' => array_keys($this->invokableClasses),
             'factories' => array_keys($this->factories),
-            'aliases' => array_keys($this->aliases),
+            'aliases'   => array_keys($this->aliases),
             'instances' => array_keys($this->instances),
         );
+
+        if (isset($services[$type])) {
+            return $services[$type];
+        }
+
+        return $services;
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1120,6 +1120,37 @@ class ServiceManagerTest extends TestCase
         }
     }
 
+    /**
+     * @group reg1
+     * @return \stdClass
+     */
+    public function testGetRegisteredServicesReturnsTypeContent()
+    {
+        $this->serviceManager->setService('service101', new \stdClass());
+        $this->serviceManager->setFactory('factory202', function ($sm) {
+        	return new \stdClass();
+        });
+
+        $instances = $this->serviceManager->getRegisteredServices('instances');
+        $this->assertContains('service101', $instances);
+    }
+
+    /**
+     * @group reg1
+     * @return \stdClass
+     */
+    public function testGetRegisteredServicesReturnsAll()
+    {
+        $this->serviceManager->setService('service1', new \stdClass());
+        $this->serviceManager->setFactory('factory1', function ($sm) {
+            return new \stdClass();
+        });
+
+        $services = $this->serviceManager->getRegisteredServices();
+        $this->assertArrayHasKey('factories', $services);
+        $this->assertArrayHasKey('instances', $services);
+    }
+
     public function getServiceOfVariousTypes()
     {
         return array(

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1124,7 +1124,7 @@ class ServiceManagerTest extends TestCase
     {
         $this->serviceManager->setService('service101', new \stdClass());
         $this->serviceManager->setFactory('factory202', function ($sm) {
-        	return new \stdClass();
+            return new \stdClass();
         });
 
         $instances = $this->serviceManager->getRegisteredServices('instances');

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1120,10 +1120,6 @@ class ServiceManagerTest extends TestCase
         }
     }
 
-    /**
-     * @group reg1
-     * @return \stdClass
-     */
     public function testGetRegisteredServicesReturnsTypeContent()
     {
         $this->serviceManager->setService('service101', new \stdClass());
@@ -1135,10 +1131,6 @@ class ServiceManagerTest extends TestCase
         $this->assertContains('service101', $instances);
     }
 
-    /**
-     * @group reg1
-     * @return \stdClass
-     */
     public function testGetRegisteredServicesReturnsAll()
     {
         $this->serviceManager->setService('service1', new \stdClass());


### PR DESCRIPTION
ServiceManager::getRegisteredServices()

There are occasions that you may want to see specific list of certain sm content like 'instances'. This pr makes improvements on getregisteredservices() instead of having a new method hasInstances()

this is a minor improvement and should not affect anything.
