### PR TITLE
Fixed boolean/integer BC break in Zend\Config\Writer\PhpArray

### DIFF
--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -78,8 +78,12 @@ class PhpArray extends AbstractWriter
                 }
             } elseif (is_object($value)) {
                 $arrayString .= var_export($value, true) . ",\n";
-            } else {
+            } else if (is_bool($value)) {
+                $arrayString .= ($value ? 'true' : 'false') . ",\n";
+            } elseif (is_string($value)) {
                 $arrayString .= "'" . addslashes($value) . "',\n";
+            } else {
+                $arrayString .= $value . ",\n";
             }
         }
 

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -35,7 +35,9 @@ class PhpArrayTest extends AbstractWriterTestCase
             'test' => 'foo',
             'bar' => array(0 => 'baz', 1 => 'foo'),
             'emptyArray' => array(),
-            'object' => (object) array('foo' => 'bar')
+            'object' => (object) array('foo' => 'bar'),
+            'integer' => 123,
+            'boolean' => false,
         ));
 
         $configString = $this->writer->toString($config);
@@ -52,6 +54,8 @@ class PhpArrayTest extends AbstractWriterTestCase
         $expected .= "    'object' => stdClass::__set_state(array(\n";
         $expected .= "   'foo' => 'bar',\n";
         $expected .= ")),\n";
+        $expected .= "    'integer' => 123,\n";
+        $expected .= "    'boolean' => false,\n";
         $expected .= ");\n";
 
         $this->assertEquals($expected, $configString);


### PR DESCRIPTION
I realized I accidentally broke BC with the readable format config array PR. This is a simple fix that will preserve the config value's datatype when it isn't a string.

See [PR 5259](https://github.com/zendframework/zf2/pull/5259)
