### PR TITLE
Add unsetValueOption() to the Form\Element\Select and Form\Element\MultiCheckbox

### DIFF
--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -72,6 +72,19 @@ class MultiCheckbox extends Checkbox
     }
 
     /**
+     * @param string $key
+     * @return Select
+     */
+    public function unsetValueOption($key)
+    {
+        if (isset($this->valueOptions[$key])) {
+            unset($this->valueOptions[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Set options for an element. Accepted options are:
      * - label: label to associate with the element
      * - label_attributes: attributes to use when the label is rendered

--- a/library/Zend/Form/Element/MultiCheckbox.php
+++ b/library/Zend/Form/Element/MultiCheckbox.php
@@ -73,7 +73,7 @@ class MultiCheckbox extends Checkbox
 
     /**
      * @param string $key
-     * @return Select
+     * @return self
      */
     public function unsetValueOption($key)
     {

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -85,6 +85,19 @@ class Select extends Element implements InputProviderInterface
     }
 
     /**
+     * @param string $key
+     * @return Select
+     */
+    public function unsetValueOption($key)
+    {
+        if (isset($this->valueOptions[$key])) {
+            unset($this->valueOptions[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Set options for an element. Accepted options are:
      * - label: label to associate with the element
      * - label_attributes: attributes to use when the label is rendered

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -86,7 +86,7 @@ class Select extends Element implements InputProviderInterface
 
     /**
      * @param string $key
-     * @return Select
+     * @return self
      */
     public function unsetValueOption($key)
     {

--- a/tests/ZendTest/Form/Element/MultiCheckboxTest.php
+++ b/tests/ZendTest/Form/Element/MultiCheckboxTest.php
@@ -145,4 +145,32 @@ class MultiCheckboxTest extends TestCase
         $inputSpec = $element->getInputSpecification();
         $this->assertArrayNotHasKey('validators', $inputSpec);
     }
+
+    public function testUnsetValueOption()
+    {
+        $element = new MultiCheckboxElement();
+        $element->setValueOptions(array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
+        ));
+        $element->unsetValueOption('Option 2');
+
+        $valueOptions = $element->getValueOptions();
+        $this->assertArrayNotHasKey('Option 2', $valueOptions);
+    }
+
+    public function testUnsetUndefinedValueOption()
+    {
+        $element = new MultiCheckboxElement();
+        $element->setValueOptions(array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
+        ));
+        $element->unsetValueOption('Option Undefined');
+
+        $valueOptions = $element->getValueOptions();
+        $this->assertArrayNotHasKey('Option Undefined', $valueOptions);
+    }
 }

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -207,4 +207,32 @@ class SelectTest extends TestCase
         $this->assertArrayNotHasKey('validators', $inputSpec);
     }
 
+    public function testUnsetValueOption()
+    {
+        $element = new SelectElement();
+        $element->setValueOptions(array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
+        ));
+        $element->unsetValueOption('Option 2');
+
+        $valueOptions = $element->getValueOptions();
+        $this->assertArrayNotHasKey('Option 2', $valueOptions);
+    }
+
+    public function testUnsetUndefinedValueOption()
+    {
+        $element = new SelectElement();
+        $element->setValueOptions(array(
+            'Option 1' => 'option1',
+            'Option 2' => 'option2',
+            'Option 3' => 'option3',
+        ));
+        $element->unsetValueOption('Option Undefined');
+
+        $valueOptions = $element->getValueOptions();
+        $this->assertArrayNotHasKey('Option Undefined', $valueOptions);
+    }
+
 }


### PR DESCRIPTION
It could be nice to have such a method to remove a value option from a form element in runtime.

Instead of this in the user land:

```
$valueOptions = $element->getValueOptions();
if (isset($valueOptions['something'])) {
    unset($valueOptions['something']);
    $element->setValueOptions($valueOptions);
}
```

just this:

```
$element->unsetValueOption('something');
```
