### PR TITLE
Fix graphme_substr for PHP >= 5.4.18 or >=5.5.1

### DIFF
--- a/library/Zend/Stdlib/StringWrapper/Intl.php
+++ b/library/Zend/Stdlib/StringWrapper/Intl.php
@@ -65,7 +65,12 @@ class Intl extends AbstractStringWrapper
      */
     public function substr($str, $offset = 0, $length = null)
     {
-        return grapheme_substr($str, $offset, $length);
+        // Due fix of PHP #62759 The third argument returns an empty string if is 0 or null.
+        if ($length) {
+            return grapheme_substr($str, $offset, $length);
+        }
+
+        return grapheme_substr($str, $offset);
     }
 
     /**

--- a/library/Zend/Stdlib/StringWrapper/Intl.php
+++ b/library/Zend/Stdlib/StringWrapper/Intl.php
@@ -66,7 +66,7 @@ class Intl extends AbstractStringWrapper
     public function substr($str, $offset = 0, $length = null)
     {
         // Due fix of PHP #62759 The third argument returns an empty string if is 0 or null.
-        if ($length) {
+        if ($length !== null) {
             return grapheme_substr($str, $offset, $length);
         }
 

--- a/tests/ZendTest/Validator/BarcodeTest.php
+++ b/tests/ZendTest/Validator/BarcodeTest.php
@@ -428,6 +428,10 @@ class BarcodeTest extends \PHPUnit_Framework_TestCase
      */
     public function testCODE128()
     {
+        if (!extension_loaded('iconv')) {
+            $this->markTestSkipped('Missing ext/intl');
+        }
+
         $barcode = new Barcode('code128');
         $this->assertTrue($barcode->isValid('ˆCODE128:Š'));
         $this->assertTrue($barcode->isValid('‡01231[Š'));


### PR DESCRIPTION
Due the changes introduced in the intl extension for fix #62759 now the third argument returns an empty string if is null or 0

Open issue #66219 due the new bug introduced in the previous change.

This fix the issue when `$length` argument is null but not when is `0`
