### PR TITLE
Fix for #4707 pgsql getLastGeneratedValue() Problem

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pgsql/Pgsql.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Pgsql.php
@@ -217,10 +217,11 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Get last generated value
      *
+     * @param string $name
      * @return mixed
      */
-    public function getLastGeneratedValue()
+    public function getLastGeneratedValue($name = null)
     {
-        return $this->connection->getLastGeneratedValue();
+        return $this->connection->getLastGeneratedValue($name);
     }
 }


### PR DESCRIPTION
Added the sequence name to getLastGeneratedValue() which is required for PostgreSQL
