### PR TITLE
Implemented internalRemoveItems for Zend\Cache\Storage\Adapter\Redis

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -335,9 +335,16 @@ class Redis extends AbstractAdapter implements
         }
 
         $redis = $this->getRedisResource();
-        $nrOfKeysRemoved = $redis->delete($normalizedKeys);
 
         $failedKeys = array();
+        foreach ($normalizedKeys as $index => & $normalizedKey) {
+            if (!$redis->exists($normalizedKey)) {
+                unset($normalizedKeys[$index]);
+                $failedKeys[] = $normalizedKey;
+            }
+        }
+
+        $nrOfKeysRemoved = $redis->delete($normalizedKeys);
         if ($nrOfKeysRemoved != count($normalizedKeys)) {
             foreach ($normalizedKeys as $normalizedKey) {
                 if ($redis->exists($normalizedKey)) {


### PR DESCRIPTION
I have implemented internalRemoveItems for the redis cache adapte which gives much better performance when removing multiple keys at once.

This is my first contribution to the zend framework, so please be patient if i did anything wrong.
