### PR TITLE
Update AbstractStandalone.php

### DIFF
--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -171,10 +171,10 @@ abstract class AbstractStandalone extends AbstractHelper implements
         ) {
             $enc     = $this->getView()->getEncoding();
             $escaper = $this->getView()->plugin('escapeHtml');
-            return $escaper((string) $string);
+            return ( ($this->autoEscape) ? $escaper((string) $string) : $string);
         }
 
-        return $this->getEscaper()->escapeHtml((string) $string);
+        return ( ($this->autoEscape) ? $this->getEscaper()->escapeHtml((string) $string) : $string);
     }
 
     /**


### PR DESCRIPTION
The autoEscape (boolean) value is never used. Every string is escaped. Now strings arent escaped if you set autoEscape to false.
