### PR TITLE
Changed the default cost of bcrypt to 10

### DIFF
--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -22,8 +22,12 @@ class Bcrypt implements PasswordInterface
 
     /**
      * @var string
+     *
+     * Changed from 14 to 10 to prevent possibile DOS attacks
+     * due to the high computational time
+     * @see http://timoh6.github.io/2013/11/26/Aggressive-password-stretching.html
      */
-    protected $cost = '14';
+    protected $cost = '10';
 
     /**
      * @var string

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -37,7 +37,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         } else {
             $this->prefix = '$2a$';
         }
-        $this->bcryptPassword = $this->prefix . '14$MTIzNDU2Nzg5MDEyMzQ1NeWUUefVlefsTbFhsbqKFv/vPSZBrSFVm';
+        $this->bcryptPassword = $this->prefix . '10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y';
     }
 
     public function testConstructByOptions()
@@ -140,7 +140,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         $this->bcrypt->setSalt($this->salt);
 
         if (version_compare(PHP_VERSION, '5.3.7') >= 0) {
-            $this->assertEquals('$2y$14$MTIzNDU2Nzg5MDEyMzQ1NexAbOIUHkG6Ra.TK9QxHOVUhDxOe4dkW',
+            $this->assertEquals('$2y$10$MTIzNDU2Nzg5MDEyMzQ1NemFdU/4JOrNpxMym09Mbp0m4hKTgfQo.',
                                 $this->bcrypt->create($password));
         } else {
             $this->setExpectedException('Zend\Crypt\Password\Exception\RuntimeException',


### PR DESCRIPTION
I changed the default cost of bcrypt to 10 according to prevent potential DOS attacks due to the high computational time of the previous cost value of 14. The security is not compromised with a value of 10, that is the same default value used by  password_hash()  of PHP 5.5.
See this article for more info about potential DOS attacks on bcrypt: http://timoh6.github.io/2013/11/26/Aggressive-password-stretching.html
