### PR TITLE
More lenient db detection in Logger abstract factory

### DIFF
--- a/library/Zend/Log/LoggerAbstractServiceFactory.php
+++ b/library/Zend/Log/LoggerAbstractServiceFactory.php
@@ -95,17 +95,9 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         foreach ($config['writers'] as $index => $writerConfig) {
-            if (!isset($writerConfig['name'])
-                || strtolower($writerConfig['name']) != 'db'
+            if (!isset($writerConfig['options']['db'])
+                || !is_string($writerConfig['options']['db'])
             ) {
-                continue;
-            }
-            if (!isset($writerConfig['options'])
-                || !isset($writerConfig['options']['db'])
-            ) {
-                continue;
-            }
-            if (!is_string($writerConfig['options']['db'])) {
                 continue;
             }
             if (!$services->has($writerConfig['options']['db'])) {


### PR DESCRIPTION
The fix for #5254 was too strict in that it checked for a very specific writer _name_, when it should only be checking the "db" options key. This PR modifies the behavior of the logger abstract factory to do that.
