### PR TITLE
fix for #4614 breaks error handler using Zend\Log

### DIFF
--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -84,7 +84,6 @@ class Base implements FormatterInterface
             $jsonFlags |= defined('JSON_UNESCAPED_UNICODE') ? JSON_UNESCAPED_UNICODE : 0;
         }
 
-        ErrorHandler::start();
         if ($value instanceof DateTime) {
             $value = $value->format($this->getDateTimeFormat());
         } elseif ($value instanceof Traversable) {
@@ -98,7 +97,6 @@ class Base implements FormatterInterface
         } elseif (!is_object($value)) {
             $value = gettype($value);
         }
-        ErrorHandler::stop();
 
         return (string) $value;
     }

--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -83,14 +83,19 @@ class Base implements FormatterInterface
             $jsonFlags |= defined('JSON_UNESCAPED_UNICODE') ? JSON_UNESCAPED_UNICODE : 0;
         }
 
+        // Error suppression is used in several of these cases as a fix for each of
+        // #5383 and #4616. Without it, #4616 fails whenever recursion occurs during
+        // json_encode() operations; usage of a dedicated error handler callback
+        // causes #5383 to fail when the Logger is being used as an error handler.
+        // The only viable solution here is error suppression, ugly as it may be.
         if ($value instanceof DateTime) {
             $value = $value->format($this->getDateTimeFormat());
         } elseif ($value instanceof Traversable) {
-            $value = json_encode(iterator_to_array($value), $jsonFlags);
+            $value = @json_encode(iterator_to_array($value), $jsonFlags);
         } elseif (is_array($value)) {
-            $value = json_encode($value, $jsonFlags);
+            $value = @json_encode($value, $jsonFlags);
         } elseif (is_object($value) && !method_exists($value, '__toString')) {
-            $value = sprintf('object(%s) %s', get_class($value), json_encode($value));
+            $value = sprintf('object(%s) %s', get_class($value), @json_encode($value));
         } elseif (is_resource($value)) {
             $value = sprintf('resource(%s)', get_resource_type($value));
         } elseif (!is_object($value)) {

--- a/library/Zend/Log/Formatter/Base.php
+++ b/library/Zend/Log/Formatter/Base.php
@@ -11,7 +11,6 @@ namespace Zend\Log\Formatter;
 
 use DateTime;
 use Traversable;
-use Zend\Stdlib\ErrorHandler;
 
 class Base implements FormatterInterface
 {

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -14,6 +14,7 @@ use ErrorException;
 use Zend\Log\Logger;
 use Zend\Log\Processor\Backtrace;
 use Zend\Log\Writer\Mock as MockWriter;
+use Zend\Log\Writer\Stream as StreamWriter;
 use Zend\Log\Filter\Mock as MockFilter;
 use Zend\Stdlib\SplPriorityQueue;
 use Zend\Validator\Digits as DigitsFilter;
@@ -384,5 +385,27 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Zend\Log\Logger', $logger->info('Hi', array('extra' => '')));
         fclose($stream);
+    }
+
+    public function testErrorHandlerWithStreamWriter()
+    {
+        $options = array(
+                         'errorhandler' => true,
+                   );
+        $logger = new Logger($options);
+        $stream = fopen('php://memory', 'w+');
+        $streamWriter = new StreamWriter($stream);
+        // error handler does not like this feature so turn it off
+        $streamWriter->setConvertWriteErrorsToExceptions(false);
+        $logger->addWriter($streamWriter);
+
+        // we raise two notices - both should be logged
+        echo $test;
+        echo $second;
+
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        $this->assertContains('test', $contents);
+        $this->assertContains('second', $contents);
     }
 }

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -387,14 +387,16 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         fclose($stream);
     }
 
+    /**
+     * @group 5383
+     */
     public function testErrorHandlerWithStreamWriter()
     {
-        $options = array(
-                         'errorhandler' => true,
-                   );
-        $logger = new Logger($options);
-        $stream = fopen('php://memory', 'w+');
+        $options      = array('errorhandler' => true);
+        $logger       = new Logger($options);
+        $stream       = fopen('php://memory', 'w+');
         $streamWriter = new StreamWriter($stream);
+
         // error handler does not like this feature so turn it off
         $streamWriter->setConvertWriteErrorsToExceptions(false);
         $logger->addWriter($streamWriter);


### PR DESCRIPTION
In #4616 problem was reintroduced with calling Zend\Stdlib\ErroHandler::start/stop() one level deeper than it was removed from in #2330 - when we tried to use default Zend\Log\Logger::registerErrorHandler() it only logs first php error.
We are using LogWriterStream and after some testing and searching even with $stream_writer->setConvertWriteErrorsToExceptions(false); but tracking showed, that another calls to Zend\Stdlib\ErrorHandler occurs in formatter which was added later.
