### PR TITLE
Debugging Travis Segfaults

### DIFF
--- a/tests/ZendTest/Soap/Client/DotNetTest.php
+++ b/tests/ZendTest/Soap/Client/DotNetTest.php
@@ -92,6 +92,10 @@ class DotNetTest extends PHPUnit_Framework_TestCase
      */
     public function testDefaultSoapClientRequestIsDoneWhenNotUsingNtlmAuthentication()
     {
+        if (version_compare(phpversion(), '5.5.6', '=')) {
+            $this->markTestSkipped('This test is incompatible with PHP 5.5.6 only, causes segfault.');
+        }
+
         $soapClient = $this->getMock('Zend\Soap\Client\Common',
                                      array('_doRequest'),
                                      array(array($this->client, '_doRequest'),

--- a/tests/ZendTest/Soap/Client/DotNetTest.php
+++ b/tests/ZendTest/Soap/Client/DotNetTest.php
@@ -92,8 +92,8 @@ class DotNetTest extends PHPUnit_Framework_TestCase
      */
     public function testDefaultSoapClientRequestIsDoneWhenNotUsingNtlmAuthentication()
     {
-        if (version_compare(phpversion(), '5.5.6', '=')) {
-            $this->markTestSkipped('This test is incompatible with PHP 5.5.6 only, causes segfault.');
+        if (version_compare(phpversion(), '5.5.6', '=') || version_compare(phpversion(), '5.5.7', '=')) {
+            $this->markTestSkipped('This test is incompatible with PHP 5.5.6-7 only, causes segfault.');
         }
 
         $soapClient = $this->getMock('Zend\Soap\Client\Common',


### PR DESCRIPTION
There is a problem in ext/soap that was introduced in 5.5.6 and is now fixed, but won't be available until 5.5.8.  This PR will skip the test producing the segfaults with SOAP.
