### PR TITLE
ViewHelper Cleanup

### DIFF
--- a/library/Zend/View/Helper/AbstractHelper.php
+++ b/library/Zend/View/Helper/AbstractHelper.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-use Zend\View\Helper\HelperInterface;
 use Zend\View\Renderer\RendererInterface as Renderer;
 
 abstract class AbstractHelper implements HelperInterface

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -12,8 +12,6 @@ namespace Zend\View\Helper;
 use Zend\Mvc\Controller\Plugin\FlashMessenger as PluginFlashMessenger;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\View\Helper\AbstractHelper;
-use Zend\View\Helper\EscapeHtml;
 use Zend\I18n\View\Helper\AbstractTranslatorHelper;
 
 /**

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -169,7 +169,6 @@ abstract class AbstractStandalone extends AbstractHelper implements
         if ($this->getView() instanceof RendererInterface
             && method_exists($this->getView(), 'getEncoding')
         ) {
-            $enc     = $this->getView()->getEncoding();
             $escaper = $this->getView()->plugin('escapeHtml');
             return $escaper((string) $string);
         }

--- a/library/Zend/View/View.php
+++ b/library/Zend/View/View.php
@@ -182,7 +182,7 @@ class View implements EventManagerAwareInterface
         }
 
         $event->setRenderer($renderer);
-        $results = $events->trigger(ViewEvent::EVENT_RENDERER_POST, $event);
+        $events->trigger(ViewEvent::EVENT_RENDERER_POST, $event);
 
         // If EVENT_RENDERER or EVENT_RENDERER_POST changed the model, make sure
         // we use this new model instead of the current $model


### PR DESCRIPTION
unused variables removed
unnecessary namespaces removed

@samsonasik pointed out - fix now in a separated branch
