### PR TITLE
Fixed session_cache_limiter available options

### DIFF
--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -42,6 +42,7 @@ class SessionConfig extends StandardConfig
      * @var array Valid cache limiters (per session.cache_limiter)
      */
     protected $validCacheLimiters = array(
+        '',
         'nocache',
         'public',
         'private',
@@ -65,8 +66,8 @@ class SessionConfig extends StandardConfig
     /**
      * Set storage option in backend configuration store
      *
-     * @param  string $storageName
-     * @param  mixed $storageValue
+     * @param  string                             $storageName
+     * @param  mixed                              $storageValue
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -90,6 +91,7 @@ class SessionConfig extends StandardConfig
             throw new Exception\InvalidArgumentException("'" . $key .
                     "' is not a valid sessions-related ini setting.");
         }
+
         return $this;
     }
 
@@ -124,7 +126,7 @@ class SessionConfig extends StandardConfig
     /**
      * Set session.save_handler
      *
-     * @param  string $phpSaveHandler
+     * @param  string                             $phpSaveHandler
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -141,13 +143,14 @@ class SessionConfig extends StandardConfig
         }
 
         $this->setOption('save_handler', $phpSaveHandler);
+
         return $this;
     }
 
     /**
      * Set session.save_path
      *
-     * @param  string $savePath
+     * @param  string                             $savePath
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException on invalid path
      */
@@ -158,14 +161,14 @@ class SessionConfig extends StandardConfig
         }
         $this->savePath = $savePath;
         $this->setOption('save_path', $savePath);
+
         return $this;
     }
-
 
     /**
      * Set session.serialize_handler
      *
-     * @param  string $serializeHandler
+     * @param  string                             $serializeHandler
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -181,6 +184,7 @@ class SessionConfig extends StandardConfig
         }
 
         $this->serializeHandler = (string) $serializeHandler;
+
         return $this;
     }
 
@@ -201,13 +205,14 @@ class SessionConfig extends StandardConfig
         }
         $this->setOption('cache_limiter', $cacheLimiter);
         ini_set('session.cache_limiter', $cacheLimiter);
+
         return $this;
     }
 
     /**
      * Set session.hash_function
      *
-     * @param  string|int $hashFunction
+     * @param  string|int                         $hashFunction
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -221,13 +226,14 @@ class SessionConfig extends StandardConfig
 
         $this->setOption('hash_function', $hashFunction);
         ini_set('session.hash_function', $hashFunction);
+
         return $this;
     }
 
     /**
      * Set session.hash_bits_per_character
      *
-     * @param  int $hashBitsPerCharacter
+     * @param  int                                $hashBitsPerCharacter
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -242,6 +248,7 @@ class SessionConfig extends StandardConfig
         $hashBitsPerCharacter = (int) $hashBitsPerCharacter;
         $this->setOption('hash_bits_per_character', $hashBitsPerCharacter);
         ini_set('session.hash_bits_per_character', $hashBitsPerCharacter);
+
         return $this;
     }
 
@@ -260,13 +267,14 @@ class SessionConfig extends StandardConfig
              */
             $this->validHashFunctions = array('0', '1') + hash_algos();
         }
+
         return $this->validHashFunctions;
     }
 
     /**
      * Handle PHP errors
      *
-     * @param  int $code
+     * @param  int    $code
      * @param  string $message
      * @return void
      */

--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -66,8 +66,8 @@ class SessionConfig extends StandardConfig
     /**
      * Set storage option in backend configuration store
      *
-     * @param  string                             $storageName
-     * @param  mixed                              $storageValue
+     * @param  string $storageName
+     * @param  mixed $storageValue
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -91,7 +91,6 @@ class SessionConfig extends StandardConfig
             throw new Exception\InvalidArgumentException("'" . $key .
                     "' is not a valid sessions-related ini setting.");
         }
-
         return $this;
     }
 
@@ -126,7 +125,7 @@ class SessionConfig extends StandardConfig
     /**
      * Set session.save_handler
      *
-     * @param  string                             $phpSaveHandler
+     * @param  string $phpSaveHandler
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -143,14 +142,13 @@ class SessionConfig extends StandardConfig
         }
 
         $this->setOption('save_handler', $phpSaveHandler);
-
         return $this;
     }
 
     /**
      * Set session.save_path
      *
-     * @param  string                             $savePath
+     * @param  string $savePath
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException on invalid path
      */
@@ -161,14 +159,14 @@ class SessionConfig extends StandardConfig
         }
         $this->savePath = $savePath;
         $this->setOption('save_path', $savePath);
-
         return $this;
     }
+
 
     /**
      * Set session.serialize_handler
      *
-     * @param  string                             $serializeHandler
+     * @param  string $serializeHandler
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -184,7 +182,6 @@ class SessionConfig extends StandardConfig
         }
 
         $this->serializeHandler = (string) $serializeHandler;
-
         return $this;
     }
 
@@ -205,14 +202,13 @@ class SessionConfig extends StandardConfig
         }
         $this->setOption('cache_limiter', $cacheLimiter);
         ini_set('session.cache_limiter', $cacheLimiter);
-
         return $this;
     }
 
     /**
      * Set session.hash_function
      *
-     * @param  string|int                         $hashFunction
+     * @param  string|int $hashFunction
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -226,14 +222,13 @@ class SessionConfig extends StandardConfig
 
         $this->setOption('hash_function', $hashFunction);
         ini_set('session.hash_function', $hashFunction);
-
         return $this;
     }
 
     /**
      * Set session.hash_bits_per_character
      *
-     * @param  int                                $hashBitsPerCharacter
+     * @param  int $hashBitsPerCharacter
      * @return SessionConfig
      * @throws Exception\InvalidArgumentException
      */
@@ -248,7 +243,6 @@ class SessionConfig extends StandardConfig
         $hashBitsPerCharacter = (int) $hashBitsPerCharacter;
         $this->setOption('hash_bits_per_character', $hashBitsPerCharacter);
         ini_set('session.hash_bits_per_character', $hashBitsPerCharacter);
-
         return $this;
     }
 
@@ -267,14 +261,13 @@ class SessionConfig extends StandardConfig
              */
             $this->validHashFunctions = array('0', '1') + hash_algos();
         }
-
         return $this->validHashFunctions;
     }
 
     /**
      * Handle PHP errors
      *
-     * @param  int    $code
+     * @param  int $code
      * @param  string $message
      * @return void
      */

--- a/tests/ZendTest/Session/Config/SessionConfigTest.php
+++ b/tests/ZendTest/Session/Config/SessionConfigTest.php
@@ -517,6 +517,7 @@ class SessionConfigTest extends \PHPUnit_Framework_TestCase
     public function cacheLimiters()
     {
         return array(
+            array(''),
             array('nocache'),
             array('public'),
             array('private'),
@@ -614,6 +615,7 @@ class SessionConfigTest extends \PHPUnit_Framework_TestCase
         foreach ($hashFunctions as $function) {
             $provider[] = array($function);
         }
+
         return $provider;
     }
 

--- a/tests/ZendTest/Session/Config/SessionConfigTest.php
+++ b/tests/ZendTest/Session/Config/SessionConfigTest.php
@@ -7,7 +7,7 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\Session;
+namespace ZendTest\Session\Config;
 
 use Zend\Session\Config\SessionConfig;
 
@@ -615,7 +615,6 @@ class SessionConfigTest extends \PHPUnit_Framework_TestCase
         foreach ($hashFunctions as $function) {
             $provider[] = array($function);
         }
-
         return $provider;
     }
 


### PR DESCRIPTION
Added empty string option for session_cache_limiter as mentionned in the php manual: "Setting the cache limiter to '' will turn off automatic sending of cache headers entirely."
- PSR2 CS fix
