### PR TITLE
Decode the raw path before preg matching

### DIFF
--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -349,8 +349,7 @@ class Segment implements RouteInterface
 
         $uri  = $request->getUri();
 
-        $rawPath = $uri->getPath();
-        $path = $this->decode($rawPath);
+        $path = $uri->getPath();
 
         $regex = $this->regex;
 
@@ -364,7 +363,7 @@ class Segment implements RouteInterface
             $locale     = (isset($options['locale']) ? $options['locale'] : null);
 
             foreach ($this->translationKeys as $key) {
-                $regex = str_replace('#' . $key . '#', $translator->translate($key, $textDomain, $locale), $regex);
+                $regex = str_replace('#' . $key . '#', $this->encode($translator->translate($key, $textDomain, $locale)), $regex);
             }
         }
 

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -348,7 +348,9 @@ class Segment implements RouteInterface
         }
 
         $uri  = $request->getUri();
-        $path = $uri->getPath();
+
+        $rawPath = $uri->getPath();
+        $path = $this->decode($rawPath);
 
         $regex = $this->regex;
 


### PR DESCRIPTION
Decode the raw path before preg matching to enable the use of translation on segments into languages with special characters.

For example:
'router' => array(
        'router_class' => 'Zend\Mvc\Router\Http\TranslatorAwareTreeRouteStack',
....
                    'route' => '/{category}/:category',
....

with the following in the ja_JP.php language file:
'category' => 'カテゴリー',

would now enable you to use fully translated urls:
http://example.org/カテゴリー/花

This fails currently because the route tries to match against an url encoded value of the japanese word for category.
