### PR TITLE
Allow RuntimeDefinition to still process explicit classes

### DIFF
--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -90,7 +90,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function forceLoadClass($class)
     {
-        $this->processClass($class);
+        $this->processClass($class, true);
     }
 
     /**
@@ -118,10 +118,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function getClassSupertypes($class)
     {
-        if (!array_key_exists($class, $this->classes)) {
-            $this->processClass($class);
-        }
-
+        $this->processClass($class);
         return $this->classes[$class]['supertypes'];
     }
 
@@ -130,10 +127,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function getInstantiator($class)
     {
-        if (!array_key_exists($class, $this->classes)) {
-            $this->processClass($class);
-        }
-
+        $this->processClass($class);
         return $this->classes[$class]['instantiator'];
     }
 
@@ -142,10 +136,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function hasMethods($class)
     {
-        if (!array_key_exists($class, $this->classes)) {
-            $this->processClass($class);
-        }
-
+        $this->processClass($class);
         return (count($this->classes[$class]['methods']) > 0);
     }
 
@@ -154,10 +145,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function hasMethod($class, $method)
     {
-        if (!array_key_exists($class, $this->classes)) {
-            $this->processClass($class);
-        }
-
+        $this->processClass($class);
         return isset($this->classes[$class]['methods'][$method]);
     }
 
@@ -166,10 +154,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function getMethods($class)
     {
-        if (!array_key_exists($class, $this->classes)) {
-            $this->processClass($class);
-        }
-
+        $this->processClass($class);
         return $this->classes[$class]['methods'];
     }
 
@@ -178,10 +163,7 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function hasMethodParameters($class, $method)
     {
-        if (!isset($this->classes[$class])) {
-            return false;
-        }
-
+        $this->processClass($class);
         return (array_key_exists($method, $this->classes[$class]['parameters']));
     }
 
@@ -190,18 +172,27 @@ class RuntimeDefinition implements DefinitionInterface
      */
     public function getMethodParameters($class, $method)
     {
-        if (!is_array($this->classes[$class])) {
-            $this->processClass($class);
-        }
-
+        $this->processClass($class);
         return $this->classes[$class]['parameters'][$method];
     }
 
     /**
      * @param string $class
      */
-    protected function processClass($class)
+    protected function hasProcessedClass($class)
     {
+        return array_key_exists($class, $this->classes) && is_array($this->classes[$class]);
+    }
+
+    /**
+     * @param string $class
+     * @param bool $forceLoad
+     */
+    protected function processClass($class, $forceLoad = false)
+    {
+        if (!$forceLoad && $this->hasProcessedClass($class)) {
+            return;
+        }
         $strategy = $this->introspectionStrategy; // localize for readability
 
         /** @var $rClass \Zend\Code\Reflection\ClassReflection */

--- a/tests/ZendTest/Di/Definition/RuntimeDefinitionTest.php
+++ b/tests/ZendTest/Di/Definition/RuntimeDefinitionTest.php
@@ -102,4 +102,17 @@ class RuntimeDefinitionTest extends TestCase
         $this->assertTrue($definition->hasMethod('ZendTest\Di\TestAsset\AwareClasses\B', 'setSomething'));
         $this->assertFalse($definition->hasMethod('ZendTest\Di\TestAsset\AwareClasses\B', 'getSomething'));
     }
+
+    /**
+     * Test to see if we can introspect explicit classes
+     */
+    public function testExplicitClassesStillGetProccessedByIntrospectionStrategy()
+    {
+        $className = 'ZendTest\Di\TestAsset\ConstructorInjection\OptionalParameters';
+        $explicitClasses = array($className => true);
+        $definition = new RuntimeDefinition(null, $explicitClasses);
+
+        $this->assertTrue($definition->hasClass($className));
+        $this->assertSame(array("__construct"=> 3), $definition->getMethods($className));
+    }
 }


### PR DESCRIPTION
Prior to this commit, explicit classes passed to a Di RuntimeDefinition would not be processed as they already existed in the classes array. This behaviour doesn't match [the documentation](http://framework.zend.com/manual/2.2/en/modules/zend.di.definitions.html#runtimedefinition), which suggests that defining explicit classes provides functionality to apply different introspection strategies to different sets of classes. As we'd like the documented behaviour, I'm in favour of fixing the implementation rather than the documentation. Without the fix, defining explicitClasses seems to offer the same behaviour as an ArrayDefinition. This commit adds tests to demonstrate the problem and changes to implement the desired behaviour.

It also consolidates the check to see if a class has already been processed at the cost of adding a flag to processClass.
