### PR TITLE
Http\Headers undefined index when calling ::fromString(' content-type: text/plain')

### DIFF
--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -59,7 +59,7 @@ class Headers implements Countable, Iterator
         foreach (explode("\r\n", $string) as $line) {
 
             // check if a header name is present
-            if (preg_match('/^(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
+            if (preg_match('/^\s*(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
                 if ($current) {
                     // a header name was present, then store the current complete line
                     $headers->headersKeys[] = static::createKey($current['name']);
@@ -70,15 +70,23 @@ class Headers implements Countable, Iterator
                     'line' => trim($line)
                 );
             } elseif (preg_match('/^\s+.*$/', $line, $matches)) {
-                // continuation: append to current line
-                $current['line'] .= trim($line);
+                if ($current) {
+                    // continuation: append to current line
+                    $current['line'] .= trim($line);
+                } else {
+                    // Line does not match header format!
+                    throw new Exception\RuntimeException(sprintf(
+                        'Line "%s" does not match header format!',
+                        $line
+                    ));
+                }
             } elseif (preg_match('/^\s*$/', $line)) {
                 // empty line indicates end of headers
                 break;
             } else {
                 // Line does not match header format!
                 throw new Exception\RuntimeException(sprintf(
-                    'Line "%s"does not match header format!',
+                    'Line "%s" does not match header format!',
                     $line
                 ));
             }

--- a/tests/ZendTest/Http/HeadersTest.php
+++ b/tests/ZendTest/Http/HeadersTest.php
@@ -38,9 +38,31 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo-bar', $header->getFieldValue());
     }
 
+    public function testHeadersFromStringFactoryCreateSingleObjectWithLeadingWhitespaces()
+    {
+        $headers = Headers::fromString("   Fake: foo-bar");
+        $this->assertEquals(1, $headers->count());
+
+        $header = $headers->get('fake');
+        $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $header);
+        $this->assertEquals('Fake', $header->getFieldName());
+        $this->assertEquals('foo-bar', $header->getFieldValue());
+    }
+
     public function testHeadersFromStringFactoryCreatesSingleObjectWithContinuationLine()
     {
         $headers = Headers::fromString("Fake: foo-bar,\r\n      blah-blah");
+        $this->assertEquals(1, $headers->count());
+
+        $header = $headers->get('fake');
+        $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $header);
+        $this->assertEquals('Fake', $header->getFieldName());
+        $this->assertEquals('foo-bar,blah-blah', $header->getFieldValue());
+    }
+
+    public function testHeadersFromStringFactoryCreatesSingleObjectWithContinuationLineAndLeadingWhitespaces()
+    {
+        $headers = Headers::fromString("   Fake: foo-bar,\r\n      blah-blah");
         $this->assertEquals(1, $headers->count());
 
         $header = $headers->get('fake');
@@ -60,15 +82,48 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo-bar', $header->getFieldValue());
     }
 
+    public function testHeadersFromStringFactoryCreatesSingleObjectWithHeaderBreakLineAndLeadingWhitespaces()
+    {
+        $headers = Headers::fromString("   Fake: foo-bar\r\n\r\n");
+        $this->assertEquals(1, $headers->count());
+
+        $header = $headers->get('fake');
+        $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $header);
+        $this->assertEquals('Fake', $header->getFieldName());
+        $this->assertEquals('foo-bar', $header->getFieldValue());
+    }
+
     public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLine()
     {
         $this->setExpectedException('Zend\Http\Exception\RuntimeException', 'does not match');
         Headers::fromString("Fake = foo-bar\r\n\r\n");
     }
 
+    public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLineAndLeadingWhitespaces()
+    {
+        $this->setExpectedException('Zend\Http\Exception\RuntimeException', 'does not match');
+        Headers::fromString("   Fake = foo-bar\r\n\r\n");
+    }
+
     public function testHeadersFromStringFactoryCreatesMultipleObjects()
     {
         $headers = Headers::fromString("Fake: foo-bar\r\nAnother-Fake: boo-baz");
+        $this->assertEquals(2, $headers->count());
+
+        $header = $headers->get('fake');
+        $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $header);
+        $this->assertEquals('Fake', $header->getFieldName());
+        $this->assertEquals('foo-bar', $header->getFieldValue());
+
+        $header = $headers->get('anotherfake');
+        $this->assertInstanceOf('Zend\Http\Header\GenericHeader', $header);
+        $this->assertEquals('Another-Fake', $header->getFieldName());
+        $this->assertEquals('boo-baz', $header->getFieldValue());
+    }
+
+    public function testHeadersFromStringFactoryCreatesMultipleObjectsWithLeadingWhitespaces()
+    {
+        $headers = Headers::fromString("   Fake: foo-bar\r\nAnother-Fake: boo-baz");
         $this->assertEquals(2, $headers->count());
 
         $header = $headers->get('fake');


### PR DESCRIPTION
Hi,

This is my first contribution, so please try to be patient with me :)
When calling:

```
$headers = Zend\Http\Headers::fromString(' content-type: text/plain');
```

we get a

PHP Notice:  Undefined index: line in /home/markus/projects/zf2/library/Zend/Http/Headers.php on line 74
PHP Notice:  Undefined index: name in /home/markus/projects/zf2/library/Zend/Http/Headers.php on line 87

Would it be an option to throw an exception?

```
diff --git a/library/Zend/Http/Headers.php b/library/Zend/Http/Headers.php
index 6843fe1..b3ec64b 100644
--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -70,8 +70,16 @@ class Headers implements Countable, Iterator
                     'line' => trim($line)
                 );
             } elseif (preg_match('/^\s+.*$/', $line, $matches)) {
-                // continuation: append to current line
-                $current['line'] .= trim($line);
+                if ($current) {
+                    // continuation: append to current line
+                    $current['line'] .= trim($line);
+                } else {
+                    // Line does not match header format!
+                    throw new Exception\RuntimeException(sprintf(
+                        'Line "%s" does not match header format!',
+                        $line
+                    ));
+                }
             } elseif (preg_match('/^\s*$/', $line)) {
                 // empty line indicates end of headers
                 break;

```

Or maybe the first regex could match one or more whitespaces at the beginning

```
// check if a header name is present
if (preg_match('/^\s*(?P<name>[^()><@,;:\"\\/\[\]?=}{ \t]+):.*$/', $line, $matches)) {
```

Or is it totally okay to get this notices?
