### PR TITLE
make 'listeners' key can be configured outside application.config.php

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -251,11 +251,11 @@ class Application implements
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
 
-        $configurationListeners = isset($configuration['listeners']) ? $configuration['listeners'] : array();
-        $config                 = $serviceManager->get('Config');
-        $configListeners        = isset($config['listeners']) ? $config['listeners'] : array();
+        $listenersFromAppConfig     = isset($configuration['listeners']) ? $configuration['listeners'] : array();
+        $config                     = $serviceManager->get('Config');
+        $listenersFromConfigService = isset($config['listeners']) ? $config['listeners'] : array();
 
-        $listeners = array_unique(array_merge($configurationListeners, $configListeners));
+        $listeners = array_unique(array_merge($listenersFromConfigService, $listenersFromAppConfig));
 
         return $serviceManager->get('Application')->bootstrap($listeners);
     }

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -247,10 +247,13 @@ class Application implements
     public static function init($configuration = array())
     {
         $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
-        $listeners = isset($configuration['listeners']) ? $configuration['listeners'] : array();
         $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
+
+        $config    = $this->getConfig();
+        $listeners = isset($config['listeners']) ? $config['listeners'] : array();
+
         return $serviceManager->get('Application')->bootstrap($listeners);
     }
 

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -251,7 +251,7 @@ class Application implements
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
 
-        $config    = $serviceManager->get('Config');
+        $config    = array_unique(array_merge($configuration, $serviceManager->get('Config')));
         $listeners = isset($config['listeners']) ? $config['listeners'] : array();
 
         return $serviceManager->get('Application')->bootstrap($listeners);

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -251,8 +251,11 @@ class Application implements
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
 
-        $config    = array_unique(array_merge($configuration, $serviceManager->get('Config')));
-        $listeners = isset($config['listeners']) ? $config['listeners'] : array();
+        $configurationListeners = isset($configuration['listeners']) ? $configuration['listeners'] : array();
+        $config                 = $serviceManager->get('Config');
+        $configListeners        = isset($config['listeners']) ? $config['listeners'] : array();
+
+        $listeners = array_unique(array_merge($configurationListeners, $configListeners));
 
         return $serviceManager->get('Application')->bootstrap($listeners);
     }

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -251,7 +251,7 @@ class Application implements
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
 
-        $config    = $this->getConfig();
+        $config    = $serviceManager->get('Config');
         $listeners = isset($config['listeners']) ? $config['listeners'] : array();
 
         return $serviceManager->get('Application')->bootstrap($listeners);


### PR DESCRIPTION
because in ZF2 Skeleton App use : Zend\Mvc\Application::init(require 'config/application.config.php')
