### PR TITLE
Fixed issue with Math\Rand::getInteger() on ranges close to PHP_INT_MAX

### DIFF
--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -143,7 +143,7 @@ abstract class Rand
         $filter = (int) ((1 << $bits) - 1);
 
         do {
-            $rnd  = hexdec(bin2hex(self::getBytes($bytes, $strong)));
+            $rnd  = hexdec(bin2hex(static::getBytes($bytes, $strong)));
             $rnd &= $filter;
         } while ($rnd > $range);
 

--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -130,13 +130,21 @@ abstract class Rand
                 'The supplied range is too great to generate'
             );
         }
-        $log    = log($range, 2);
-        $bytes  = (int) ($log / 8) + 1;
-        $bits   = (int) $log + 1;
-        $filter = (int) (1 << $bits) - 1;
+
+        // calculate number of bits required to store range on this machine
+        $r = $range;
+        $bits = 0;
+        while ($r >>= 1) {
+            $bits++;
+        }
+
+        $bits   = (int) max($bits, 1);
+        $bytes  = (int) max(ceil($bits / 8), 1);
+        $filter = (int) ((1 << $bits) - 1);
+
         do {
-            $rnd = hexdec(bin2hex(self::getBytes($bytes, $strong)));
-            $rnd = $rnd & $filter;
+            $rnd  = hexdec(bin2hex(self::getBytes($bytes, $strong)));
+            $rnd &= $filter;
         } while ($rnd > $range);
 
         return ($min + $rnd);

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -100,12 +100,13 @@ class RandTest extends \PHPUnit_Framework_TestCase
 
     public function testIntegerRangeOverflow()
     {
-        $x = Rand::getInteger(0, PHP_INT_MAX);
-        for ($i = 0; $i < 5; $i++) {
-            $x ^= Rand::getInteger(0, PHP_INT_MAX);
+        $values = array();
+        $cycles = 100;
+        for ($i = 0; $i < $cycles; $i++) {
+            $values[$i] = Rand::getInteger(0, PHP_INT_MAX);
         }
 
-        $this->assertFalse($x === 0);
+        $this->assertFalse(array_unique($values) === 1);
     }
 
     public function testRandFloat()

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -98,6 +98,16 @@ class RandTest extends \PHPUnit_Framework_TestCase
         $rand = Rand::getInteger(100, 0);
     }
 
+    public function testIntegerRangeOverflow()
+    {
+        $x = Rand::getInteger(0, PHP_INT_MAX);
+        for ($i = 0; $i < 5; $i++) {
+            $x ^= Rand::getInteger(0, PHP_INT_MAX);
+        }
+
+        $this->assertFalse($x === 0);
+    }
+
     public function testRandFloat()
     {
         for ($length = 1; $length < 512; $length++) {


### PR DESCRIPTION
When min - max range is close or equal to `PHP_INT_MAX`  `log()` produces number of bits
equal to machine size integer. So `$filter = (int) ((1 << $bits) - 1);` evaluates to zero.
In this case `getInteger(0, PHP_INT_MAX)` returns only zeros.

PR includes correct bit calculation and test
