### PR TITLE
Prettify the output of Zend\Code\Generator\ValueGenerator for multi line arrays

### DIFF
--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -351,12 +351,8 @@ class ValueGenerator extends AbstractGenerator
                 break;
             case self::TYPE_ARRAY:
                 $output .= 'array(';
-                $curArrayMultiblock = false;
-                if (count($value) > 1) {
-                    $curArrayMultiblock = true;
-                    if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
-                        $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth + 1);
-                    }
+                if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
+                    $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth + 1);
                 }
                 $outputParts = array();
                 $noKeyIndex  = 0;
@@ -384,8 +380,8 @@ class ValueGenerator extends AbstractGenerator
                     ? self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth + 1)
                     : ' ';
                 $output .= implode(',' . $padding, $outputParts);
-                if ($curArrayMultiblock == true && $this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
-                    $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth + 1);
+                if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
+                    $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
                 $output .= ')';
                 break;

--- a/tests/ZendTest/Code/Generator/PropertyGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/PropertyGeneratorTest.php
@@ -105,7 +105,7 @@ class PropertyGeneratorTest extends \PHPUnit_Framework_TestCase
         'null' => null,
         'true' => true,
         'bar\'s' => 'bar\'s'
-        );
+    );
 EOS;
 
         $property = new PropertyGenerator('myFoo', $targetValue);

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -40,9 +40,15 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testPropertyDefaultValueCanHandleArray()
     {
+        $expectedSource = <<<EOS
+array(
+        'foo'
+    )
+EOS;
+
         $valueGenerator = new ValueGenerator();
         $valueGenerator->setValue(array('foo'));
-        $this->assertEquals('array(\'foo\')', $valueGenerator->generate());
+        $this->assertEquals($expectedSource, $valueGenerator->generate());
     }
 
     public function testPropertyDefaultValueCanHandleUnquotedString()
@@ -95,10 +101,10 @@ array(
                 'baz1',
                 'baz2',
                 'constant2' => ArrayObject::STD_PROP_LIST
-                )
-            ),
+            )
+        ),
         PHP_EOL
-        )
+    )
 EOS;
 
         $valueGenerator = new ValueGenerator();
@@ -127,7 +133,7 @@ array(
         'c',
         7 => 'd',
         3 => 'e'
-        )
+    )
 EOS;
 
         $this->assertEquals($expectedSource, $valueGenerator->generate());


### PR DESCRIPTION
This fix prettifies the output for multi line arrays generated with `Zend\Code\Generator\ValueGenerator`

Without this fix, an array looks like this. 

```
array(
    'controllers' => array('invokables' => array(
            'Event\Controller\IndexController' => 'Event\Controller\IndexController',
            'Event\Controller\ShopController' => 'Event\Controller\ShopController',
            )),
    'view_manager' => array('template_path_stack' => array(__DIR__ . '/../view'))
    )
```

With the fix, the same array will look like this:

```
array(
    'controllers' => array(
        'invokables' => array(
            'Event\Controller\IndexController' => 'Event\Controller\IndexController',
            'Event\Controller\ShopController' => 'Event\Controller\ShopController',
        )
    ),
    'view_manager' => array(
        'template_path_stack' => array(
            __DIR__ . '/../view'
        )
    )
)
```

Please note the changes for the entry for 'view_manager' and the positions of the braces.
