### PR TITLE
Adding attributes to fieldsets. Legends are optional for fieldsets.

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -80,6 +80,7 @@ class FormCollection extends AbstractHelper
             return '';
         }
 
+        $attributes       = $element->getAttributes();
         $markup           = '';
         $templateMarkup   = '';
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
@@ -106,6 +107,7 @@ class FormCollection extends AbstractHelper
         // Every collection is wrapped by a fieldset if needed
         if ($this->shouldWrap) {
             $label = $element->getLabel();
+            $legend = '';
 
             if (!empty($label)) {
 
@@ -118,12 +120,18 @@ class FormCollection extends AbstractHelper
 
                 $label = $escapeHtmlHelper($label);
 
-                $markup = sprintf(
-                    '<fieldset><legend>%s</legend>%s</fieldset>',
-                    $label,
-                    $markup
+                $legend = sprintf(
+                    '<legend>%s</legend>',
+                    $label
                 );
             }
+
+            $markup = sprintf(
+                '<fieldset %s>%s%s</fieldset>',
+                $this->createAttributesString($attributes),
+                $legend,
+                $markup
+            );
         }
 
         return $markup;

--- a/tests/ZendTest/Form/View/Helper/FormTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormTest.php
@@ -90,7 +90,7 @@ class FormTest extends CommonTestCase
         $this->assertContains('<form', $markup);
         $this->assertContains('id="login-form"', $markup);
         $this->assertContains('<label><span>Name of the city</span>', $markup);
-        $this->assertContains('<fieldset><legend>Country</legend>', $markup);
+        $this->assertContains('<fieldset ><legend>Country</legend>', $markup);
         $this->assertContains('<input type="submit" name="send"', $markup);
         $this->assertContains('</form>', $markup);
     }


### PR DESCRIPTION
As the comment says: Every collection is wrapped by a fieldset if needed

With this patch, a legend is not required for a fieldset.
- Now, if a label is specified, a legend will be created.
- Before, a fieldset would not be wrapped around the markup unless a label was set.
- Now, a fieldset will be wrapped around the markup if $this->shouldWrap is true, regardless if a label has been set for the legend.
