### PR TITLE
Acl assertions enhancement

### DIFF
--- a/library/Zend/Permissions/Acl/Assertion/AssertionAggregate.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionAggregate.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Permissions\Acl\Assertion;
+
+use Zend\Permissions\Acl\Acl;
+use Zend\Permissions\Acl\Role\RoleInterface;
+use Zend\Permissions\Acl\Resource\ResourceInterface;
+use Zend\Permissions\Acl\Exception\InvalidArgumentException;
+use Zend\Permissions\Acl\Exception\RuntimeException;
+
+class AssertionAggregate implements AssertionInterface
+{
+
+    const MODE_ALL = 'all';
+
+    const MODE_AT_LEAST_ONE = 'at_least_one';
+
+    protected $assertions = array();
+
+    /**
+     *
+     * @var $manager AssertionManager
+     */
+    protected $assertionManager;
+
+    protected $mode = self::MODE_ALL;
+
+    /**
+     * Stacks an assertion in aggregate
+     *
+     * @param AssertionInterface|string $assertion
+     *            if string, must match a AssertionManager declared service (checked later)
+     *
+     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     */
+    public function addAssertion($assertion)
+    {
+        $this->assertions[] = $assertion;
+
+        return $this;
+    }
+
+    public function addAssertions(array $assertions)
+    {
+        foreach ($assertions as $assertion) {
+            $this->addAssertion($assertion);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Empties assertions stack
+     *
+     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     */
+    public function clearAssertions()
+    {
+        $this->assertions = array();
+
+        return $this;
+    }
+
+    /**
+     *
+     * @param AssertionManager $manager
+     *
+     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     */
+    public function setAssertionManager(AssertionManager $manager)
+    {
+        $this->assertionManager = $manager;
+
+        return $this;
+    }
+
+    public function getAssertionManager()
+    {
+        return $this->assertionManager;
+    }
+
+    /**
+     * Set assertion chain behavior
+     *
+     * AssertionAggregate should assert to true when:
+     *
+     * - all assertions are true with MODE_ALL
+     * - at least one assertion is true with MODE_AT_LEAST_ONE
+     *
+     * @param string $mode
+     *            indicates how assertion chain result should interpreted (either 'all' or 'at_least_one')
+     * @throws Exception
+     *
+     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     */
+    public function setMode($mode)
+    {
+        if ($mode != self::MODE_ALL && $mode != self::MODE_AT_LEAST_ONE) {
+            throw new InvalidArgumentException('invalid assertion aggregate mode');
+        }
+
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    /**
+     * Return current mode
+     *
+     * @return string
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    {
+        // check if assertions are set
+        if (! $this->assertions) {
+            throw new RuntimeException('no assertion have been aggregated to this AssertionAggregate');
+        }
+
+        foreach ($this->assertions as $assertion) {
+
+            // jit assertion mloading
+            if (! $assertion instanceof AssertionInterface) {
+                if (class_exists($assertion)) {
+                    $assertion = new $assertion();
+                } else {
+                    if ($manager = $this->getAssertionManager()) {
+                        try {
+                            $assertion = $manager->get($assertion);
+                        } catch (\Exception $e) {
+                            throw new Exception\InvalidAssertionException('assertion "' . $assertion . '" is not defined in assertion manager');
+                        }
+                    } else {
+                        throw new RuntimeException('no assertion manager is set - cannot look up for assertions');
+                    }
+                }
+            }
+
+            $result = (bool) $assertion->assert($acl, $role, $resource, $privilege);
+
+            if ($this->getMode() == self::MODE_ALL && ! $result) {
+                // on false is enough
+                return false;
+            }
+
+            if ($this->getMode() == self::MODE_AT_LEAST_ONE && $result) {
+                // one true is enough
+                return true;
+            }
+        }
+
+        if ($this->getMode() == self::MODE_ALL) {
+            // none of the assertions returned false
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/library/Zend/Permissions/Acl/Assertion/AssertionAggregate.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionAggregate.php
@@ -37,7 +37,7 @@ class AssertionAggregate implements AssertionInterface
      * @param AssertionInterface|string $assertion
      *            if string, must match a AssertionManager declared service (checked later)
      *
-     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     * @return self
      */
     public function addAssertion($assertion)
     {
@@ -58,7 +58,7 @@ class AssertionAggregate implements AssertionInterface
     /**
      * Empties assertions stack
      *
-     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     * @return self
      */
     public function clearAssertions()
     {
@@ -71,7 +71,7 @@ class AssertionAggregate implements AssertionInterface
      *
      * @param AssertionManager $manager
      *
-     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     * @return self
      */
     public function setAssertionManager(AssertionManager $manager)
     {
@@ -97,7 +97,7 @@ class AssertionAggregate implements AssertionInterface
      *            indicates how assertion chain result should interpreted (either 'all' or 'at_least_one')
      * @throws Exception
      *
-     * @return \Zend\Permissions\Acl\Assertion\AssertionAggregate
+     * @return self
      */
     public function setMode($mode)
     {
@@ -120,6 +120,12 @@ class AssertionAggregate implements AssertionInterface
         return $this->mode;
     }
 
+    /**
+     * @see \Zend\Permissions\Acl\Assertion\AssertionInterface::assert()
+     *
+     * @throws RuntimeException
+     * @return bool
+     */
     public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
     {
         // check if assertions are set

--- a/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
@@ -22,8 +22,9 @@ class AssertionManager extends AbstractPluginManager
      * Checks that the element is an instance of AssertionInterface
      *
      * @param mixed $plugin
-     * @throws Zend\PErmissions\Acl\Exception\InvalidElementException
-     * @return void
+     *
+     * @throws InvalidArgumentException
+     * @return bool
      */
     public function validatePlugin($plugin)
     {

--- a/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
@@ -14,7 +14,7 @@ use Zend\Permissions\Acl\Exception\InvalidArgumentException;
 class AssertionManager extends AbstractPluginManager
 {
 
-    protected $sharedByDefault = false;
+    protected $sharedByDefault = true;
 
     /**
      * Validate the plugin

--- a/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Permissions\Acl\Assertion;
+
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\Permissions\Acl\Exception\InvalidArgumentException;
+
+class AssertionManager extends AbstractPluginManager
+{
+
+    protected $sharedByDefault = false;
+
+    /**
+     * Validate the plugin
+     *
+     * Checks that the element is an instance of AssertionInterface
+     *
+     * @param mixed $plugin
+     * @throws Zend\PErmissions\Acl\Exception\InvalidElementException
+     * @return void
+     */
+    public function validatePlugin($plugin)
+    {
+        if (! $plugin instanceof AssertionInterface) {
+            throw new InvalidArgumentException(sprintf('Plugin of type %s is invalid; must implement Zend\Permissions\Acl\Assertion\AssertionInterface', (is_object($plugin) ? get_class($plugin) : gettype($plugin))));
+        }
+
+        return true;
+    }
+}

--- a/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionManager.php
@@ -29,7 +29,9 @@ class AssertionManager extends AbstractPluginManager
     public function validatePlugin($plugin)
     {
         if (! $plugin instanceof AssertionInterface) {
-            throw new InvalidArgumentException(sprintf('Plugin of type %s is invalid; must implement Zend\Permissions\Acl\Assertion\AssertionInterface', (is_object($plugin) ? get_class($plugin) : gettype($plugin))));
+            throw new InvalidArgumentException(sprintf('Plugin of type %s is invalid; must implement 
+                Zend\Permissions\Acl\Assertion\AssertionInterface', 
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin))));
         }
 
         return true;

--- a/library/Zend/Permissions/Acl/Assertion/Exception/InvalidAssertionException.php
+++ b/library/Zend/Permissions/Acl/Assertion/Exception/InvalidAssertionException.php
@@ -1,0 +1,8 @@
+<?php
+namespace Zend\Permissions\Acl\Assertion\Exception;
+
+use Zend\Permissions\Acl\Exception\ExceptionInterface;
+
+class InvalidAssertionException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/tests/ZendTest/Permissions/Acl/Assertion/AssertionAggregateTest.php
+++ b/tests/ZendTest/Permissions/Acl/Assertion/AssertionAggregateTest.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Permissions\Acl\Assertion;
+
+use Zend\Permissions\Acl\Assertion\AssertionAggregate;
+use ZendTest\Permissions\Acl\TestAsset\MockAssertion;
+use Zend\Di\Exception\UndefinedReferenceException;
+
+class AssertionAggregateTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     *
+     * @var
+     *
+     */
+    protected $assertionAggregate;
+
+    public function setUp()
+    {
+        $this->assertionAggregate = new AssertionAggregate();
+    }
+
+    public function testAddAssertion()
+    {
+        $assertion = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $this->assertionAggregate->addAssertion($assertion);
+
+        $this->assertAttributeEquals(array(
+            $assertion
+        ), 'assertions', $this->assertionAggregate);
+
+        $aggregate = $this->assertionAggregate->addAssertion('other.assertion');
+        $this->assertAttributeEquals(array(
+            $assertion,
+            'other.assertion'
+        ), 'assertions', $this->assertionAggregate);
+
+        // test fluent interface
+        $this->assertSame($this->assertionAggregate, $aggregate);
+
+        return clone $this->assertionAggregate;
+    }
+
+    public function testAddAssertions()
+    {
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+
+        $aggregate = $this->assertionAggregate->addAssertions($assertions);
+
+        $this->assertAttributeEquals($assertions, 'assertions', $this->assertionAggregate);
+
+        // test fluent interface
+        $this->assertSame($this->assertionAggregate, $aggregate);
+    }
+
+    /**
+     * @depends testAddAssertion
+     */
+    public function testClearAssertions(AssertionAggregate $assertionAggregate)
+    {
+        $this->assertAttributeCount(2, 'assertions', $assertionAggregate);
+
+        $aggregate = $assertionAggregate->clearAssertions();
+
+        $this->assertAttributeEmpty('assertions', $assertionAggregate);
+
+        // test fluent interface
+        $this->assertSame($assertionAggregate, $aggregate);
+    }
+
+    public function testDefaultModeValue()
+    {
+        $this->assertAttributeEquals(AssertionAggregate::MODE_ALL, 'mode', $this->assertionAggregate);
+    }
+
+    /**
+     * @dataProvider getDataForTestSetMode
+     */
+    public function testSetMode($mode, $exception = false)
+    {
+        if ($exception) {
+            $this->setExpectedException('\Zend\Permissions\Acl\Exception\InvalidArgumentException');
+            $this->assertionAggregate->setMode($mode);
+        } else {
+            $this->assertionAggregate->setMode($mode);
+            $this->assertAttributeEquals($mode, 'mode', $this->assertionAggregate);
+        }
+    }
+
+    public static function getDataForTestSetMode()
+    {
+        return array(
+            array(
+                AssertionAggregate::MODE_ALL
+            ),
+            array(
+                AssertionAggregate::MODE_AT_LEAST_ONE
+            ),
+            array(
+                'invalid mode',
+                true
+            )
+        );
+    }
+
+    public function testManagerAccessors()
+    {
+        $manager = $this->getMock('Zend\Permissions\Acl\Assertion\AssertionManager');
+
+        $aggregate = $this->assertionAggregate->setAssertionManager($manager);
+        $this->assertAttributeEquals($manager, 'assertionManager', $this->assertionAggregate);
+        $this->assertEquals($manager, $this->assertionAggregate->getAssertionManager());
+        $this->assertSame($this->assertionAggregate, $aggregate);
+    }
+
+    public function testCallingAssertWillFetchAssertionFromManager()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(), array(
+            'test.resource'
+        ));
+
+        $assertion = $this->getMockForAbstractClass('Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertion->expects($this->once())
+            ->method('assert')
+            ->will($this->returnValue(true));
+
+        $manager = $this->getMock('Zend\Permissions\Acl\Assertion\AssertionManager', array(
+            'get'
+        ));
+        $manager->expects($this->once())
+            ->method('get')
+            ->with('assertion')
+            ->will($this->returnValue($assertion));
+
+        $this->assertionAggregate->setAssertionManager($manager);
+        $this->assertionAggregate->addAssertion('assertion');
+
+        $this->assertTrue($this->assertionAggregate->assert($acl, $role, $resource, 'privilege'));
+    }
+
+    public function testAssertThrowsAnExceptionWhenReferingToNonExistentAssertion()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(), array(
+            'test.resource'
+        ));
+
+        $manager = $this->getMock('Zend\Permissions\Acl\Assertion\AssertionManager', array(
+            'get'
+        ));
+        $manager->expects($this->once())
+            ->method('get')
+            ->with('assertion')
+            ->will($this->throwException(new UndefinedReferenceException()));
+
+        $this->assertionAggregate->setAssertionManager($manager);
+
+        $this->setExpectedException('Zend\Permissions\Acl\Assertion\Exception\InvalidAssertionException');
+        $this->assertionAggregate->addAssertion('assertion');
+        $this->assertionAggregate->assert($acl, $role, $resource, 'privilege');
+    }
+
+    public function testAssertWithModeAll()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(), array(
+            'test.resource'
+        ));
+
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+
+        $assertions[0]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(true));
+        $assertions[1]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(true));
+        $assertions[2]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(true));
+
+        foreach ($assertions as $assertion) {
+            $this->assertionAggregate->addAssertion($assertion);
+        }
+
+        $this->assertTrue($this->assertionAggregate->assert($acl, $role, $resource, 'privilege'));
+    }
+
+    public function testAssertWithModeAtLeastOne()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(), array(
+            'test.resource'
+        ));
+
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+
+        $assertions[0]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(false));
+        $assertions[1]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(false));
+        $assertions[2]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(true));
+
+        foreach ($assertions as $assertion) {
+            $this->assertionAggregate->addAssertion($assertion);
+        }
+
+        $this->assertionAggregate->setMode(AssertionAggregate::MODE_AT_LEAST_ONE);
+        $this->assertTrue($this->assertionAggregate->assert($acl, $role, $resource, 'privilege'));
+    }
+
+    public function testDoesNotAssertWithModeAll()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(
+            'assert'
+        ), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(
+            'assert'
+        ), array(
+            'test.resource'
+        ));
+
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+
+        $assertions[0]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(true));
+        $assertions[1]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(true));
+        $assertions[2]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(false));
+
+        foreach ($assertions as $assertion) {
+            $this->assertionAggregate->addAssertion($assertion);
+        }
+
+        $this->assertFalse($this->assertionAggregate->assert($acl, $role, $resource, 'privilege'));
+    }
+
+    public function testDoesNotAssertWithModeAtLeastOne()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(
+            'assert'
+        ), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(
+            'assert'
+        ), array(
+            'test.resource'
+        ));
+
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass('\Zend\Permissions\Acl\Assertion\AssertionInterface');
+
+        $assertions[0]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(false));
+        $assertions[1]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(false));
+        $assertions[2]->expects($this->once())
+            ->method('assert')
+            ->with($acl, $role, $resource, 'privilege')
+            ->will($this->returnValue(false));
+
+        foreach ($assertions as $assertion) {
+            $this->assertionAggregate->addAssertion($assertion);
+        }
+
+        $this->assertionAggregate->setMode(AssertionAggregate::MODE_AT_LEAST_ONE);
+        $this->assertFalse($this->assertionAggregate->assert($acl, $role, $resource, 'privilege'));
+    }
+
+    public function testAssertThrowsAnExceptionWhenNoAssertionIsAggregated()
+    {
+        $acl = $this->getMock('\Zend\Permissions\Acl\Acl');
+        $role = $this->getMock('\Zend\Permissions\Acl\Role\GenericRole', array(
+            'assert'
+        ), array(
+            'test.role'
+        ));
+        $resource = $this->getMock('\Zend\Permissions\Acl\Resource\GenericResource', array(
+            'assert'
+        ), array(
+            'test.resource'
+        ));
+
+        $this->setExpectedException('Zend\Permissions\Acl\Exception\RuntimeException');
+
+        $this->assertionAggregate->assert($acl, $role, $resource, 'privilege');
+    }
+}

--- a/tests/ZendTest/Permissions/Acl/Assertion/AssertionAggregateTest.php
+++ b/tests/ZendTest/Permissions/Acl/Assertion/AssertionAggregateTest.php
@@ -15,11 +15,6 @@ use Zend\Di\Exception\UndefinedReferenceException;
 class AssertionAggregateTest extends \PHPUnit_Framework_TestCase
 {
 
-    /**
-     *
-     * @var
-     *
-     */
     protected $assertionAggregate;
 
     public function setUp()

--- a/tests/ZendTest/Permissions/Acl/Assertion/AssertionManagerTest.php
+++ b/tests/ZendTest/Permissions/Acl/Assertion/AssertionManagerTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Permissions\Acl\Assertion;
+
+use Zend\Permissions\Acl\Assertion\AssertionManager;
+
+class AssertionManagerTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $manager;
+
+    public function setUp()
+    {
+        $this->manager = new AssertionManager();
+    }
+
+    public function testValidatePlugin()
+    {
+        $assertion = $this->getMockForAbstractClass('Zend\Permissions\Acl\Assertion\AssertionInterface');
+
+        $this->assertTrue($this->manager->validatePlugin($assertion));
+
+        $this->setExpectedException('Zend\Permissions\Acl\Exception\InvalidArgumentException');
+
+        $this->manager->validatePlugin('invalid plugin');
+    }
+}


### PR DESCRIPTION
AssertionAggregate allows aggregating multiple assertion to be associated with one ACL rule. This has been done without modifying a single file of existing code.

AssertionManager is a simple Plugin Manager allowing to declare Acl asseertions as services. It can be used by AssertionAggregate to add assertions by passing their service name. It could also by used by the Acl component itself, and should be declared as a default service, so that it could rely on Config service to get intialized, but those features would need to alter existing code and I didn't want to do that at this time.
