### PR TITLE
Giving a Warning namespaces to FlashMessager

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
+++ b/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
@@ -32,6 +32,11 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     const NAMESPACE_SUCCESS = 'success';
 
     /**
+     * Warning messages namespace
+     */
+    const NAMESPACE_WARNING = 'warning';
+
+    /**
      * Error messages namespace
      */
     const NAMESPACE_ERROR = 'error';
@@ -205,6 +210,22 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     }
 
     /**
+     * Add a message with "warning" type
+     *
+     * @param string        $message
+     * @return FlashMessenger
+     */
+    public function addWarningMessage($message)
+    {
+        $namespace = $this->getNamespace();
+        $this->setNamespace(self::NAMESPACE_WARNING);
+        $this->addMessage($message);
+        $this->setNamespace($namespace);
+
+        return $this;
+    }
+
+    /**
      * Add a message with "error" type
      *
      * @param  string         $message
@@ -256,6 +277,21 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     {
         $namespace = $this->getNamespace();
         $this->setNamespace(self::NAMESPACE_SUCCESS);
+        $hasMessages = $this->hasMessages();
+        $this->setNamespace($namespace);
+
+        return $hasMessages;
+    }
+
+    /**
+     * Whether "warning" namespace has messages
+     *
+     * @return bool
+     */
+    public function hasWarningMessages()
+    {
+        $namespace = $this->getNamespace();
+        $this->setNamespace(self::NAMESPACE_WARNING);
         $hasMessages = $this->hasMessages();
         $this->setNamespace($namespace);
 
@@ -315,6 +351,21 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     {
         $namespace = $this->getNamespace();
         $this->setNamespace(self::NAMESPACE_SUCCESS);
+        $messages = $this->getMessages();
+        $this->setNamespace($namespace);
+
+        return $messages;
+    }
+
+    /**
+     * Get messages from "warning" namespace
+     *
+     * @return array
+     */
+    public function getWarningMessages()
+    {
+        $namespace = $this->getNamespace();
+        $this->setNamespace(self::NAMESPACE_WARNING);
         $messages = $this->getMessages();
         $this->setNamespace($namespace);
 
@@ -432,6 +483,22 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     }
 
     /**
+     * Check to see if messages have been added to "warning"
+     * namespace within this request
+     *
+     * @return bool
+     */
+    public function hasCurrentWarningMessages()
+    {
+        $namespace = $this->getNamespace();
+        $this->setNamespace(self::NAMESPACE_WARNING);
+        $hasMessages = $this->hasCurrentMessages();
+        $this->setNamespace($namespace);
+
+        return $hasMessages;
+    }
+
+    /**
      * Check to see if messages have been added to "error"
      * namespace within this request
      *
@@ -491,6 +558,22 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
     {
         $namespace = $this->getNamespace();
         $this->setNamespace(self::NAMESPACE_SUCCESS);
+        $messages = $this->getCurrentMessages();
+        $this->setNamespace($namespace);
+
+        return $messages;
+    }
+
+    /**
+     * Get messages that have been added to the "warning"
+     * namespace within this request
+     *
+     * @return array
+     */
+    public function getCurrentWarningMessages()
+    {
+        $namespace = $this->getNamespace();
+        $this->setNamespace(self::NAMESPACE_WARNING);
         $messages = $this->getCurrentMessages();
         $this->setNamespace($namespace);
 


### PR DESCRIPTION
This change was made by another user and excluded afterwards for some reason. Just putting it back
