### PR TITLE
Http\Client - fetching adapter using getAdapter method instead of using adapter object directly

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -684,9 +684,10 @@ class Client implements Stdlib\DispatchableInterface
         ErrorHandler::start();
         $fp    = fopen($this->streamName, "w+b");
         $error = ErrorHandler::stop();
+        $adapter = $this->getAdapter();
         if (false === $fp) {
-            if ($this->adapter instanceof Client\Adapter\AdapterInterface) {
-                $this->adapter->close();
+            if ($adapter instanceof Client\Adapter\AdapterInterface) {
+                $adapter->close();
             }
             throw new Exception\RuntimeException("Could not open temp file {$this->streamName}", 0, $error);
         }
@@ -1354,22 +1355,23 @@ class Client implements Stdlib\DispatchableInterface
      */
     protected function doRequest(Http $uri, $method, $secure = false, $headers = array(), $body = '')
     {
+        $adapter = $this->getAdapter();
         // Open the connection, send the request and read the response
-        $this->adapter->connect($uri->getHost(), $uri->getPort(), $secure);
+        $adapter->connect($uri->getHost(), $uri->getPort(), $secure);
 
         if ($this->config['outputstream']) {
-            if ($this->adapter instanceof Client\Adapter\StreamInterface) {
+            if ($adapter instanceof Client\Adapter\StreamInterface) {
                 $stream = $this->openTempStream();
-                $this->adapter->setOutputStream($stream);
+                $adapter->setOutputStream($stream);
             } else {
                 throw new Exception\RuntimeException('Adapter does not support streaming');
             }
         }
         // HTTP connection
-        $this->lastRawRequest = $this->adapter->write($method,
+        $this->lastRawRequest = $adapter->write($method,
             $uri, $this->config['httpversion'], $headers, $body);
 
-        return $this->adapter->read();
+        return $adapter->read();
     }
 
     /**


### PR DESCRIPTION
Adapter object fetching in `Http\Client` changed to use `getAdapter` method instead of accessing it directly (`$this->adapter`).

`getAdapter` method has additional functionality which has a fallback to fetching adapter from `config` if current adapter object is `null`. 
