### PR TITLE
BaseInputFilter handles missing data properly

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -539,6 +539,11 @@ class BaseInputFilter implements InputFilterInterface, UnknownInputsCapableInter
                     continue;
                 }
 
+                if ($input instanceof ArrayInput) {
+                    $input->setValue(array());
+                    continue;
+                }
+
                 $input->setValue(null);
                 continue;
             }

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -870,7 +870,7 @@ class BaseInputFilterTest extends TestCase
         $arrayInput
             ->expects($this->once())
             ->method('setValue')
-            ->with([]);
+            ->with(array());
 
         $filter = new InputFilter();
         $filter->add($arrayInput, 'arrayInput');

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -860,4 +860,20 @@ class BaseInputFilterTest extends TestCase
         $this->assertTrue($filter->get('foo')->isValid(), 'Filtered value is not valid');
         $this->assertTrue($filter->isValid(), 'Input filter did return value from filter');
     }
+
+    /**
+     * @group 5638
+     */
+    public function testPopulateSupportsArrayInputEvenIfDataMissing()
+    {
+        $arrayInput = $this->getMock('Zend\InputFilter\ArrayInput');
+        $arrayInput
+            ->expects($this->once())
+            ->method('setValue')
+            ->with([]);
+
+        $filter = new InputFilter();
+        $filter->add($arrayInput, 'arrayInput');
+        $filter->setData(array('foo' => 'bar'));
+    }
 }


### PR DESCRIPTION
Previously BaseInputFilter::populate would pass a null value to setValue
this would cause the ArrayInput to throw an exception even if the
ArrayInput is not part of the validation group.

Something else that should be looked at is introducing a validator
instead of using a exception Zend\InputFilter\ArrayInput filter because
the exception will break the application if not managed correctly.
