### PR TITLE
Addressing issue #5624. Implemented fix and added test case.

### DIFF
--- a/library/Zend/Json/Server/Smd.php
+++ b/library/Zend/Json/Server/Smd.php
@@ -373,11 +373,12 @@ class Smd
             return $this->toDojoArray();
         }
 
+        $description = $this->getDescription();
         $transport   = $this->getTransport();
         $envelope    = $this->getEnvelope();
         $contentType = $this->getContentType();
         $SMDVersion  = static::SMD_VERSION;
-        $service = compact('transport', 'envelope', 'contentType', 'SMDVersion');
+        $service = compact('transport', 'envelope', 'contentType', 'SMDVersion', 'description');
 
         if (null !== ($target = $this->getTarget())) {
             $service['target']     = $target;

--- a/library/Zend/Json/Server/Smd/Service.php
+++ b/library/Zend/Json/Server/Smd/Service.php
@@ -395,12 +395,13 @@ class Service
         $transport  = $this->getTransport();
         $parameters = $this->getParams();
         $returns    = $this->getReturn();
+        $name       = $this->getName();
 
         if (empty($target)) {
-            return compact('envelope', 'transport', 'parameters', 'returns');
+            return compact('envelope', 'transport', 'name', 'parameters', 'returns');
         }
 
-        return $paramInfo = compact('envelope', 'target', 'transport', 'parameters', 'returns');
+        return $paramInfo = compact('envelope', 'target', 'transport', 'name', 'parameters', 'returns');
     }
 
     /**

--- a/library/Zend/Json/Server/Smd/Service.php
+++ b/library/Zend/Json/Server/Smd/Service.php
@@ -401,7 +401,7 @@ class Service
             return compact('envelope', 'transport', 'name', 'parameters', 'returns');
         }
 
-        return $paramInfo = compact('envelope', 'target', 'transport', 'name', 'parameters', 'returns');
+        return compact('envelope', 'target', 'transport', 'name', 'parameters', 'returns');
     }
 
     /**

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -381,4 +381,31 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('foo', $services));
         $this->assertTrue(array_key_exists('bar', $services));
     }
+
+    /**
+     * @group ZF2-5624
+     */
+    public function testSetOptionsShouldAccommodateToArrayOutput() {
+        $smdSource = new Smd();
+        $smdSource->setContentType('application/json');
+        $smdSource->setDescription('description');
+        $smdSource->setEnvelope(Smd::ENV_JSONRPC_1);
+        $smdSource->setId(uniqid());
+        $smdSource->setTarget('http://foo');
+        $smdSource->setTransport('POST');
+        $smdSource->setServices(array(array('name' => 'foo')));
+
+        $smdDest = new Smd();
+        // prior to fix the following resulted in:
+        // .. Zend\Json\Server\Exception\InvalidArgumentException : SMD service description requires a name; none provided
+        $smdDest->setOptions($smdSource->toArray());
+
+        $this->assertEquals($smdSource->getContentType(),$smdDest->getContentType());
+        $this->assertEquals($smdSource->getDescription(),$smdDest->getDescription());
+        $this->assertEquals($smdSource->getEnvelope(),$smdDest->getEnvelope());
+        $this->assertEquals($smdSource->getId(),$smdDest->getId());
+        $this->assertEquals($smdSource->getTarget(),$smdDest->getTarget());
+        $this->assertEquals($smdSource->getTransport(),$smdDest->getTransport());
+        $this->assertEquals($smdSource->getServices(),$smdDest->getServices());
+    }
 }

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -385,7 +385,8 @@ class SmdTest extends \PHPUnit_Framework_TestCase
     /**
      * @group ZF2-5624
      */
-    public function testSetOptionsShouldAccommodateToArrayOutput() {
+    public function testSetOptionsShouldAccommodateToArrayOutput()
+    {
         $smdSource = new Smd();
         $smdSource->setContentType('application/json');
         $smdSource->setDescription('description');

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -393,19 +393,29 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $smdSource->setId(uniqid());
         $smdSource->setTarget('http://foo');
         $smdSource->setTransport('POST');
-        $smdSource->setServices(array(array('name' => 'foo')));
+        $smdSource->setServices(array(
+            array('name' => 'foo')
+        ));
 
-        $smdDest = new Smd();
+        $smdDestination = new Smd();
         // prior to fix the following resulted in:
-        // .. Zend\Json\Server\Exception\InvalidArgumentException : SMD service description requires a name; none provided
-        $smdDest->setOptions($smdSource->toArray());
+        // .. Zend\Json\Server\Exception\InvalidArgumentException
+        // ... : SMD service description requires a name; none provided
+        $smdDestination->setOptions($smdSource->toArray());
 
-        $this->assertEquals($smdSource->getContentType(),$smdDest->getContentType());
-        $this->assertEquals($smdSource->getDescription(),$smdDest->getDescription());
-        $this->assertEquals($smdSource->getEnvelope(),$smdDest->getEnvelope());
-        $this->assertEquals($smdSource->getId(),$smdDest->getId());
-        $this->assertEquals($smdSource->getTarget(),$smdDest->getTarget());
-        $this->assertEquals($smdSource->getTransport(),$smdDest->getTransport());
-        $this->assertEquals($smdSource->getServices(),$smdDest->getServices());
+        $this->assertEquals($smdSource->getContentType(),
+            $smdDestination->getContentType());
+        $this->assertEquals($smdSource->getDescription(),
+            $smdDestination->getDescription());
+        $this->assertEquals($smdSource->getEnvelope(),
+            $smdDestination->getEnvelope());
+        $this->assertEquals($smdSource->getId(),
+            $smdDestination->getId());
+        $this->assertEquals($smdSource->getTarget(),
+            $smdDestination->getTarget());
+        $this->assertEquals($smdSource->getTransport(),
+            $smdDestination->getTransport());
+        $this->assertEquals($smdSource->getServices(),
+            $smdDestination->getServices());
     }
 }


### PR DESCRIPTION
Updated toArray on Zend/Json/Server/Smd and Smd/Service to include the required attributes according to the SMD spec; Added test to show setOptions on toArray output appropriately configures Smd
