### PR TITLE
Set custom class name for active li element

### DIFF
--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -716,6 +716,16 @@ class Menu extends AbstractHelper
 
         return $this;
     }
+
+    /**
+     * Returns CSS class to use for the first 'ul' element when rendering
+     *
+     * @return string
+     */
+    public function getUlClass()
+    {
+        return $this->ulClass;
+    }
     
     /**
      * Sets CSS class to use for the active 'li' element when rendering
@@ -731,14 +741,14 @@ class Menu extends AbstractHelper
 
         return $this;
     }
-
+    
     /**
-     * Returns CSS class to use for the first 'ul' element when rendering
+     * Returns CSS class to use for the active 'li' element when rendering
      *
      * @return string
      */
-    public function getUlClass()
+    public function getLiActiveClass()
     {
-        return $this->ulClass;
+        return $this->liActiveClass;
     }
 }

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -116,7 +116,7 @@ class Menu extends AbstractHelper
      * from {@link renderMenu()})
      *
      * @param  AbstractContainer $container          container to render
-     * @param  string            $ulClass            CSS class for first UL 
+     * @param  string            $ulClass            CSS class for first UL
      * @param  string            $indent             initial indentation
      * @param  int|null          $minDepth           minimum depth
      * @param  int|null          $maxDepth           maximum depth
@@ -557,7 +557,7 @@ class Menu extends AbstractHelper
         } else {
             $options['ulClass'] = $this->getUlClass();
         }
-        
+
         if (array_key_exists('minDepth', $options)) {
             if (null !== $options['minDepth']) {
                 $options['minDepth'] = (int) $options['minDepth'];

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -116,24 +116,24 @@ class Menu extends AbstractHelper
      * from {@link renderMenu()})
      *
      * @param  AbstractContainer $container          container to render
-     * @param  string            $ulClass            CSS class for first UL
-     * @param  string            $liActiveClass      CSS class for active LI
+     * @param  string            $ulClass            CSS class for first UL 
      * @param  string            $indent             initial indentation
      * @param  int|null          $minDepth           minimum depth
      * @param  int|null          $maxDepth           maximum depth
      * @param  bool              $escapeLabels       Whether or not to escape the labels
      * @param  bool              $addClassToListItem Whether or not page class applied to <li> element
+     * @param  string            $liActiveClass      CSS class for active LI
      * @return string
      */
     protected function renderDeepestMenu(
         AbstractContainer $container,
         $ulClass,
-        $liActiveClass,
         $indent,
         $minDepth,
         $maxDepth,
         $escapeLabels,
-        $addClassToListItem
+        $addClassToListItem,
+        $liActiveClass
     ) {
         if (!$active = $this->findActive($container, $minDepth - 1, $maxDepth)) {
             return '';
@@ -210,23 +210,23 @@ class Menu extends AbstractHelper
         if ($options['onlyActiveBranch'] && !$options['renderParents']) {
             $html = $this->renderDeepestMenu($container,
                 $options['ulClass'],
-                $options['liActiveClass'],
                 $options['indent'],
                 $options['minDepth'],
                 $options['maxDepth'],
                 $options['escapeLabels'],
-                $options['addClassToListItem']
+                $options['addClassToListItem'],
+                $options['liActiveClass']
             );
         } else {
             $html = $this->renderNormalMenu($container,
                 $options['ulClass'],
-                $options['liActiveClass'],
                 $options['indent'],
                 $options['minDepth'],
                 $options['maxDepth'],
                 $options['onlyActiveBranch'],
                 $options['escapeLabels'],
-                $options['addClassToListItem']
+                $options['addClassToListItem'],
+                $options['liActiveClass']
             );
         }
 
@@ -238,25 +238,25 @@ class Menu extends AbstractHelper
      *
      * @param  AbstractContainer $container          container to render
      * @param  string            $ulClass            CSS class for first UL
-     * @param  string            $liActiveClass      CSS class for active LI
      * @param  string            $indent             initial indentation
      * @param  int|null          $minDepth           minimum depth
      * @param  int|null          $maxDepth           maximum depth
      * @param  bool              $onlyActive         render only active branch?
      * @param  bool              $escapeLabels       Whether or not to escape the labels
      * @param  bool              $addClassToListItem Whether or not page class applied to <li> element
+     * @param  string            $liActiveClass      CSS class for active LI
      * @return string
      */
     protected function renderNormalMenu(
         AbstractContainer $container,
         $ulClass,
-        $liActiveClass,
         $indent,
         $minDepth,
         $maxDepth,
         $onlyActive,
         $escapeLabels,
-        $addClassToListItem
+        $addClassToListItem,
+        $liActiveClass
     ) {
         $html = '';
 
@@ -435,45 +435,46 @@ class Menu extends AbstractHelper
      *     'minDepth'         => null,
      *     'maxDepth'         => null,
      *     'onlyActiveBranch' => true,
-     *     'renderParents'    => false
+     *     'renderParents'    => false,
+     *     'liActiveClass'    => $liActiveClass      
      * ));
      * </code>
      *
-     * @param  AbstractContainer $container [optional] container to
-     *                                      render. Default is to render
-     *                                      the container registered in
-     *                                      the helper.
-     * @param  string            $ulClass   [optional] CSS class to
-     *                                      use for UL element. Default
-     *                                      is to use the value from
-     *                                      {@link getUlClass()}.
+     * @param  AbstractContainer $container     [optional] container to
+     *                                          render. Default is to render
+     *                                          the container registered in
+     *                                          the helper.
+     * @param  string            $ulClass       [optional] CSS class to
+     *                                          use for UL element. Default
+     *                                          is to use the value from
+     *                                          {@link getUlClass()}.
+     * @param  string|int        $indent        [optional] indentation as
+     *                                          a string or number of
+     *                                          spaces. Default is to use
+     *                                          the value retrieved from
+     *                                          {@link getIndent()}.
      * @param  string            $liActiveClass [optional] CSS class to
      *                                          use for UL element. Default
      *                                          is to use the value from
      *                                          {@link getUlClass()}.
-     * @param  string|int        $indent    [optional] indentation as
-     *                                      a string or number of
-     *                                      spaces. Default is to use
-     *                                      the value retrieved from
-     *                                      {@link getIndent()}.
      * @return string
      */
     public function renderSubMenu(
         AbstractContainer $container = null,
         $ulClass = null,
-        $liActiveClass = null,
-        $indent = null
+        $indent = null,
+        $liActiveClass = null
     ) {
         return $this->renderMenu($container, array(
             'indent'             => $indent,
             'ulClass'            => $ulClass,
-            'liActiveClass'      => $liActiveClass,
             'minDepth'           => null,
             'maxDepth'           => null,
             'onlyActiveBranch'   => true,
             'renderParents'      => false,
             'escapeLabels'       => true,
             'addClassToListItem' => false,
+            'liActiveClass'      => $liActiveClass
         ));
     }
 
@@ -557,12 +558,6 @@ class Menu extends AbstractHelper
             $options['ulClass'] = $this->getUlClass();
         }
         
-        if (isset($options['liActiveClass']) && $options['liActiveClass'] !== null) {
-            $options['liActiveClass'] = (string) $options['liActiveClass'];
-        } else {
-            $options['liActiveClass'] = $this->getLiActiveClass();
-        }
-
         if (array_key_exists('minDepth', $options)) {
             if (null !== $options['minDepth']) {
                 $options['minDepth'] = (int) $options['minDepth'];
@@ -597,6 +592,12 @@ class Menu extends AbstractHelper
 
         if (!isset($options['addClassToListItem'])) {
             $options['addClassToListItem'] = $this->getAddClassToListItem();
+        }
+        
+        if (isset($options['liActiveClass']) && $options['liActiveClass'] !== null) {
+            $options['liActiveClass'] = (string) $options['liActiveClass'];
+        } else {
+            $options['liActiveClass'] = $this->getLiActiveClass();
         }
 
         return $options;

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -117,6 +117,7 @@ class Menu extends AbstractHelper
      *
      * @param  AbstractContainer $container          container to render
      * @param  string            $ulClass            CSS class for first UL
+     * @param  string            $liActiveClass      CSS class for active LI
      * @param  string            $indent             initial indentation
      * @param  int|null          $minDepth           minimum depth
      * @param  int|null          $maxDepth           maximum depth
@@ -127,6 +128,7 @@ class Menu extends AbstractHelper
     protected function renderDeepestMenu(
         AbstractContainer $container,
         $ulClass,
+        $liActiveClass,
         $indent,
         $minDepth,
         $maxDepth,
@@ -162,7 +164,7 @@ class Menu extends AbstractHelper
             $liClasses = array();
             // Is page active?
             if ($subPage->isActive(true)) {
-                $liClasses[] = $this->liActiveClass;
+                $liClasses[] = $liActiveClass;
             }
             // Add CSS class from page to <li>
             if ($addClassToListItem && $subPage->getClass()) {
@@ -208,6 +210,7 @@ class Menu extends AbstractHelper
         if ($options['onlyActiveBranch'] && !$options['renderParents']) {
             $html = $this->renderDeepestMenu($container,
                 $options['ulClass'],
+                $options['liActiveClass'],
                 $options['indent'],
                 $options['minDepth'],
                 $options['maxDepth'],
@@ -217,6 +220,7 @@ class Menu extends AbstractHelper
         } else {
             $html = $this->renderNormalMenu($container,
                 $options['ulClass'],
+                $options['liActiveClass'],
                 $options['indent'],
                 $options['minDepth'],
                 $options['maxDepth'],
@@ -234,6 +238,7 @@ class Menu extends AbstractHelper
      *
      * @param  AbstractContainer $container          container to render
      * @param  string            $ulClass            CSS class for first UL
+     * @param  string            $liActiveClass      CSS class for active LI
      * @param  string            $indent             initial indentation
      * @param  int|null          $minDepth           minimum depth
      * @param  int|null          $maxDepth           maximum depth
@@ -245,6 +250,7 @@ class Menu extends AbstractHelper
     protected function renderNormalMenu(
         AbstractContainer $container,
         $ulClass,
+        $liActiveClass,
         $indent,
         $minDepth,
         $maxDepth,
@@ -331,7 +337,7 @@ class Menu extends AbstractHelper
             $liClasses = array();
             // Is page active?
             if ($isActive) {
-                $liClasses[] = $this->liActiveClass;
+                $liClasses[] = $liActiveClass;
             }
             // Add CSS class from page to <li>
             if ($addClassToListItem && $page->getClass()) {
@@ -441,6 +447,10 @@ class Menu extends AbstractHelper
      *                                      use for UL element. Default
      *                                      is to use the value from
      *                                      {@link getUlClass()}.
+     * @param  string            $liActiveClass [optional] CSS class to
+     *                                          use for UL element. Default
+     *                                          is to use the value from
+     *                                          {@link getUlClass()}.
      * @param  string|int        $indent    [optional] indentation as
      *                                      a string or number of
      *                                      spaces. Default is to use
@@ -451,11 +461,13 @@ class Menu extends AbstractHelper
     public function renderSubMenu(
         AbstractContainer $container = null,
         $ulClass = null,
+        $liActiveClass = null,
         $indent = null
     ) {
         return $this->renderMenu($container, array(
             'indent'             => $indent,
             'ulClass'            => $ulClass,
+            'liActiveClass'      => $liActiveClass,
             'minDepth'           => null,
             'maxDepth'           => null,
             'onlyActiveBranch'   => true,
@@ -543,6 +555,12 @@ class Menu extends AbstractHelper
             $options['ulClass'] = (string) $options['ulClass'];
         } else {
             $options['ulClass'] = $this->getUlClass();
+        }
+        
+        if (isset($options['liActiveClass']) && $options['liActiveClass'] !== null) {
+            $options['liActiveClass'] = (string) $options['liActiveClass'];
+        } else {
+            $options['liActiveClass'] = $this->getLiActiveClass();
         }
 
         if (array_key_exists('minDepth', $options)) {

--- a/library/Zend/View/Helper/Navigation/Menu.php
+++ b/library/Zend/View/Helper/Navigation/Menu.php
@@ -63,6 +63,13 @@ class Menu extends AbstractHelper
     protected $ulClass = 'navigation';
 
     /**
+     * CSS class to use for the active li element
+     *
+     * @var string
+     */
+    protected $liActiveClass = 'active';
+    
+    /**
      * View helper entry point:
      * Retrieves helper and optionally sets container to operate on
      *
@@ -155,7 +162,7 @@ class Menu extends AbstractHelper
             $liClasses = array();
             // Is page active?
             if ($subPage->isActive(true)) {
-                $liClasses[] = 'active';
+                $liClasses[] = $this->liActiveClass;
             }
             // Add CSS class from page to <li>
             if ($addClassToListItem && $subPage->getClass()) {
@@ -324,7 +331,7 @@ class Menu extends AbstractHelper
             $liClasses = array();
             // Is page active?
             if ($isActive) {
-                $liClasses[] = 'active';
+                $liClasses[] = $this->liActiveClass;
             }
             // Add CSS class from page to <li>
             if ($addClassToListItem && $page->getClass()) {
@@ -705,6 +712,21 @@ class Menu extends AbstractHelper
     {
         if (is_string($ulClass)) {
             $this->ulClass = $ulClass;
+        }
+
+        return $this;
+    }
+    
+    /**
+     * Sets CSS class to use for the active 'li' element when rendering
+     *
+     * @param  string $liActiveClass CSS class to set
+     * @return Menu
+     */
+    public function setLiActiveClass($liActiveClass)
+    {
+        if (is_string($liActiveClass)) {
+            $this->liActiveClass = $liActiveClass;
         }
 
         return $this;

--- a/tests/ZendTest/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/MenuTest.php
@@ -169,6 +169,13 @@ class MenuTest extends AbstractTest
         $expected = $this->_getExpected('menu/css.html');
         $this->assertEquals($expected, $this->_helper->render($this->_nav2));
     }
+    
+    public function testSetLiActiveCssClass()
+    {
+        $this->_helper->setLiActiveClassClass('activated');
+        $expected = $this->_getExpected('menu/css2.html');
+        $this->assertEquals($expected, $this->_helper->render($this->_nav2));
+    }
 
     public function testOptionEscapeLabelsAsTrue()
     {

--- a/tests/ZendTest/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/MenuTest.php
@@ -172,7 +172,7 @@ class MenuTest extends AbstractTest
     
     public function testSetLiActiveCssClass()
     {
-        $this->_helper->setLiActiveClassClass('activated');
+        $this->_helper->setLiActiveClass('activated');
         $expected = $this->_getExpected('menu/css2.html');
         $this->assertEquals($expected, $this->_helper->render($this->_nav2));
     }

--- a/tests/ZendTest/View/Helper/Navigation/_files/expected/menu/css2.html
+++ b/tests/ZendTest/View/Helper/Navigation/_files/expected/menu/css2.html
@@ -1,0 +1,11 @@
+<ul class="navigation">
+    <li>
+        <a href="site1">Site 1</a>
+    </li>
+    <li class="activated">
+        <a href="site2">Site 2</a>
+    </li>
+    <li>
+        <a href="site3">Site 3</a>
+    </li>
+</ul>


### PR DESCRIPTION
Add ability to set custom class name for active "li" element in menu.
Example:
echo $this->navigation('navigation')->menu()
     ->setUlClass('uk-navbar-nav uk-hidden-small')
     ->setLiActiveClass('uk-active')
     ->setMaxDepth(0)
     ->setRenderInvisible(false);
