### PR TITLE
Allow modules to load their own dependencies

### DIFF
--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -140,8 +140,24 @@ class ModuleManager implements ModuleManagerInterface
             return $this->loadedModules[$moduleName];
         }
 
-        $event = clone $this->getEvent();
+        /*
+         * Keep track of nested module loading using the $loadFinished
+         * property.
+         *
+         * Increment the value for each loadModule() call and then decrement
+         * once the loading process is complete.
+         *
+         * To load a module, we clone the event if we are inside a nested
+         * loadModule() call, and use the original event otherwise.
+         */
+        if (!isset($this->loadFinished)) {
+             $this->loadFinished = 0;
+        }
+
+        $event = ($this->loadFinished > 0) ? clone $this->getEvent() : $this->getEvent();
         $event->setModuleName($moduleName);
+
+        $this->loadFinished++;
 
         if (!is_object($module)) {
             $module = $this->loadModuleByName($event);
@@ -150,6 +166,8 @@ class ModuleManager implements ModuleManagerInterface
 
         $this->loadedModules[$moduleName] = $module;
         $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
+
+        $this->loadFinished--;
 
         return $module;
     }

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -140,10 +140,8 @@ class ModuleManager implements ModuleManagerInterface
             return $this->loadedModules[$moduleName];
         }
 
-        $event = ($this->loadFinished === false) ? clone $this->getEvent() : $this->getEvent();
+        $event = clone $this->getEvent();
         $event->setModuleName($moduleName);
-
-        $this->loadFinished = false;
 
         if (!is_object($module)) {
             $module = $this->loadModuleByName($event);
@@ -152,8 +150,6 @@ class ModuleManager implements ModuleManagerInterface
 
         $this->loadedModules[$moduleName] = $module;
         $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
-
-        $this->loadFinished = true;
 
         return $module;
     }

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -142,6 +142,9 @@ class ModuleManagerTest extends TestCase
         $config = $configListener->getMergedConfig();
         $this->assertTrue(isset($config['loaded']));
         $this->assertSame('oh, yeah baby!', $config['loaded']);
+
+        $this->assertTrue(isset($config['baz']));
+        $this->assertSame('bar', $config['baz']);
     }
 
     public function testModuleIsMarkedAsLoadedWhenLoadModuleEventIsTriggered()

--- a/tests/ZendTest/ModuleManager/TestAsset/LoadOtherModule/Module.php
+++ b/tests/ZendTest/ModuleManager/TestAsset/LoadOtherModule/Module.php
@@ -15,6 +15,7 @@ class Module
     public function init($moduleManager)
     {
         $moduleManager->loadModule('BarModule');
+        $moduleManager->loadModule('BazModule');
     }
 
     public function getConfig()


### PR DESCRIPTION
Just testing the waters here.

Let's say our application has 3 modules A, B, and C. Module B depends on modules C, D, and E.

```
A
B -> C, D, E
C
```

But in our `application.config.php` we only specify A, B, and C.

``` php
return array(
    'modules' => array(
        'A',
        'B',
        'C',
    ),
);
```

This little patch will allow B to load its dependencies D and E without having the user to specify it in their `application.config.php`.

``` php
namespace B;

use Zend\ModuleManager\ModuleManager;

class Module
{
    public function init(ModuleManager $modules)
    {
        $modules->loadModule('C');
        $modules->loadModule('D');
        $modules->loadModule('E');
    }
}
```
