### PR TITLE
Add a new Hydrator for working with DOMNodes

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Dom.php
+++ b/library/Zend/Stdlib/Hydrator/Dom.php
@@ -10,7 +10,6 @@
 namespace Zend\Stdlib\Hydrator;
 
 use DOMNode;
-use DOMElement;
 use DOMXPath;
 use Zend\Stdlib\Exception;
 
@@ -20,81 +19,81 @@ class Dom extends AbstractHydrator implements HydratorOptionsInterface
      * @var array
      */
     protected $queryMap = array();
-    
+
     /**
      * @var DOMXPath
      */
     protected $xpath;
-    
+
     /**
      * Construct a new DOM hydrator
      *
-     * @param array $queryMap = null
-     * @param DOMXPath $xpath = null
+     * @param  array    $queryMap = null
+     * @param  DOMXPath $xpath    = null
      * @return void
      */
     public function __construct($queryMap = null, DOMXPath $xpath = null)
     {
         parent::__construct();
-        
-        if($queryMap) {
+
+        if ($queryMap) {
             $this->setQueryMap($queryMap);
         }
-        
-        if($xpath) {
+
+        if ($xpath) {
             $this->setXPath($xpath);
         }
     }
-    
+
     /**
-     * @param array $options
+     * @param  array $options
      * @return DOM
      */
     public function setOptions($options)
     {
-        if($options instanceof Traversable) {
+        if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
-        } elseif(!is_array($options)) {
+        } elseif (!is_array($options)) {
             throw new Exception\InvalidArgumentException(
                 'The options parameter must be an array or a Traversable'
             );
         }
-        
-        if(isset($options['queryMap'])) {
+
+        if (isset($options['queryMap'])) {
             $this->setQueryMap($options['queryMap']);
         }
-        
-        if(isset($options["xpath"])) {
+
+        if (isset($options["xpath"])) {
             $this->setXPath($options["xpath"]);
         }
 
         return $this;
     }
-    
+
     /**
      * Get the query map
-     * 
+     *
      * @return array
      */
     public function getQueryMap()
     {
         return $this->queryMap?:array();
     }
-    
+
     /**
      * Set a map of keys to XPath query strings
      *
-     * @param array $queryMap
+     * @param  array $queryMap
      * @return DOM
      */
     public function setQueryMap($queryMap)
     {
         $queryMap = is_array($queryMap)?$queryMap:null;
         $this->queryMap = $queryMap;
-        
+
         return $this;
     }
-    
+
     /**
      * Get the XPath associated with this hydrator
      *
@@ -104,11 +103,11 @@ class Dom extends AbstractHydrator implements HydratorOptionsInterface
     {
         return $this->xpath;
     }
-    
+
     /**
      * Set the XPath for this hydrator
      *
-     * @param DOMXPath $xpath
+     * @param  DOMXPath $xpath
      * @return DOM
      */
     public function setXPath(DOMXPath $xpath)
@@ -117,17 +116,17 @@ class Dom extends AbstractHydrator implements HydratorOptionsInterface
             throw new Exception\InvalidArgumentException(
                 "The xpath must be null or a DOMXPath"
             );
-    
+
         $this->xpath = $xpath;
-        
+
         return $this;
     }
-    
+
     /**
      * Extract values from the given context node, using each query
      * in the query map.
      *
-     * @param DOMNode $node
+     * @param  DOMNode $node
      * @return array
      */
     public function extract($node)
@@ -136,43 +135,43 @@ class Dom extends AbstractHydrator implements HydratorOptionsInterface
             throw new Exception\BadMethodCallException(sprintf(
                 '%s expects the provided $object to be a DOMNode', __METHOD__
             ));
-        
-        if(!($this->xpath instanceof DOMXPath)) {
+
+        if (!($this->xpath instanceof DOMXPath)) {
             $this->setXPath(new DOMXPath($node->ownerDocument));
         }
-        
+
         $xpath = $this->getXPath();
 
         $attributes = array();
-        
-        foreach($this->getQueryMap() as $attribute => $query) {
+
+        foreach ($this->getQueryMap() as $attribute => $query) {
             $attributeNodes = $xpath->query($query, $node);
             if(!$attributeNodes)
                 throw new \InvalidArgumentException("Malformed query");
-            if($attributeNodes->length === 1) {
+            if ($attributeNodes->length === 1) {
                 $attributeNode = $attributeNodes->item(0);
-                if($attributeNode instanceof DOMNode) {
+                if ($attributeNode instanceof DOMNode) {
                     $attributes[$attribute] = $attributeNode->nodeValue;
                 }
-            } elseif($attributeNodes->length > 1) {
+            } elseif ($attributeNodes->length > 1) {
                 $attributes[$attribute] = array();
-                foreach($attributeNodes as $attributeNode) {
-                    if($attributeNode instanceof DOMNode) {
+                foreach ($attributeNodes as $attributeNode) {
+                    if ($attributeNode instanceof DOMNode) {
                         $attributes[$attribute][] = $attributeNode->nodeValue;
                     }
                 }
             }
         }
-        
+
         return $attributes;
     }
-    
+
     /**
      * Hydrate the given DOMNode with the input data, based on the query
      * map.
      *
-     * @param array $data
-     * @param DOMNode $node
+     * @param  array   $data
+     * @param  DOMNode $node
      * @return DOMNode
      */
     public function hydrate(array $data, $node)
@@ -181,25 +180,25 @@ class Dom extends AbstractHydrator implements HydratorOptionsInterface
             throw new Exception\BadMethodCallException(sprintf(
                 '%s expects the provided $object to be a DOMNode)', __METHOD__
             ));
-        
-        if(!($this->xpath instanceof DOMXPath)) {
+
+        if (!($this->xpath instanceof DOMXPath)) {
             $this->setXPath(new DOMXPath($node->ownerDocument));
         }
-        
+
         $xpath = $this->getXPath();
-        
+
         $queryMap = $this->getQueryMap();
-        
-        foreach($data as $attribute => $value) {
+
+        foreach ($data as $attribute => $value) {
             if(!isset($queryMap[$attribute]))
                 continue;
-            
+
             $attributeNode = $xpath->query($queryMap[$attribute], $node)->item(0);
-            if($attributeNode instanceof DOMNode) {
+            if ($attributeNode instanceof DOMNode) {
                 $attributeNode->nodeValue = $value;
             }
         }
-        
+
         return $node;
     }
 }

--- a/library/Zend/Stdlib/Hydrator/Dom.php
+++ b/library/Zend/Stdlib/Hydrator/Dom.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Hydrator;
+
+use DOMNode;
+use DOMElement;
+use DOMXPath;
+use Zend\Stdlib\Exception;
+
+class Dom extends AbstractHydrator implements HydratorOptionsInterface
+{
+    /**
+     * @var array
+     */
+    protected $queryMap = array();
+    
+    /**
+     * @var DOMXPath
+     */
+    protected $xpath;
+    
+    /**
+     * Construct a new DOM hydrator
+     *
+     * @param array $queryMap = null
+     * @param DOMXPath $xpath = null
+     * @return void
+     */
+    public function __construct($queryMap = null, DOMXPath $xpath = null)
+    {
+        parent::__construct();
+        
+        if($queryMap) {
+            $this->setQueryMap($queryMap);
+        }
+        
+        if($xpath) {
+            $this->setXPath($xpath);
+        }
+    }
+    
+    /**
+     * @param array $options
+     * @return DOM
+     */
+    public function setOptions($options)
+    {
+        if($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        } elseif(!is_array($options)) {
+            throw new Exception\InvalidArgumentException(
+                'The options parameter must be an array or a Traversable'
+            );
+        }
+        
+        if(isset($options['queryMap'])) {
+            $this->setQueryMap($options['queryMap']);
+        }
+        
+        if(isset($options["xpath"])) {
+            $this->setXPath($options["xpath"]);
+        }
+
+        return $this;
+    }
+    
+    /**
+     * Get the query map
+     * 
+     * @return array
+     */
+    public function getQueryMap()
+    {
+        return $this->queryMap?:array();
+    }
+    
+    /**
+     * Set a map of keys to XPath query strings
+     *
+     * @param array $queryMap
+     * @return DOM
+     */
+    public function setQueryMap($queryMap)
+    {
+        $queryMap = is_array($queryMap)?$queryMap:null;
+        $this->queryMap = $queryMap;
+        
+        return $this;
+    }
+    
+    /**
+     * Get the XPath associated with this hydrator
+     *
+     * @return DOMXPath
+     */
+    public function getXPath()
+    {
+        return $this->xpath;
+    }
+    
+    /**
+     * Set the XPath for this hydrator
+     *
+     * @param DOMXPath $xpath
+     * @return DOM
+     */
+    public function setXPath(DOMXPath $xpath)
+    {
+        if(!is_null($xpath) && !($xpath instanceof DOMXPath))
+            throw new Exception\InvalidArgumentException(
+                "The xpath must be null or a DOMXPath"
+            );
+    
+        $this->xpath = $xpath;
+        
+        return $this;
+    }
+    
+    /**
+     * Extract values from the given context node, using each query
+     * in the query map.
+     *
+     * @param DOMNode $node
+     * @return array
+     */
+    public function extract($node)
+    {
+        if(!($node instanceof DOMNode))
+            throw new Exception\BadMethodCallException(sprintf(
+                '%s expects the provided $object to be a DOMNode', __METHOD__
+            ));
+        
+        if(!($this->xpath instanceof DOMXPath)) {
+            $this->setXPath(new DOMXPath($node->ownerDocument));
+        }
+        
+        $xpath = $this->getXPath();
+
+        $attributes = array();
+        
+        foreach($this->getQueryMap() as $attribute => $query) {
+            $attributeNodes = $xpath->query($query, $node);
+            if(!$attributeNodes)
+                throw new \InvalidArgumentException("Malformed query");
+            if($attributeNodes->length === 1) {
+                $attributeNode = $attributeNodes->item(0);
+                if($attributeNode instanceof DOMNode) {
+                    $attributes[$attribute] = $attributeNode->nodeValue;
+                }
+            } elseif($attributeNodes->length > 1) {
+                $attributes[$attribute] = array();
+                foreach($attributeNodes as $attributeNode) {
+                    if($attributeNode instanceof DOMNode) {
+                        $attributes[$attribute][] = $attributeNode->nodeValue;
+                    }
+                }
+            }
+        }
+        
+        return $attributes;
+    }
+    
+    /**
+     * Hydrate the given DOMNode with the input data, based on the query
+     * map.
+     *
+     * @param array $data
+     * @param DOMNode $node
+     * @return DOMNode
+     */
+    public function hydrate(array $data, $node)
+    {
+        if(!($node instanceof DOMNode))
+            throw new Exception\BadMethodCallException(sprintf(
+                '%s expects the provided $object to be a DOMNode)', __METHOD__
+            ));
+        
+        if(!($this->xpath instanceof DOMXPath)) {
+            $this->setXPath(new DOMXPath($node->ownerDocument));
+        }
+        
+        $xpath = $this->getXPath();
+        
+        $queryMap = $this->getQueryMap();
+        
+        foreach($data as $attribute => $value) {
+            if(!isset($queryMap[$attribute]))
+                continue;
+            
+            $attributeNode = $xpath->query($queryMap[$attribute], $node)->item(0);
+            if($attributeNode instanceof DOMNode) {
+                $attributeNode->nodeValue = $value;
+            }
+        }
+        
+        return $node;
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/DomTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/DomTest.php
@@ -23,10 +23,10 @@ use Zend\Stdlib\Hydrator\Dom;
 class DomTest extends \PHPUnit_Framework_TestCase
 {
     protected $hydrator;
-    
+
     /**
      * Test extraction of a sample DOMNode
-     * 
+     *
      * @dataProvider extractionProvider
      */
     public function testExtraction(DOMNode $node, array $queryMap, array $values)
@@ -35,7 +35,7 @@ class DomTest extends \PHPUnit_Framework_TestCase
         $result = $this->hydrator->extract($node);
         $this->assertEquals($values, $result);
     }
-    
+
     /**
      * Test hydration of a DOMNode
      *
@@ -45,14 +45,14 @@ class DomTest extends \PHPUnit_Framework_TestCase
     {
         $this->hydrator->setQueryMap($queryMap);
         $result = $this->hydrator->hydrate($values, $node);
-        
+
         $xpath = $this->hydrator->getXPath();
-        
-        foreach($queryMap as $key => $path) {
+
+        foreach ($queryMap as $key => $path) {
             $this->assertEquals($values[$key], $xpath->query($path, $result)->item(0)->nodeValue);
         }
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -60,29 +60,29 @@ class DomTest extends \PHPUnit_Framework_TestCase
     {
         $this->hydrator = new Dom;
     }
-    
+
     public function extractionProvider()
     {
         $document = new DOMDocument;
         $document->load(__DIR__.'/_files/DomTestNode_Extraction.xml');
         $xpath = new DOMXPath($document);
-        
+
         $testNode = $xpath->query("//*")->item(0);
-    
+
         $queryMap = array(
             "sampleattr" => "@sampleattr",
             "NodeOne" => "NodeOne",
             "NodeTwo" => "NodeTwo",
             "NodeThree" => "ParentNode/NodeThree"
         );
-        
+
         $values = array(
             "sampleattr" => "sampleattr_value",
             "NodeOne" => "NodeOne_value",
             "NodeTwo" => "",
             "NodeThree" => "NodeThree_value"
         );
-        
+
         return array(
             array(
                 $testNode,
@@ -91,29 +91,29 @@ class DomTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
-    
+
     public function hydrationProvider()
     {
         $document = new DOMDocument;
         $document->load(__DIR__.'/_files/DomTestNode_Extraction.xml');
         $xpath = new DOMXPath($document);
-        
+
         $testNode = $xpath->query("//*")->item(0);
-        
+
         $queryMap = array(
             "sampleattr" => "@sampleattr",
             "NodeOne" => "NodeOne",
             "NodeTwo" => "NodeTwo",
             "NodeThree" => "ParentNode/NodeThree"
         );
-        
+
         $values = array(
             "sampleattr" => "sampleattr_value",
             "NodeOne" => "NodeOne_value",
             "NodeTwo" => "",
             "NodeThree" => "NodeThree_value"
         );
-        
+
         return array(
             array(
                 $testNode,

--- a/tests/ZendTest/Stdlib/Hydrator/DomTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/DomTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator;
+
+use DOMDocument;
+use DOMNode;
+use DOMXPath;
+use Zend\Stdlib\Hydrator\Dom;
+
+/**
+ * Unit tests for {@see \Zend\Stdlib\Hydrator\Dom}
+ *
+ * @covers \Zend\Stdlib\Hydrator\Dom
+ * @group Zend_Stdlib
+ */
+class DomTest extends \PHPUnit_Framework_TestCase
+{
+    protected $hydrator;
+    
+    /**
+     * Test extraction of a sample DOMNode
+     * 
+     * @dataProvider extractionProvider
+     */
+    public function testExtraction(DOMNode $node, array $queryMap, array $values)
+    {
+        $this->hydrator->setQueryMap($queryMap);
+        $result = $this->hydrator->extract($node);
+        $this->assertEquals($values, $result);
+    }
+    
+    /**
+     * Test hydration of a DOMNode
+     *
+     * @dataProvider hydrationProvider
+     */
+    public function testHydration(DOMNode $node, array $queryMap, array $values)
+    {
+        $this->hydrator->setQueryMap($queryMap);
+        $result = $this->hydrator->hydrate($values, $node);
+        
+        $xpath = $this->hydrator->getXPath();
+        
+        foreach($queryMap as $key => $path) {
+            $this->assertEquals($values[$key], $xpath->query($path, $result)->item(0)->nodeValue);
+        }
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->hydrator = new Dom;
+    }
+    
+    public function extractionProvider()
+    {
+        $document = new DOMDocument;
+        $document->load(__DIR__.'/_files/DomTestNode_Extraction.xml');
+        $xpath = new DOMXPath($document);
+        
+        $testNode = $xpath->query("//*")->item(0);
+    
+        $queryMap = array(
+            "sampleattr" => "@sampleattr",
+            "NodeOne" => "NodeOne",
+            "NodeTwo" => "NodeTwo",
+            "NodeThree" => "ParentNode/NodeThree"
+        );
+        
+        $values = array(
+            "sampleattr" => "sampleattr_value",
+            "NodeOne" => "NodeOne_value",
+            "NodeTwo" => "",
+            "NodeThree" => "NodeThree_value"
+        );
+        
+        return array(
+            array(
+                $testNode,
+                $queryMap,
+                $values
+            )
+        );
+    }
+    
+    public function hydrationProvider()
+    {
+        $document = new DOMDocument;
+        $document->load(__DIR__.'/_files/DomTestNode_Extraction.xml');
+        $xpath = new DOMXPath($document);
+        
+        $testNode = $xpath->query("//*")->item(0);
+        
+        $queryMap = array(
+            "sampleattr" => "@sampleattr",
+            "NodeOne" => "NodeOne",
+            "NodeTwo" => "NodeTwo",
+            "NodeThree" => "ParentNode/NodeThree"
+        );
+        
+        $values = array(
+            "sampleattr" => "sampleattr_value",
+            "NodeOne" => "NodeOne_value",
+            "NodeTwo" => "",
+            "NodeThree" => "NodeThree_value"
+        );
+        
+        return array(
+            array(
+                $testNode,
+                $queryMap,
+                $values
+            )
+        );
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/_files/DomTestNode_Extraction.xml
+++ b/tests/ZendTest/Stdlib/Hydrator/_files/DomTestNode_Extraction.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DomTestNode sampleattr="sampleattr_value">
+    <NodeOne>NodeOne_value</NodeOne>
+    <NodeTwo></NodeTwo>
+    <ParentNode>
+        <NodeThree>NodeThree_value</NodeThree>
+    </ParentNode>
+</DomTestNode>

--- a/tests/ZendTest/Stdlib/Hydrator/_files/DomTestNode_Hydration.xml
+++ b/tests/ZendTest/Stdlib/Hydrator/_files/DomTestNode_Hydration.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DomTestNode sampleattr="">
+    <NodeOne></NodeOne>
+    <NodeTwo></NodeTwo>
+    <ParentNode>
+        <NodeThree></NodeThree>
+    </ParentNode>
+</DomTestNode>


### PR DESCRIPTION
I developed this new hydrator as part of client project and found it to be immensely useful. Its purpose is to extract and hydrate DOMNode instances based on supplied XPath queries.

At this point, I'm submitting this PR as mostly a request for comments on the code. I believe it could be a valuable addition to ZF2, but it might not be exactly in line with the standard way of doing things.
