### PR TITLE
Fix a fatal error when assert WWW-Authenticate header is sent - Hotfix/5658

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -88,15 +88,31 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $header
             ));
         }
-        if ($match != $responseHeader->getFieldValue()) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+
+        if (!$responseHeader instanceof \ArrayIterator) {
+            $responseHeader = array($responseHeader);
+        }
+
+        $headerMatched = false;
+
+        foreach ($responseHeader as $currentHeader) {
+            if ($match == $currentHeader->getFieldValue()) {
+                $this->assertEquals($match, $currentHeader->getFieldValue());
+                $headerMatched = true;
+                break;
+            }
+        }
+
+        if (!$headerMatched) {
+            throw new \PHPUnit_Framework_ExpectationFailedException(sprintf(
                 'Failed asserting response header "%s" exists and contains "%s", actual content is "%s"',
                 $header,
                 $match,
-                $responseHeader->getFieldValue()
+                $currentHeader->getFieldValue()
             ));
         }
-        $this->assertEquals($match, $responseHeader->getFieldValue());
+
+        $this->assertEquals($match, $currentHeader->getFieldValue());
     }
 
     /**
@@ -114,14 +130,22 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $header
             ));
         }
-        if ($match == $responseHeader->getFieldValue()) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
-                'Failed asserting response header "%s" DOES NOT CONTAIN "%s"',
-                $header,
-                $match
-            ));
+
+        if (!$responseHeader instanceof \ArrayIterator) {
+            $responseHeader = array($responseHeader);
         }
-        $this->assertNotEquals($match, $responseHeader->getFieldValue());
+
+        foreach ($responseHeader as $currentHeader) {
+            if ($match == $currentHeader->getFieldValue()) {
+                throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+                    'Failed asserting response header "%s" DOES NOT CONTAIN "%s"',
+                    $header,
+                    $match
+                ));
+            }
+        }
+
+        $this->assertNotEquals($match, $currentHeader->getFieldValue());
     }
 
     /**
@@ -139,15 +163,31 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $header
             ));
         }
-        if (!preg_match($pattern, $responseHeader->getFieldValue())) {
+
+        if (!$responseHeader instanceof \ArrayIterator) {
+            $responseHeader = array($responseHeader);
+        }
+
+        $headerMatched = false;
+
+        foreach ($responseHeader as $currentHeader) {
+            $headerMatched = (bool) preg_match($pattern, $currentHeader->getFieldValue());
+
+            if ($headerMatched) {
+                break;
+            }
+        }
+
+        if (!$headerMatched) {
             throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
                 'Failed asserting response header "%s" exists and matches regex "%s", actual content is "%s"',
                 $header,
                 $pattern,
-                $responseHeader->getFieldValue()
+                $currentHeader->getFieldValue()
             ));
         }
-        $this->assertTrue((bool) preg_match($pattern, $responseHeader->getFieldValue()));
+
+        $this->assertTrue($headerMatched);
     }
 
     /**
@@ -165,14 +205,26 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $header
             ));
         }
-        if (preg_match($pattern, $responseHeader->getFieldValue())) {
-            throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
-                'Failed asserting response header "%s" DOES NOT MATCH regex "%s"',
-                $header,
-                $pattern
-            ));
+
+        if (!$responseHeader instanceof \ArrayIterator) {
+            $responseHeader = array($responseHeader);
         }
-        $this->assertFalse((bool) preg_match($pattern, $responseHeader->getFieldValue()));
+
+        $headerMatched = false;
+
+        foreach ($responseHeader as $currentHeader) {
+            $headerMatched = (bool) preg_match($pattern, $currentHeader->getFieldValue());
+
+            if ($headerMatched) {
+                throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
+                    'Failed asserting response header "%s" DOES NOT MATCH regex "%s"',
+                    $header,
+                    $pattern
+                ));
+            }
+        }
+
+        $this->assertFalse($headerMatched);
     }
 
     /**

--- a/library/Zend/Test/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -97,7 +97,6 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
 
         foreach ($responseHeader as $currentHeader) {
             if ($match == $currentHeader->getFieldValue()) {
-                $this->assertEquals($match, $currentHeader->getFieldValue());
                 $headerMatched = true;
                 break;
             }

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -84,6 +84,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseHeaderContains('Content-Type', 'text/json');
     }
 
+    public function testAssertResponseHeaderContainsMultipleHeaderInterface()
+    {
+        $this->dispatch('/tests');
+        $this->assertResponseHeaderContains('WWW-Authenticate', 'Basic realm="ZF2"');
+    }
+
     public function testAssertNotResponseHeaderContains()
     {
         $this->dispatch('/tests');
@@ -91,6 +97,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotResponseHeaderContains('Content-Type', 'text/html');
+    }
+
+    public function testAssertNotResponseHeaderContainsMultipleHeaderInterface()
+    {
+        $this->dispatch('/tests');
+        $this->assertNotResponseHeaderContains('WWW-Authenticate', 'Basic realm="ZF3"');
     }
 
     public function testAssertResponseHeaderRegex()
@@ -105,6 +117,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseHeaderRegex('Content-Type', '#json#');
     }
 
+    public function testAssertResponseHeaderRegexMultipleHeaderInterface()
+    {
+        $this->dispatch('/tests');
+        $this->assertResponseHeaderRegex('WWW-Authenticate', '#"ZF2"$#');
+    }
+
     public function testAssertNotResponseHeaderRegex()
     {
         $this->dispatch('/tests');
@@ -112,6 +130,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotResponseHeaderRegex('Content-Type', '#html$#');
+    }
+
+    public function testAssertNotResponseHeaderRegexMultipleHeaderInterface()
+    {
+        $this->dispatch('/tests');
+        $this->assertNotResponseHeaderRegex('WWW-Authenticate', '#"ZF3"$#');
     }
 
     public function testAssertRedirect()

--- a/tests/ZendTest/Test/_files/Baz/src/Baz/Controller/IndexController.php
+++ b/tests/ZendTest/Test/_files/Baz/src/Baz/Controller/IndexController.php
@@ -15,7 +15,10 @@ class IndexController extends AbstractActionController
 {
     public function unittestsAction()
     {
-        $this->getResponse()->getHeaders()->addHeaderLine('Content-Type: text/html');
+        $this->getResponse()
+            ->getHeaders()
+            ->addHeaderLine('Content-Type: text/html')
+            ->addHeaderLine('WWW-Authenticate: Basic realm="ZF2"');
 
         $num_get = $this->getRequest()->getQuery()->get('num_get', 0);
         $num_post = $this->getRequest()->getPost()->get('num_post', 0);


### PR DESCRIPTION
Fix a fatal error that occured when an assert[Not]ReponseHeader\* method is called to check a MultipleHeaderInterface (like WWW-Authenticate).

When dealing with MultipleHeaderInterface :
- assert\* methods will check that at least one header match.
- assertNot\* methods will check that every headers doesn't match.

Concerns issue #5658
