### PR TITLE
[Minor BC] Remove translation of validator keys

### DIFF
--- a/library/Zend/Validator/AbstractValidator.php
+++ b/library/Zend/Validator/AbstractValidator.php
@@ -575,13 +575,6 @@ abstract class AbstractValidator implements
             return $message;
         }
 
-        $translated = $translator->translate(
-            $messageKey, $this->getTranslatorTextDomain()
-        );
-        if ($translated !== $messageKey) {
-            return $translated;
-        }
-
         return $translator->translate(
             $message, $this->getTranslatorTextDomain()
         );

--- a/tests/ZendTest/Validator/AbstractTest.php
+++ b/tests/ZendTest/Validator/AbstractTest.php
@@ -76,28 +76,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = array(
-            'fooMessage' => 'This is the translated message for %value%',
-        );
-        $translator = new TestAsset\Translator();
-        $translator->getPluginManager()->setService('default', $loader);
-        $translator->addTranslationFile('default', null);
-
-        $this->validator->setTranslator($translator);
-        $this->assertFalse($this->validator->isValid('bar'));
-        $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('fooMessage', $messages));
-        $this->assertContains('bar', $messages['fooMessage'], var_export($messages, 1));
-        $this->assertContains('This is the translated message for ', $messages['fooMessage']);
-    }
-
-    public function testCanTranslateMessagesInsteadOfKeys()
-    {
-        if (!extension_loaded('intl')) {
-            $this->markTestSkipped('ext/intl not enabled');
-        }
-
-        $loader = new TestAsset\ArrayTranslator();
-        $loader->translations = array(
             '%value% was passed' => 'This is the translated message for %value%',
         );
         $translator = new TestAsset\Translator();

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -420,7 +420,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
         $hostnameValidator = new Hostname();
         $translations = array(
             'hostnameIpAddressNotAllowed'   => 'hostnameIpAddressNotAllowed translation',
-            'hostnameUnknownTld'            => 'hostnameUnknownTld translation',
+            'hostnameUnknownTld'            => 'The input appears to be a DNS hostname but cannot match TLD against known list',
             'hostnameDashCharacter'         => 'hostnameDashCharacter translation',
             'hostnameInvalidHostnameSchema' => 'hostnameInvalidHostnameSchema translation',
             'hostnameUndecipherableTld'     => 'hostnameUndecipherableTld translation',

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -261,7 +261,7 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
         }
 
         $translations = array(
-            'hostnameInvalidLocalName' => 'this is the IP error message',
+            'hostnameInvalidLocalName' => 'The input does not appear to be a valid local network name',
         );
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = $translations;

--- a/tests/ZendTest/Validator/StaticValidatorTest.php
+++ b/tests/ZendTest/Validator/StaticValidatorTest.php
@@ -96,7 +96,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
 
         $loader = new TestAsset\ArrayTranslator();
         $loader->translations = array(
-            Alpha::INVALID => 'This is the translated message for %value%',
+            'Invalid type given. String expected' => 'This is the translated message for %value%',
         );
         $translator = new TestAsset\Translator();
         $translator->getPluginManager()->setService('default', $loader);
@@ -105,6 +105,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->setTranslator($translator);
         $this->assertFalse($this->validator->isValid(123));
         $messages = $this->validator->getMessages();
+
         $this->assertTrue(array_key_exists(Alpha::INVALID, $messages));
         $this->assertEquals('This is...', $messages[Alpha::INVALID]);
     }


### PR DESCRIPTION
Removes the translation of validator message **_keys**_ which is totally
absurd in the first place. They are constants that should not be
modified.
