### PR TITLE
Remove translations in Zend\Form\View\Helper\FormElementErrors #5646

### DIFF
--- a/library/Zend/Form/View/Helper/FormElementErrors.php
+++ b/library/Zend/Form/View/Helper/FormElementErrors.php
@@ -78,11 +78,7 @@ class FormElementErrors extends AbstractHelper
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
         $messagesToPrint = array();
-        $self = $this;
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, $self) {
-            if (null !== ($translator = $self->getTranslator())) {
-                $item = $translator->translate($item, $self->getTranslatorTextDomain());
-            }
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml) {
             $messagesToPrint[] = $escapeHtml($item);
         });
 

--- a/tests/ZendTest/Form/View/Helper/FormElementErrorsTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementErrorsTest.php
@@ -129,41 +129,4 @@ class FormElementErrorsTest extends CommonTestCase
         $helper = $this->helper;
         $this->assertEquals($helper(), $helper);
     }
-
-    public function testCanTranslateContent()
-    {
-        $messages = array(array(
-            'First validator message',
-        ));
-
-        $element = new Element('foo');
-        $element->setMessages($messages);
-
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
-        $mockTranslator->expects($this->exactly(1))
-                       ->method('translate')
-                       ->will($this->returnValue('translated content'));
-
-        $this->helper->setTranslator($mockTranslator);
-        $this->assertTrue($this->helper->hasTranslator());
-
-        $markup = $this->helper->__invoke($element);
-        $this->assertRegexp('#<ul[^>]*>\s*<li>translated content</li>\s*</ul>#s', $markup);
-    }
-
-    public function testTranslatorMethods()
-    {
-        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
-        $this->helper->setTranslator($translatorMock, 'foo');
-
-        $this->assertEquals($translatorMock, $this->helper->getTranslator());
-        $this->assertEquals('foo', $this->helper->getTranslatorTextDomain());
-        $this->assertTrue($this->helper->hasTranslator());
-        $this->assertTrue($this->helper->isTranslatorEnabled());
-
-        $this->helper->setTranslatorEnabled(false);
-        $this->assertFalse($this->helper->isTranslatorEnabled());
-    }
-
-
 }


### PR DESCRIPTION
For some reason we are retranslating the messages again in the `Zend\Form\View\Helper\FormElementErrors` view helper.
This has probably gone unnoticed due to the fact that missing translations don't cause any error. 

Closes #5646
