### PR TITLE
Update Select.php

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -347,7 +347,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     /**
      * Create where clause
      *
-     * @param  Where|\Closure|string|array $predicate
+     * @param  Where|\Closure|string|array|Predicate\PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return Select
      */
@@ -355,6 +355,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         if ($predicate instanceof Having) {
             $this->having = $predicate;
+        elseif ($predicate instanceof Predicate\PredicateInterface) {
+            $this->having->addPredicate($predicate, $combination);
         } elseif ($predicate instanceof \Closure) {
             $predicate($this->having);
         } else {


### PR DESCRIPTION
Add the ability to send a Predicate\PredicateInterface value for $predicate param on Zend_Db\Sql\Select::having($predicate,$combination)

With just 2 more lines, the having method is working like where method.
