### PR TITLE
Add controller namespace prefix to template mapping

### DIFF
--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -122,8 +122,8 @@ class ViewManager extends AbstractListenerAggregate
         $routeNotFoundStrategy   = $this->getRouteNotFoundStrategy();
         $exceptionStrategy       = $this->getExceptionStrategy();
         $mvcRenderingStrategy    = $this->getMvcRenderingStrategy();
+        $injectTemplateListener  = $this->getInjectTemplateListener();
         $createViewModelListener = new CreateViewModelListener();
-        $injectTemplateListener  = new InjectTemplateListener();
         $injectViewModelListener = new InjectViewModelListener();
 
         $this->registerMvcRenderingStrategies($events);
@@ -343,6 +343,15 @@ class ViewManager extends AbstractListenerAggregate
         $this->services->setAlias('404Strategy', 'RouteNotFoundStrategy');
 
         return $this->routeNotFoundStrategy;
+    }
+
+    public function getInjectTemplateListener()
+    {
+        $listener = new InjectTemplateListener();
+        if (isset($this->config['controller_map'])) {
+            $listener->setControllerMap($this->config['controller_map']);
+        }
+        return $listener;
     }
 
     /**

--- a/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
@@ -164,6 +164,25 @@ class InjectTemplateListenerTest extends TestCase
         $this->assertEquals('zend-test/sample/test', $myViewModel->getTemplate());
     }
 
+    public function testFullControllerNameMatchIsMapped()
+    {
+        $this->listener->setControllerMap(array(
+            'Foo\Bar\Controller\IndexController' => 'string-value',
+        ));
+        $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
+        $this->assertEquals('string-value', $template);
+    }
+
+    public function testOnlyFullNamespaceMatchIsMapped()
+    {
+        $this->listener->setControllerMap(array(
+            'Foo' => 'foo-matched',
+            'Foo\Bar' => 'foo-bar-matched',
+        ));
+        $template = $this->listener->mapController('Foo\BarBaz\Controller\IndexController');
+        $this->assertEquals('foo-matched/bar-baz/index', $template);
+    }
+
     public function testControllerMapMatchedPrefixReplacedByStringValue()
     {
         $this->listener->setControllerMap(array(
@@ -172,7 +191,6 @@ class InjectTemplateListenerTest extends TestCase
         $template = $this->listener->mapController('Foo\Bar\Controller\IndexController');
         $this->assertEquals('string-value/index', $template);
     }
-
 
     public function testUsingNamespaceRouteParameterGivesSameResultAsFullControllerParameter()
     {


### PR DESCRIPTION
Zf2 modules are not at the core of the framework unlike zf1.
We no longer rely on naming conventions but rather on design by contract. As such current controller to template name resolution, where only top level namespace and class name are used, makes no sense. And there are valid use cases where it does not work at all.

Consider controller class `Vendor\Module\Controller\FooController`:
it will be resolved to `vendor/foo/action`. So as `Vendor\OtherModule\Controller\FooController` and even  `Vendor\OtherModule\Controller\Bar\FooController`.  
Unless... namespace parameter is specified in route, then resulting template name will suddenly change. Even if controller class does not match that namespace (surprise, mothaf...a!). Most unexpected and unreliable behaviour. 

To fix that annoying bit this PR introduces new behaviour. for controller class to view template name resolution
It is very simple:
1. strip `\Controller\` namespace
2. strip trailing Controller in classname
3. inflect CamelCase to dash
4. replace namespace separator with slash

Eg: `Xerkus\FooModule\Controller\Bar\FooController` -> `xerkus/foo-module/bar/foo/action`

To prevent BC break, this behaviour will only be applied if namespace is whitelisted:

```
'view_manager' => array(
    'controller_map' => array(
        // for one of my modules
        'Xerkus\FooModule' => true,
        // for all modules under my vendor namespace
        'Xerkus' => true,
        //for one controller
        'ZfcUser\Controller\UserController' => true
    ),
);
```

Most common use case is for modules that follow PSR-0, namely  `<Vendor name>\(Namespace\)*<Class Name>` rule.

As side effect of whitelist introduction, this PR introduces a way to specify a map of namespaces to template name prefixes  
Eg

```
'view_manager' => array(
    'controller_map' => array(
        'Xerkus\FooModule' => 'xrks-foo',
        // Xerkus\FooModule\Controller\BarController -> xrks-foo/bar/action
        'ZfcUser' => 'zf-commons/zfc-user',
        // ZfcUser\Controller\UserController -> zf-commons/zfc-user/user/action
        'ZfcUser\Controller\UserController' => 'user'
        // ZfcUser\Controller\UserController -> user/action
    ),
);
```

I consider that more of an edge case use case.

As side note: i'd want to see that behaviour as default in zf3, unless it will be handled completely differently.
