### PR TITLE
fix Zend\Db\Adapter\Platform\PlatformInterface::quoteIdentifierInFragment

### DIFF
--- a/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Adapter\Platform;
+
+abstract class AbstractPlatform implements PlatformInterface
+{
+    /**
+     * @var array
+     */
+    protected $quoteIdentifier = array('"', '"');
+
+    /**
+     * @var string
+     */
+    protected $quoteIdentifierTo = '\'';
+
+    /**
+     * @var bool
+     */
+    protected $quoteIdentifiers = true;
+    /**
+     * Quote identifier in fragment
+     *
+     * @param  string $identifier
+     * @param  array $safeWords
+     * @return string
+     */
+    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
+    {
+        if (!$this->quoteIdentifiers) {
+            return $identifier;
+        }
+        $safeRegex = '';
+        $safeWordsInt = array('*'=>1, ' '=>1, '.'=>1, 'as'=>1);
+        foreach($safeWords as $sWord) {
+            $safeWordsInt[strtolower($sWord)] = 1;
+            $safeRegex .= '|' . preg_quote($sWord);
+        }
+
+        $parts = preg_split('/([\.\s]' . $safeRegex . ')/i', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
+        $identifier = '';
+        foreach ($parts as $part) {
+            $identifier .= isset($safeWordsInt[strtolower($part)])
+                    ? $part
+                    : $this->quoteIdentifier[0] . str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $part) . $this->quoteIdentifier[1];
+        }
+        return $identifier;
+    }
+
+    /**
+     * Quote identifier
+     *
+     * @param  string $identifier
+     * @return string
+     */
+    public function quoteIdentifier($identifier)
+    {
+        if (!$this->quoteIdentifiers) {
+            return $identifier;
+        }
+        return $this->quoteIdentifier[0] . str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $identifier) . $this->quoteIdentifier[1];
+    }
+
+    /**
+     * Get quote indentifier symbol
+     *
+     * @return string
+     */
+    public function getQuoteIdentifierSymbol()
+    {
+        return $this->quoteIdentifier[0];
+    }
+
+    /**
+     * Quote value list
+     *
+     * @param string|string[] $valueList
+     * @return string
+     */
+    public function quoteValueList($valueList)
+    {
+        if (!is_array($valueList)) {
+            return $this->quoteValue($valueList);
+        }
+
+        $value = reset($valueList);
+        do {
+            $valueList[key($valueList)] = $this->quoteValue($value);
+        } while ($value = next($valueList));
+        return implode(', ', $valueList);
+    }
+}

--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -9,15 +9,10 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class IbmDb2 implements PlatformInterface
+class IbmDb2 extends AbstractPlatform
 {
 
     protected $quoteValueAllowed = false;
-
-    /**
-     * @var bool
-     */
-    protected $quoteIdentifiers = true;
 
     /**
      * @var string
@@ -49,30 +44,6 @@ class IbmDb2 implements PlatformInterface
     public function getName()
     {
         return 'IBM DB2';
-    }
-
-    /**
-     * Get quote indentifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        if ($this->quoteIdentifiers === false) {
-            return $identifier;
-        }
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
     /**
@@ -138,25 +109,6 @@ class IbmDb2 implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -165,45 +117,4 @@ class IbmDb2 implements PlatformInterface
     {
         return $this->identifierSeparator;
     }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        if ($this->quoteIdentifiers === false) {
-            return $identifier;
-        }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-
-        return implode('', $parts);
-    }
-
 }

--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -9,14 +9,8 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class Oracle implements PlatformInterface
+class Oracle extends AbstractPlatform
 {
-
-    /**
-     * @var bool
-     */
-    protected $quoteIdentifiers = true;
-
     /**
      * @param array $options
      */
@@ -38,30 +32,6 @@ class Oracle implements PlatformInterface
     public function getName()
     {
         return 'Oracle';
-    }
-
-    /**
-     * Get quote identifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        if ($this->quoteIdentifiers === false) {
-            return $identifier;
-        }
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
     /**
@@ -121,25 +91,6 @@ class Oracle implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -148,42 +99,4 @@ class Oracle implements PlatformInterface
     {
         return '.';
     }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        if ($this->quoteIdentifiers === false) {
-            return $identifier;
-        }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
-    }
-
 }

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -14,7 +14,7 @@ use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Driver\Pgsql;
 use Zend\Db\Adapter\Exception;
 
-class Postgresql implements PlatformInterface
+class Postgresql extends AbstractPlatform
 {
     /** @var resource|\PDO */
     protected $resource = null;
@@ -53,27 +53,6 @@ class Postgresql implements PlatformInterface
     public function getName()
     {
         return 'PostgreSQL';
-    }
-
-    /**
-     * Get quote indentifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
     /**
@@ -148,25 +127,6 @@ class Postgresql implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -175,39 +135,4 @@ class Postgresql implements PlatformInterface
     {
         return '.';
     }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
-    }
-
 }

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class Sql92 implements PlatformInterface
+class Sql92 extends AbstractPlatform
 {
     /**
      * Get name
@@ -19,27 +19,6 @@ class Sql92 implements PlatformInterface
     public function getName()
     {
         return 'SQL92';
-    }
-
-    /**
-     * Get quote indentifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
     /**
@@ -95,25 +74,6 @@ class Sql92 implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -122,41 +82,4 @@ class Sql92 implements PlatformInterface
     {
         return '.';
     }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-
-        return implode('', $parts);
-    }
-
 }

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -13,8 +13,17 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class SqlServer implements PlatformInterface
+class SqlServer extends AbstractPlatform
 {
+    /**
+     * @var array
+     */
+    protected $quoteIdentifier = array('[',']');
+
+    /**
+     * @var string
+     */
+    protected $quoteIdentifierTo = '\\';
 
     /** @var resource|\PDO */
     protected $resource = null;
@@ -61,18 +70,7 @@ class SqlServer implements PlatformInterface
      */
     public function getQuoteIdentifierSymbol()
     {
-        return array('[', ']');
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '[' . $identifier . ']';
+        return $this->quoteIdentifier;
     }
 
     /**
@@ -141,24 +139,6 @@ class SqlServer implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -167,39 +147,4 @@ class SqlServer implements PlatformInterface
     {
         return '.';
     }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '[' . $part . ']';
-            }
-        }
-        return implode('', $parts);
-    }
-
 }

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -13,8 +13,17 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class Sqlite implements PlatformInterface
+class Sqlite extends AbstractPlatform
 {
+    /**
+     * @var array
+     */
+    protected $quoteIdentifier = array('"','"');
+
+    /**
+     * @var string
+     */
+    protected $quoteIdentifierTo = '\'';
 
     /** @var \PDO */
     protected $resource = null;
@@ -51,27 +60,6 @@ class Sqlite implements PlatformInterface
     public function getName()
     {
         return 'SQLite';
-    }
-
-    /**
-     * Get quote identifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
     }
 
     /**
@@ -148,24 +136,6 @@ class Sqlite implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -174,39 +144,4 @@ class Sqlite implements PlatformInterface
     {
         return '.';
     }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
-    }
-
 }

--- a/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
@@ -150,5 +150,11 @@ class IbmDb2Test extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -50,6 +50,7 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('`identifier`', $this->platform->quoteIdentifier('identifier'));
         $this->assertEquals('`ident``ifier`', $this->platform->quoteIdentifier('ident`ifier'));
+        $this->assertEquals('`namespace:$identifier`', $this->platform->quoteIdentifier('namespace:$identifier'));
     }
 
     /**
@@ -127,14 +128,50 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('`foo`.`bar`', $this->platform->quoteIdentifierInFragment('foo.bar'));
         $this->assertEquals('`foo` as `bar`', $this->platform->quoteIdentifierInFragment('foo as bar'));
         $this->assertEquals('`$TableName`.`bar`', $this->platform->quoteIdentifierInFragment('$TableName.bar'));
+        $this->assertEquals('`cmis:$TableName` as `cmis:TableAlias`', $this->platform->quoteIdentifierInFragment('cmis:$TableName as cmis:TableAlias'));
 
         // single char words
         $this->assertEquals('(`foo`.`bar` = `boo`.`baz`)', $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz)', array('(', ')', '=')));
+        $this->assertEquals('(`foo`.`bar`=`boo`.`baz`)', $this->platform->quoteIdentifierInFragment('(foo.bar=boo.baz)', array('(', ')', '=')));
+        $this->assertEquals('`foo`=`bar`', $this->platform->quoteIdentifierInFragment('foo=bar', array('=')));
 
         // case insensitive safe words
         $this->assertEquals(
             '(`foo`.`bar` = `boo`.`baz`) AND (`foo`.`baz` = `boo`.`baz`)',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '(`foo`.`bar` = `boo`.baz) AND (`foo`.baz = `boo`.baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
+    }
+
+    /**
+     * @deprecated will be removed if this PR will accepted
+     */
+    public function testPerf()
+    {
+        $indexTo     = 1000;
+        $identifier  = 'foo.bar';
+        $platform    = new \ZendTest\Db\TestAsset\MysqlOrig;
+        $platformNew = new Mysql;
+        //======================================================================
+        $time = microtime(true);
+        for ($index = 0; $index < $indexTo; $index++) {
+            $platform->quoteIdentifierInFragment($identifier);
+        }
+        $time = round(microtime(true) - $time, 3);
+        //======================================================================
+        $timeNew = microtime(true);
+        for ($index = 0; $index < $indexTo; $index++) {
+            $platformNew->quoteIdentifierInFragment($identifier);
+        }
+        $timeNew = round(microtime(true) - $timeNew, 3);
+        //======================================================================
+
+        $perfPercent = abs(round(($time-$timeNew)/$time, 2) * 100);
+        print PHP_EOL . "performance degradation : $perfPercent%" . PHP_EOL;
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -147,31 +147,4 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
         );
     }
-
-    /**
-     * @deprecated will be removed if this PR will accepted
-     */
-    public function testPerf()
-    {
-        $indexTo     = 1000;
-        $identifier  = 'foo.bar';
-        $platform    = new \ZendTest\Db\TestAsset\MysqlOrig;
-        $platformNew = new Mysql;
-        //======================================================================
-        $time = microtime(true);
-        for ($index = 0; $index < $indexTo; $index++) {
-            $platform->quoteIdentifierInFragment($identifier);
-        }
-        $time = round(microtime(true) - $time, 3);
-        //======================================================================
-        $timeNew = microtime(true);
-        for ($index = 0; $index < $indexTo; $index++) {
-            $platformNew->quoteIdentifierInFragment($identifier);
-        }
-        $timeNew = round(microtime(true) - $timeNew, 3);
-        //======================================================================
-
-        $perfPercent = abs(round(($time-$timeNew)/$time, 2) * 100);
-        print PHP_EOL . "performance degradation : $perfPercent%" . PHP_EOL;
-    }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -142,5 +142,11 @@ class OracleTest extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
@@ -130,5 +130,11 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
@@ -130,5 +130,11 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 }

--- a/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
@@ -129,6 +129,12 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
             '([foo].[bar] = [boo].[baz]) AND ([foo].[baz] = [boo].[baz])',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '([foo].[bar] = [boo].baz) AND ([foo].baz = [boo].baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
@@ -130,6 +130,12 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
             '("foo"."bar" = "boo"."baz") AND ("foo"."baz" = "boo"."baz")',
             $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and'))
         );
+
+        // case insensitive safe words in field
+        $this->assertEquals(
+            '("foo"."bar" = "boo".baz) AND ("foo".baz = "boo".baz)',
+            $this->platform->quoteIdentifierInFragment('(foo.bar = boo.baz) AND (foo.baz = boo.baz)', array('(', ')', '=', 'and', 'bAz'))
+        );
     }
 
     /**


### PR DESCRIPTION
Current implementation is wrong because quoteIdentifierInFragment and quoteIdentifier methods should work in a similar way.
quoteIdentifierInFragment shoud split string by "." and " ", thereafter call quoteIdentifier for each part.

this is recreate https://github.com/zendframework/zf2/pull/4769 , bacause repo for 4769 is deleted.
