### PR TITLE
Fix BC break with skeleton for Translator Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,21 @@ version of PHP available to ensure you have the latest security fixes.
 
 Additional updates that may affect existing applications include:
 
-- [#5406](https://github.com/zendframework/zf2/pull/5406) makes the i18n
-  component optional for the MVC. It does this by introducing a new interface,
+- [#5406](https://github.com/zendframework/zf2/pull/5406) and
+  [#5689](https://github.com/zendframework/zf2/pull/5689) make the i18n
+  component optional for the MVC. 5406 does this by introducing a new interface,
   `Zend\I18n\Translator\TranslatorInterface` and a `DummyTranslator`
   implementation, and altering the MvcTranslator service factory to instantiate
   a `DummyTranslator` to inject into the `Zend\Mvc\I18n\Translator` instance.
-  This change should be mostly transparent to end-users. However, if you want
-  to define and configure a `Zend\I18n\Translator\Translator` instance to use
-  with the MVC, you will need to add service configuration such as the following
-  to your application somewhere:
+  5689 updates the MVC translator factory to look for one of the following:
 
-  ```php
-  return array(
-      'service_manager' => array(
-          'factories' => array(
-              'Zend\I18n\Translator\TranslatorInterface' => 'Zend\I18n\Translator\TranslatorServiceFactory',
-          ),
-      ),
-  );
-  ```
-
-  and also ensure you define the translation configuration per the `translator`
-  key [as seen in the skeleton application](https://github.com/zendframework/ZendSkeletonApplication/blob/master/module/Application/config/module.config.php).
+  - A defined `Zend\I18n\Translator\TranslatorInterface` service; if found,
+    this will be injected into a `Zend\Mvc\I18n\Translator` instance.
+  - Defined `translator` configuration; if so, this will be passed to the
+    `Zend\I18n\Translator\Translator::factory` method, and the result injected
+    in a `Zend\Mvc\I18n\Translator` instance.
+  - If no configuration is found, a `DummyTranslator` will be created and injected
+    into a `Zend\Mvc\I18n\Translator` instance.
 
 - [#5469](https://github.com/zendframework/zf2/pull/5469) adds a new abstract
   controller, `Zend\Mvc\Controller\AbstractConsoleController`, for simplifying

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ version of PHP available to ensure you have the latest security fixes.
 
 Additional updates that may affect existing applications include:
 
+- [#5406](https://github.com/zendframework/zf2/pull/5406) makes the i18n
+  component optional for the MVC. It does this by introducing a new interface,
+  `Zend\I18n\Translator\TranslatorInterface` and a `DummyTranslator`
+  implementation, and altering the MvcTranslator service factory to instantiate
+  a `DummyTranslator` to inject into the `Zend\Mvc\I18n\Translator` instance.
+  This change should be mostly transparent to end-users. However, if you want
+  to define and configure a `Zend\I18n\Translator\Translator` instance to use
+  with the MVC, you will need to add service configuration such as the following
+  to your application somewhere:
+
+  ```php
+  return array(
+      'service_manager' => array(
+          'factories' => array(
+              'Zend\I18n\Translator\TranslatorInterface' => 'Zend\I18n\Translator\TranslatorServiceFactory',
+          ),
+      ),
+  );
+  ```
+
+  and also ensure you define the translation configuration per the `translator`
+  key [as seen in the skeleton application](https://github.com/zendframework/ZendSkeletonApplication/blob/master/module/Application/config/module.config.php).
+
 - [#5469](https://github.com/zendframework/zf2/pull/5469) adds a new abstract
   controller, `Zend\Mvc\Controller\AbstractConsoleController`, for simplifying
   the creation of console controllers.

--- a/library/Zend/Mvc/I18n/DummyTranslator.php
+++ b/library/Zend/Mvc/I18n/DummyTranslator.php
@@ -10,11 +10,8 @@
 namespace Zend\Mvc\I18n;
 
 use Zend\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
-use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
 
-class DummyTranslator implements
-    I18nTranslatorInterface,
-    ValidatorTranslatorInterface
+class DummyTranslator implements I18nTranslatorInterface
 {
     public function translate($message, $textDomain = 'default', $locale = null)
     {

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -74,6 +74,7 @@ class ServiceListenerFactory implements FactoryInterface
             'ViewResolver'                   => 'Zend\Mvc\Service\ViewResolverFactory',
             'ViewTemplateMapResolver'        => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',
             'ViewTemplatePathStack'          => 'Zend\Mvc\Service\ViewTemplatePathStackFactory',
+            'Zend\I18n\Translator\TranslatorInterface' => 'Zend\I18n\Translator\TranslatorServiceFactory',
         ),
         'aliases' => array(
             'Configuration'                          => 'Config',

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -74,7 +74,6 @@ class ServiceListenerFactory implements FactoryInterface
             'ViewResolver'                   => 'Zend\Mvc\Service\ViewResolverFactory',
             'ViewTemplateMapResolver'        => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',
             'ViewTemplatePathStack'          => 'Zend\Mvc\Service\ViewTemplatePathStackFactory',
-            'Zend\I18n\Translator\TranslatorInterface' => 'Zend\I18n\Translator\TranslatorServiceFactory',
         ),
         'aliases' => array(
             'Configuration'                          => 'Config',

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -9,8 +9,9 @@
 
 namespace Zend\Mvc\Service;
 
+use Zend\I18n\Translator\Translator;
 use Zend\Mvc\I18n\DummyTranslator;
-use Zend\Mvc\I18n\Translator;
+use Zend\Mvc\I18n\Translator as MvcTranslator;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -20,12 +21,23 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  */
 class TranslatorServiceFactory implements FactoryInterface
 {
+    /**
+     * @param ServiceLocatorInterface $serviceLocator 
+     * @return MvcTranslator
+     */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        if (!$serviceLocator->has('Zend\I18n\Translator\TranslatorInterface')) {
-            return new DummyTranslator();
+        if ($serviceLocator->has('Zend\I18n\Translator\TranslatorInterface')) {
+            return new MvcTranslator($serviceLocator->get('Zend\I18n\Translator\TranslatorInterface'));
         }
 
-        return new Translator($serviceLocator->get('Zend\I18n\Translator\TranslatorInterface'));
+        if ($serviceLocator->has('Config')) {
+            $config = $serviceLocator->get('Config');
+            if (isset($config['translator']) && !empty($config['translator'])) {
+                return new MvcTranslator(Translator::factory($config['translator']));
+            }
+        }
+
+        return new MvcTranslator(new DummyTranslator());
     }
 }

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -22,7 +22,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 class TranslatorServiceFactory implements FactoryInterface
 {
     /**
-     * @param ServiceLocatorInterface $serviceLocator 
+     * @param ServiceLocatorInterface $serviceLocator
      * @return MvcTranslator
      */
     public function createService(ServiceLocatorInterface $serviceLocator)

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -11,20 +11,21 @@ namespace Zend\Mvc\Service;
 
 use Zend\Mvc\I18n\DummyTranslator;
 use Zend\Mvc\I18n\Translator;
+use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Overrides the translator factory from the i18n component in order to
  * replace it with the bridge class from this namespace.
  */
-class TranslatorServiceFactory
+class TranslatorServiceFactory implements FactoryInterface
 {
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        if (!$serviceLocator->has('translator')) {
+        if (!$serviceLocator->has('Zend\I18n\Translator\TranslatorInterface')) {
             return new DummyTranslator();
         }
 
-        return new Translator($serviceLocator->get('translator'));
+        return new Translator($serviceLocator->get('Zend\I18n\Translator\TranslatorInterface'));
     }
 }

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -158,8 +158,8 @@ class HelperPluginManager extends AbstractPluginManager
             return;
         }
 
-        if ($locator->has('translator')) {
-            $helper->setTranslator($locator->get('translator'));
+        if ($locator->has('Zend\I18n\Translator\TranslatorInterface')) {
+            $helper->setTranslator($locator->get('Zend\I18n\Translator\TranslatorInterface'));
             return;
         }
     }

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -162,6 +162,11 @@ class HelperPluginManager extends AbstractPluginManager
             $helper->setTranslator($locator->get('Zend\I18n\Translator\TranslatorInterface'));
             return;
         }
+
+        if ($locator->has('Translator')) {
+            $helper->setTranslator($locator->get('Translator'));
+            return;
+        }
     }
 
     /**

--- a/tests/ZendTest/View/HelperPluginManagerTest.php
+++ b/tests/ZendTest/View/HelperPluginManagerTest.php
@@ -100,4 +100,15 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $helper = $this->helpers->get('HeadTitle');
         $this->assertSame($translator, $helper->getTranslator());
     }
+
+    public function testIfHelperIsTranslatorAwareAndBothMvcTranslatorAndTranslatorAreUnavailableAndTranslatorInterfaceIsAvailableItWillInjectTheTranslator()
+    {
+        $translator = new Translator();
+        $services   = new ServiceManager();
+        $services->setService('Zend\I18n\Translator\TranslatorInterface', $translator);
+        $this->helpers->setServiceLocator($services);
+
+        $helper = $this->helpers->get('HeadTitle');
+        $this->assertSame($translator, $helper->getTranslator());
+    }
 }


### PR DESCRIPTION
- Mvc\TranslatorServiceFactory was missing the "implements FactoryInterface" declaration, making it fail as a valid factory.
- Just fixing the factory did not work, however, as a circular dependency was occurring, as changes in TranslatorServiceFactory meant it was looking for existence of an alias already defined in the skeleton, and pointing back at the same service.

What I did was:
- Add a check for a `Zend\I18n\Translator\TranslatorInterface` service in the factory; if it exists, it is pulled and pushed into a `Zend\Mvc\I18n\Translator` instance, and that instance is returned.
- If a `translator` key is present in configuration, and non-empty, that is passed to `Zend\I18n\Translator\Translator::factory`, and the result passed to a `Zend\Mvc\I18n\Translator` instance, which is returned.
- Finally, if none of the above are true, a `DummyTranslator` instance is created, passed to a `Zend\Mvc\I18n\Translator` instance, and that instance is returned.

This addresses all BC breaks with the existing skeleton.

Fixes #5684 .
