### PR TITLE
Input Factory supports "break_on_failure" option

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -225,6 +225,9 @@ class Factory
                 case 'fallback_value':
                     $input->setFallbackValue($value);
                     break;
+                case 'break_on_failure':
+                    $input->setBreakOnFailure($value);
+                    break;
                 case 'filters':
                     if ($value instanceof FilterChain) {
                         $input->setFilterChain($value);


### PR DESCRIPTION
Adding support to Zend\InputFilter\Factory::createInput for Input's "break_on_failure" option
