### PR TITLE
Additional MVC Translator BC fixes

### DIFF
--- a/library/Zend/Mvc/Exception/BadMethodCallException.php
+++ b/library/Zend/Mvc/Exception/BadMethodCallException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Exception;
+
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -37,8 +37,8 @@ class Translator implements
      * with pre-2.3.0 code.
      *
      * @deprecated
-     * @param string $method 
-     * @param array $args 
+     * @param string $method
+     * @param array $args
      * @return mixed
      */
     public function __call($method, array $args)
@@ -62,10 +62,10 @@ class Translator implements
 
     /**
      * Translate a message using the given text domain and locale
-     * 
-     * @param string $message 
-     * @param string $textDomain 
-     * @param string $locale 
+     *
+     * @param string $message
+     * @param string $textDomain
+     * @param string $locale
      * @return string
      */
     public function translate($message, $textDomain = 'default', $locale = null)
@@ -75,12 +75,12 @@ class Translator implements
 
     /**
      * Provide a pluralized translation of the given string using the given text domain and locale
-     * 
-     * @param string $singular 
-     * @param string $plural 
-     * @param string $number 
-     * @param string $textDomain 
-     * @param string $locale 
+     *
+     * @param string $singular
+     * @param string $plural
+     * @param string $number
+     * @param string $textDomain
+     * @param string $locale
      * @return string
      */
     public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)

--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -10,6 +10,7 @@
 namespace Zend\Mvc\I18n;
 
 use Zend\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
+use Zend\Mvc\Exception;
 use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
 
 class Translator implements
@@ -29,11 +30,59 @@ class Translator implements
         $this->translator = $translator;
     }
 
+    /**
+     * Proxy unknown method calls to underlying translator instance
+     *
+     * Note: this method is only implemented to keep backwards compatibility
+     * with pre-2.3.0 code.
+     *
+     * @deprecated
+     * @param string $method 
+     * @param array $args 
+     * @return mixed
+     */
+    public function __call($method, array $args)
+    {
+        if (!method_exists($this->translator, $method)) {
+            throw new Exception\BadMethodCallException(sprintf(
+                'Unable to call method "%s"; does not exist in translator',
+                $method
+            ));
+        }
+        return call_user_func_array(array($this->translator, $method), $args);
+    }
+
+    /**
+     * @return I18nTranslatorInterface
+     */
+    public function getTranslator()
+    {
+        return $this->translator;
+    }
+
+    /**
+     * Translate a message using the given text domain and locale
+     * 
+     * @param string $message 
+     * @param string $textDomain 
+     * @param string $locale 
+     * @return string
+     */
     public function translate($message, $textDomain = 'default', $locale = null)
     {
         return $this->translator->translate($message, $textDomain, $locale);
     }
 
+    /**
+     * Provide a pluralized translation of the given string using the given text domain and locale
+     * 
+     * @param string $singular 
+     * @param string $plural 
+     * @param string $number 
+     * @param string $textDomain 
+     * @param string $locale 
+     * @return string
+     */
     public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)
     {
         return $this->translator->translatePlural($singular, $plural, $number, $textDomain, $locale);

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -34,7 +34,9 @@ class TranslatorServiceFactory implements FactoryInterface
         if ($serviceLocator->has('Config')) {
             $config = $serviceLocator->get('Config');
             if (isset($config['translator']) && !empty($config['translator'])) {
-                return new MvcTranslator(Translator::factory($config['translator']));
+                $i18nTranslator = Translator::factory($config['translator']);
+                $serviceLocator->setService('Zend\I18n\Translator\TranslatorInterface', $i18nTranslator);
+                return new MvcTranslator($i18nTranslator);
             }
         }
 

--- a/tests/ZendTest/Mvc/I18n/TranslatorTest.php
+++ b/tests/ZendTest/Mvc/I18n/TranslatorTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\I18n;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\I18n\Translator;
+
+class TranslatorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->i18nTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $this->translator = new Translator($this->i18nTranslator);
+    }
+
+    public function testCanRetrieveComposedTranslator()
+    {
+        $this->assertSame($this->i18nTranslator, $this->translator->getTranslator());
+    }
+
+    public function testCanProxyToComposedTranslatorMethods()
+    {
+        $this->i18nTranslator->expects($this->once())
+            ->method('setLocale')
+            ->with($this->equalTo('en_US'));
+        $this->translator->setLocale('en_US');
+    }
+}

--- a/tests/ZendTest/Mvc/I18n/TranslatorTest.php
+++ b/tests/ZendTest/Mvc/I18n/TranslatorTest.php
@@ -20,6 +20,16 @@ class TranslatorTest extends TestCase
         $this->translator = new Translator($this->i18nTranslator);
     }
 
+    public function testIsAnI18nTranslator()
+    {
+        $this->assertInstanceOf('Zend\I18n\Translator\TranslatorInterface', $this->translator);
+    }
+
+    public function testIsAValidatorTranslator()
+    {
+        $this->assertInstanceOf('Zend\Validator\Translator\TranslatorInterface', $this->translator);
+    }
+
     public function testCanRetrieveComposedTranslator()
     {
         $this->assertSame($this->i18nTranslator, $this->translator->getTranslator());

--- a/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Service\TranslatorServiceFactory;
+use Zend\ServiceManager\ServiceManager;
+
+class TranslatorServiceFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->factory = new TranslatorServiceFactory();
+        $this->services = new ServiceManager();
+    }
+
+    public function testReturnsMvcTranslatorWithTranslatorInterfaceServiceComposedWhenPresent()
+    {
+        $i18nTranslator = $this->getMock('Zend\I18n\Translator\TranslatorInterface');
+        $this->services->setService('Zend\I18n\Translator\TranslatorInterface', $i18nTranslator);
+
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertSame($i18nTranslator, $translator->getTranslator());
+    }
+
+    public function testReturnsMvcTranslatorWithDummyTranslatorComposedWhenNoTranslatorInterfaceOrConfigServicesPresent()
+    {
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertInstanceOf('Zend\Mvc\I18n\DummyTranslator', $translator->getTranslator());
+    }
+
+    public function testReturnsTranslatorBasedOnConfigurationWhenNoTranslatorInterfaceServicePresent()
+    {
+        $config = array('translator' => array(
+            'locale' => 'en_US',
+        ));
+        $this->services->setService('Config', $config);
+
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator->getTranslator());
+
+        return array(
+            'translator' => $translator->getTranslator(),
+            'services'   => $this->services,
+        );
+    }
+
+    /**
+     * @depends testReturnsTranslatorBasedOnConfigurationWhenNoTranslatorInterfaceServicePresent
+     */
+    public function testSetsInstantiatedI18nTranslatorInstanceInServiceManager($dependencies)
+    {
+        $translator = $dependencies['translator'];
+        $services   = $dependencies['services'];
+        $this->assertTrue($services->has('Zend\I18n\Translator\TranslatorInterface'));
+        $this->assertSame($translator, $services->get('Zend\I18n\Translator\TranslatorInterface'));
+    }
+
+    public function testPrefersTranslatorInterfaceImplementationOverConfig()
+    {
+        $config = array('translator' => array(
+            'locale' => 'en_US',
+        ));
+        $this->services->setService('Config', $config);
+
+        $i18nTranslator = $this->getMock('Zend\I18n\Translator\TranslatorInterface');
+        $this->services->setService('Zend\I18n\Translator\TranslatorInterface', $i18nTranslator);
+
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertSame($i18nTranslator, $translator->getTranslator());
+    }
+}


### PR DESCRIPTION
- Made MVC translator a proxy (added `__call` method)
- Added a `getTranslator()` method to the MVC translator
- Inject the `Zend\I18n\Translator\TranslatorInterface` service into the service manager if the MVC translator factory creates a new i18n Translator instance.

This PR also adds unit tests for both the MVC translator and its associated factory.
