### PR TITLE
Improving exception messaging for PDO using errorInfo()

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Statement.php
@@ -242,7 +242,8 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             if ($this->profiler) {
                 $this->profiler->profilerFinish();
             }
-            throw new Exception\InvalidQueryException('Statement could not be executed', null, $e);
+            throw new Exception\InvalidQueryException(
+                'Statement could not be executed (' . implode(' - ', $this->resource->errorInfo()) . ')', null, $e);
         }
 
         if ($this->profiler) {


### PR DESCRIPTION
Sometimes it's really annoying receiving a simple, totally not meaningful exception message like "Statement could not be executed" as there can be tons of reasons why it could not be executed.

As I've spent too much time trying to figure out what was wrong I modified this file with current change and fixed the issue immediately.

So to help fellow developers in their development I would like to offer this improvement.

Michelangelo
