### PR TITLE
Db\Sql - cleaning code duplicates

### DIFF
--- a/library/Zend/Db/Sql/AbstractPreparableSql.php
+++ b/library/Zend/Db/Sql/AbstractPreparableSql.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql;
+
+use Zend\Db\Adapter\StatementContainerInterface;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\ParameterContainer;
+
+abstract class AbstractPreparableSql extends AbstractSql implements PreparableSqlInterface
+{
+    /**
+     * @param AdapterInterface $adapter
+     * @param StatementContainerInterface $statementContainer
+     * @return StatementContainerInterface
+     */
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
+    {
+        $parameterContainer = $statementContainer->getParameterContainer();
+        if (!$parameterContainer instanceof ParameterContainer) {
+            $parameterContainer = new ParameterContainer();
+            $statementContainer->setParameterContainer($parameterContainer);
+        }
+
+        $sql = $this->buildSqlString($adapter->getPlatform(), $adapter->getDriver(), $parameterContainer);
+
+        $statementContainer->setSql($sql);
+        return $statementContainer;
+    }
+}

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -77,6 +77,7 @@ abstract class AbstractSql implements SqlInterface
      */
     protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, $namedParameterPrefix = null)
     {
+        $namedParameterPrefix = !$namedParameterPrefix ? $namedParameterPrefix : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
         // static counter for the number of times this method was invoked across the PHP runtime
         static $runtimeExpressionPrefix = 0;
 
@@ -238,8 +239,9 @@ abstract class AbstractSql implements SqlInterface
      * @param null|ParameterContainer $parameterContainer
      * @return string
      */
-    protected function resolveColumnValue($column, PlatformInterface $platform, DriverInterface $driver = null, $namedParameterPrefix = null, ParameterContainer $parameterContainer = null)
+    protected function resolveColumnValue($column, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, $namedParameterPrefix = null)
     {
+        $namedParameterPrefix = !$namedParameterPrefix ? $namedParameterPrefix : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
         $isIdentifier = false;
         $fromTable = '';
         if (is_array($column)) {

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -198,4 +198,14 @@ abstract class AbstractSql
         }
         return $sql;
     }
+
+    protected function resolveParameterContainer($statementContainer)
+    {
+        $parameterContainer = $statementContainer->getParameterContainer();
+        if (!$parameterContainer instanceof ParameterContainer) {
+            $parameterContainer = new ParameterContainer();
+            $statementContainer->setParameterContainer($parameterContainer);
+        }
+        return $parameterContainer;
+    }
 }

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -50,6 +50,7 @@ abstract class AbstractSql implements SqlInterface
      */
     protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
+        $this->localizeVariables();
         $sqls       = array();
         $parameters = array();
         foreach ($this->specifications as $name => $specification) {
@@ -289,5 +290,15 @@ abstract class AbstractSql implements SqlInterface
             $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
         }
         return $table;
+    }
+
+    protected function localizeVariables()
+    {
+        if (!$this instanceof PlatformDecoratorInterface) {
+            return;
+        }
+        foreach (get_object_vars($this->subject) as $name => $value) {
+            $this->{$name} = $value;
+        }
     }
 }

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -199,6 +199,26 @@ abstract class AbstractSql
         return $sql;
     }
 
+
+    protected function resolveTable($table, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    {
+        $schema = null;
+        if ($table instanceof TableIdentifier) {
+            list($table, $schema) = $table->getTableAndSchema();
+        }
+
+        if ($table instanceof Select) {
+            $table = '(' . $this->processSubselect($table, $platform, $driver, $parameterContainer) . ')';
+        } elseif ($table) {
+            $table = $platform->quoteIdentifier($table);
+        }
+
+        if ($schema && $table) {
+            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
+        }
+        return $table;
+    }
+
     protected function resolveParameterContainer($statementContainer)
     {
         $parameterContainer = $statementContainer->getParameterContainer();

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -32,18 +32,20 @@ abstract class AbstractSql
      */
     protected $instanceParameterIndex = array();
 
-    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, DriverInterface $driver = null, $namedParameterPrefix = null)
+    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, $namedParameterPrefix = null)
     {
         // static counter for the number of times this method was invoked across the PHP runtime
         static $runtimeExpressionPrefix = 0;
 
-        if ($driver && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
+        if ($parameterContainer && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
             $namedParameterPrefix = sprintf('expr%04dParam', ++$runtimeExpressionPrefix);
         }
 
         $sql = '';
         $statementContainer = new StatementContainer;
-        $parameterContainer = $statementContainer->getParameterContainer();
+        $parameterContainerInternal = $parameterContainer
+                ? $statementContainer->getParameterContainer()
+                : null;
 
         // initialize variables
         $parts = $expression->getExpressionData();
@@ -79,19 +81,19 @@ abstract class AbstractSql
                     $values[$vIndex] = '(' . $this->processSubSelect($value, $platform, $driver, $parameterContainer) . ')';
                 } elseif($value instanceof ExpressionInterface) {
                     // recursive call to satisfy nested expressions
-                    $innerStatementContainer = $this->processExpression($value, $platform, $driver, $namedParameterPrefix . $vIndex . 'subpart');
+                    $innerStatementContainer = $this->processExpression($value, $platform, $driver, $parameterContainer, $namedParameterPrefix . $vIndex . 'subpart');
                     $values[$vIndex] = $innerStatementContainer->getSql();
-                    if ($driver) {
-                        $parameterContainer->merge($innerStatementContainer->getParameterContainer());
+                    if ($parameterContainerInternal) {
+                        $parameterContainerInternal->merge($innerStatementContainer->getParameterContainer());
                     }
                 } elseif ($type == ExpressionInterface::TYPE_IDENTIFIER) {
                     $values[$vIndex] = $platform->quoteIdentifierInFragment($value);
                 } elseif ($type == ExpressionInterface::TYPE_VALUE) {
                     // if prepareType is set, it means that this particular value must be
                     // passed back to the statement in a way it can be used as a placeholder value
-                    if ($driver) {
+                    if ($parameterContainerInternal) {
                         $name = $namedParameterPrefix . $expressionParamIndex++;
-                        $parameterContainer->offsetSet($name, $value);
+                        $parameterContainerInternal->offsetSet($name, $value);
                         $values[$vIndex] = $driver->formatParameterName($name);
                         continue;
                     }
@@ -164,7 +166,7 @@ abstract class AbstractSql
 
     protected function processSubSelect(Select $subselect, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
-        if ($driver) {
+        if ($parameterContainer) {
             $stmtContainer = new StatementContainer;
 
             // Track subselect prefix and count for parameters
@@ -222,7 +224,7 @@ abstract class AbstractSql
         }
 
         if ($column instanceof ExpressionInterface) {
-            $exprData = $this->processExpression($column, $platform, $driver, $namedParameterPrefix);
+            $exprData = $this->processExpression($column, $platform, $driver, $parameterContainer, $namedParameterPrefix);
             if ($parameterContainer) {
                 $parameterContainer->merge($exprData->getParameterContainer());
             }

--- a/library/Zend/Db/Sql/Combine.php
+++ b/library/Zend/Db/Sql/Combine.php
@@ -10,16 +10,13 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\DriverInterface;
-use Zend\Db\Adapter\StatementContainerInterface;
-use Zend\Db\Adapter\Platform\Sql92 as AdapterSql92Platform;
 use Zend\Db\Adapter\ParameterContainer;
 
 /**
  * Combine SQL statement - allows combining multiple select statements into one
  */
-class Combine extends AbstractSql implements SqlInterface, PreparableSqlInterface
+class Combine extends AbstractPreparableSql
 {
     const COLUMNS = 'columns';
     const COMBINE = 'combine';
@@ -131,32 +128,6 @@ class Combine extends AbstractSql implements SqlInterface, PreparableSqlInterfac
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function getSqlString(PlatformInterface $adapterPlatform = null)
-    {
-        return $this->buildSqlString($adapterPlatform ?: new AdapterSql92Platform);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer = null)
-    {
-        $statementContainer = $statementContainer ?: $adapter->getDriver()->createStatement();
-        $parameterContainer = $statementContainer->getParameterContainer();
-
-        if (!$parameterContainer instanceof ParameterContainer) {
-            $parameterContainer = new ParameterContainer();
-            $statementContainer->setParameterContainer($parameterContainer);
-        }
-
-        $sql = $this->buildSqlString($adapter->getPlatform(), $adapter->getDriver(), $parameterContainer);
-
-        return $statementContainer->setSql($sql);
-    }
-
-    /**
      * Build sql string
      *
      * @param PlatformInterface  $platform
@@ -165,7 +136,7 @@ class Combine extends AbstractSql implements SqlInterface, PreparableSqlInterfac
      *
      * @return string
      */
-    private function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         if (!$this->combine) {
             return null;

--- a/library/Zend/Db/Sql/Ddl/AlterTable.php
+++ b/library/Zend/Db/Sql/Ddl/AlterTable.php
@@ -186,7 +186,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     {
         $sqls = array();
         foreach ($this->addColumns as $column) {
-            $sqls[] = $this->processExpression($column, $adapterPlatform)->getSql();
+            $sqls[] = $this->processExpression($column, $adapterPlatform);
         }
 
         return array($sqls);
@@ -198,7 +198,7 @@ class AlterTable extends AbstractSql implements SqlInterface
         foreach ($this->changeColumns as $name => $column) {
             $sqls[] = array(
                 $adapterPlatform->quoteIdentifier($name),
-                $this->processExpression($column, $adapterPlatform)->getSql()
+                $this->processExpression($column, $adapterPlatform)
             );
         }
 

--- a/library/Zend/Db/Sql/Ddl/AlterTable.php
+++ b/library/Zend/Db/Sql/Ddl/AlterTable.php
@@ -10,7 +10,6 @@
 namespace Zend\Db\Sql\Ddl;
 
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\Platform\Sql92 as AdapterSql92Platform;
 use Zend\Db\Sql\AbstractSql;
 
 class AlterTable extends AbstractSql implements SqlInterface
@@ -55,27 +54,27 @@ class AlterTable extends AbstractSql implements SqlInterface
         self::TABLE => "ALTER TABLE %1\$s\n",
         self::ADD_COLUMNS  => array(
             "%1\$s" => array(
-                array(1 => 'ADD COLUMN %1$s', 'combinedby' => ",\n")
+                array(1 => "ADD COLUMN %1\$s,\n", 'combinedby' => "")
             )
         ),
         self::CHANGE_COLUMNS  => array(
             "%1\$s" => array(
-                array(2 => 'CHANGE COLUMN %1$s %2$s', 'combinedby' => ",\n"),
+                array(2 => "CHANGE COLUMN %1\$s %2\$s,\n", 'combinedby' => ""),
             )
         ),
         self::DROP_COLUMNS  => array(
             "%1\$s" => array(
-                array(1 => 'DROP COLUMN %1$s', 'combinedby' => ",\n"),
+                array(1 => "DROP COLUMN %1\$s,\n", 'combinedby' => ""),
             )
         ),
         self::ADD_CONSTRAINTS  => array(
             "%1\$s" => array(
-                array(1 => 'ADD %1$s', 'combinedby' => ",\n"),
+                array(1 => "ADD %1\$s,\n", 'combinedby' => ""),
             )
         ),
         self::DROP_CONSTRAINTS  => array(
             "%1\$s" => array(
-                array(1 => 'DROP CONSTRAINT %1$s', 'combinedby' => ",\n"),
+                array(1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ""),
             )
         )
     );
@@ -176,36 +175,6 @@ class AlterTable extends AbstractSql implements SqlInterface
         );
 
         return (isset($key) && array_key_exists($key, $rawState)) ? $rawState[$key] : $rawState;
-    }
-
-    /**
-     * @param  PlatformInterface $adapterPlatform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $adapterPlatform = null)
-    {
-        // get platform, or create default
-        $adapterPlatform = ($adapterPlatform) ?: new AdapterSql92Platform;
-
-        $sqls = array();
-        $parameters = array();
-
-        foreach ($this->specifications as $name => $specification) {
-            $parameters[$name] = $this->{'process' . $name}($adapterPlatform, null, null, $sqls, $parameters);
-            if ($specification && is_array($parameters[$name]) && ($parameters[$name] != array(array()))) {
-                $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
-            }
-            if (stripos($name, 'table') === false && $parameters[$name] !== array(array())) {
-                $sqls[] = ",\n";
-            }
-        }
-
-        // remove last ,\n
-        array_pop($sqls);
-
-        $sql = implode('', $sqls);
-
-        return $sql;
     }
 
     protected function processTable(PlatformInterface $adapterPlatform = null)

--- a/library/Zend/Db/Sql/Ddl/CreateTable.php
+++ b/library/Zend/Db/Sql/Ddl/CreateTable.php
@@ -133,15 +133,10 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     protected function processTable(PlatformInterface $adapterPlatform = null)
     {
-        $ret = array();
-        if ($this->isTemporary) {
-            $ret[] = 'TEMPORARY ';
-        } else {
-            $ret[] = '';
-        }
-
-        $ret[] = $adapterPlatform->quoteIdentifier($this->table);
-        return $ret;
+        return array(
+            $this->isTemporary ? 'TEMPORARY ' : '',
+            $adapterPlatform->quoteIdentifier($this->table),
+        );
     }
 
     protected function processColumns(PlatformInterface $adapterPlatform = null)

--- a/library/Zend/Db/Sql/Ddl/CreateTable.php
+++ b/library/Zend/Db/Sql/Ddl/CreateTable.php
@@ -152,7 +152,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
         $sqls = array();
         foreach ($this->columns as $column) {
-            $sqls[] = $this->processExpression($column, $adapterPlatform)->getSql();
+            $sqls[] = $this->processExpression($column, $adapterPlatform);
         }
         return array($sqls);
     }
@@ -172,7 +172,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
         $sqls = array();
         foreach ($this->constraints as $constraint) {
-            $sqls[] = $this->processExpression($constraint, $adapterPlatform)->getSql();
+            $sqls[] = $this->processExpression($constraint, $adapterPlatform);
         }
         return array($sqls);
     }

--- a/library/Zend/Db/Sql/Ddl/DropTable.php
+++ b/library/Zend/Db/Sql/Ddl/DropTable.php
@@ -10,7 +10,6 @@
 namespace Zend\Db\Sql\Ddl;
 
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\Platform\Sql92 as AdapterSql92Platform;
 use Zend\Db\Sql\AbstractSql;
 
 class DropTable extends AbstractSql implements SqlInterface
@@ -35,39 +34,6 @@ class DropTable extends AbstractSql implements SqlInterface
     public function __construct($table = '')
     {
         $this->table = $table;
-    }
-
-    /**
-     * @param  null|PlatformInterface $adapterPlatform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $adapterPlatform = null)
-    {
-        // get platform, or create default
-        $adapterPlatform = ($adapterPlatform) ?: new AdapterSql92Platform;
-
-        $sqls       = array();
-        $parameters = array();
-
-        foreach ($this->specifications as $name => $specification) {
-            $parameters[$name] = $this->{'process' . $name}(
-                $adapterPlatform,
-                null,
-                null,
-                $sqls,
-                $parameters
-            );
-
-            if ($specification && is_array($parameters[$name])) {
-                $sqls[$name] = $this->createSqlFromSpecificationAndParameters(
-                    $specification,
-                    $parameters[$name]
-                );
-            }
-        }
-
-        $sql = implode(' ', $sqls);
-        return $sql;
     }
 
     protected function processTable(PlatformInterface $adapterPlatform = null)

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -121,21 +121,10 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $platform = $adapter->getPlatform();
         $parameterContainer = $this->resolveParameterContainer($statementContainer);
 
-        $table = $this->table;
-        $schema = null;
-
-        // create quoted table name to use in delete processing
-        if ($table instanceof TableIdentifier) {
-            list($table, $schema) = $table->getTableAndSchema();
-        }
-
-        $table = $platform->quoteIdentifier($table);
-
-        if ($schema) {
-            $table = $platform->quoteIdentifier($schema) . $platform->getIdentifierSeparator() . $table;
-        }
-
-        $sql = sprintf($this->specifications[static::SPECIFICATION_DELETE], $table);
+        $sql = sprintf(
+            $this->specifications[static::SPECIFICATION_DELETE],
+            $this->resolveTable($this->table, $platform, $driver, $parameterContainer)
+        );
 
         // process where
         if ($this->where->count() > 0) {
@@ -157,21 +146,11 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     public function getSqlString(PlatformInterface $adapterPlatform = null)
     {
         $adapterPlatform = ($adapterPlatform) ?: new Sql92;
-        $table = $this->table;
-        $schema = null;
 
-        // create quoted table name to use in delete processing
-        if ($table instanceof TableIdentifier) {
-            list($table, $schema) = $table->getTableAndSchema();
-        }
-
-        $table = $adapterPlatform->quoteIdentifier($table);
-
-        if ($schema) {
-            $table = $adapterPlatform->quoteIdentifier($schema) . $adapterPlatform->getIdentifierSeparator() . $table;
-        }
-
-        $sql = sprintf($this->specifications[static::SPECIFICATION_DELETE], $table);
+        $sql = sprintf(
+            $this->specifications[static::SPECIFICATION_DELETE],
+            $this->resolveTable($this->table, $adapterPlatform)
+        );
 
         if ($this->where->count() > 0) {
             $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -120,13 +120,9 @@ class Delete extends AbstractPreparableSql
         if ($this->where->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where');
-        if ($parameterContainer) {
-            $parameterContainer->merge($whereParts->getParameterContainer());
-        }
         return sprintf(
             $this->specifications[static::SPECIFICATION_WHERE],
-            $whereParts->getSql()
+            $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where')
         );
     }
 

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Db\Adapter\StatementContainerInterface;
@@ -128,7 +129,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process where
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
+            $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
@@ -153,7 +154,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
         );
 
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');
+            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, null, 'where');
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
 

--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -10,7 +10,6 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\AdapterInterface;
-use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Db\Adapter\StatementContainerInterface;
@@ -120,12 +119,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         $driver = $adapter->getDriver();
         $platform = $adapter->getPlatform();
-        $parameterContainer = $statementContainer->getParameterContainer();
-
-        if (!$parameterContainer instanceof ParameterContainer) {
-            $parameterContainer = new ParameterContainer();
-            $statementContainer->setParameterContainer($parameterContainer);
-        }
+        $parameterContainer = $this->resolveParameterContainer($statementContainer);
 
         $table = $this->table;
         $schema = null;

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -162,12 +162,8 @@ class Insert extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         $driver   = $adapter->getDriver();
         $platform = $adapter->getPlatform();
-        $parameterContainer = $statementContainer->getParameterContainer();
+        $parameterContainer = $this->resolveParameterContainer($statementContainer);
 
-        if (!$parameterContainer instanceof ParameterContainer) {
-            $parameterContainer = new ParameterContainer();
-            $statementContainer->setParameterContainer($parameterContainer);
-        }
 
         $table = $this->table;
         $schema = null;

--- a/library/Zend/Db/Sql/Insert.php
+++ b/library/Zend/Db/Sql/Insert.php
@@ -170,7 +170,6 @@ class Insert extends AbstractPreparableSql
                     $value,
                     $platform,
                     $driver,
-                    null,
                     $parameterContainer
                 );
             }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -9,11 +9,9 @@
 
 namespace Zend\Db\Sql\Platform\IbmDb2;
 
-use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Sql\Select;
 
@@ -61,22 +59,14 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         return $table . ' ' . $alias;
     }
 
-    /**
-     * @param AdapterInterface            $adapter
-     * @param StatementContainerInterface $statementContainer
-     */
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    protected function localizeVariables()
     {
-        // localize variables
-        foreach (get_object_vars($this->subject) as $name => $value) {
-            $this->{$name} = $value;
-        }
+        parent::localizeVariables();
         // set specifications
         unset($this->specifications[self::LIMIT]);
         unset($this->specifications[self::OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
-        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -27,7 +27,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     /**
      * @var Select
      */
-    protected $select = null;
+    protected $subject = null;
 
     /**
      * @return bool
@@ -50,7 +50,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      */
     public function setSubject($select)
     {
-        $this->select = $select;
+        $this->subject = $select;
     }
 
     /**
@@ -65,10 +65,10 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      * @param AdapterInterface            $adapter
      * @param StatementContainerInterface $statementContainer
      */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
+        foreach (get_object_vars($this->subject) as $name => $value) {
             $this->{$name} = $value;
         }
         // set specifications
@@ -76,25 +76,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         unset($this->specifications[self::OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
-        parent::prepareStatement($adapter, $statementContainer);
-    }
-
-    /**
-     * @param  PlatformInterface $platform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $platform = null)
-    {
-        // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
-            $this->{$name} = $value;
-        }
-
-        unset($this->specifications[self::LIMIT]);
-        unset($this->specifications[self::OFFSET]);
-        $this->specifications['LIMITOFFSET'] = null;
-
-        return parent::getSqlString($platform);
+        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -12,33 +12,31 @@ namespace Zend\Db\Sql\Platform\Mysql\Ddl;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\CreateTable;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
 
 class CreateTableDecorator extends CreateTable implements PlatformDecoratorInterface
 {
     /**
      * @var CreateTable
      */
-    protected $createTable;
+    protected $subject;
 
     /**
      * @param CreateTable $subject
      */
     public function setSubject($subject)
     {
-        $this->createTable = $subject;
+        $this->subject = $subject;
     }
 
-    /**
-     * @param  null|PlatformInterface $platform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $platform = null)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         // localize variables
-        foreach (get_object_vars($this->createTable) as $name => $value) {
+        foreach (get_object_vars($this->subject) as $name => $value) {
             $this->{$name} = $value;
         }
-        return parent::getSqlString($platform);
+        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     protected function processColumns(PlatformInterface $platform = null)

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -12,8 +12,6 @@ namespace Zend\Db\Sql\Platform\Mysql\Ddl;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\CreateTable;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
-use Zend\Db\Adapter\Driver\DriverInterface;
-use Zend\Db\Adapter\ParameterContainer;
 
 class CreateTableDecorator extends CreateTable implements PlatformDecoratorInterface
 {
@@ -28,15 +26,6 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     public function setSubject($subject)
     {
         $this->subject = $subject;
-    }
-
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
-    {
-        // localize variables
-        foreach (get_object_vars($this->subject) as $name => $value) {
-            $this->{$name} = $value;
-        }
-        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     protected function processColumns(PlatformInterface $platform = null)

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -43,6 +43,9 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
 
     protected function processColumns(PlatformInterface $platform = null)
     {
+        if (!$this->columns) {
+            return null;
+        }
         $sqls = array();
         foreach ($this->columns as $i => $column) {
             $sql           = $this->processExpression($column, $platform);

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -45,11 +45,8 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     {
         $sqls = array();
         foreach ($this->columns as $i => $column) {
-            $stmtContainer = $this->processExpression($column, $platform);
-            $sql           = $stmtContainer->getSql();
-            $columnOptions = $column->getOptions();
-
-            foreach ($columnOptions as $coName => $coValue) {
+            $sql           = $this->processExpression($column, $platform);
+            foreach ($column->getOptions() as $coName => $coValue) {
                 switch (strtolower(str_replace(array('-', '_', ' '), '', $coName))) {
                     case 'identity':
                     case 'serial':
@@ -78,8 +75,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
                         break;
                 }
             }
-            $stmtContainer->setSql($sql);
-            $sqls[$i] = $stmtContainer;
+            $sqls[$i] = $sql;
         }
         return array($sqls);
     }

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -30,16 +30,12 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         $this->subject = $select;
     }
 
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    protected function localizeVariables()
     {
-        // localize variables
-        foreach (get_object_vars($this->subject) as $name => $value) {
-            $this->{$name} = $value;
-        }
+        parent::localizeVariables();
         if ($this->limit === null && $this->offset !== null) {
             $this->specifications[self::LIMIT] = 'LIMIT 18446744073709551615';
         }
-        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     protected function processLimit(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -9,11 +9,9 @@
 
 namespace Zend\Db\Sql\Platform\Mysql;
 
-use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Sql\Select;
 
@@ -22,46 +20,26 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     /**
      * @var Select
      */
-    protected $select = null;
+    protected $subject = null;
 
     /**
      * @param Select $select
      */
     public function setSubject($select)
     {
-        $this->select = $select;
+        $this->subject = $select;
     }
 
-    /**
-     * @param AdapterInterface $adapter
-     * @param StatementContainerInterface $statementContainer
-     */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
+        foreach (get_object_vars($this->subject) as $name => $value) {
             $this->{$name} = $value;
         }
         if ($this->limit === null && $this->offset !== null) {
             $this->specifications[self::LIMIT] = 'LIMIT 18446744073709551615';
         }
-        parent::prepareStatement($adapter, $statementContainer);
-    }
-
-    /**
-     * @param PlatformInterface $platform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $platform = null)
-    {
-        // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
-            $this->{$name} = $value;
-        }
-        if ($this->limit === null && $this->offset !== null) {
-            $this->specifications[self::LIMIT] = 'LIMIT 18446744073709551615';
-        }
-        return parent::getSqlString($platform);
+        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     protected function processLimit(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -73,13 +73,11 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             return null;
         }
         if ($parameterContainer) {
-            $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
-        } else {
-            $sql = $this->limit;
+            return array($driver->formatParameterName('limit'));
         }
 
-        return array($sql);
+        return array($this->limit);
     }
 
     protected function processOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -72,7 +72,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($this->limit === null) {
             return null;
         }
-        if ($driver) {
+        if ($parameterContainer) {
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
@@ -87,7 +87,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($this->offset === null) {
             return null;
         }
-        if ($driver) {
+        if ($parameterContainer) {
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
             return array($driver->formatParameterName('offset'));
         }

--- a/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
@@ -12,8 +12,6 @@ namespace Zend\Db\Sql\Platform\Oracle;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\StatementContainerInterface;
-use Zend\Db\Sql\ExpressionInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Sql\Select;
 
@@ -38,7 +36,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      */
     protected function renderTable($table, $alias = null)
     {
-        return $table . ' ' . $alias;
+        return $table . ($alias ? ' ' . $alias : '');
     }
 
     protected function localizeVariables()
@@ -117,37 +115,4 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             $this->specifications[self::SELECT], $parameters[self::SELECT]
         );
     }
-
-
-    protected function processJoins(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
-    {
-        if (!$this->joins) {
-            return null;
-        }
-
-        // process joins
-        $joinSpecArgArray = array();
-        foreach ($this->joins as $j => $join) {
-            $joinSpecArgArray[$j] = array();
-            // type
-            $joinSpecArgArray[$j][] = strtoupper($join['type']);
-            // table name
-            $joinSpecArgArray[$j][] = (is_array($join['name']))
-                ? $platform->quoteIdentifier(current($join['name'])) . ' ' . $platform->quoteIdentifier(key($join['name']))
-                : $platform->quoteIdentifier($join['name']);
-            // on expression
-            $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
-                ? $this->processExpression($join['on'], $platform, $driver, 'join')
-                : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN')); // on
-            if ($joinSpecArgArray[$j][2] instanceof StatementContainerInterface) {
-                if ($parameterContainer) {
-                    $parameterContainer->merge($joinSpecArgArray[$j][2]->getParameterContainer());
-                }
-                $joinSpecArgArray[$j][2] = $joinSpecArgArray[$j][2]->getSql();
-            }
-        }
-
-        return array($joinSpecArgArray);
-    }
-
 }

--- a/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
@@ -137,7 +137,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
                 : $platform->quoteIdentifier($join['name']);
             // on expression
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
-                ? $this->processExpression($join['on'], $platform, $driver, $this->processInfo['paramPrefix'] . 'join')
+                ? $this->processExpression($join['on'], $platform, $driver, 'join')
                 : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN')); // on
             if ($joinSpecArgArray[$j][2] instanceof StatementContainerInterface) {
                 if ($parameterContainer) {

--- a/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
@@ -41,20 +41,13 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         return $table . ' ' . $alias;
     }
 
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    protected function localizeVariables()
     {
-        // localize variables
-        foreach (get_object_vars($this->subject) as $name => $value) {
-            $this->{$name} = $value;
-        }
-
-        // set specifications
+        parent::localizeVariables();
         unset($this->specifications[self::LIMIT]);
         unset($this->specifications[self::OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
-
-        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Oracle/SelectDecorator.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Db\Sql\Platform\Oracle;
 
-use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
@@ -24,14 +23,14 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     /**
      * @var Select
      */
-    protected $select = null;
+    protected $subject = null;
 
     /**
      * @param Select $select
      */
     public function setSubject($select)
     {
-        $this->select = $select;
+        $this->subject = $select;
     }
 
     /**
@@ -42,32 +41,10 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         return $table . ' ' . $alias;
     }
 
-    /**
-     * @param AdapterInterface $adapter
-     * @param StatementContainerInterface $statementContainer
-     */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
-            $this->{$name} = $value;
-        }
-        // set specifications
-        unset($this->specifications[self::LIMIT]);
-        unset($this->specifications[self::OFFSET]);
-
-        $this->specifications['LIMITOFFSET'] = null;
-        parent::prepareStatement($adapter, $statementContainer);
-    }
-
-    /**
-     * @param PlatformInterface $platform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $platform = null)
-    {
-        // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
+        foreach (get_object_vars($this->subject) as $name => $value) {
             $this->{$name} = $value;
         }
 
@@ -76,7 +53,8 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         unset($this->specifications[self::OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
-        return parent::getSqlString($platform);
+
+        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
@@ -12,8 +12,6 @@ namespace Zend\Db\Sql\Platform\SqlServer\Ddl;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\CreateTable;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
-use Zend\Db\Adapter\Driver\DriverInterface;
-use Zend\Db\Adapter\ParameterContainer;
 
 class CreateTableDecorator extends CreateTable implements PlatformDecoratorInterface
 {
@@ -30,15 +28,6 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
     {
         $this->subject = $subject;
         return $this;
-    }
-
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
-    {
-        // localize variables
-        foreach (get_object_vars($this->subject) as $name => $value) {
-            $this->{$name} = $value;
-        }
-        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
@@ -49,13 +49,10 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
      */
     protected function processTable(PlatformInterface $adapterPlatform = null)
     {
-        $ret = array('');
-        if ($this->isTemporary) {
-            $table = '#';
-        } else {
-            $table = '';
-        }
-        $ret[] = $adapterPlatform->quoteIdentifier($table . ltrim($this->table, '#'));
-        return $ret;
+        $table = ($this->isTemporary ? '#' : '') . ltrim($this->table, '#');
+        return array(
+            '',
+            $adapterPlatform->quoteIdentifier($table),
+        );
     }
 }

--- a/library/Zend/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
@@ -12,13 +12,15 @@ namespace Zend\Db\Sql\Platform\SqlServer\Ddl;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Sql\Ddl\CreateTable;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
 
 class CreateTableDecorator extends CreateTable implements PlatformDecoratorInterface
 {
     /**
      * @var CreateTable
      */
-    protected $createTable;
+    protected $subject;
 
     /**
      * @param CreateTable $subject
@@ -26,21 +28,17 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
      */
     public function setSubject($subject)
     {
-        $this->createTable = $subject;
+        $this->subject = $subject;
         return $this;
     }
 
-    /**
-     * @param  null|PlatformInterface $platform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $platform = null)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         // localize variables
-        foreach (get_object_vars($this->createTable) as $name => $value) {
+        foreach (get_object_vars($this->subject) as $name => $value) {
             $this->{$name} = $value;
         }
-        return parent::getSqlString($platform);
+        return parent::buildSqlString($platform, $driver, $parameterContainer);
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
@@ -30,18 +30,15 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         $this->subject = $select;
     }
 
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
+    protected function localizeVariables()
     {
-        // localize variables
-        foreach (get_object_vars($this->subject) as $name => $value) {
-            $this->{$name} = $value;
-        }
-
+        parent::localizeVariables();
         // set specifications
         unset($this->specifications[self::LIMIT]);
         unset($this->specifications[self::OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
+
     }
 
     /**

--- a/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/SelectDecorator.php
@@ -9,12 +9,9 @@
 
 namespace Zend\Db\Sql\Platform\SqlServer;
 
-use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\Driver\Sqlsrv\Statement;
-use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Sql\Select;
 
@@ -23,24 +20,20 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     /**
      * @var Select
      */
-    protected $select = null;
+    protected $subject = null;
 
     /**
      * @param Select $select
      */
     public function setSubject($select)
     {
-        $this->select = $select;
+        $this->subject = $select;
     }
 
-    /**
-     * @param AdapterInterface $adapter
-     * @param StatementContainerInterface $statementContainer
-     */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
+    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
         // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
+        foreach (get_object_vars($this->subject) as $name => $value) {
             $this->{$name} = $value;
         }
 
@@ -49,32 +42,6 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         unset($this->specifications[self::OFFSET]);
 
         $this->specifications['LIMITOFFSET'] = null;
-        parent::prepareStatement($adapter, $statementContainer);
-
-        //set statement cursor type
-        if ($statementContainer instanceof Statement) {
-            $statementContainer->setPrepareOptions(array('Scrollable'=>\SQLSRV_CURSOR_STATIC));
-        }
-
-    }
-
-    /**
-     * @param PlatformInterface $platform
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $platform = null)
-    {
-        // localize variables
-        foreach (get_object_vars($this->select) as $name => $value) {
-            $this->{$name} = $value;
-        }
-
-        // set specifications
-        unset($this->specifications[self::LIMIT]);
-        unset($this->specifications[self::OFFSET]);
-
-        $this->specifications['LIMITOFFSET'] = null;
-        return parent::getSqlString($platform);
     }
 
     /**

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -9,19 +9,17 @@
 
 namespace Zend\Db\Sql;
 
-use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
-use Zend\Db\Adapter\Platform\Sql92 as AdapterSql92Platform;
 
 /**
  *
  * @property Where $where
  * @property Having $having
  */
-class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
+class Select extends AbstractPreparableSql
 {
     /**#@+
      * Constant
@@ -473,60 +471,6 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             self::COMBINE    => $this->combine
         );
         return (isset($key) && array_key_exists($key, $rawState)) ? $rawState[$key] : $rawState;
-    }
-
-    /**
-     * Prepare statement
-     *
-     * @param AdapterInterface $adapter
-     * @param StatementContainerInterface $statementContainer
-     * @return void
-     */
-    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
-    {
-        $parameterContainer = $this->resolveParameterContainer($statementContainer);
-
-        $sqls = array();
-        $parameters = array();
-        $platform = $adapter->getPlatform();
-        $driver = $adapter->getDriver();
-
-        foreach ($this->specifications as $name => $specification) {
-            $parameters[$name] = $this->{'process' . $name}($platform, $driver, $parameterContainer, $sqls, $parameters);
-            if ($specification && is_array($parameters[$name])) {
-                $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
-            }
-        }
-
-        $sql = implode(' ', $sqls);
-
-        $statementContainer->setSql($sql);
-        return;
-    }
-
-    /**
-     * Get SQL string for statement
-     *
-     * @param  null|PlatformInterface $adapterPlatform If null, defaults to Sql92
-     * @return string
-     */
-    public function getSqlString(PlatformInterface $adapterPlatform = null)
-    {
-        // get platform, or create default
-        $adapterPlatform = ($adapterPlatform) ?: new AdapterSql92Platform;
-
-        $sqls = array();
-        $parameters = array();
-
-        foreach ($this->specifications as $name => $specification) {
-            $parameters[$name] = $this->{'process' . $name}($adapterPlatform, null, null, $sqls, $parameters);
-            if ($specification && is_array($parameters[$name])) {
-                $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
-            }
-        }
-
-        $sql = implode(' ', $sqls);
-        return $sql;
     }
 
     /**

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -484,12 +484,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
     {
-        // ensure statement has a ParameterContainer
-        $parameterContainer = $statementContainer->getParameterContainer();
-        if (!$parameterContainer instanceof ParameterContainer) {
-            $parameterContainer = new ParameterContainer();
-            $statementContainer->setParameterContainer($parameterContainer);
-        }
+        $parameterContainer = $this->resolveParameterContainer($statementContainer);
 
         $sqls = array();
         $parameters = array();

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -539,8 +539,8 @@ class Select extends AbstractPreparableSql
                 ),
                 $platform,
                 $driver,
-                $this->processInfo['paramPrefix'] . ((is_string($columnIndexOrAs)) ? $columnIndexOrAs : 'column'),
-                $parameterContainer
+                $parameterContainer,
+                (is_string($columnIndexOrAs) ? $columnIndexOrAs : 'column')
             );
             // process As portion
             if (is_string($columnIndexOrAs)) {
@@ -569,8 +569,8 @@ class Select extends AbstractPreparableSql
                     ),
                     $platform,
                     $driver,
-                    $this->processInfo['paramPrefix'] . ((is_string($jKey)) ? $jKey : 'column'),
-                    $parameterContainer
+                    $parameterContainer,
+                    (is_string($jKey) ? $jKey : 'column')
                 );
                 if (is_string($jKey)) {
                     $jColumns[] = $platform->quoteIdentifier($jKey);
@@ -633,7 +633,7 @@ class Select extends AbstractPreparableSql
             // on expression
             // note: for Expression objects, pass them to processExpression with a prefix specific to each join (used for named parameters)
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
-                ? $this->processExpression($join['on'], $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'join' . ($j+1) . 'part')
+                ? $this->processExpression($join['on'], $platform, $driver, $parameterContainer, 'join' . ($j+1) . 'part')
                 : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN', '<', '>')); // on
         }
 
@@ -646,7 +646,7 @@ class Select extends AbstractPreparableSql
             return null;
         }
         return array(
-            $this->processExpression($this->where, $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'where')
+            $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where')
         );
     }
 
@@ -665,8 +665,8 @@ class Select extends AbstractPreparableSql
                 ),
                 $platform,
                 $driver,
-                $this->processInfo['paramPrefix'] . 'group',
-                $parameterContainer
+                $parameterContainer,
+                'group'
             );
         }
         return array($groups);
@@ -678,7 +678,7 @@ class Select extends AbstractPreparableSql
             return null;
         }
         return array(
-            $this->processExpression($this->having, $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'having')
+            $this->processExpression($this->having, $platform, $driver, $parameterContainer, 'having')
         );
     }
 

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -627,8 +627,7 @@ class Select extends AbstractPreparableSql
             }
             $joinSpecArgArray[$j] = array(
                 strtoupper($join['type']),
-                (isset($joinAs)) ? $joinName . ' AS ' . $joinAs : $joinName,
-
+                $this->renderTable($joinName, $joinAs),
             );
             // on expression
             // note: for Expression objects, pass them to processExpression with a prefix specific to each join (used for named parameters)

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -631,7 +631,6 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $columns = array();
         foreach ($this->columns as $columnIndexOrAs => $column) {
 
-            $columnName = '';
             if ($column === self::SQL_STAR) {
                 $columns[] = array($fromTable . self::SQL_STAR);
                 continue;
@@ -647,9 +646,9 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 if ($parameterContainer) {
                     $parameterContainer->merge($columnParts->getParameterContainer());
                 }
-                $columnName .= $columnParts->getSql();
+                $columnName = $columnParts->getSql();
             } else {
-                $columnName .= $fromTable . $platform->quoteIdentifier($column);
+                $columnName = $fromTable . $platform->quoteIdentifier($column);
             }
 
             // process As portion
@@ -665,6 +664,13 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process join columns
         foreach ($this->joins as $join) {
+            $joinName = (is_array($join['name'])) ? key($join['name']) : $join['name'];
+            if ($joinName instanceof TableIdentifier) {
+                $joinName = $platform->quoteIdentifier($joinName->getSchema()) . $separator . $platform->quoteIdentifier($joinName->getTable());
+            } else {
+                $joinName = $platform->quoteIdentifier($joinName);
+            }
+
             foreach ($join['columns'] as $jKey => $jColumn) {
                 $jColumns = array();
                 if ($jColumn instanceof ExpressionInterface) {

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -121,6 +121,11 @@ class Sql
         return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($this->adapter, $statement);
     }
 
+    /**
+     * @param SqlInterface $sqlObject
+     * @param PlatformInterface $platform
+     * @return string
+     */
     public function getSqlStringForSqlObject(SqlInterface $sqlObject, PlatformInterface $platform = null)
     {
         $platform = ($platform) ?: $this->adapter->getPlatform();

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -118,28 +118,12 @@ class Sql
     public function prepareStatementForSqlObject(PreparableSqlInterface $sqlObject, StatementInterface $statement = null)
     {
         $statement = ($statement) ?: $this->adapter->getDriver()->createStatement();
-
-        if ($this->sqlPlatform) {
-            $this->sqlPlatform->setSubject($sqlObject);
-            $this->sqlPlatform->prepareStatement($this->adapter, $statement);
-        } else {
-            $sqlObject->prepareStatement($this->adapter, $statement);
-        }
-
-        return $statement;
+        return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($this->adapter, $statement);
     }
 
     public function getSqlStringForSqlObject(SqlInterface $sqlObject, PlatformInterface $platform = null)
     {
         $platform = ($platform) ?: $this->adapter->getPlatform();
-
-        if ($this->sqlPlatform) {
-            $this->sqlPlatform->setSubject($sqlObject);
-            $sqlString = $this->sqlPlatform->getSqlString($platform);
-        } else {
-            $sqlString = $sqlObject->getSqlString($platform);
-        }
-
-        return $sqlString;
+        return $this->sqlPlatform->setSubject($sqlObject)->getSqlString($platform);
     }
 }

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -250,9 +250,8 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
      */
     public function __get($name)
     {
-        switch (strtolower($name)) {
-            case 'where':
-                return $this->where;
+        if (strtolower($name) == 'where') {
+            return $this->where;
         }
     }
 

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -169,10 +169,9 @@ class Update extends AbstractPreparableSql
         if ($this->where->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where');
         return sprintf(
             $this->specifications[static::SPECIFICATION_WHERE],
-            $whereParts->getSql()
+            $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where')
         );
     }
 

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -151,7 +151,6 @@ class Update extends AbstractPreparableSql
                     $value,
                     $platform,
                     $driver,
-                    null,
                     $parameterContainer
                 );
             }

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Db\Adapter\StatementContainerInterface;
@@ -178,7 +179,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process where
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
+            $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
@@ -209,7 +210,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
             $set
         );
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');
+            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, null, 'where');
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
         return $sql;

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -10,7 +10,6 @@
 namespace Zend\Db\Sql;
 
 use Zend\Db\Adapter\AdapterInterface;
-use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Db\Adapter\StatementContainerInterface;
@@ -151,12 +150,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
     {
         $driver   = $adapter->getDriver();
         $platform = $adapter->getPlatform();
-        $parameterContainer = $statementContainer->getParameterContainer();
-
-        if (!$parameterContainer instanceof ParameterContainer) {
-            $parameterContainer = new ParameterContainer();
-            $statementContainer->setParameterContainer($parameterContainer);
-        }
+        $parameterContainer = $this->resolveParameterContainer($statementContainer);
 
         $table = $this->table;
         $schema = null;

--- a/tests/ZendTest/Db/Sql/CombineTest.php
+++ b/tests/ZendTest/Db/Sql/CombineTest.php
@@ -13,6 +13,7 @@ use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Sql\Combine;
 use Zend\Db\Sql\Select;
 use Zend\Db\Sql\Predicate\Expression;
+use Zend\Db\Adapter\StatementContainer;
 
 class CombineTest extends \PHPUnit_Framework_TestCase
 {
@@ -111,7 +112,7 @@ class CombineTest extends \PHPUnit_Framework_TestCase
 
         $adapter = $this->getMockAdapter();
 
-        $statement = $this->combine->prepareStatement($adapter);
+        $statement = $this->combine->prepareStatement($adapter, new StatementContainer);
         $this->assertInstanceOf('Zend\Db\Adapter\StatementContainerInterface', $statement);
         $this->assertEquals(
             '(SELECT "t1".* FROM "t1" WHERE "x1" = ?) UNION (SELECT "t2".* FROM "t2" WHERE "x2" = ?)',

--- a/tests/ZendTest/Db/Sql/Ddl/AlterTableTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/AlterTableTest.php
@@ -96,14 +96,17 @@ class AlterTableTest extends \PHPUnit_Framework_TestCase
         $at->dropConstraint('my_index');
         $expected =<<<EOS
 ALTER TABLE "foo"
-ADD COLUMN "another" VARCHAR(255) NOT NULL ,
-CHANGE COLUMN "name" "new_name" VARCHAR(50) NOT NULL ,
-DROP COLUMN "foo",
-ADD CONSTRAINT "my_fk" FOREIGN KEY ("other_id") REFERENCES "other_table" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-DROP CONSTRAINT "my_index"
+ ADD COLUMN "another" VARCHAR(255) NOT NULL ,
+ CHANGE COLUMN "name" "new_name" VARCHAR(50) NOT NULL ,
+ DROP COLUMN "foo",
+ ADD CONSTRAINT "my_fk" FOREIGN KEY ("other_id") REFERENCES "other_table" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+ DROP CONSTRAINT "my_index"
 EOS;
 
-        $expected = str_replace("\r\n", "\n", $expected);
-        $this->assertEquals($expected, $at->getSqlString());
+        $actual = $at->getSqlString();
+        $this->assertEquals(
+            str_replace(array("\r", "\n"), "", $expected),
+            str_replace(array("\r", "\n"), "", $actual)
+        );
     }
 }

--- a/tests/ZendTest/Db/Sql/Ddl/CreateTableTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/CreateTableTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Db\Sql\Ddl;
 
 use Zend\Db\Sql\Ddl\Column\Column;
+use Zend\Db\Sql\Ddl\Constraint;
 use Zend\Db\Sql\Ddl\CreateTable;
 
 class CreateTableTest extends \PHPUnit_Framework_TestCase
@@ -124,17 +125,32 @@ class CreateTableTest extends \PHPUnit_Framework_TestCase
     public function testGetSqlString()
     {
         $ct = new CreateTable('foo');
-        $this->assertEquals("CREATE TABLE \"foo\" (\n)", $ct->getSqlString());
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n)", $ct->getSqlString());
 
         $ct = new CreateTable('foo', true);
-        $this->assertEquals("CREATE TEMPORARY TABLE \"foo\" (\n)", $ct->getSqlString());
+        $this->assertEquals("CREATE TEMPORARY TABLE \"foo\" ( \n)", $ct->getSqlString());
 
         $ct = new CreateTable('foo');
         $ct->addColumn(new Column('bar'));
-        $this->assertEquals("CREATE TABLE \"foo\" (\n    \"bar\" INTEGER NOT NULL\n)", $ct->getSqlString());
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ct->getSqlString());
 
         $ct = new CreateTable('foo', true);
         $ct->addColumn(new Column('bar'));
-        $this->assertEquals("CREATE TEMPORARY TABLE \"foo\" (\n    \"bar\" INTEGER NOT NULL\n)", $ct->getSqlString());
+        $this->assertEquals("CREATE TEMPORARY TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ct->getSqlString());
+
+        $ct = new CreateTable('foo', true);
+        $ct->addColumn(new Column('bar'));
+        $ct->addColumn(new Column('baz'));
+        $this->assertEquals("CREATE TEMPORARY TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL,\n    \"baz\" INTEGER NOT NULL \n)", $ct->getSqlString());
+
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+        $ct->addConstraint(new Constraint\PrimaryKey('bat'));
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL , \n    PRIMARY KEY (\"bat\") \n)", $ct->getSqlString());
+
+        $ct = new CreateTable('foo');
+        $ct->addConstraint(new Constraint\PrimaryKey('bar'));
+        $ct->addConstraint(new Constraint\PrimaryKey('bat'));
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n    PRIMARY KEY (\"bar\"),\n    PRIMARY KEY (\"bat\") \n)", $ct->getSqlString());
     }
 }

--- a/tests/ZendTest/Db/Sql/DeleteTest.php
+++ b/tests/ZendTest/Db/Sql/DeleteTest.php
@@ -222,4 +222,9 @@ class DeleteIgnore extends Delete
         self::SPECIFICATION_DELETE => 'DELETE IGNORE FROM %1$s',
         self::SPECIFICATION_WHERE  => 'WHERE %1$s',
     );
+
+    protected function processdeleteIgnore(\Zend\Db\Adapter\Platform\PlatformInterface $platform, \Zend\Db\Adapter\Driver\DriverInterface $driver = null, \Zend\Db\Adapter\ParameterContainer $parameterContainer = null)
+    {
+        return parent::processDelete($platform, $driver, $parameterContainer);
+    }
 }

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -37,11 +37,11 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     public function testInto()
     {
         $this->insert->into('table', 'schema');
-        $this->assertEquals('table', $this->readAttribute($this->insert, 'table'));
+        $this->assertEquals('table', $this->insert->getRawState('table'));
 
         $tableIdentifier = new TableIdentifier('table', 'schema');
         $this->insert->into($tableIdentifier);
-        $this->assertEquals($tableIdentifier, $this->readAttribute($this->insert, 'table'));
+        $this->assertEquals($tableIdentifier, $this->insert->getRawState('table'));
     }
 
     /**
@@ -50,7 +50,7 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     public function testColumns()
     {
         $this->insert->columns(array('foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $this->readAttribute($this->insert, 'columns'));
+        $this->assertEquals(array('foo', 'bar'), $this->insert->getRawState('columns'));
     }
 
     /**
@@ -59,18 +59,18 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     public function testValues()
     {
         $this->insert->values(array('foo' => 'bar'));
-        $this->assertEquals(array('foo'), $this->readAttribute($this->insert, 'columns'));
-        $this->assertEquals(array('bar'), $this->readAttribute($this->insert, 'values'));
+        $this->assertEquals(array('foo'), $this->insert->getRawState('columns'));
+        $this->assertEquals(array('bar'), $this->insert->getRawState('values'));
 
         // test will merge cols and values of previously set stuff
         $this->insert->values(array('foo' => 'bax'), Insert::VALUES_MERGE);
         $this->insert->values(array('boom' => 'bam'), Insert::VALUES_MERGE);
-        $this->assertEquals(array('foo', 'boom'), $this->readAttribute($this->insert, 'columns'));
-        $this->assertEquals(array('bax', 'bam'), $this->readAttribute($this->insert, 'values'));
+        $this->assertEquals(array('foo', 'boom'), $this->insert->getRawState('columns'));
+        $this->assertEquals(array('bax', 'bam'), $this->insert->getRawState('values'));
 
         $this->insert->values(array('foo' => 'bax'));
-        $this->assertEquals(array('foo'), $this->readAttribute($this->insert, 'columns'));
-        $this->assertEquals(array('bax'), $this->readAttribute($this->insert, 'values'));
+        $this->assertEquals(array('foo'), $this->insert->getRawState('columns'));
+        $this->assertEquals(array('bax'), $this->insert->getRawState('values'));
     }
 
     /**
@@ -94,7 +94,7 @@ class InsertTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(
             'Zend\Db\Sql\Exception\InvalidArgumentException',
-            'A Zend\Db\Sql\Select instance cannot be provided with the merge flag when values already exist'
+            'A Zend\Db\Sql\Select instance cannot be provided with the merge flag'
         );
         $this->insert->values(new Select, Insert::VALUES_MERGE);
     }
@@ -210,10 +210,12 @@ class InsertTest extends \PHPUnit_Framework_TestCase
         $this->insert = new Insert;
         $select = new Select();
         $this->insert->into('foo')->select($select->from('bar'));
+
         $this->assertEquals('INSERT INTO "foo"  SELECT "bar".* FROM "bar"', $this->insert->getSqlString(new TrustingSql92Platform()));
 
         // with Select and columns
         $this->insert->columns(array('col1', 'col2'));
+
         $this->assertEquals('INSERT INTO "foo" ("col1", "col2") SELECT "bar".* FROM "bar"', $this->insert->getSqlString(new TrustingSql92Platform()));
     }
 
@@ -223,8 +225,8 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     public function test__set()
     {
         $this->insert->foo = 'bar';
-        $this->assertEquals(array('foo'), $this->readAttribute($this->insert, 'columns'));
-        $this->assertEquals(array('bar'), $this->readAttribute($this->insert, 'values'));
+        $this->assertEquals(array('foo'), $this->insert->getRawState('columns'));
+        $this->assertEquals(array('bar'), $this->insert->getRawState('values'));
     }
 
     /**
@@ -233,11 +235,11 @@ class InsertTest extends \PHPUnit_Framework_TestCase
     public function test__unset()
     {
         $this->insert->foo = 'bar';
-        $this->assertEquals(array('foo'), $this->readAttribute($this->insert, 'columns'));
-        $this->assertEquals(array('bar'), $this->readAttribute($this->insert, 'values'));
+        $this->assertEquals(array('foo'), $this->insert->getRawState('columns'));
+        $this->assertEquals(array('bar'), $this->insert->getRawState('values'));
         unset($this->insert->foo);
-        $this->assertEquals(array(), $this->readAttribute($this->insert, 'columns'));
-        $this->assertEquals(array(), $this->readAttribute($this->insert, 'values'));
+        $this->assertEquals(array(), $this->insert->getRawState('columns'));
+        $this->assertEquals(array(), $this->insert->getRawState('values'));
     }
 
     /**

--- a/tests/ZendTest/Db/Sql/InsertTest.php
+++ b/tests/ZendTest/Db/Sql/InsertTest.php
@@ -177,16 +177,19 @@ class InsertTest extends \PHPUnit_Framework_TestCase
 
         $mockStatement = new \Zend\Db\Adapter\StatementContainer();
 
+        $select = new Select('bar');
         $this->insert
                 ->into('foo')
                 ->columns(array('col1'))
-                ->select(new Select('bar'))
+                ->select($select->where(array('x'=>5)))
                 ->prepareStatement($mockAdapter, $mockStatement);
 
         $this->assertEquals(
-            'INSERT INTO "foo" ("col1") SELECT "bar".* FROM "bar"',
+            'INSERT INTO "foo" ("col1") SELECT "bar".* FROM "bar" WHERE "x" = ?',
             $mockStatement->getSql()
         );
+        $parameters = $mockStatement->getParameterContainer()->getNamedArray();
+        $this->assertSame(array('subselect1where1'=>5), $parameters);
     }
 
     /**
@@ -344,6 +347,12 @@ class Replace extends Insert
     const SPECIFICATION_INSERT = 'replace';
 
     protected $specifications = array(
-        self::SPECIFICATION_INSERT => 'REPLACE INTO %1$s (%2$s) VALUES (%3$s)'
+        self::SPECIFICATION_INSERT => 'REPLACE INTO %1$s (%2$s) VALUES (%3$s)',
+        self::SPECIFICATION_SELECT => 'REPLACE INTO %1$s %2$s %3$s',
     );
+
+    protected function processreplace(\Zend\Db\Adapter\Platform\PlatformInterface $platform, \Zend\Db\Adapter\Driver\DriverInterface $driver = null, \Zend\Db\Adapter\ParameterContainer $parameterContainer = null)
+    {
+        return parent::processInsert($platform, $driver, $parameterContainer);
+    }
 }

--- a/tests/ZendTest/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/SqlServer/Ddl/CreateTableDecoratorTest.php
@@ -23,17 +23,17 @@ class CreateTableDecoratorTest extends \PHPUnit_Framework_TestCase
         $ctd = new CreateTableDecorator();
 
         $ct = new CreateTable('foo');
-        $this->assertEquals("CREATE TABLE \"foo\" (\n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n)", $ctd->setSubject($ct)->getSqlString());
 
         $ct = new CreateTable('foo', true);
-        $this->assertEquals("CREATE TABLE \"#foo\" (\n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE \"#foo\" ( \n)", $ctd->setSubject($ct)->getSqlString());
 
         $ct = new CreateTable('foo');
         $ct->addColumn(new Column('bar'));
-        $this->assertEquals("CREATE TABLE \"foo\" (\n    \"bar\" INTEGER NOT NULL\n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ctd->setSubject($ct)->getSqlString());
 
         $ct = new CreateTable('foo', true);
         $ct->addColumn(new Column('bar'));
-        $this->assertEquals("CREATE TABLE \"#foo\" (\n    \"bar\" INTEGER NOT NULL\n)", $ctd->setSubject($ct)->getSqlString());
+        $this->assertEquals("CREATE TABLE \"#foo\" ( \n    \"bar\" INTEGER NOT NULL \n)", $ctd->setSubject($ct)->getSqlString());
     }
 }

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -1155,11 +1155,11 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         );
 
         $select43 = new Select();
-        $select43->from(array('x' => 'foo'))->columns(array('bar'), false);
-        $sqlPrep43 = 'SELECT "bar" AS "bar" FROM "foo" AS "x"';
-        $sqlStr43 = 'SELECT "bar" AS "bar" FROM "foo" AS "x"';
+        $select43->from(array('x' => 'foo'))->columns(array('bar' => 'foo.bar'), false);
+        $sqlPrep43 = 'SELECT "foo"."bar" AS "bar" FROM "foo" AS "x"';
+        $sqlStr43 = 'SELECT "foo"."bar" AS "bar" FROM "foo" AS "x"';
         $internalTests43 = array(
-            'processSelect' => array(array(array('"bar"', '"bar"')), '"foo" AS "x"')
+            'processSelect' => array(array(array('"foo"."bar"', '"bar"')), '"foo" AS "x"')
         );
 
         $select44 = new Select;

--- a/tests/ZendTest/Db/Sql/SqlFunctionalTest.php
+++ b/tests/ZendTest/Db/Sql/SqlFunctionalTest.php
@@ -1,0 +1,522 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql;
+
+use Zend\Db\Sql;
+use Zend\Db\Adapter;
+use ZendTest\Db\TestAsset;
+
+/**
+ * @method \Zend\Db\Sql\Select select(null|string $table)
+ * @method \Zend\Db\Sql\Update update(null|string $table)
+ * @method \Zend\Db\Sql\Delete delete(null|string $table)
+ * @method \Zend\Db\Sql\Insert insert(null|string $table)
+ * @method \Zend\Db\Sql\Ddl\CreateTable createTable(null|string $table)
+ * @method \Zend\Db\Sql\Ddl\Column\Column createColumn(null|string $name)
+ */
+class SqlFunctionalTest extends \PHPUnit_Framework_TestCase
+{
+    protected function dataProvider_CommonProcessMethods()
+    {
+        return array(
+            'Select::processOffset()' => array(
+                'sqlObject' => $this->select('foo')->offset(10),
+                'expected'  => array(
+                    'sql92' => array(
+                        'string'     => 'SELECT "foo".* FROM "foo" OFFSET \'10\'',
+                        'prepare'    => 'SELECT "foo".* FROM "foo" OFFSET ?',
+                        'parameters' => array('offset' => 10),
+                    ),
+                    'MySql' => array(
+                        'string'     => 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10',
+                        'prepare'    => 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET ?',
+                        'parameters' => array('offset' => 10),
+                    ),
+                    'Oracle' => array(
+                        'string'     => 'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b ) WHERE b_rownum > (10)',
+                        'prepare'    => 'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b ) WHERE b_rownum > (:offset)',
+                        'parameters' => array('offset' => 10),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'SELECT * FROM ( SELECT [foo].*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 10+1 AND 0+10',
+                        'prepare'    => 'SELECT * FROM ( SELECT [foo].*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN ?+1 AND ?+?',
+                        'parameters' => array('offset' => 10, 'limit' => null, 'offsetForSum' => 10),
+                    ),
+                ),
+            ),
+            'Select::processLimit()' => array(
+                'sqlObject' => $this->select('foo')->limit(10),
+                'expected'  => array(
+                    'sql92' => array(
+                        'string'     => 'SELECT "foo".* FROM "foo" LIMIT \'10\'',
+                        'prepare'    => 'SELECT "foo".* FROM "foo" LIMIT ?',
+                        'parameters' => array('limit' => 10),
+                    ),
+                    'MySql' => array(
+                        'string'     => 'SELECT `foo`.* FROM `foo` LIMIT 10',
+                        'prepare'    => 'SELECT `foo`.* FROM `foo` LIMIT ?',
+                        'parameters' => array('limit' => 10),
+                    ),
+                    'Oracle' => array(
+                        'string'     => 'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b WHERE rownum <= (0+10)) WHERE b_rownum >= (0 + 1)',
+                        'prepare'    => 'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b WHERE rownum <= (:offset+:limit)) WHERE b_rownum >= (:offset + 1)',
+                        'parameters' => array('offset' => 0, 'limit' => 10),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'SELECT * FROM ( SELECT [foo].*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 0+1 AND 10+0',
+                        'prepare'    => 'SELECT * FROM ( SELECT [foo].*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN ?+1 AND ?+?',
+                        'parameters' => array('offset' => null, 'limit' => 10, 'offsetForSum' => null),
+                    ),
+                ),
+            ),
+            'Select::processLimitOffset()' => array(
+                'sqlObject' => $this->select('foo')->limit(10)->offset(5),
+                'expected'  => array(
+                    'sql92' => array(
+                        'string'     => 'SELECT "foo".* FROM "foo" LIMIT \'10\' OFFSET \'5\'',
+                        'prepare'    => 'SELECT "foo".* FROM "foo" LIMIT ? OFFSET ?',
+                        'parameters' => array('limit' => 10, 'offset' => 5),
+                    ),
+                    'MySql' => array(
+                        'string'     => 'SELECT `foo`.* FROM `foo` LIMIT 10 OFFSET 5',
+                        'prepare'    => 'SELECT `foo`.* FROM `foo` LIMIT ? OFFSET ?',
+                        'parameters' => array('limit' => 10, 'offset' => 5),
+                    ),
+                    'Oracle' => array(
+                        'string'     => 'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b WHERE rownum <= (5+10)) WHERE b_rownum >= (5 + 1)',
+                        'prepare'    => 'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b WHERE rownum <= (:offset+:limit)) WHERE b_rownum >= (:offset + 1)',
+                        'parameters' => array('offset' => 5, 'limit' => 10),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'SELECT * FROM ( SELECT [foo].*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 5+1 AND 10+5',
+                        'prepare'    => 'SELECT * FROM ( SELECT [foo].*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS [__ZEND_ROW_NUMBER] FROM [foo] ) AS [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION] WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN ?+1 AND ?+?',
+                        'parameters' => array('offset' => 5, 'limit' => 10, 'offsetForSum' => 5),
+                    ),
+                ),
+            ),
+            'Select::processJoin()' => array(
+                'sqlObject' => $this->select('a')->join(array('b'=>$this->select('c')->where(array('cc'=>10))), 'd=e')->where(array('x'=>20)),
+                'expected'  => array(
+                    'sql92' => array(
+                        'string'     => 'SELECT "a".*, "b".* FROM "a" INNER JOIN (SELECT "c".* FROM "c" WHERE "cc" = \'10\') AS "b" ON "d"="e" WHERE "x" = \'20\'',
+                        'prepare'    => 'SELECT "a".*, "b".* FROM "a" INNER JOIN (SELECT "c".* FROM "c" WHERE "cc" = ?) AS "b" ON "d"="e" WHERE "x" = ?',
+                        'parameters' => array('subselect1where1'=>10, 'where1'=>20),
+                    ),
+                    'MySql' => array(
+                        'string'     => 'SELECT `a`.*, `b`.* FROM `a` INNER JOIN (SELECT `c`.* FROM `c` WHERE `cc` = \'10\') AS `b` ON `d`=`e` WHERE `x` = \'20\'',
+                        'prepare'    => 'SELECT `a`.*, `b`.* FROM `a` INNER JOIN (SELECT `c`.* FROM `c` WHERE `cc` = ?) AS `b` ON `d`=`e` WHERE `x` = ?',
+                        'parameters' => array('subselect2where1'=>10, 'where2'=>20),
+                    ),
+                    'Oracle' => array(
+                        'string'     => 'SELECT "a".*, "b".* FROM "a" INNER JOIN (SELECT "c".* FROM "c" WHERE "cc" = \'10\') "b" ON "d"="e" WHERE "x" = \'20\'',
+                        'prepare'    => 'SELECT "a".*, "b".* FROM "a" INNER JOIN (SELECT "c".* FROM "c" WHERE "cc" = ?) "b" ON "d"="e" WHERE "x" = ?',
+                        'parameters' => array('subselect2where1'=>10, 'where2'=>20),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'SELECT [a].*, [b].* FROM [a] INNER JOIN (SELECT [c].* FROM [c] WHERE [cc] = \'10\') AS [b] ON [d]=[e] WHERE [x] = \'20\'',
+                        'prepare'    => 'SELECT [a].*, [b].* FROM [a] INNER JOIN (SELECT [c].* FROM [c] WHERE [cc] = ?) AS [b] ON [d]=[e] WHERE [x] = ?',
+                        'parameters' => array('subselect2where1'=>10, 'where2'=>20),
+                    ),
+                ),
+            ),
+            'Ddl::CreateTable::processColumns()' => array(
+                'sqlObject' => $this->createTable('foo')
+                                    ->addColumn($this->createColumn('col1')->setOption('identity', true)->setOption('comment', 'Comment1'))
+                                    ->addColumn($this->createColumn('col2')->setOption('identity', true)->setOption('comment', 'Comment2')),
+                'expected'  => array(
+                    'sql92'     => "CREATE TABLE \"foo\" ( \n    \"col1\" INTEGER NOT NULL,\n    \"col2\" INTEGER NOT NULL \n)",
+                    'MySql'     => "CREATE TABLE `foo` ( \n    `col1` INTEGER NOT NULL AUTO_INCREMENT COMMENT 'Comment1',\n    `col2` INTEGER NOT NULL AUTO_INCREMENT COMMENT 'Comment2' \n)",
+                    'Oracle'    => "CREATE TABLE \"foo\" ( \n    \"col1\" INTEGER NOT NULL,\n    \"col2\" INTEGER NOT NULL \n)",
+                    'SqlServer' => "CREATE TABLE [foo] ( \n    [col1] INTEGER NOT NULL,\n    [col2] INTEGER NOT NULL \n)",
+                ),
+            ),
+            'Ddl::CreateTable::processTable()' => array(
+                'sqlObject' => $this->createTable('foo')->setTemporary(true),
+                'expected'  => array(
+                    'sql92'     => "CREATE TEMPORARY TABLE \"foo\" ( \n)",
+                    'MySql'     => "CREATE TEMPORARY TABLE `foo` ( \n)",
+                    'Oracle'    => "CREATE TEMPORARY TABLE \"foo\" ( \n)",
+                    'SqlServer' => "CREATE TABLE [#foo] ( \n)",
+                ),
+            ),
+            'Select::processSubSelect()' => array(
+                'sqlObject' => $this->select(array('a' => $this->select(array('b' => $this->select('c')->where(array('cc'=>'CC'))))->where(array('bb'=>'BB'))))->where(array('aa'=>'AA')),
+                'expected'  => array(
+                    'sql92' => array(
+                        'string'     => 'SELECT "a".* FROM (SELECT "b".* FROM (SELECT "c".* FROM "c" WHERE "cc" = \'CC\') AS "b" WHERE "bb" = \'BB\') AS "a" WHERE "aa" = \'AA\'',
+                        'prepare'    => 'SELECT "a".* FROM (SELECT "b".* FROM (SELECT "c".* FROM "c" WHERE "cc" = ?) AS "b" WHERE "bb" = ?) AS "a" WHERE "aa" = ?',
+                        'parameters' => array('subselect2where1' => 'CC', 'subselect1where1' => 'BB', 'where1' => 'AA'),
+                    ),
+                    'MySql' => array(
+                        'string'     => 'SELECT `a`.* FROM (SELECT `b`.* FROM (SELECT `c`.* FROM `c` WHERE `cc` = \'CC\') AS `b` WHERE `bb` = \'BB\') AS `a` WHERE `aa` = \'AA\'',
+                        'prepare'    => 'SELECT `a`.* FROM (SELECT `b`.* FROM (SELECT `c`.* FROM `c` WHERE `cc` = ?) AS `b` WHERE `bb` = ?) AS `a` WHERE `aa` = ?',
+                        'parameters' => array('subselect4where1' => 'CC', 'subselect3where1' => 'BB', 'where2' => 'AA'),
+                    ),
+                    'Oracle' => array(
+                        'string'     => 'SELECT "a".* FROM (SELECT "b".* FROM (SELECT "c".* FROM "c" WHERE "cc" = \'CC\') "b" WHERE "bb" = \'BB\') "a" WHERE "aa" = \'AA\'',
+                        'prepare'    => 'SELECT "a".* FROM (SELECT "b".* FROM (SELECT "c".* FROM "c" WHERE "cc" = ?) "b" WHERE "bb" = ?) "a" WHERE "aa" = ?',
+                        'parameters' => array('subselect4where1' => 'CC', 'subselect3where1' => 'BB', 'where2' => 'AA'),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'SELECT [a].* FROM (SELECT [b].* FROM (SELECT [c].* FROM [c] WHERE [cc] = \'CC\') AS [b] WHERE [bb] = \'BB\') AS [a] WHERE [aa] = \'AA\'',
+                        'prepare'    => 'SELECT [a].* FROM (SELECT [b].* FROM (SELECT [c].* FROM [c] WHERE [cc] = ?) AS [b] WHERE [bb] = ?) AS [a] WHERE [aa] = ?',
+                        'parameters' => array('subselect4where1' => 'CC', 'subselect3where1' => 'BB', 'where2' => 'AA'),
+                    ),
+                ),
+            ),
+            'Delete::processSubSelect()' => array(
+                'sqlObject' => $this->delete('foo')->where(array('x'=>$this->select('foo')->where(array('x'=>'y')))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'string'     => 'DELETE FROM "foo" WHERE "x" = (SELECT "foo".* FROM "foo" WHERE "x" = \'y\')',
+                        'prepare'    => 'DELETE FROM "foo" WHERE "x" = (SELECT "foo".* FROM "foo" WHERE "x" = ?)',
+                        'parameters' => array('subselect1where1' => 'y'),
+                    ),
+                    'MySql'     => array(
+                        'string'     => 'DELETE FROM `foo` WHERE `x` = (SELECT `foo`.* FROM `foo` WHERE `x` = \'y\')',
+                        'prepare'    => 'DELETE FROM `foo` WHERE `x` = (SELECT `foo`.* FROM `foo` WHERE `x` = ?)',
+                        'parameters' => array('subselect2where1' => 'y'),
+                    ),
+                    'Oracle'    => array(
+                        'string'     => 'DELETE FROM "foo" WHERE "x" = (SELECT "foo".* FROM "foo" WHERE "x" = \'y\')',
+                        'prepare'    => 'DELETE FROM "foo" WHERE "x" = (SELECT "foo".* FROM "foo" WHERE "x" = ?)',
+                        'parameters' => array('subselect3where1' => 'y'),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'DELETE FROM [foo] WHERE [x] = (SELECT [foo].* FROM [foo] WHERE [x] = \'y\')',
+                        'prepare'    => 'DELETE FROM [foo] WHERE [x] = (SELECT [foo].* FROM [foo] WHERE [x] = ?)',
+                        'parameters' => array('subselect4where1' => 'y'),
+                    ),
+                ),
+            ),
+            'Update::processSubSelect()' => array(
+                'sqlObject' => $this->update('foo')->set(array('x'=>$this->select('foo'))),
+                'expected'  => array(
+                    'sql92'     => 'UPDATE "foo" SET "x" = (SELECT "foo".* FROM "foo")',
+                    'MySql'     => 'UPDATE `foo` SET `x` = (SELECT `foo`.* FROM `foo`)',
+                    'Oracle'    => 'UPDATE "foo" SET "x" = (SELECT "foo".* FROM "foo")',
+                    'SqlServer' => 'UPDATE [foo] SET [x] = (SELECT [foo].* FROM [foo])',
+                ),
+            ),
+            'Insert::processSubSelect()' => array(
+                'sqlObject' => $this->insert('foo')->select($this->select('foo')->where(array('x'=>'y'))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'string'     => 'INSERT INTO "foo"  SELECT "foo".* FROM "foo" WHERE "x" = \'y\'',
+                        'prepare'    => 'INSERT INTO "foo"  SELECT "foo".* FROM "foo" WHERE "x" = ?',
+                        'parameters' => array('subselect1where1' => 'y'),
+                    ),
+                    'MySql'     => array(
+                        'string'     => 'INSERT INTO `foo`  SELECT `foo`.* FROM `foo` WHERE `x` = \'y\'',
+                        'prepare'    => 'INSERT INTO `foo`  SELECT `foo`.* FROM `foo` WHERE `x` = ?',
+                        'parameters' => array('subselect2where1' => 'y'),
+                    ),
+                    'Oracle'    => array(
+                        'string'     => 'INSERT INTO "foo"  SELECT "foo".* FROM "foo" WHERE "x" = \'y\'',
+                        'prepare'    => 'INSERT INTO "foo"  SELECT "foo".* FROM "foo" WHERE "x" = ?',
+                        'parameters' => array('subselect3where1' => 'y'),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'INSERT INTO [foo]  SELECT [foo].* FROM [foo] WHERE [x] = \'y\'',
+                        'prepare'    => 'INSERT INTO [foo]  SELECT [foo].* FROM [foo] WHERE [x] = ?',
+                        'parameters' => array('subselect4where1' => 'y'),
+                    ),
+                ),
+            ),
+            'Update::processExpression()' => array(
+                'sqlObject' => $this->update('foo')->set(array('x'=>new Sql\Expression('?', array($this->select('foo')->where(array('x'=>'y')))))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'string'     => 'UPDATE "foo" SET "x" = (SELECT "foo".* FROM "foo" WHERE "x" = \'y\')',
+                        'prepare'    => 'UPDATE "foo" SET "x" = (SELECT "foo".* FROM "foo" WHERE "x" = ?)',
+                        'parameters' => array('subselect1where1' => 'y'),
+                    ),
+                    'MySql'     => array(
+                        'string'     => 'UPDATE `foo` SET `x` = (SELECT `foo`.* FROM `foo` WHERE `x` = \'y\')',
+                        'prepare'    => 'UPDATE `foo` SET `x` = (SELECT `foo`.* FROM `foo` WHERE `x` = ?)',
+                        'parameters' => array('subselect2where1' => 'y'),
+                    ),
+                    'Oracle'    => array(
+                        'string'     => 'UPDATE "foo" SET "x" = (SELECT "foo".* FROM "foo" WHERE "x" = \'y\')',
+                        'prepare'    => 'UPDATE "foo" SET "x" = (SELECT "foo".* FROM "foo" WHERE "x" = ?)',
+                        'parameters' => array('subselect3where1' => 'y'),
+                    ),
+                    'SqlServer' => array(
+                        'string'     => 'UPDATE [foo] SET [x] = (SELECT [foo].* FROM [foo] WHERE [x] = \'y\')',
+                        'prepare'    => 'UPDATE [foo] SET [x] = (SELECT [foo].* FROM [foo] WHERE [x] = ?)',
+                        'parameters' => array('subselect4where1' => 'y'),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    protected function dataProvider_Decorators()
+    {
+        return array(
+            'RootDecorators::Select' => array(
+                'sqlObject' => $this->select('foo')->where(array('x'=>$this->select('bar'))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Select' => new TestAsset\SelectDecorator,
+                        ),
+                        'string' => 'SELECT "foo".* FROM "foo" WHERE "x" = (SELECT "bar".* FROM "bar")',
+                    ),
+                    'MySql'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Select' => new TestAsset\SelectDecorator,
+                        ),
+                        'string' => 'SELECT `foo`.* FROM `foo` WHERE `x` = (SELECT `bar`.* FROM `bar`)',
+                    ),
+                    'Oracle'    => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Select' => new TestAsset\SelectDecorator,
+                        ),
+                        'string' => 'SELECT "foo".* FROM "foo" WHERE "x" = (SELECT "bar".* FROM "bar")',
+                    ),
+                    'SqlServer' => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Select' => new TestAsset\SelectDecorator,
+                        ),
+                        'string' => 'SELECT [foo].* FROM [foo] WHERE [x] = (SELECT [bar].* FROM [bar])',
+                    ),
+                ),
+            ),
+            /* TODO - should be implemeted
+            'RootDecorators::Insert' => array(
+                'sqlObject' => $this->insert('foo')->select($this->select()),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Insert' => new TestAsset\InsertDecorator, // Decorator for root sqlObject
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_Sql92=}')
+                        ),
+                        'string' => 'INSERT INTO "foo"  {=SELECT_Sql92=}',
+                    ),
+                    'MySql'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Insert' => new TestAsset\InsertDecorator, // Decorator for root sqlObject
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_MySql=}')
+                        ),
+                        'string' => 'INSERT INTO `foo`  {=SELECT_MySql=}',
+                    ),
+                    'Oracle'    => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Insert' => new TestAsset\InsertDecorator, // Decorator for root sqlObject
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Oracle\SelectDecorator', '{=SELECT_Oracle=}')
+                        ),
+                        'string' => 'INSERT INTO "foo"  {=SELECT_Oracle=}',
+                    ),
+                    'SqlServer' => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Insert' => new TestAsset\InsertDecorator, // Decorator for root sqlObject
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\SqlServer\SelectDecorator', '{=SELECT_SqlServer=}')
+                        ),
+                        'string' => 'INSERT INTO [foo]  {=SELECT_SqlServer=}',
+                    ),
+                ),
+            ),
+            'RootDecorators::Delete' => array(
+                'sqlObject' => $this->delete('foo')->where(array('x'=>$this->select('foo'))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Delete' => new TestAsset\DeleteDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_Sql92=}')
+                        ),
+                        'string' => 'DELETE FROM "foo" WHERE "x" = ({=SELECT_Sql92=})',
+                    ),
+                    'MySql'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Delete' => new TestAsset\DeleteDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_MySql=}')
+                        ),
+                        'string' => 'DELETE FROM `foo` WHERE `x` = ({=SELECT_MySql=})',
+                    ),
+                    'Oracle'    => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Delete' => new TestAsset\DeleteDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Oracle\SelectDecorator', '{=SELECT_Oracle=}')
+                        ),
+                        'string' => 'DELETE FROM "foo" WHERE "x" = ({=SELECT_Oracle=})',
+                    ),
+                    'SqlServer' => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Delete' => new TestAsset\DeleteDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\SqlServer\SelectDecorator', '{=SELECT_SqlServer=}')
+                        ),
+                        'string' => 'DELETE FROM [foo] WHERE [x] = ({=SELECT_SqlServer=})',
+                    ),
+                ),
+            ),
+            'RootDecorators::Update' => array(
+                'sqlObject' => $this->update('foo')->where(array('x'=>$this->select('foo'))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Update' => new TestAsset\UpdateDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_Sql92=}')
+                        ),
+                        'string' => 'UPDATE "foo" SET  WHERE "x" = ({=SELECT_Sql92=})',
+                    ),
+                    'MySql'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Update' => new TestAsset\UpdateDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_MySql=}')
+                        ),
+                        'string' => 'UPDATE `foo` SET  WHERE `x` = ({=SELECT_MySql=})',
+                    ),
+                    'Oracle'    => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Update' => new TestAsset\UpdateDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\Oracle\SelectDecorator', '{=SELECT_Oracle=}')
+                        ),
+                        'string' => 'UPDATE "foo" SET  WHERE "x" = ({=SELECT_Oracle=})',
+                    ),
+                    'SqlServer' => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Update' => new TestAsset\UpdateDecorator,
+                            'Zend\Db\Sql\Select' => array('Zend\Db\Sql\Platform\SqlServer\SelectDecorator', '{=SELECT_SqlServer=}')
+                        ),
+                        'string' => 'UPDATE [foo] SET  WHERE [x] = ({=SELECT_SqlServer=})',
+                    ),
+                ),
+            ),
+            'DecorableExpression()' => array(
+                'sqlObject' => $this->update('foo')->where(array('x'=>new Sql\Expression('?', array($this->select('foo'))))),
+                'expected'  => array(
+                    'sql92'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Expression' => new TestAsset\DecorableExpression,
+                            'Zend\Db\Sql\Select'     => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_Sql92=}')
+                        ),
+                        'string'     => 'UPDATE "foo" SET  WHERE "x" = {decorate-({=SELECT_Sql92=})-decorate}',
+                    ),
+                    'MySql'     => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Expression' => new TestAsset\DecorableExpression,
+                            'Zend\Db\Sql\Select'     => array('Zend\Db\Sql\Platform\Mysql\SelectDecorator', '{=SELECT_MySql=}')
+                        ),
+                        'string'     => 'UPDATE `foo` SET  WHERE `x` = {decorate-({=SELECT_MySql=})-decorate}',
+                    ),
+                    'Oracle'    => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Expression' => new TestAsset\DecorableExpression,
+                            'Zend\Db\Sql\Select'     => array('Zend\Db\Sql\Platform\Oracle\SelectDecorator', '{=SELECT_Oracle=}')
+                        ),
+                        'string'     => 'UPDATE "foo" SET  WHERE "x" = {decorate-({=SELECT_Oracle=})-decorate}',
+                    ),
+                    'SqlServer' => array(
+                        'decorators' => array(
+                            'Zend\Db\Sql\Expression' => new TestAsset\DecorableExpression,
+                            'Zend\Db\Sql\Select'     => array('Zend\Db\Sql\Platform\SqlServer\SelectDecorator', '{=SELECT_SqlServer=}')
+                        ),
+                        'string'     => 'UPDATE [foo] SET  WHERE [x] = {decorate-({=SELECT_SqlServer=})-decorate}',
+                    ),
+                ),
+            ),*/
+        );
+    }
+
+    public function dataProvider()
+    {
+        $data = array_merge(
+            $this->dataProvider_CommonProcessMethods(),
+            $this->dataProvider_Decorators()
+        );
+
+        $res = array();
+        foreach($data as $index => $test) {
+            foreach($test['expected'] as $platform => $expected) {
+                $res[$index . '->' . $platform] = array(
+                    'sqlObject' => $test['sqlObject'],
+                    'platform'  => $platform,
+                    'expected'  => $expected,
+                );
+            }
+        }
+        return $res;
+    }
+
+    /**
+     * @param type $sqlObject
+     * @param type $platform
+     * @param type $expected
+     * @dataProvider dataProvider
+     */
+    public function test($sqlObject, $platform, $expected)
+    {
+        $sql = new Sql\Sql($this->resolveAdapter($platform));
+
+        if (is_array($expected) && isset($expected['decorators'])) {
+            foreach($expected['decorators'] as $type=>$decorator) {
+                $sql->getSqlPlatform()->setTypeDecorator($type, $this->resolveDecorator($decorator));
+            }
+        }
+
+        $expectedString = is_string($expected) ? $expected : (isset($expected['string']) ? $expected['string'] : null);
+        if ($expectedString) {
+            $actual = $sql->getSqlStringForSqlObject($sqlObject);
+            $this->assertEquals($expectedString, $actual, "getSqlString()");
+        }
+        if (is_array($expected) && isset($expected['prepare'])) {
+            $actual = $sql->prepareStatementForSqlObject($sqlObject);
+            $this->assertEquals($expected['prepare'], $actual->getSql(), "prepareStatement()");
+            if (isset($expected['parameters'])) {
+                $actual = $actual->getParameterContainer()->getNamedArray();
+                $this->assertSame($expected['parameters'], $actual, "parameterContainer()");
+            }
+        }
+    }
+
+    protected function resolveDecorator($decorator)
+    {
+        if (is_array($decorator)) {
+            $decoratorMock = $this->getMock($decorator[0], array('buildSqlString'), array(null));
+            $decoratorMock->expects($this->any())->method('buildSqlString')->will($this->returnValue($decorator[1]));
+            return $decoratorMock;
+        }
+        if ($decorator instanceof Sql\Platform\PlatformDecoratorInterface) {
+            return $decorator;
+        }
+        return null;
+    }
+
+    protected function resolveAdapter($platform)
+    {
+        switch($platform) {
+            case 'sql92'     : $platform  = new TestAsset\TrustingSql92Platform();     break;
+            case 'MySql'     : $platform  = new TestAsset\TrustingMysqlPlatform();     break;
+            case 'Oracle'    : $platform  = new TestAsset\TrustingOraclePlatform();    break;
+            case 'SqlServer' : $platform  = new TestAsset\TrustingSqlServerPlatform(); break;
+            default : $platform = null;
+        }
+
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockDriver->expects($this->any())->method('createStatement')->will($this->returnCallback(function () {return new Adapter\StatementContainer;}));
+
+        return new Adapter\Adapter($mockDriver, $platform);
+    }
+
+    public function __call($name, $arguments)
+    {
+        $arg0 = isset($arguments[0]) ? $arguments[0] : null;
+        switch ($name) {
+            case 'select'       : return new Sql\Select($arg0);
+            case 'delete'       : return new Sql\Delete($arg0);
+            case 'update'       : return new Sql\Update($arg0);
+            case 'insert'       : return new Sql\Insert($arg0);
+            case 'createTable'  : return new Sql\Ddl\CreateTable($arg0);
+            case 'createColumn' : return new Sql\Ddl\Column\Column($arg0);
+        }
+    }
+}

--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -330,4 +330,9 @@ class UpdateIgnore extends Update
         self::SPECIFICATION_UPDATE => 'UPDATE IGNORE %1$s SET %2$s',
         self::SPECIFICATION_WHERE  => 'WHERE %1$s'
     );
+
+    protected function processupdateIgnore(\Zend\Db\Adapter\Platform\PlatformInterface $platform, \Zend\Db\Adapter\Driver\DriverInterface $driver = null, \Zend\Db\Adapter\ParameterContainer $parameterContainer = null)
+    {
+        return parent::processUpdate($platform, $driver, $parameterContainer);
+    }
 }

--- a/tests/ZendTest/Db/TestAsset/DeleteDecorator.php
+++ b/tests/ZendTest/Db/TestAsset/DeleteDecorator.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Sql;
+
+class DeleteDecorator extends Sql\Delete implements Sql\Platform\PlatformDecoratorInterface
+{
+    protected $subject = null;
+
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        return $this;
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/InsertDecorator.php
+++ b/tests/ZendTest/Db/TestAsset/InsertDecorator.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Sql;
+
+class InsertDecorator extends Sql\Insert implements Sql\Platform\PlatformDecoratorInterface
+{
+    protected $subject = null;
+
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        return $this;
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/SelectDecorator.php
+++ b/tests/ZendTest/Db/TestAsset/SelectDecorator.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Sql;
+
+class SelectDecorator extends Sql\Select implements Sql\Platform\PlatformDecoratorInterface
+{
+    protected $subject = null;
+
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        return $this;
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/TrustingMysqlPlatform.php
+++ b/tests/ZendTest/Db/TestAsset/TrustingMysqlPlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\Mysql;
+
+class TrustingMysqlPlatform extends Mysql
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/TrustingOraclePlatform.php
+++ b/tests/ZendTest/Db/TestAsset/TrustingOraclePlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\Oracle;
+
+class TrustingOraclePlatform extends Oracle
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/TrustingSqlServerPlatform.php
+++ b/tests/ZendTest/Db/TestAsset/TrustingSqlServerPlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\SqlServer;
+
+class TrustingSqlServerPlatform extends SqlServer
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/UpdateDecorator.php
+++ b/tests/ZendTest/Db/TestAsset/UpdateDecorator.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Sql;
+
+class UpdateDecorator extends Sql\Update implements Sql\Platform\PlatformDecoratorInterface
+{
+    protected $subject = null;
+
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+        return $this;
+    }
+}


### PR DESCRIPTION
moved to functions :
- resolving columns (`AbstractSql::resolveColumnValue`)
- resolving `$this->table` (`AbstractSql::resolveTable`)
- resolve `$parameterContainer` (`AbstractSql::resolveParameterContainer`)

`Insert` reorganized because :
- for using common method for resolving columns
- use of `$columns` and `$values` ​​is redundant, `$columns` only is enough

`AbstractSql::processExpression` and `AbstractSql::processSubSelect` : do more readable

Added new commits (step 6 - step 9):
- delete dependency between `$driver` and `$parameterContainer` for `process...` methods.
- move prepareStatement() and getSqlString() to AbstractSql because it duplicates in many places
- AbstractSql::processExpression() should return string and paremeters push to `ParameterContainer` directly - this remove excess `ParameterContainer::merge()` calls and simplificate code
- some code optimization
