### PR TITLE
Update FormCollection.php

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -148,13 +148,14 @@ class FormCollection extends AbstractHelper
     public function renderTemplate(CollectionElement $collection)
     {
         $elementHelper          = $this->getElementHelper();
+        $fieldsetHelper         = $this->getFieldsetHelper();
         $escapeHtmlAttribHelper = $this->getEscapeHtmlAttrHelper();
         $templateMarkup         = '';
 
         $elementOrFieldset = $collection->getTemplateElement();
 
         if ($elementOrFieldset instanceof FieldsetInterface) {
-            $templateMarkup .= $this->render($elementOrFieldset);
+            $templateMarkup .= $fieldsetHelper($elementOrFieldset);
         } elseif ($elementOrFieldset instanceof ElementInterface) {
             $templateMarkup .= $elementHelper($elementOrFieldset);
         }


### PR DESCRIPTION
When displaying a collection, if I use a specific FieldsetHelper during the template generation, it is not used.
