### PR TITLE
Implemented writeTextBlock method in Zend\Console\Adapter\AbstractAdapter

### DIFF
--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -108,16 +108,16 @@ abstract class AbstractAdapter implements AdapterInterface
      * If X or Y coordinate value is negative, it will be calculated as the distance from far right or bottom edge
      * of the console (respectively).
      *
-     * @param  int                              $x1          Top-left corner X coordinate (column)
-     * @param  int                              $y1          Top-left corner Y coordinate (row)
-     * @param  int                              $x2          Bottom-right corner X coordinate (column)
-     * @param  int                              $y2          Bottom-right corner Y coordinate (row)
-     * @param  int                              $lineStyle   (optional) Box border style.
-     * @param  int                              $fillStyle   (optional) Box fill style or a single character to fill it with.
-     * @param  int                              $color       (optional) Foreground color
-     * @param  int                              $bgColor     (optional) Background color
-     * @param  null|int                         $fillColor   (optional) Foreground color of box fill
-     * @param  null|int                         $fillBgColor (optional) Background color of box fill
+     * @param int      $x1           Top-left corner X coordinate (column)
+     * @param int      $y1           Top-left corner Y coordinate (row)
+     * @param int      $x2           Bottom-right corner X coordinate (column)
+     * @param int      $y2           Bottom-right corner Y coordinate (row)
+     * @param int      $lineStyle    (optional) Box border style.
+     * @param int      $fillStyle    (optional) Box fill style or a single character to fill it with.
+     * @param int      $color        (optional) Foreground color
+     * @param int      $bgColor      (optional) Background color
+     * @param null|int $fillColor    (optional) Foreground color of box fill
+     * @param null|int $fillBgColor  (optional) Background color of box fill
      * @throws Exception\BadMethodCallException if coordinates are invalid
      */
     public function writeBox(
@@ -280,13 +280,13 @@ abstract class AbstractAdapter implements AdapterInterface
      * In case a line of text does not fit desired width, it will be wrapped to the next line.
      * In case the whole text does not fit in desired height, it will be truncated.
      *
-     * @param  string                             $text    Text to write
-     * @param  int                                $width   Maximum block width. Negative value means distance from right edge.
-     * @param  int|null                           $height  Maximum block height. Negative value means distance from bottom edge.
-     * @param  int                                $x       Block X coordinate (column)
-     * @param  int                                $y       Block Y coordinate (row)
-     * @param  null|int                           $color   (optional) Text color
-     * @param  null|int                           $bgColor (optional) Text background color
+     * @param string   $text    Text to write
+     * @param int      $width   Maximum block width. Negative value means distance from right edge.
+     * @param int|null $height  Maximum block height. Negative value means distance from bottom edge.
+     * @param int      $x       Block X coordinate (column)
+     * @param int      $y       Block Y coordinate (row)
+     * @param null|int $color   (optional) Text color
+     * @param null|int $bgColor (optional) Text background color
      * @throws Exception\InvalidArgumentException
      */
     public function writeTextBlock(
@@ -512,7 +512,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Read a single line from the console input
      *
-     * @param  int    $maxLength Maximum response length
+     * @param int $maxLength        Maximum response length
      * @return string
      */
     public function readLine($maxLength = 2048)
@@ -527,7 +527,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Read a single character from the console input
      *
-     * @param  string|null $mask A list of allowed chars
+     * @param string|null   $mask   A list of allowed chars
      * @return string
      */
     public function readChar($mask = null)

--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -280,13 +280,14 @@ abstract class AbstractAdapter implements AdapterInterface
      * In case a line of text does not fit desired width, it will be wrapped to the next line.
      * In case the whole text does not fit in desired height, it will be truncated.
      *
-     * @param string   $text    Text to write
-     * @param int      $width   Maximum block width. Negative value means distance from right edge.
-     * @param int|null $height  Maximum block height. Negative value means distance from bottom edge.
-     * @param int      $x       Block X coordinate (column)
-     * @param int      $y       Block Y coordinate (row)
-     * @param null|int $color   (optional) Text color
-     * @param null|int $bgColor (optional) Text background color
+     * @param  string                             $text    Text to write
+     * @param  int                                $width   Maximum block width. Negative value means distance from right edge.
+     * @param  int|null                           $height  Maximum block height. Negative value means distance from bottom edge.
+     * @param  int                                $x       Block X coordinate (column)
+     * @param  int                                $y       Block Y coordinate (row)
+     * @param  null|int                           $color   (optional) Text color
+     * @param  null|int                           $bgColor (optional) Text background color
+     * @throws Exception\InvalidArgumentException
      */
     public function writeTextBlock(
         $text,
@@ -297,6 +298,18 @@ abstract class AbstractAdapter implements AdapterInterface
         $color = null,
         $bgColor = null
     ) {
+        if ($x < 0 || $y < 0) {
+            throw new Exception\InvalidArgumentException('Supplied X,Y coordinates are invalid.');
+        }
+
+        if ($width < 1) {
+            throw new Exception\InvalidArgumentException('Invalid width supplied.');
+        }
+
+        if (null !== $height && $height < 1) {
+            throw new Exception\InvalidArgumentException('Invalid height supplied.');
+        }
+
         //ensure the text is not wider than the width
         if (strlen($text) > $width) {
             $text = wordwrap($text, $width, PHP_EOL, true);

--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -108,16 +108,16 @@ abstract class AbstractAdapter implements AdapterInterface
      * If X or Y coordinate value is negative, it will be calculated as the distance from far right or bottom edge
      * of the console (respectively).
      *
-     * @param int      $x1           Top-left corner X coordinate (column)
-     * @param int      $y1           Top-left corner Y coordinate (row)
-     * @param int      $x2           Bottom-right corner X coordinate (column)
-     * @param int      $y2           Bottom-right corner Y coordinate (row)
-     * @param int      $lineStyle    (optional) Box border style.
-     * @param int      $fillStyle    (optional) Box fill style or a single character to fill it with.
-     * @param int      $color        (optional) Foreground color
-     * @param int      $bgColor      (optional) Background color
-     * @param null|int $fillColor    (optional) Foreground color of box fill
-     * @param null|int $fillBgColor  (optional) Background color of box fill
+     * @param  int                              $x1          Top-left corner X coordinate (column)
+     * @param  int                              $y1          Top-left corner Y coordinate (row)
+     * @param  int                              $x2          Bottom-right corner X coordinate (column)
+     * @param  int                              $y2          Bottom-right corner Y coordinate (row)
+     * @param  int                              $lineStyle   (optional) Box border style.
+     * @param  int                              $fillStyle   (optional) Box fill style or a single character to fill it with.
+     * @param  int                              $color       (optional) Foreground color
+     * @param  int                              $bgColor     (optional) Background color
+     * @param  null|int                         $fillColor   (optional) Foreground color of box fill
+     * @param  null|int                         $fillBgColor (optional) Background color of box fill
      * @throws Exception\BadMethodCallException if coordinates are invalid
      */
     public function writeBox(
@@ -244,7 +244,6 @@ abstract class AbstractAdapter implements AdapterInterface
             }
         }
 
-
         // Draw corners
         if ($lineStyle !== static::LINE_NONE) {
             if ($color !== null) {
@@ -298,6 +297,32 @@ abstract class AbstractAdapter implements AdapterInterface
         $color = null,
         $bgColor = null
     ) {
+        //ensure the text is not wider than the width
+        if (strlen($text) > $width) {
+            $text = wordwrap($text, $width, PHP_EOL, true);
+        } else {
+            //just write the line at the spec'd position
+            $this->setPos($x, $y);
+            $this->write($text, $color, $bgColor);
+
+            return;
+        }
+
+        //convert to array of lines
+        $lines = explode(PHP_EOL, $text);
+
+        //truncate if height was specified
+        if (null !== $height && count($lines) > $height) {
+            $lines = array_slice($lines, 0, $height);
+        }
+
+        //write each line
+        $curY = $y;
+        foreach ($lines as $line) {
+            $this->setPos($x, $curY);
+            $this->write($line, $color, $bgColor);
+            $curY++;//next line
+        }
     }
 
     /**
@@ -474,7 +499,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Read a single line from the console input
      *
-     * @param int $maxLength        Maximum response length
+     * @param  int    $maxLength Maximum response length
      * @return string
      */
     public function readLine($maxLength = 2048)
@@ -482,13 +507,14 @@ abstract class AbstractAdapter implements AdapterInterface
         $f    = fopen('php://stdin','r');
         $line = stream_get_line($f, $maxLength, PHP_EOL);
         fclose($f);
+
         return rtrim($line,"\n\r");
     }
 
     /**
      * Read a single character from the console input
      *
-     * @param string|null   $mask   A list of allowed chars
+     * @param  string|null $mask A list of allowed chars
      * @return string
      */
     public function readChar($mask = null)
@@ -498,6 +524,7 @@ abstract class AbstractAdapter implements AdapterInterface
             $char = fread($f,1);
         } while ("" === $char || ($mask !== null && false === strstr($mask, $char)));
         fclose($f);
+
         return $char;
     }
 

--- a/library/Zend/Console/Adapter/AbstractAdapter.php
+++ b/library/Zend/Console/Adapter/AbstractAdapter.php
@@ -244,6 +244,7 @@ abstract class AbstractAdapter implements AdapterInterface
             }
         }
 
+
         // Draw corners
         if ($lineStyle !== static::LINE_NONE) {
             if ($color !== null) {
@@ -520,7 +521,6 @@ abstract class AbstractAdapter implements AdapterInterface
         $f    = fopen('php://stdin','r');
         $line = stream_get_line($f, $maxLength, PHP_EOL);
         fclose($f);
-
         return rtrim($line,"\n\r");
     }
 
@@ -537,7 +537,6 @@ abstract class AbstractAdapter implements AdapterInterface
             $char = fread($f,1);
         } while ("" === $char || ($mask !== null && false === strstr($mask, $char)));
         fclose($f);
-
         return $char;
     }
 

--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -225,9 +225,9 @@ class Posix extends AbstractAdapter
     /**
      * Prepare a string that will be rendered in color.
      *
-     * @param  string   $string
-     * @param  int      $color
-     * @param  null|int $bgColor
+     * @param  string                           $string
+     * @param  int                              $color
+     * @param  null|int                         $bgColor
      * @throws Exception\BadMethodCallException
      * @return string
      */
@@ -235,6 +235,7 @@ class Posix extends AbstractAdapter
     {
         $color   = $this->getColorCode($color, 'fg');
         $bgColor = $this->getColorCode($bgColor, 'bg');
+
         return ($color !== null ? "\x1b[" . $color   . 'm' : '')
             . ($bgColor !== null ? "\x1b[" . $bgColor . 'm' : '')
             . $string
@@ -244,7 +245,7 @@ class Posix extends AbstractAdapter
     /**
      * Change current drawing color.
      *
-     * @param int $color
+     * @param  int                              $color
      * @throws Exception\BadMethodCallException
      */
     public function setColor($color)
@@ -256,7 +257,7 @@ class Posix extends AbstractAdapter
     /**
      * Change current drawing background color
      *
-     * @param int $bgColor
+     * @param  int                              $bgColor
      * @throws Exception\BadMethodCallException
      */
     public function setBgColor($bgColor)
@@ -308,13 +309,14 @@ class Posix extends AbstractAdapter
         if ($this->isUtf8()) {
             return new Charset\Utf8;
         }
+
         return new Charset\DECSG();
     }
 
     /**
      * Read a single character from the console input
      *
-     * @param  string|null $mask   A list of allowed chars
+     * @param  string|null $mask A list of allowed chars
      * @return string
      */
     public function readChar($mask = null)
@@ -328,6 +330,7 @@ class Posix extends AbstractAdapter
         fclose($stream);
 
         $this->restoreTTYMode();
+
         return $char;
     }
 
@@ -372,7 +375,8 @@ class Posix extends AbstractAdapter
     /**
      * Get the final color code and throw exception on error
      *
-     * @param  null|int|Xterm256 $color
+     * @param  null|int|Xterm256                $color
+     * @param  string                           $type  (optional) Foreground 'fg' or background 'bg'.
      * @throws Exception\BadMethodCallException
      * @return string
      */
@@ -386,6 +390,7 @@ class Posix extends AbstractAdapter
             } else {
                 $code = sprintf($code, $color::BACKGROUND);
             }
+
             return $code;
         }
 

--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -225,9 +225,9 @@ class Posix extends AbstractAdapter
     /**
      * Prepare a string that will be rendered in color.
      *
-     * @param  string                           $string
-     * @param  int                              $color
-     * @param  null|int                         $bgColor
+     * @param  string   $string
+     * @param  int      $color
+     * @param  null|int $bgColor
      * @throws Exception\BadMethodCallException
      * @return string
      */
@@ -245,7 +245,7 @@ class Posix extends AbstractAdapter
     /**
      * Change current drawing color.
      *
-     * @param  int                              $color
+     * @param int $color
      * @throws Exception\BadMethodCallException
      */
     public function setColor($color)
@@ -257,7 +257,7 @@ class Posix extends AbstractAdapter
     /**
      * Change current drawing background color
      *
-     * @param  int                              $bgColor
+     * @param int $bgColor
      * @throws Exception\BadMethodCallException
      */
     public function setBgColor($bgColor)
@@ -316,7 +316,7 @@ class Posix extends AbstractAdapter
     /**
      * Read a single character from the console input
      *
-     * @param  string|null $mask A list of allowed chars
+     * @param  string|null $mask   A list of allowed chars
      * @return string
      */
     public function readChar($mask = null)
@@ -375,8 +375,8 @@ class Posix extends AbstractAdapter
     /**
      * Get the final color code and throw exception on error
      *
-     * @param  null|int|Xterm256                $color
-     * @param  string                           $type  (optional) Foreground 'fg' or background 'bg'.
+     * @param  null|int|Xterm256 $color
+     * @param  string            $type  (optional) Foreground 'fg' or background 'bg'.
      * @throws Exception\BadMethodCallException
      * @return string
      */

--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -387,7 +387,6 @@ class Posix extends AbstractAdapter
             } else {
                 $code = sprintf($code, $color::BACKGROUND);
             }
-
             return $code;
         }
 
@@ -401,6 +400,7 @@ class Posix extends AbstractAdapter
 
             return static::$ansiColorMap[$type][$color];
         }
+
         return null;
     }
 }

--- a/library/Zend/Console/Adapter/Posix.php
+++ b/library/Zend/Console/Adapter/Posix.php
@@ -235,7 +235,6 @@ class Posix extends AbstractAdapter
     {
         $color   = $this->getColorCode($color, 'fg');
         $bgColor = $this->getColorCode($bgColor, 'bg');
-
         return ($color !== null ? "\x1b[" . $color   . 'm' : '')
             . ($bgColor !== null ? "\x1b[" . $bgColor . 'm' : '')
             . $string
@@ -309,7 +308,6 @@ class Posix extends AbstractAdapter
         if ($this->isUtf8()) {
             return new Charset\Utf8;
         }
-
         return new Charset\DECSG();
     }
 
@@ -330,7 +328,6 @@ class Posix extends AbstractAdapter
         fclose($stream);
 
         $this->restoreTTYMode();
-
         return $char;
     }
 
@@ -404,7 +401,6 @@ class Posix extends AbstractAdapter
 
             return static::$ansiColorMap[$type][$color];
         }
-
         return null;
     }
 }

--- a/tests/ZendTest/Console/Adapter/AbstractAdapterTest.php
+++ b/tests/ZendTest/Console/Adapter/AbstractAdapterTest.php
@@ -144,4 +144,45 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $encodedText = $this->adapter->encodeText(utf8_decode($text));
         $this->assertEquals(utf8_decode($text),$encodedText);
     }
+
+    public function testWriteTextBlockSameAsWidth()
+    {
+        //set some text that's the same size as the width
+        $text = 'hello there, I am short!';
+        $width = strlen($text);
+
+        ob_start();
+        $this->adapter->writeTextBlock($text, $width);
+        $this->assertSame($text, ob_get_clean());
+    }
+
+    public function testTextBlockLongUnbreakableWord()
+    {
+        $text = 'thisisaverylongwordthatwontbreakproperlysothereyouhaveit and here is some more text';
+        $expected = array('thisisaver', 'ylongwordt', 'hatwontbre', 'akproperly'
+           , 'sothereyou', 'haveit and', 'here is', 'some more'
+           , 'text');
+
+        ob_start();
+        $this->adapter->writeTextBlock($text, 10);
+        $this->assertSame($expected, $this->adapter->writtenData);
+
+        //just get rid of the data in ob
+        ob_get_clean();
+    }
+    public function testTextBlockLongerThanHeight()
+    {
+        $text = 'thisisaverylongwordthatwontbreakproperlysothereyouhaveit and here is some more text';
+        $expected = array('thisisaver', 'ylongwordt', 'hatwontbre');
+
+        //reset tracking of written data
+        $this->adapter->writtenData = array();
+
+        ob_start();
+        $this->adapter->writeTextBlock($text, 10, 3);
+        $this->assertSame($expected, $this->adapter->writtenData);
+
+        //just get rid of the data in ob
+        ob_get_clean();
+    }
 }

--- a/tests/ZendTest/Console/Adapter/AbstractAdapterTest.php
+++ b/tests/ZendTest/Console/Adapter/AbstractAdapterTest.php
@@ -185,4 +185,31 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         //just get rid of the data in ob
         ob_get_clean();
     }
+
+    /**
+     * @expectedException \Zend\Console\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Supplied X,Y coordinates are invalid.
+     */
+    public function testInvalidCoords()
+    {
+        $this->adapter->writeTextBlock('', 1, 1, -1, -9);
+    }
+
+    /**
+     * @expectedException \Zend\Console\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid width supplied.
+     */
+    public function testInvalidWidth()
+    {
+        $this->adapter->writeTextBlock('', 0);
+    }
+
+    /**
+     * @expectedException \Zend\Console\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid height supplied.
+     */
+    public function testInvalidHeight()
+    {
+        $this->adapter->writeTextBlock('', 80, 0, 2, 2);
+    }
 }

--- a/tests/ZendTest/Console/TestAssets/ConsoleAdapter.php
+++ b/tests/ZendTest/Console/TestAssets/ConsoleAdapter.php
@@ -24,6 +24,8 @@ class ConsoleAdapter extends AbstractAdapter
 
     public $testIsUtf8 = true;
 
+    public $writtenData = array();
+
     /**
      * Read a single line from the console input
      *
@@ -85,5 +87,17 @@ class ConsoleAdapter extends AbstractAdapter
     public function getWidth()
     {
         return $this->testWidth;
+    }
+
+    /**
+     * Tracks exactly what data has been written
+     * @param string $text
+     * @param null $color
+     * @param null $bgColor
+     */
+    public function write($text, $color = null, $bgColor = null)
+    {
+        $this->writtenData[] = $text;
+        parent::write($text, $color, $bgColor);
     }
 }


### PR DESCRIPTION
I noticed that the `Zend\Console\Adapter\AbstractAdapter::writeTextBlock()` method was not implemented, so I implemented it, added tests, and ran `php-cs-fixer`.

Also, in order to be able to verify how this method writes data, I added an array to the test asset class `ConsoleAdapter`. Without this tracking array, the output buffering doesn't correctly show which data I expect since there isn't a way to track text in between calls to `AbstractAdapter::setPos()`.
