### PR TITLE
added a submodule loading to testCanLoadMultipleModules

### DIFF
--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -91,14 +91,16 @@ class ModuleManagerTest extends TestCase
     public function testCanLoadMultipleModules()
     {
         $configListener = $this->defaultListeners->getConfigListener();
-        $moduleManager  = new ModuleManager(array('BarModule', 'BazModule'));
+        $moduleManager  = new ModuleManager(array('BarModule', 'BazModule', 'SubModule\Sub'));
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
         $moduleManager->loadModules();
         $loadedModules = $moduleManager->getLoadedModules();
         $this->assertInstanceOf('BarModule\Module', $loadedModules['BarModule']);
         $this->assertInstanceOf('BazModule\Module', $loadedModules['BazModule']);
+        $this->assertInstanceOf('SubModule\Sub\Module', $loadedModules['SubModule\Sub']);
         $this->assertInstanceOf('BarModule\Module', $moduleManager->getModule('BarModule'));
         $this->assertInstanceOf('BazModule\Module', $moduleManager->getModule('BazModule'));
+        $this->assertInstanceOf('SubModule\Sub\Module', $moduleManager->getModule('SubModule\Sub'));
         $this->assertNull($moduleManager->getModule('NotLoaded'));
         $config = $configListener->getMergedConfig();
         $this->assertSame('foo', $config->bar);


### PR DESCRIPTION
I added a test-assertion in testCanLoadMultipleModules for loading namespaced modules (modules with a slash in their name). Although testCanLoadSomeObjectModule already loads a submodule, this test does it without using the ModuleObjects.
