### PR TITLE
Feature/make collection configurable

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -133,12 +133,12 @@ class FormCollection extends AbstractHelper
                 }
 
                 $label = sprintf(
-                    $this->getLabelWrapper(),
+                    $this->labelWrapper,
                     $escapeHtmlHelper($label)
                 );
             }
             $markup = sprintf(
-                $this->getWrapper(),
+                $this->wrapper,
                 $markup,
                 $label,
                 $templateMarkup
@@ -173,7 +173,7 @@ class FormCollection extends AbstractHelper
         }
 
         return sprintf(
-            $this->getTemplateWrapper(),
+            $this->templateWrapper,
             $escapeHtmlAttribHelper($templateMarkup)
         );
     }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -370,6 +370,8 @@ class FormCollection extends AbstractHelper
     public function setTemplateWrapper($templateWrapper)
     {
         $this->templateWrapper = $templateWrapper;
+
+        return $this;
     }
 
 }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -309,7 +309,7 @@ class FormCollection extends AbstractHelper
      *
      * @param string $wrapper
      *
-     * @return FormCollection
+     * @return self
      */
     public function setWrapper($wrapper)
     {
@@ -326,7 +326,7 @@ class FormCollection extends AbstractHelper
      *
      * @param string $labelWrapper
      *
-     * @return FormCollection
+     * @return self
      */
     public function setLabelWrapper($labelWrapper)
     {
@@ -365,7 +365,7 @@ class FormCollection extends AbstractHelper
      *
      * @param string $templateWrapper
      *
-     * @return FormCollection
+     * @return self
      */
     public function setTemplateWrapper($templateWrapper)
     {

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -26,6 +26,27 @@ class FormCollection extends AbstractHelper
     protected $shouldWrap = true;
 
     /**
+     * This is the default wrapper that the collection is wrapped into
+     *
+     * @var string
+     */
+    protected $wrapper = '<fieldset>%2$s%1$s%3$s</fieldset>';
+
+    /**
+     * This is the default label-wrapper
+     *
+     * @var string
+     */
+    protected $labelWrapper = '<legend>%s</legend>';
+
+    /**
+     * Where shall the template-data be inserted into
+     *
+     * @var string
+     */
+    protected $templateWrapper = '<span data-template="%s"></span>';
+
+    /**
      * The name of the default view helper that is used to render sub elements.
      *
      * @var string
@@ -98,11 +119,6 @@ class FormCollection extends AbstractHelper
             }
         }
 
-        // If $templateMarkup is not empty, use it for simplify adding new element in JavaScript
-        if (!empty($templateMarkup)) {
-            $markup .= $templateMarkup;
-        }
-
         // Every collection is wrapped by a fieldset if needed
         if ($this->shouldWrap) {
             $label = $element->getLabel();
@@ -116,14 +132,19 @@ class FormCollection extends AbstractHelper
                     );
                 }
 
-                $label = $escapeHtmlHelper($label);
-
-                $markup = sprintf(
-                    '<fieldset><legend>%s</legend>%s</fieldset>',
-                    $label,
-                    $markup
+                $label = sprintf(
+                    $this->getLabelWrapper(),
+                    $escapeHtmlHelper($label)
                 );
             }
+            $markup = sprintf(
+                $this->getWrapper(),
+                $markup,
+                $label,
+                $templateMarkup
+            );
+        } else {
+            $markup .= $templateMarkup;
         }
 
         return $markup;
@@ -139,18 +160,20 @@ class FormCollection extends AbstractHelper
     {
         $elementHelper          = $this->getElementHelper();
         $escapeHtmlAttribHelper = $this->getEscapeHtmlAttrHelper();
+        $fieldsetHelper         = $this->getFieldsetHelper();
+
         $templateMarkup         = '';
 
         $elementOrFieldset = $collection->getTemplateElement();
 
         if ($elementOrFieldset instanceof FieldsetInterface) {
-            $templateMarkup .= $this->render($elementOrFieldset);
+            $templateMarkup .= $fieldsetHelper($elementOrFieldset);
         } elseif ($elementOrFieldset instanceof ElementInterface) {
             $templateMarkup .= $elementHelper($elementOrFieldset);
         }
 
         return sprintf(
-            '<span data-template="%s"></span>',
+            $this->getTemplateWrapper(),
             $escapeHtmlAttribHelper($templateMarkup)
         );
     }
@@ -260,4 +283,93 @@ class FormCollection extends AbstractHelper
 
         return $this;
     }
+
+    /**
+     * Get the wrapper for the collection
+     *
+     * @return string
+     */
+    public function getWrapper()
+    {
+        return $this->wrapper;
+    }
+
+    /**
+     * Set the wrapper for this collection
+     *
+     * The string given will be passed through sprintf with the following three
+     * replacements:
+     *
+     * 1. The content of the collection
+     * 2. The label of the collection. If no label is given this will be an empty
+     *   string
+     * 3. The template span-tag. This might also be an empty string
+     *
+     * The preset default is <pre><fieldset>%2$s%2$s%3$s</fieldset></pre>
+     *
+     * @param string $wrapper
+     *
+     * @return FormCollection
+     */
+    public function setWrapper($wrapper)
+    {
+        $this->wrapper = $wrapper;
+
+        return $this;
+    }
+
+    /**
+     * Set the label-wrapper
+     * The string will be passed through sprintf with the label as single
+     * parameter
+     * This defaults to '<legend>%s</legend>'
+     *
+     * @param string $labelWrapper
+     *
+     * @return FormCollection
+     */
+    public function setLabelWrapper($labelWrapper)
+    {
+        $this->labelWrapper = $labelWrapper;
+
+        return $this;
+    }
+
+    /**
+     * Get the wrapper for the label
+     *
+     * @return string
+     */
+    public function getLabelWrapper()
+    {
+        return $this->labelWrapper;
+    }
+
+    /**
+     * Ge the wrapper for the template
+     *
+     * @return string
+     */
+    public function getTemplateWrapper()
+    {
+        return $this->templateWrapper;
+    }
+
+    /**
+     * Set the string where the template will be inserted into
+     *
+     * This string will be passed through sprintf and has the template as single
+     * parameter
+     *
+     * THis defaults to '<span data-template="%s"></span>'
+     *
+     * @param string $templateWrapper
+     *
+     * @return FormCollection
+     */
+    public function setTemplateWrapper($templateWrapper)
+    {
+        $this->templateWrapper = $templateWrapper;
+    }
+
 }

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -305,7 +305,7 @@ class FormCollection extends AbstractHelper
      *   string
      * 3. The template span-tag. This might also be an empty string
      *
-     * The preset default is <pre><fieldset>%2$s%2$s%3$s</fieldset></pre>
+     * The preset default is <pre><fieldset>%2$s%1$s%3$s</fieldset></pre>
      *
      * @param string $wrapper
      *

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -261,4 +261,46 @@ class FormCollectionTest extends TestCase
         $this->assertRegExp('/\<div class="foo">.*?<\/div>/', $markup);
 
     }
+
+    public function testCollectionRendersTemplateWithoutWrapper()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setShouldCreateTemplate(true);
+        $this->helper->setShouldWrap(false);
+        $this->helper->setTemplateWrapper('<div class="foo">%s</div>');
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertNotContains('<fieldset>', $markup);
+        $this->assertRegExp('/\<div class="foo">.*?<\/div>/', $markup);
+    }
+
+    public function testCollectionRendersFieldsetCorrectly()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('fieldsets');
+        $collection->setShouldCreateTemplate(true);
+        $this->helper->setShouldWrap(true);
+        $this->helper->setWrapper('<div>%2$s%1$s%3$s</div>');
+        $this->helper->setTemplateWrapper('<div class="foo">%s</div>');
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertNotContains('<fieldset>', $markup);
+        $this->assertRegExp('/\<div class="foo">.*?<\/div>/', $markup);
+    }
+
+    public function testGetterAndSetter()
+    {
+        $this->assertSame($this->helper, $this->helper->setWrapper('foo'));
+        $this->assertAttributeEquals('foo', 'wrapper', $this->helper);
+        $this->assertEquals('foo', $this->helper->getWrapper());
+        $this->assertSame($this->helper, $this->helper->setLabelWrapper('foo'));
+        $this->assertAttributeEquals('foo', 'labelWrapper', $this->helper);
+        $this->assertEquals('foo', $this->helper->getLabelWrapper());
+        $this->assertSame($this->helper, $this->helper->setTemplateWrapper('foo'));
+        $this->assertAttributeEquals('foo', 'templateWrapper', $this->helper);
+        $this->assertEquals('foo', $this->helper->getTemplateWrapper());
+    }
 }

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -176,4 +176,89 @@ class FormCollectionTest extends TestCase
 
         $this->assertContains('>translated legend<', $markup);
     }
+
+    public function testCollectionIsWrappedByFieldsetWithoutLegend()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $this->helper->setShouldWrap(true);
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertNotContains('<legend>', $markup);
+        $this->assertStringStartsWith('<fieldset>', $markup);
+        $this->assertStringEndsWith('</fieldset>', $markup);
+    }
+
+    public function testCollectionIsWrappedByFieldsetWithLabel()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('foo');
+        $this->helper->setShouldWrap(true);
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertContains('<legend>foo</legend>', $markup);
+        $this->assertStringStartsWith('<fieldset>', $markup);
+        $this->assertStringEndsWith('</fieldset>', $markup);
+    }
+
+    public function testCollectionIsWrappedByCustomElement()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $this->helper->setShouldWrap(true);
+        $this->helper->setWrapper('<div>%2$s%1$s%3$s</div>');
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertNotContains('<legend>', $markup);
+        $this->assertStringStartsWith('<div>', $markup);
+        $this->assertStringEndsWith('</div>', $markup);
+
+    }
+
+    public function testCollectionContainsTemplateAtPos3()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setShouldCreateTemplate(true);
+        $this->helper->setShouldWrap(true);
+        $this->helper->setWrapper('<div>%3$s%2$s%1$s</div>');
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertNotContains('<legend>', $markup);
+        $this->assertStringStartsWith('<div><span', $markup);
+        $this->assertStringEndsWith('</div>', $markup);
+    }
+
+    public function testCollectionRendersLabelCorrectly()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('foo');
+        $this->helper->setShouldWrap(true);
+        $this->helper->setLabelWrapper('<h1>%s</h1>');
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertContains('<h1>foo</h1>', $markup);
+        $this->assertStringStartsWith('<fieldset><h1>foo</h1>', $markup);
+    }
+
+    public function testCollectionCollectionRendersTemplateCorrectly()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setShouldCreateTemplate(true);
+        $this->helper->setTemplateWrapper('<div class="foo">%s</div>');
+
+        $markup = $this->helper->render($collection);
+
+        $this->assertNotContains('<legend>', $markup);
+        $this->assertRegExp('/\<div class="foo">.*?<\/div>/', $markup);
+
+    }
 }


### PR DESCRIPTION
This commit adds more configuration options to the
FormCollection-ViewHelper.

The hard-coded fieldset-wrapper is now configurable as is the hard-coded
legend as well as the hard-coded position and template of the
template-provider. The defaults have been set to the currently
hard-coded values, so that no BC-break should happen.

Also the behaviour of the template-renderer has been changed in so far
as the template is now rendered using the collection-object and not the
content of the collection-object

THis might be a case of BC-Break in edge-cases but the current
default-behaviour as provided by the unit-tests is not broken.

No tests have been changed, there have only been additions

This PR is a follow-up to #5565
