### PR TITLE
Zend\Log\Logger: impossible to specify label for FirePHP

### DIFF
--- a/library/Zend/Log/Formatter/FirePhp.php
+++ b/library/Zend/Log/Formatter/FirePhp.php
@@ -20,6 +20,10 @@ class FirePhp implements FormatterInterface
     public function format($event)
     {
         $label = null;
+        if (!empty($event['extra']['label'])) {
+            $label = $event['extra']['label'];
+            unset($event['extra']['label']);
+        }
         if (!empty($event['extra'])) {
             $line  = $event['extra'];
             $label = $event['message'];


### PR DESCRIPTION
Currently it is impossible to specify a label for logging to FirePHP. I feel this is a step back from ZF1 where this was possible.

There was a pull request where label arguments for FirePHP were at least being used in some way: https://github.com/zendframework/zf2/pull/2822/files

Relevant lines of code:
L1: https://github.com/zendframework/zf2/blob/ca59a6cc26b5289f258e90880cf20649d8335450/library/Zend/Log/Logger.php#L374
L2: https://github.com/zendframework/zf2/blob/ca59a6cc26b5289f258e90880cf20649d8335450/library/Zend/Log/Formatter/FirePhp.php#L30
L3: https://github.com/zendframework/zf2/blob/ca59a6cc26b5289f258e90880cf20649d8335450/library/Zend/Log/Writer/FirePhp.php#L68
Where ca59a6cc26b5289f258e90880cf20649d8335450 is the SHA1 of the master branch at the time of writing this issue.

As can be seen in L1, $extra is expected to be an array, and is inserted to $event['extra'].
In L2, if extra is not empty, it becomes the message, and $event['message'] becomes the label (rather than the message).
In L3 you can see the assignments, but that the label, which comes from $event which has to be an array according to L1, should be able to be a string as well.

It would be great if you could specify a label as a $extra array's property, and try to extract that as the label somewhere in L2.
Or it could be like ZF1 where $message could also be a 2-element array, where one element is the label and the other is the content. ( "Try ot out" section's first example: http://www.christophdorn.com/Blog/2008/09/02/firephp-and-zend-framework-16/ )
