### PR TITLE
ArrayUtils:merge() replaced array_key_exists() to isset() for performance

### DIFF
--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -254,7 +254,7 @@ abstract class ArrayUtils
      * @param  array $b
      * @return array
      */
-    public static function merge(array $a, array &$b)
+    public static function merge(array $a, array $b)
     {
         foreach ($b as $key => $value) {
             if (isset($a[$key])) {

--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -254,10 +254,10 @@ abstract class ArrayUtils
      * @param  array $b
      * @return array
      */
-    public static function merge(array $a, array $b)
+    public static function merge(array $a, array &$b)
     {
         foreach ($b as $key => $value) {
-            if (array_key_exists($key, $a)) {
+            if (isset($a[$key])) {
                 if (is_int($key)) {
                     $a[] = $value;
                 } elseif (is_array($value) && is_array($a[$key])) {

--- a/tests/ZendTest/Stdlib/ArrayUtilsTest.php
+++ b/tests/ZendTest/Stdlib/ArrayUtilsTest.php
@@ -191,6 +191,22 @@ class ArrayUtilsTest extends TestCase
                     'bar' => 'bat'
                 )
             ),
+            'merge-with-null' => array(
+                array(
+                    'foo' => null,
+                    null  => 'rod',
+                    'cat' => 'bar'
+                ),
+                array(
+                    'foo' => 'baz',
+                    null  => 'zad'
+                ),
+                array(
+                    'foo' => 'baz',
+                    null  => 'zad',
+                    'cat' => 'bar'
+                )
+            ),
         );
     }
 

--- a/tests/ZendTest/Stdlib/ArrayUtilsTest.php
+++ b/tests/ZendTest/Stdlib/ArrayUtilsTest.php
@@ -195,16 +195,19 @@ class ArrayUtilsTest extends TestCase
                 array(
                     'foo' => null,
                     null  => 'rod',
-                    'cat' => 'bar'
-                ),
-                array(
-                    'foo' => 'baz',
-                    null  => 'zad'
+                    'cat' => 'bar',
+                    'god' => 'rad'
                 ),
                 array(
                     'foo' => 'baz',
                     null  => 'zad',
-                    'cat' => 'bar'
+                    'god' => null
+                ),
+                array(
+                    'foo' => 'baz',
+                    null  => 'zad',
+                    'cat' => 'bar',
+                    'god' => null
                 )
             ),
         );


### PR DESCRIPTION
minor performance tweak for ArrayUtils::merge() since array_key_exists() chokes on larger arrays.

here are some performance comparisons and some considerable performance improvement:

a. using isset and &$b
http://3v4l.org/ubuVs

b. using only isset
http://3v4l.org/mTvKJ

c. original array_key_exists
http://3v4l.org/egnKV
