### PR TITLE
Zend\Test Fix persistence with multi dispatch

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -281,16 +281,19 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
      *
      * @return AbstractControllerTestCase
      */
-    public function reset()
+    public function reset($keepPersistence = false)
     {
         // force to re-create all components
         $this->application = null;
 
         // reset server datas
-        $_SESSION = array();
+        if (!$keepPersistence) {
+            $_SESSION = array();
+            $_COOKIE  = array();
+        }
+        
         $_GET     = array();
         $_POST    = array();
-        $_COOKIE  = array();
 
         // reset singleton
         StaticEventManager::resetInstance();

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -34,6 +34,7 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? static::rmdir("$dir/$file") : unlink("$dir/$file");
         }
+
         return rmdir($dir);
     }
 

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -489,7 +489,7 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertEquals($request->getMethod(), 'PUT');
         $this->assertEquals('num_post=5&foo=bar', $request->getContent());
     }
-    /*
+
     public function testAssertUriWithHostname()
     {
         $this->dispatch('http://my.domain.tld:443');
@@ -521,6 +521,54 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertXpathQueryCount('//div[@class="get"]', 0);
         $this->assertQueryCount('div.post', 0);
         $this->assertXpathQueryCount('//div[@class="post"]', 0);
+    }
+
+    public function testAssertWithMultiDispatchWithoutPersistence()
+    {
+        $this->dispatch('/tests-persistence');
+
+        $controller = $this->getApplicationServiceLocator()
+                            ->get('ControllerLoader')
+                            ->get('baz_index');
+        $flashMessenger = $controller->flashMessenger();
+        $messages = $flashMessenger->getMessages();
+        $this->assertCount(0, $messages);
+
+        $this->reset(false);
+
+        $this->dispatch('/tests');
+
+        $controller = $this->getApplicationServiceLocator()
+                            ->get('ControllerLoader')
+                            ->get('baz_index');
+        $flashMessenger = $controller->flashMessenger();
+        $messages = $flashMessenger->getMessages();
+
+        $this->assertCount(0, $messages);
+    }
+
+    public function testAssertWithMultiDispatchWithPersistence()
+    {
+        $this->dispatch('/tests-persistence');
+
+        $controller = $this->getApplicationServiceLocator()
+                            ->get('ControllerLoader')
+                            ->get('baz_index');
+        $flashMessenger = $controller->flashMessenger();
+        $messages = $flashMessenger->getMessages();
+        $this->assertCount(0, $messages);
+
+        $this->reset(true);
+
+        $this->dispatch('/tests');
+
+        $controller = $this->getApplicationServiceLocator()
+                            ->get('ControllerLoader')
+                            ->get('baz_index');
+        $flashMessenger = $controller->flashMessenger();
+        $messages = $flashMessenger->getMessages();
+
+        $this->assertCount(1, $messages);
     }
 
     public function testAssertWithEventShared()

--- a/tests/ZendTest/Test/PHPUnit/Util/ModuleLoaderTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Util/ModuleLoaderTest.php
@@ -27,6 +27,7 @@ class ModuleLoaderTest extends PHPUnit_Framework_TestCase
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? static::rmdir("$dir/$file") : unlink("$dir/$file");
         }
+
         return rmdir($dir);
     }
 

--- a/tests/ZendTest/Test/_files/Baz/config/module.config.php
+++ b/tests/ZendTest/Test/_files/Baz/config/module.config.php
@@ -48,6 +48,16 @@ return array(
                     ),
                 ),
             ),
+            'persistence' => array(
+                'type' => 'literal',
+                'options' => array(
+                    'route'    => '/tests-persistence',
+                    'defaults' => array(
+                        'controller' => 'baz_index',
+                        'action'     => 'persistencetest',
+                    ),
+                ),
+            ),
             'exception' => array(
                 'type' => 'literal',
                 'options' => array(

--- a/tests/ZendTest/Test/_files/Baz/src/Baz/Controller/IndexController.php
+++ b/tests/ZendTest/Test/_files/Baz/src/Baz/Controller/IndexController.php
@@ -28,6 +28,11 @@ class IndexController extends AbstractActionController
         return 'foo, bar';
     }
 
+    public function persistencetestAction()
+    {
+        $this->flashMessenger()->addMessage('test');
+    }
+
     public function redirectAction()
     {
         return $this->redirect()->toUrl('http://www.zend.com');

--- a/tests/ZendTest/Test/_files/modules-path/with-subdir/Bar/Module.php
+++ b/tests/ZendTest/Test/_files/modules-path/with-subdir/Bar/Module.php
@@ -34,6 +34,7 @@ class Module
                 'BarObject' => function ($sm) {
                     $foo      = $sm->get('FooObject');
                     $foo->bar = 'baz';
+
                     return $foo;
                 }
             ),


### PR DESCRIPTION
When I write my functional tests, sometimes I need to assert error/validation messages created by flash messenger. So, sometimes I need to preserve my session for the tests.
