### PR TITLE
Adds cache storage adapter for authentication (implements Zend\Authentication\Storage\StorageInterface)

### DIFF
--- a/library/Zend/Authentication/Storage/Cache.php
+++ b/library/Zend/Authentication/Storage/Cache.php
@@ -11,7 +11,6 @@ namespace Zend\Authentication\Storage;
 
 use Zend\Authentication\Storage\StorageInterface as AuthStorageInterface;
 use Zend\Cache\Storage\StorageInterface as CacheStorageInterface;
-use Zend\Math\Rand;
 
 class Cache implements AuthStorageInterface
 {

--- a/library/Zend/Authentication/Storage/Cache.php
+++ b/library/Zend/Authentication/Storage/Cache.php
@@ -57,12 +57,11 @@ class Cache implements AuthStorageInterface
         }
         if ($key !== null) {
             $this->key = $key;
-        } else {
+        } elseif (session_id() !== '') {
             $this->key = session_id();
-        }
-
-        if ($this->key === '') {
-            $this->key = base64_encode(Rand::getBytes(32, true));
+        } else {
+            session_start();
+            $this->key = session_id();
         }
     }
 

--- a/library/Zend/Authentication/Storage/Cache.php
+++ b/library/Zend/Authentication/Storage/Cache.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
 
 namespace Zend\Authentication\Storage;
 

--- a/library/Zend/Authentication/Storage/Cache.php
+++ b/library/Zend/Authentication/Storage/Cache.php
@@ -11,6 +11,7 @@ namespace Zend\Authentication\Storage;
 
 use Zend\Authentication\Storage\StorageInterface as AuthStorageInterface;
 use Zend\Cache\Storage\StorageInterface as CacheStorageInterface;
+use Zend\Math\Rand;
 
 class Cache implements AuthStorageInterface
 {
@@ -18,11 +19,6 @@ class Cache implements AuthStorageInterface
      * Default cache namespace
      */
     const NAMESPACE_DEFAULT = 'Zend_Auth';
-
-    /**
-     * Default cache key name for auth data
-     */
-    const KEY_DEFAULT = 'storage';
 
     /**
      * Cache adapter to mimic PHP session storage
@@ -43,7 +39,7 @@ class Cache implements AuthStorageInterface
      * 
      * @var mixed
      */
-    protected $key = self::KEY_DEFAULT;
+    protected $key;
 
     /**
      * Sets cache storage options and initializes cache namespace object
@@ -61,6 +57,12 @@ class Cache implements AuthStorageInterface
         }
         if ($key !== null) {
             $this->key = $key;
+        } else {
+            $this->key = session_id();
+        }
+
+        if ($this->key === '') {
+            $this->key = base64_encode(Rand::getBytes(32, true));
         }
     }
 

--- a/library/Zend/Authentication/Storage/Cache.php
+++ b/library/Zend/Authentication/Storage/Cache.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Zend\Authentication\Storage;
+
+use Zend\Authentication\Storage\StorageInterface as AuthStorageInterface;
+use Zend\Cache\Storage\StorageInterface as CacheStorageInterface;
+
+class Cache implements AuthStorageInterface
+{
+    /**
+     * Default cache namespace
+     */
+    const NAMESPACE_DEFAULT = 'Zend_Auth';
+
+    /**
+     * Default cache key name for auth data
+     */
+    const KEY_DEFAULT = 'storage';
+
+    /**
+     * Cache adapter to mimic PHP session storage
+     * 
+     * @var CacheStorageInterface
+     */
+    protected $cache;
+
+    /**
+     * Cache namespace
+     * 
+     * @var mixed
+     */
+    protected $namespace = self::NAMESPACE_DEFAULT;
+
+    /**
+     * Cache key name for auth data
+     * 
+     * @var mixed
+     */
+    protected $key = self::KEY_DEFAULT;
+
+    /**
+     * Sets cache storage options and initializes cache namespace object
+     * 
+     * @param mixed $namespace 
+     * @param mixed $key 
+     * @param CacheStorageInterface $cache 
+     */
+    public function __construct(CacheStorageInterface $cache, $namespace = null, $key = null)
+    {
+        $this->cache = $cache;
+
+        if ($namespace !== null) {
+            $this->setNamespace($namespace);
+        }
+        if ($key !== null) {
+            $this->key = $key;
+        }
+    }
+
+    /**
+     * Defined by Zend\Authentication\Storage\StorageInterface
+     * 
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return !$this->cache->hasItem($this->key);
+    }
+
+    /**
+     * Defined by Zend\Authentication\Storage\StorageInterface
+     * 
+     * @return mixed
+     */
+    public function read()
+    {
+        return $this->cache->getItem($this->key);
+    }
+
+    /**
+     * Defined by Zend\Authentication\Storage\StorageInterface
+     * 
+     * @param mixed $contents
+     */
+    public function write($contents)
+    {
+        $this->cache->setItem($this->key, $contents);
+    }
+
+    /**
+     * Defined by Zend\Authentication\Storage\StorageInterface
+     * 
+     */
+    public function clear()
+    {
+        $this->cache->removeItem($this->key);
+    }
+
+    /**
+     * Returns the name of the cache key being set to and read from 
+     * 
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Returns the cache storage adapter
+     * 
+     * @return CacheStorageInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Sets the cache namespace
+     * 
+     * @param string $namespace 
+     */
+    public function setNamespace($namespace)
+    {
+        $this->cache->getOptions()->setNamespace($namespace);
+    }
+
+    /**
+     * Returns the cache namespace
+     * 
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->cache->getOptions()->getNamespace();
+    }
+}

--- a/tests/ZendTest/Authentication/Storage/CacheTest.php
+++ b/tests/ZendTest/Authentication/Storage/CacheTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Authentication\Storage;
+
+use Zend\Authentication\Storage\Cache;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+  * @group      Zend_Auth
+ */
+class CacheTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->cache = new Cache(new \Zend\Cache\Storage\Adapter\Memory(), 'Test_Namespace', 'Test_Key');
+    }
+
+    /**
+     * Ensure cache without storage behaves as empty storage.
+     */
+    public function testEmptyCache()
+    {
+        $this->assertTrue($this->cache->isEmpty());
+    }
+
+    /**
+     * Ensure writing and reading to cache work correctly.
+     */
+    public function testReadAndWrite()
+    {
+        $this->cache->write('Test_Data');
+
+        $this->assertEquals($this->cache->read(), 'Test_Data');
+        $this->assertFalse($this->cache->isEmpty());
+    }
+
+    /**
+     * Ensure the clear() method correctly clears the cache storage.
+     */
+    public function testClear()
+    {
+        $this->cache->write('Test_Data');
+        $this->cache->clear();
+        $this->assertTrue($this->cache->isEmpty());
+    }
+
+    /**
+     * Ensure that getKey() method returns key supplied at instantiation.
+     */
+    public function testGetKey()
+    {
+        $this->assertEquals($this->cache->getKey(), 'Test_Key');
+    }
+
+    /**
+     * Ensure that the cache namespace can be set and retrieved correctly.
+     */
+    public function testNamespace()
+    {
+        $this->assertEquals($this->cache->getNamespace(), 'Test_Namespace');
+        $this->cache->setNamespace('New_Test_Namespace');
+        $this->assertEquals($this->cache->getNamespace(), 'New_Test_Namespace');
+    }
+}


### PR DESCRIPTION
I needed a cache storage adapter that implemented `Zend\Authentication\Storage\StorageInterface` for use with `Zend\Authentication\AuthenticationService`, so I wrote this one. It's modeled directly after `Zend\Authentication\Storage\Session` in order to mimic that class's behavior when used with the aforementioned `AuthenticationService` class.
