### PR TITLE
Fix for issue #5699 - Disable label position caching for Zend\View\Helper\FormRow::__invoke()

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -91,10 +91,8 @@ class FormRow extends AbstractHelper
             return $this;
         }
 
-        if ($labelPosition !== null) {
-            $this->setLabelPosition($labelPosition);
-        } elseif ($this->labelPosition === null) {
-            $this->setLabelPosition(self::LABEL_PREPEND);
+        if (is_null($labelPosition)) {
+            $labelPosition = $this->getLabelPosition();
         }
 
         if ($renderErrors !== null) {
@@ -105,7 +103,7 @@ class FormRow extends AbstractHelper
             $this->setPartial($partial);
         }
 
-        return $this->render($element);
+        return $this->render($element, $labelPosition);
     }
 
     /**

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -112,10 +112,11 @@ class FormRow extends AbstractHelper
      * Utility form helper that renders a label (if it exists), an element and errors
      *
      * @param  ElementInterface $element
+     * @param  null|string      $labelPosition
      * @throws \Zend\Form\Exception\DomainException
      * @return string
      */
-    public function render(ElementInterface $element)
+    public function render(ElementInterface $element, $labelPosition = null)
     {
         $escapeHtmlHelper    = $this->getEscapeHtmlHelper();
         $labelHelper         = $this->getLabelHelper();
@@ -124,6 +125,10 @@ class FormRow extends AbstractHelper
 
         $label           = $element->getLabel();
         $inputErrorClass = $this->getInputErrorClass();
+
+        if (is_null($labelPosition)) {
+            $labelPosition = $this->labelPosition;
+        }
 
         if (isset($label) && '' !== $label) {
             // Translate the label
@@ -147,7 +152,7 @@ class FormRow extends AbstractHelper
                 'element'           => $element,
                 'label'             => $label,
                 'labelAttributes'   => $this->labelAttributes,
-                'labelPosition'     => $this->labelPosition,
+                'labelPosition'     => $labelPosition,
                 'renderErrors'      => $this->renderErrors,
             );
 
@@ -213,7 +218,7 @@ class FormRow extends AbstractHelper
                     $labelOpen = $labelClose = $label = '';
                 }
 
-                switch ($this->labelPosition) {
+                switch ($labelPosition) {
                     case self::LABEL_PREPEND:
                         $markup = $labelOpen . $label . $elementString . $labelClose;
                         break;

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -481,4 +481,3 @@ class FormRowTest extends TestCase
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
     }
 }
-

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -457,7 +457,7 @@ class FormRowTest extends TestCase
         $this->helper->__invoke($element, 'append');
         $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
 
-        $this->helper->_invoke($element, 'prepend');
+        $this->helper->__invoke($element, 'prepend');
         $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
     }
 

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -410,6 +410,17 @@ class FormRowTest extends TestCase
         $this->assertSame('append', $this->helper->getLabelPosition());
     }
 
+    public function testCanSetLabelPositionWithRender()
+    {
+        $element  = new Element('foo');
+        $element->setAttribute('id', 'bar');
+        $element->setLabel('Baz');
+
+        $markup = $this->helper->render($element, 'append');
+        //var_dump($markup);
+        $this->assertRegexp('#^<input name="foo" id="bar" type="text" value=""\/?><label for="bar">Baz</label>$#', $markup);
+    }
+
     public function testLabelOptionAlwaysWrapDefaultsToFalse()
     {
         $element = new Element('foo');
@@ -430,3 +441,4 @@ class FormRowTest extends TestCase
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
     }
 }
+

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -438,6 +438,22 @@ class FormRowTest extends TestCase
         $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
     }
 
+    /**
+     * @covers Zend\Form\View\Helper\FormRow::__invoke
+     */
+    public function testCanSetLabelPositionViaInvoke()
+    {
+        $element  = new Element('foo');
+        $element->setAttribute('id', 'bar');
+        $element->setLabel('Baz');
+
+        $markup = $this->helper->__invoke($element, 'append');
+        $this->assertRegexp('#^<input name="foo" id="bar" type="text" value=""\/?><label for="bar">Baz</label>$#', $markup);
+
+        $markup = $this->helper->__invoke($element, 'prepend');
+        $this->assertRegexp('#^<label for="bar">Baz</label><input name="foo" id="bar" type="text" value=""\/?>$#', $markup);
+    }
+
     public function testLabelOptionAlwaysWrapDefaultsToFalse()
     {
         $element = new Element('foo');
@@ -458,4 +474,3 @@ class FormRowTest extends TestCase
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
     }
 }
-

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -417,8 +417,10 @@ class FormRowTest extends TestCase
         $element->setLabel('Baz');
 
         $markup = $this->helper->render($element, 'append');
-        //var_dump($markup);
         $this->assertRegexp('#^<input name="foo" id="bar" type="text" value=""\/?><label for="bar">Baz</label>$#', $markup);
+
+        $markup = $this->helper->render($element, 'prepend');
+        $this->assertRegexp('#^<label for="bar">Baz</label><input name="foo" id="bar" type="text" value=""\/?>$#', $markup);
     }
 
     public function testLabelOptionAlwaysWrapDefaultsToFalse()

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -410,7 +410,10 @@ class FormRowTest extends TestCase
         $this->assertSame('append', $this->helper->getLabelPosition());
     }
 
-    public function testCanSetLabelPositionWithRender()
+    /**
+     * @covers Zend\Form\View\Helper\FormRow::render
+     */
+    public function testCanSetLabelPositionViaRender()
     {
         $element  = new Element('foo');
         $element->setAttribute('id', 'bar');
@@ -421,6 +424,18 @@ class FormRowTest extends TestCase
 
         $markup = $this->helper->render($element, 'prepend');
         $this->assertRegexp('#^<label for="bar">Baz</label><input name="foo" id="bar" type="text" value=""\/?>$#', $markup);
+    }
+
+    public function testSetLabelPositionViaRenderIsNotCached()
+    {
+        $labelPositionBeforeRender = $this->helper->getLabelPosition();
+        $element = new Element('foo');
+
+        $this->helper->render($element, 'append');
+        $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
+
+        $this->helper->render($element, 'prepend');
+        $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
     }
 
     public function testLabelOptionAlwaysWrapDefaultsToFalse()

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -477,6 +477,7 @@ class FormRowTest extends TestCase
         $element->setAttribute('id', 'bar');
         $element->setLabel('baz');
 
+        $markup = $this->helper->render($element);
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -446,6 +446,21 @@ class FormRowTest extends TestCase
         $this->assertRegexp('#^<label for="bar">Baz</label><input name="foo" id="bar" type="text" value=""\/?>$#', $markup);
     }
 
+    /**
+     * @covers Zend\Form\View\Helper\FormRow::__invoke
+     */
+    public function testSetLabelPositionViaInvokeIsNotCached()
+    {
+        $labelPositionBeforeRender = $this->helper->getLabelPosition();
+        $element = new Element('foo');
+
+        $this->helper->__invoke($element, 'append');
+        $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
+
+        $this->helper->_invoke($element, 'prepend');
+        $this->assertSame($labelPositionBeforeRender, $this->helper->getLabelPosition());
+    }
+
     public function testLabelOptionAlwaysWrapDefaultsToFalse()
     {
         $element = new Element('foo');

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -214,14 +214,6 @@ class FormRowTest extends TestCase
         $this->assertFalse($this->helper->isTranslatorEnabled());
     }
 
-    public function testInvokeSetLabelPositionToAppend()
-    {
-        $element = new Element('foo');
-        $this->helper->__invoke($element, 'append');
-
-        $this->assertSame('append', $this->helper->getLabelPosition());
-    }
-
     public function testSetLabelPositionInputNullRaisesException()
     {
         $this->setExpectedException('Zend\Form\Exception\InvalidArgumentException');

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -470,7 +470,7 @@ class FormRowTest extends TestCase
         $element->setAttribute('id', 'bar');
         $element->setLabel('baz');
 
-        $markup = $this->helper->render($element);
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
     }
 }
+


### PR DESCRIPTION
- Reverted #4771 so `__invoke()` does not cache label position anymore
- Added new method `setDefaultLabelPosition` which is cached and reused by `Zend\View\Helper\FormRow`
- Added new method `getDefaultLabelPosition` for easy debugging purposes
- Added tests for the new functionality
