### PR TITLE
Add auto escape method to Zend\View\Helper\FlashMessenger

### DIFF
--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -42,6 +42,13 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     protected $messageSeparatorString = '</li><li>';
 
     /**
+     * Flag whether to escape messages
+     *
+     * @var bool
+     */
+    protected $autoEscape = true;
+
+    /**
      * Html escape helper
      *
      * @var EscapeHtml
@@ -139,17 +146,23 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
         }
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
+        $autoEscape      = $this->getAutoEscape();
         $messagesToPrint = array();
         $translator = $this->getTranslator();
         $translatorTextDomain = $this->getTranslatorTextDomain();
-        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, $translator, $translatorTextDomain) {
+        array_walk_recursive($messages, function ($item) use (&$messagesToPrint, $escapeHtml, $autoEscape, $translator, $translatorTextDomain) {
             if ($translator !== null) {
                 $item = $translator->translate(
                     $item,
                     $translatorTextDomain
                 );
             }
-            $messagesToPrint[] = $escapeHtml($item);
+
+            if ($autoEscape) {
+                $messagesToPrint[] = $escapeHtml($item);
+            } else {
+                $messagesToPrint[] = $item;
+            }
         });
         if (empty($messagesToPrint)) {
             return '';
@@ -159,6 +172,28 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
         $markup .= implode(sprintf($this->getMessageSeparatorString(), ' class="' . implode(' ', $classes) . '"'), $messagesToPrint);
         $markup .= $this->getMessageCloseString();
         return $markup;
+    }
+
+    /**
+     * Set whether or not auto escaping should be used
+     *
+     * @param  bool $autoEscape
+     * @return self
+     */
+    public function setAutoEscape($autoEscape = true)
+    {
+        $this->autoEscape = (bool) $autoEscape;
+        return $this;
+    }
+
+    /**
+     * Return whether auto escaping is enabled or disabled
+     *
+     * return bool
+     */
+    public function getAutoEscape()
+    {
+        return $this->autoEscape;
     }
 
     /**

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -110,7 +110,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     {
         $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getMessagesFromNamespace($namespace);
-        return $this->renderMessages($namespace, $messages, $classes);
+        return $this->renderMessages($namespace, $messages, $classes, $autoEscape);
     }
 
     /**
@@ -120,11 +120,11 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @param  array  $classes
      * @return string
      */
-    public function renderCurrent($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array())
+    public function renderCurrent($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array(), $autoEscape = null)
     {
         $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getCurrentMessagesFromNamespace($namespace);
-        return $this->renderMessages($namespace, $messages, $classes);
+        return $this->renderMessages($namespace, $messages, $classes, $autoEscape);
     }
 
     /**
@@ -134,7 +134,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @param  array $classes
      * @return string
      */
-    protected function renderMessages($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $messages = array(), array $classes = array())
+    protected function renderMessages($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $messages = array(), array $classes = array(), $autoEscape = null)
     {
         // Prepare classes for opening tag
         if (empty($classes)) {

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -101,8 +101,9 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
     /**
      * Render Messages
      *
-     * @param  string $namespace
-     * @param  array  $classes
+     * @param  string    $namespace
+     * @param  array     $classes
+     * @param  null|bool $autoEscape
      * @return string
      */
     public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array(), $autoEscape = null)

--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -105,7 +105,7 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
      * @param  array  $classes
      * @return string
      */
-    public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array())
+    public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = array(), $autoEscape = null)
     {
         $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getMessagesFromNamespace($namespace);
@@ -144,9 +144,12 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
             }
             $classes = array($classes);
         }
+        if (is_null($autoEscape)) {
+            $autoEscape = $this->getAutoEscape();
+        }
+
         // Flatten message array
         $escapeHtml      = $this->getEscapeHtmlHelper();
-        $autoEscape      = $this->getAutoEscape();
         $messagesToPrint = array();
         $translator = $this->getTranslator();
         $translatorTextDomain = $this->getTranslatorTextDomain();

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -480,4 +480,42 @@ class FlashMessengerTest extends TestCase
                                 ->render(PluginFlashMessenger::NAMESPACE_DEFAULT);
         $this->assertSame($displayAssertion, $display);
     }
+
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::render
+     */
+    public function testCanSetAutoEscapeOnRender()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT, array(), true);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::render
+     */
+    public function testRenderUsesCurrentAutoEscapeByDefault()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $this->helper->setAutoEscape(false);
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $this->helper->setAutoEscape(true);
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+    }
 }

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -454,10 +454,13 @@ class FlashMessengerTest extends TestCase
         $this->helper->setAutoEscape(false);
         $this->assertFalse($this->helper->getAutoEscape());
 
-        $this->helper->SetAutoEscape(true);
+        $this->helper->setAutoEscape(true);
         $this->assertTrue($this->helper->getAutoEscape());
     }
 
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::render
+     */
     public function testMessageIsEscapedByDefault()
     {
         $helper = new FlashMessenger;
@@ -469,6 +472,9 @@ class FlashMessengerTest extends TestCase
         $this->assertSame($displayAssertion, $display);
     }
 
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::render
+     */
     public function testMessageIsNotEscapedWhenAutoEscapeIsFalse()
     {
         $helper = new FlashMessenger;
@@ -516,6 +522,61 @@ class FlashMessengerTest extends TestCase
         $this->helper->setAutoEscape(true);
         $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
         $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testCurrentMessageIsEscapedByDefault()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->renderCurrent(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testCurrentMessageIsNotEscapedWhenAutoEscapeIsFalse()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->setAutoEscape(false)
+                                ->renderCurrent(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testCanSetAutoEscapeOnRenderCurrent()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->renderCurrent(PluginFlashMessenger::NAMESPACE_DEFAULT, array(), false);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testRenderCurrentUsesCurrentAutoEscapeByDefault()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $this->helper->setAutoEscape(false);
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->renderCurrent(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+
+        $this->helper->setAutoEscape(true);
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->renderCurrent(PluginFlashMessenger::NAMESPACE_DEFAULT);
         $this->assertSame($displayAssertion, $display);
     }
 }

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -491,7 +491,7 @@ class FlashMessengerTest extends TestCase
         unset($helper);
 
         $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
-        $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT, array(), true);
+        $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT, array(), false);
         $this->assertSame($displayAssertion, $display);
     }
 

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -443,4 +443,41 @@ class FlashMessengerTest extends TestCase
         $display = $this->helper->renderCurrent(PluginFlashMessenger::NAMESPACE_INFO);
         $this->assertEquals($displayAssertion, $display);
     }
+
+    public function testAutoEscapeDefaultsToTrue()
+    {
+        $this->assertTrue($this->helper->getAutoEscape());
+    }
+
+    public function testCanSetAutoEscape()
+    {
+        $this->helper->setAutoEscape(false);
+        $this->assertFalse($this->helper->getAutoEscape());
+
+        $this->helper->SetAutoEscape(true);
+        $this->assertTrue($this->helper->getAutoEscape());
+    }
+
+    public function testMessageIsEscapedByDefault()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->render(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    public function testMessageIsNotEscapedWhenAutoEscapeIsFalse()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->setAutoEscape(false)
+                                ->render(PluginFlashMessenger::NAMESPACE_DEFAULT);
+        $this->assertSame($displayAssertion, $display);
+    }
 }


### PR DESCRIPTION
Added methods `setAutoEscape` and `getAutoEscape` to `Zend\View\Helper\FlashMessenger` as proposed in issue #5600.
