### PR TITLE
Remove hydrator from collections

### DIFF
--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -522,7 +522,6 @@ class CollectionTest extends TestCase
                 'count' => 2
             ),
         ));
-        $form->get('collection')->setHydrator(new ObjectPropertyHydrator());
 
         $market = new stdClass();
 

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -509,7 +509,8 @@ class CollectionTest extends TestCase
         $productFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
 
         $mainFieldset = new Fieldset('shop');
-        $mainFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $mainFieldset->setObject(new stdClass);
+        $mainFieldset->setHydrator(new ObjectPropertyHydrator());
         $mainFieldset->add($productFieldset);
 
         $form = new Form();


### PR DESCRIPTION
This line shouldn't exist. It shouldn't be necessary to add a hydrator to every collection you have in your project. In the ProductFieldset test asset, there is a collection and there isnt any hydrator for that collection, so we should follow the same pattern. 

This was a hack, introduced to get the tests pass, where they should fail, and this is responsible for hiding an error that should be fixed. Instead of adding a hydrator to that collection, the collection class setObject method should be fixed to proper handle nested collections.
