### PR TITLE
Get an abstract defined service from an alias

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -501,6 +501,12 @@ class ServiceManager implements ServiceLocatorInterface
                 || $this->canCreateFromAbstractFactory($cName, $name)
             ) {
                 $instance = $this->create(array($cName, $name));
+            } elseif ($isAlias && $this->canCreateFromAbstractFactory($name, $cName)) {
+                // case of an alias leading to an abstract factory :
+                // 'my-alias' => 'my-abstract-defined-service'
+                //     $name = 'my-alias'
+                //     $cName = 'my-abstract-defined-service'
+                $instance = $this->create(array($name, $cName));
             } elseif ($usePeeringServiceManagers && !$this->retrieveFromPeeringManagerFirst) {
                 $instance = $this->retrieveFromPeeringManager($name);
             }

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -243,6 +243,16 @@ class ServiceManagerTest extends TestCase
     /**
      * @covers Zend\ServiceManager\ServiceManager::get
      */
+    public function testGetAbstractFactoryWithAlias()
+    {
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAbstractFactory');
+        $this->serviceManager->setAlias('foo', 'ZendTest\ServiceManager\TestAsset\FooAbstractFactory');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('foo'));
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::get
+     */
     public function testGetWithScopedContainer()
     {
         $this->serviceManager->setService('foo', 'bar');


### PR DESCRIPTION
When you want to get a service leading to to an abstract factory from an alias.

I ended up with this issue when trying to get a cache instance wich i defined in my configuration :

``` php
return array(
    'service_manager' => array(
        'abstract_factories' => array(
            'Zend\Cache\Service\StorageCacheAbstractServiceFactory',
        ),
        'aliases' => array (
            'app_cache' => 'memcached',
        ),
    ),
    'caches' => array(
        'memcached' => array(
            'adapter' => array(
                'name' => 'memcached',
                // other config values...
            ),
        ),
    ),
)
```

The purpose is to be able to change the cache by changing the alias.

Without this PR, ZF try to create this service : 

``` php
$this->canCreateFromAbstractFactory('memcached', 'cache_core');
```

but 'cache_core' is not a cache configuration key.
