### PR TITLE
Fixed gz decompress check for false

### DIFF
--- a/library/Zend/Filter/Compress/Gz.php
+++ b/library/Zend/Filter/Compress/Gz.php
@@ -190,7 +190,7 @@ class Gz extends AbstractCompressionAlgorithm
             $compressed = gzuncompress($content);
         }
 
-        if (!$compressed) {
+        if ($compressed === false) {
             throw new Exception\RuntimeException('Error during decompression');
         }
 


### PR DESCRIPTION
Previously if the decompressed value was, say, 0 an exception would be
thrown even though the decompression was successful. By making the check
for false strict the exception will still be thrown if there is an error
in the underlying PHP functions, while allowing us to return
decompressed values that would otherwise evaluate to false.
