### PR TITLE
Zend\Config\Writer\PhpArray needs to use var_export for strings, not addslahes()

### DIFF
--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -76,12 +76,10 @@ class PhpArray extends AbstractWriter
                                   . $this->processIndented($value, $arraySyntax, $indentLevel)
                                   . str_repeat(self::INDENT_STRING, --$indentLevel) . $arraySyntax['close'] . ",\n";
                 }
-            } elseif (is_object($value)) {
+            } elseif (is_object($value) || is_string($value)) {
                 $arrayString .= var_export($value, true) . ",\n";
             } elseif (is_bool($value)) {
                 $arrayString .= ($value ? 'true' : 'false') . ",\n";
-            } elseif (is_string($value)) {
-                $arrayString .= "'" . addslashes($value) . "',\n";
             } elseif ($value === null) {
                 $arrayString .= "null,\n";
             } else {

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -84,6 +84,21 @@ class PhpArrayTest extends AbstractWriterTestCase
         $this->assertEquals($expected, $configString);
     }
 
+    public function testRenderWithQuotesInString()
+    {
+        $config = new Config(array('one' => 'Test with "double" quotes', 'two' => 'Test with \'single\' quotes'));
+
+        $configString = $this->writer->toString($config);
+
+        $expected = "<?php\n";
+        $expected .= "return array(\n";
+        $expected .= "    'one' => 'Test with \"double\" quotes',\n";
+        $expected .= "    'two' => 'Test with \\'single\\' quotes',\n";
+        $expected .= ");\n";
+
+        $this->assertEquals($expected, $configString);
+    }
+
     public function testSetUseBracketArraySyntaxReturnsFluentInterface()
     {
         $this->assertSame($this->writer, $this->writer->setUseBracketArraySyntax(true));


### PR DESCRIPTION
Hotfix/config writer phparray needs to respect the power of the double quote when producing an array configuration file.
