### PR TITLE
increase ViewEvent consistency for getParams() with setParams()

### DIFF
--- a/library/Zend/View/ViewEvent.php
+++ b/library/Zend/View/ViewEvent.php
@@ -194,11 +194,10 @@ class ViewEvent extends Event
     public function getParams()
     {
         $params             = parent::getParams();
-        $params['model']    = $this->getModel();
-        $params['renderer'] = $this->getRenderer();
-        $params['request']  = $this->getRequest();
-        $params['response'] = $this->getResponse();
-        $params['result']   = $this->getResult();
+        foreach (array('model', 'renderer', 'request', 'response', 'result') as $param) {
+            $method = 'get' . $param;
+            $params[$param] = $this->$method();
+        }
         return $params;
     }
 


### PR DESCRIPTION
see setParams($params) ( https://github.com/zendframework/zf2/blob/master/library/Zend/View/ViewEvent.php#L218-L223 ) use foreach loop with param array, so getParams() should use this way too
