### PR TITLE
escapeHtml not working in Flashmessenger render

### DIFF
--- a/library/Zend/View/Helper/FlashMessenger.php
+++ b/library/Zend/View/Helper/FlashMessenger.php
@@ -126,7 +126,8 @@ class FlashMessenger extends AbstractTranslatorHelper implements ServiceLocatorA
                     $translatorTextDomain
                 );
             }
-            $messagesToPrint[] = $escapeHtml($item);
+            //$messagesToPrint[] = $escapeHtml($item);
+            $messagesToPrint[] = $item;
         });
 
         if (empty($messagesToPrint)) {


### PR DESCRIPTION
Hello, to add messages containing characters like 'é', 'á' or 'ã' in Flashmessenger, using the method 'render', the messages are not printed, as this could be solved?
