### PR TITLE
FIX #5767 Zend\Db\Sql\Select: getRawState('order') is inconsistent

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -128,7 +128,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     protected $where = null;
 
     /**
-     * @var null|string
+     * @var array
      */
     protected $order = array();
 
@@ -499,7 +499,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $this->offset = null;
                 break;
             case self::ORDER:
-                $this->order = null;
+                $this->order = array();
                 break;
             case self::COMBINE:
                 $this->combine = array();

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -572,7 +572,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $select->order('foo asc');
         $this->assertEquals(array('foo asc'), $select->getRawState(Select::ORDER));
         $select->reset(Select::ORDER);
-        $this->assertNull($select->getRawState(Select::ORDER));
+        $this->assertEmpty($select->getRawState(Select::ORDER));
     }
 
     /**


### PR DESCRIPTION
Zend\Db\Sql\Select: getRawState('order') is inconsistent after calling reset() #5767
