### PR TITLE
Fix escaped special chars in urlencoded parameters string incorrectly normalized

### DIFF
--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -1301,10 +1301,12 @@ class Uri implements UriInterface
      */
     protected static function normalizeQuery($query)
     {
+        // those characters have special meaning in urlencoded parameters
+        $subDelims = str_replace(array('&', '=', '+', ';'), '', self::CHAR_SUB_DELIMS);
         $query = self::encodeQueryFragment(
             self::decodeUrlEncodedChars(
                 $query,
-                '/[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]/'
+                '/[' . self::CHAR_UNRESERVED . $subDelims . ':@\/\?]/'
             )
         );
 
@@ -1321,7 +1323,14 @@ class Uri implements UriInterface
      */
     protected static function normalizeFragment($fragment)
     {
-        return static::normalizeQuery($fragment);
+        $fragment = self::encodeQueryFragment(
+            self::decodeUrlEncodedChars(
+                $fragment,
+                '/[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]/'
+            )
+        );
+
+        return $fragment;
     }
 
     /**

--- a/tests/ZendTest/Uri/UriTest.php
+++ b/tests/ZendTest/Uri/UriTest.php
@@ -1246,9 +1246,9 @@ class UriTest extends \PHPUnit_Framework_TestCase
                 'baz' => 'waka'
             ), 'foo=bar&baz=waka'),
             array(array(
-                'some key' => 'some crazy value?!#[]',
+                'some key' => 'some crazy value?!#[]&=%+',
                 '1'        => ''
-            ), 'some%20key=some%20crazy%20value%3F%21%23%5B%5D&1='),
+            ), 'some%20key=some%20crazy%20value%3F%21%23%5B%5D%26%3D%25%2B&1='),
             array(array(
                 'array'        => array('foo', 'bar', 'baz'),
                 'otherstuff[]' => 1234
@@ -1277,6 +1277,8 @@ class UriTest extends \PHPUnit_Framework_TestCase
             array('FOO:/bar/with space?que%3fry#frag%ment#', 'foo:/bar/with%20space?que?ry#frag%25ment%23'),
             array('/path/%68%65%6c%6c%6f/world', '/path/hello/world'),
             array('/foo/bar?url=http%3A%2F%2Fwww.example.com%2Fbaz', '/foo/bar?url=http://www.example.com/baz'),
+
+            array('/urlencoded/params?chars=' . urlencode('+&=;%20#'), '/urlencoded/params?chars=%2B%26%3D%3B%2520%23'),
             array('File:///SitePages/fi%6ce%20has%20spaces', 'file:///SitePages/file%20has%20spaces'),
             array('/foo/bar/../baz?do=action#showFragment', '/foo/baz?do=action#showFragment'),
 


### PR DESCRIPTION
This pull request fixes #5769
