### PR TITLE
Hotfix for #5772: token processor should not cast booleans to strings

### DIFF
--- a/library/Zend/Config/Processor/Token.php
+++ b/library/Zend/Config/Processor/Token.php
@@ -192,6 +192,12 @@ class Token implements ProcessorInterface
                     $this->map[$this->prefix . $token . $this->suffix] = $value;
                 }
             }
+
+            foreach (array_keys($this->map) as $key) {
+                if (empty($key)) {
+                    unset($this->map[$key]);
+                }
+            }
         }
 
         return $this->map;
@@ -232,10 +238,6 @@ class Token implements ProcessorInterface
      */
     private function doProcess($value, array $replacements)
     {
-        if (is_string($value)) {
-            return strtr($value, $this->map);
-        }
-
         if ($value instanceof Config) {
             if ($value->isReadOnly()) {
                 throw new Exception\InvalidArgumentException('Cannot process config because it is read-only');

--- a/library/Zend/Config/Processor/Token.php
+++ b/library/Zend/Config/Processor/Token.php
@@ -12,7 +12,6 @@ namespace Zend\Config\Processor;
 use Traversable;
 use Zend\Config\Config;
 use Zend\Config\Exception;
-use Zend\Stdlib\ArrayUtils;
 
 class Token implements ProcessorInterface
 {

--- a/library/Zend/Config/Processor/Token.php
+++ b/library/Zend/Config/Processor/Token.php
@@ -12,6 +12,7 @@ namespace Zend\Config\Processor;
 use Traversable;
 use Zend\Config\Config;
 use Zend\Config\Exception;
+use Zend\Stdlib\ArrayUtils;
 
 class Token implements ProcessorInterface
 {
@@ -176,17 +177,24 @@ class Token implements ProcessorInterface
 
     /**
      * Build replacement map
+     *
+     * @return array
      */
     protected function buildMap()
     {
-        if (!$this->suffix && !$this->prefix) {
-            $this->map = $this->tokens;
-        } else {
-            $this->map = array();
-            foreach ($this->tokens as $token => $value) {
-                $this->map[$this->prefix . $token . $this->suffix] = $value;
+        if (null === $this->map) {
+            if (!$this->suffix && !$this->prefix) {
+                $this->map = $this->tokens;
+            } else {
+                $this->map = array();
+
+                foreach ($this->tokens as $token => $value) {
+                    $this->map[$this->prefix . $token . $this->suffix] = $value;
+                }
             }
         }
+
+        return $this->map;
     }
 
     /**
@@ -198,28 +206,7 @@ class Token implements ProcessorInterface
      */
     public function process(Config $config)
     {
-        if ($config->isReadOnly()) {
-            throw new Exception\InvalidArgumentException('Cannot process config because it is read-only');
-        }
-
-        if ($this->map === null) {
-            $this->buildMap();
-        }
-
-        /**
-         * Walk through config and replace values
-         */
-        $keys = array_keys($this->map);
-        $values = array_values($this->map);
-        foreach ($config as $key => $val) {
-            if ($val instanceof Config) {
-                $this->process($val);
-            } else {
-                $config->$key = str_replace($keys, $values, $val);
-            }
-        }
-
-        return $config;
+        return $this->doProcess($config, $this->buildMap());
     }
 
     /**
@@ -230,12 +217,57 @@ class Token implements ProcessorInterface
      */
     public function processValue($value)
     {
-        if ($this->map === null) {
-            $this->buildMap();
-        }
-        $keys = array_keys($this->map);
-        $values = array_values($this->map);
+        return $this->doProcess($value, $this->buildMap());
+    }
 
-        return str_replace($keys, $values, $value);
+    /**
+     * Applies replacement map to the given value by modifying the value itself
+     *
+     * @param mixed $value
+     * @param array $replacements
+     *
+     * @return mixed
+     *
+     * @throws Exception\InvalidArgumentException if the provided value is a read-only {@see Config}
+     */
+    private function doProcess($value, array $replacements)
+    {
+        if (is_string($value)) {
+            return strtr($value, $this->map);
+        }
+
+        if ($value instanceof Config) {
+            if ($value->isReadOnly()) {
+                throw new Exception\InvalidArgumentException('Cannot process config because it is read-only');
+            }
+
+            foreach ($value as $key => $val) {
+                $value->$key = $this->doProcess($val, $replacements);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof Traversable || is_array($value)) {
+            foreach ($value as & $val) {
+                $val = $this->doProcess($val, $replacements);
+            }
+
+            return $value;
+        }
+
+        if (!is_string($value) && (is_bool($value) || is_numeric($value))) {
+            $stringVal  = (string) $value;
+            $changedVal = strtr($value, $this->map);
+
+            // replace the value only if a string replacement occurred
+            if ($changedVal !== $stringVal) {
+                return $changedVal;
+            }
+
+            return $value;
+        }
+
+        return strtr((string) $value, $this->map);
     }
 }

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -280,7 +280,8 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
                 'intKey' => 123,
                 'floatKey' => (float) 123.456,
                 'doubleKey' => (double) 456.789,
-            ), true
+            ),
+            true
         );
 
         $processor = new TokenProcessor();
@@ -292,6 +293,48 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(123, $config['intKey']);
         $this->assertSame((float) 123.456, $config['floatKey']);
         $this->assertSame((double) 456.789, $config['doubleKey']);
+    }
+
+    /**
+     * @group ZF2-5772
+     */
+    public function testTokenChangeParamsReplacesInNumerics()
+    {
+        $config = new Config(
+            array(
+                'foo' => 'bar1',
+                'trueBoolKey' => true,
+                'falseBoolKey' => false,
+                'intKey' => 123,
+                'floatKey' => (float) 123.456,
+                'doubleKey' => (double) 456.789,
+            ),
+            true
+        );
+
+        $processor = new TokenProcessor(array('1' => 'R', '9' => 'R'));
+
+        $processor->process($config);
+
+        $this->assertSame('R', $config['trueBoolKey']);
+        $this->assertSame('barR', $config['foo']);
+        $this->assertSame(false, $config['falseBoolKey']);
+        $this->assertSame('R23', $config['intKey']);
+        $this->assertSame('R23.456', $config['floatKey']);
+        $this->assertSame('456.78R', $config['doubleKey']);
+    }
+
+    /**
+     * @group ZF2-5772
+     */
+    public function testIgnoresEmptyStringReplacement()
+    {
+        $config    = new Config(array('foo' => 'bar'), true);;
+        $processor = new TokenProcessor(array('' => 'invalid'));
+
+        $processor->process($config);
+
+        $this->assertSame('bar', $config['foo']);
     }
 
     /**

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -269,6 +269,32 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group ZF2-5772
+     */
+    public function testTokenChangeParamsRetainsType()
+    {
+        $config = new Config(
+            array(
+                'trueBoolKey' => true,
+                'falseBoolKey' => false,
+                'intKey' => 123,
+                'floatKey' => (float) 123.456,
+                'doubleKey' => (double) 456.789,
+            ), true
+        );
+
+        $processor = new TokenProcessor();
+
+        $processor->process($config);
+
+        $this->assertSame(true, $config['trueBoolKey']);
+        $this->assertSame(false, $config['falseBoolKey']);
+        $this->assertSame(123, $config['intKey']);
+        $this->assertSame((float) 123.456, $config['floatKey']);
+        $this->assertSame((double) 456.789, $config['doubleKey']);
+    }
+
+    /**
      * @depends testTokenSurround
      */
     public function testUserConstants()


### PR DESCRIPTION
Hotfix for #5772

Also includes cleanups and stripping empty string replacements.
