### PR TITLE
Get the correct null value in MultiCheckbox

### DIFF
--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -203,7 +203,7 @@ class FormMultiCheckbox extends FormInput
                 $inputAttributes = array_merge($inputAttributes, $optionSpec['attributes']);
             }
 
-            if (in_array($value, $selectedOptions)) {
+            if (($value == ""  && false !== array_search($value, $selectedOptions,true)) || ($value != "" && in_array($value, $selectedOptions))) {
                 $selected = true;
             }
 


### PR DESCRIPTION
We know that in PHP, a key to null is equal to "".
But in_array doesn't verify the type. So, we can't be sure to have "" or 0.
