### PR TITLE
Allow specifying "break chain on failure" flag as Validator option

### DIFF
--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -146,6 +146,14 @@ class ValidatorChain implements
      */
     public function attachByName($name, $options = array(), $breakChainOnFailure = false)
     {
+        if (isset($options['break_chain_on_failure'])) {
+            $breakChainOnFailure = (bool) $options['break_chain_on_failure'];
+        }
+
+        if (isset($options['breakchainonfailure'])) {
+            $breakChainOnFailure = (bool) $options['breakchainonfailure'];
+        }
+
         $validator = $this->plugin($name, $options);
         $this->attach($validator, $breakChainOnFailure);
         return $this;

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -281,4 +281,25 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($unserialized));
         $this->assertFalse($unserialized->isValid(''));
     }
+
+    /**
+     * @group zfcampus_zf-apigility-admin_89
+     */
+    public function testAttachByNameAllowsSpecifyingBreakChainOnFailureFlagViaOptions()
+    {
+        $this->validator->attachByName('GreaterThan', array(
+            'break_chain_on_failure' => true,
+            'min' => 1,
+        ));
+        $this->assertEquals(1, count($this->validator));
+        $validators = $this->validator->getValidators();
+        $spec       = array_shift($validators);
+
+        $this->assertInternalType('array', $spec);
+        $this->assertArrayHasKey('instance', $spec);
+        $validator = $spec['instance'];
+        $this->assertInstanceOf('Zend\Validator\GreaterThan', $validator);
+        $this->assertArrayHasKey('breakChainOnFailure', $spec);
+        $this->assertTrue($spec['breakChainOnFailure']);
+    }
 }

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -282,13 +282,22 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($unserialized->isValid(''));
     }
 
+    public function breakChainFlags()
+    {
+        return array(
+            'underscores' => array('break_chain_on_failure'),
+            'no_underscores' => array('breakchainonfailure'),
+        );
+    }
+
     /**
      * @group zfcampus_zf-apigility-admin_89
+     * @dataProvider breakChainFlags
      */
-    public function testAttachByNameAllowsSpecifyingBreakChainOnFailureFlagViaOptions()
+    public function testAttachByNameAllowsSpecifyingBreakChainOnFailureFlagViaOptions($option)
     {
         $this->validator->attachByName('GreaterThan', array(
-            'break_chain_on_failure' => true,
+            $option => true,
             'min' => 1,
         ));
         $this->assertEquals(1, count($this->validator));


### PR DESCRIPTION
- When calling `attachByName()`, allow passing the "break chain on failure"
  flag
  as an option, instead of requiring it to be passed as the third argument to
  the method; simplifies factories.
- Fixes zfcampus/zf-apigility-admin#89
