### PR TITLE
Support PHPUnit 3.8+ compatibility

### DIFF
--- a/tests/ZendTest/Db/IntegrationTestListener.php
+++ b/tests/ZendTest/Db/IntegrationTestListener.php
@@ -107,7 +107,8 @@ class IntegrationTestListener implements PHPUnit_Framework_TestListener
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {}
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {}
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {}
-
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {} // Support PHPUnit 3.8+
+    
     /**
      * A test started.
      *

--- a/tests/ZendTest/Db/IntegrationTestListener.php
+++ b/tests/ZendTest/Db/IntegrationTestListener.php
@@ -108,7 +108,7 @@ class IntegrationTestListener implements PHPUnit_Framework_TestListener
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {}
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {}
     public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {} // Support PHPUnit 3.8+
-    
+
     /**
      * A test started.
      *


### PR DESCRIPTION
PHPUnit 3.8+ adds a method to its PHPUnit_Framework_TestListener interface called addRiskyTest(). Need to stub it out to avoid "must implement this interface method" fatals when using 3.8+.
