### PR TITLE
remove unneeded key "name" under "input_filter" per-element in FormAbstractServiceFactoryTest

### DIFF
--- a/tests/ZendTest/Form/FormAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/Form/FormAbstractServiceFactoryTest.php
@@ -174,7 +174,6 @@ class FormAbstractServiceFactoryTest extends TestCase
             ),
             'input_filter' => array(
                 'email' => array(
-                    'name'       => 'email',
                     'required'   => true,
                     'filters'    => array(
                         array(


### PR DESCRIPTION
to make no ambiguous which key must be written
