### PR TITLE
Do not exit from loadClass() early

### DIFF
--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -302,7 +302,6 @@ class StandardAutoloader implements SplAutoloader
                 if (file_exists($filename)) {
                     return include $filename;
                 }
-                return false;
             }
         }
         return false;

--- a/tests/ZendTest/Loader/StandardAutoloaderTest.php
+++ b/tests/ZendTest/Loader/StandardAutoloaderTest.php
@@ -195,7 +195,8 @@ class StandardAutoloaderTest extends \PHPUnit_Framework_TestCase
         $loader = new StandardAutoloader();
         $loader->registerNamespace('ZendTest\Loader\TestAsset\Parent', __DIR__ . '/TestAsset/Parent');
         $loader->registerNamespace('ZendTest\Loader\TestAsset\Parent\Child', __DIR__ . '/TestAsset/Child');
-        $loader->autoload('ZendTest\Loader\TestAsset\Parent\Child\Subclass');
+        $result = $loader->autoload('ZendTest\Loader\TestAsset\Parent\Child\Subclass');
+        $this->assertTrue($result !== false);
         $this->assertTrue(class_exists('ZendTest\Loader\TestAsset\Parent\Child\Subclass', false));
     }
 }

--- a/tests/ZendTest/Loader/StandardAutoloaderTest.php
+++ b/tests/ZendTest/Loader/StandardAutoloaderTest.php
@@ -190,4 +190,12 @@ class StandardAutoloaderTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($expected, 'namespaces', $loader);
     }
 
+    public function testWillLoopThroughAllNamespacesUntilMatchIsFoundWhenAutoloading()
+    {
+        $loader = new StandardAutoloader();
+        $loader->registerNamespace('ZendTest\Loader\TestAsset\Parent', __DIR__ . '/TestAsset/Parent');
+        $loader->registerNamespace('ZendTest\Loader\TestAsset\Parent\Child', __DIR__ . '/TestAsset/Child');
+        $loader->autoload('ZendTest\Loader\TestAsset\Parent\Child\Subclass');
+        $this->assertTrue(class_exists('ZendTest\Loader\TestAsset\Parent\Child\Subclass', false));
+    }
 }

--- a/tests/ZendTest/Loader/TestAsset/Child/Subclass.php
+++ b/tests/ZendTest/Loader/TestAsset/Child/Subclass.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Loader\TestAsset\Parent\Child;
+
+/**
+ * @group      Loader
+ */
+class Subclass
+{
+}


### PR DESCRIPTION
In loadClass(), if the namespace/prefix matches, but the classfile is not 
found, we were returning a boolean false immediately. However, if a more 
specific namespace/prefix matches, but is later in the stack, we're 
essentially ignoring it, making the class unreachable.

This patch removes the `return false` line in the `foreach` loop, allowing a
namespace registered later to match and potentially fulfill the autoloading.

There _will_ be a performance impact, which means it's always better to
register the more specific namespace earlier.
