### PR TITLE
Add missing dependencies to Barcode's composer.json

### DIFF
--- a/library/Zend/Barcode/composer.json
+++ b/library/Zend/Barcode/composer.json
@@ -14,7 +14,9 @@
     "target-dir": "Zend/Barcode",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-validator": "self.version"
     },
     "require-dev": {
         "zendframework/zendpdf": "*"


### PR DESCRIPTION
`zendframework/zend-servicemanager` and `zendframework/zend-validator` are required dependencies for the Barcode component. They are missing from its `composer.json`.

This PR add the required dependency.

The related errors are:
- `Fatal error: Class 'Zend\ServiceManager\AbstractPluginManager' not found in /project/vendor/zendframework/zend-barcode/Zend/Barcode/ObjectPluginManager.php on line 22`
- `Fatal error: Class 'Zend\Validator\Barcode' not found in /project/vendor/zendframework/zend-barcode/Zend/Barcode/Object/AbstractObject.php on line 1200`
