### PR TITLE
Correct references toPHPUnit_Runner_Version::VERSION

### DIFF
--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -73,7 +73,7 @@ class NumberFormatTest extends TestCase
     public function numberToFormattedProvider()
     {
         if (!extension_loaded('intl')) {
-            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
                 return array(array());
@@ -108,7 +108,7 @@ class NumberFormatTest extends TestCase
     public function formattedToNumberProvider()
     {
         if (!extension_loaded('intl')) {
-            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
                 return array(array());

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -68,7 +68,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     public function basicProvider()
     {
         if (!extension_loaded('intl')) {
-            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
                 return array(array());

--- a/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/DateFormatTest.php
@@ -56,7 +56,7 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     public function dateTestsDataProvider()
     {
         if (!extension_loaded('intl')) {
-            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
                 return array(array());
@@ -156,7 +156,7 @@ class DateFormatTest extends \PHPUnit_Framework_TestCase
     public function dateTestsDataProviderWithPattern()
     {
         if (!extension_loaded('intl')) {
-            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
                 return array(array());

--- a/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/NumberFormatTest.php
@@ -55,7 +55,7 @@ class NumberFormatTest extends \PHPUnit_Framework_TestCase
     public function currencyTestsDataProvider()
     {
         if (!extension_loaded('intl')) {
-            if (version_compare(\PHPUnit_Runner_Version::VERSION, '3.8.0-dev') === 1) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
                 return array(array());


### PR DESCRIPTION
From PHPUnit's history, this looks like it was meant to be internal.
It's also been removed from recent versions of PHPUnit.

Fixes several tests under PHPUnit 3.8
