### PR TITLE
Fix barcode's composer.json

### DIFF
--- a/library/Zend/Barcode/composer.json
+++ b/library/Zend/Barcode/composer.json
@@ -14,16 +14,14 @@
     "target-dir": "Zend/Barcode",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-validator": "self.version"
     },
     "require-dev": {
-        "zendframework/zend-servicemanager": "self.version",
-        "zendframework/zend-validator": "self.version",
         "zendframework/zendpdf": "*"
     },
     "suggest": {
-        "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
-        "zendframework/zend-validator": "Zend\\Validator component",
         "zendframework/zendpdf": "ZendPdf component"
     },
     "extra": {


### PR DESCRIPTION
Related to zendframework/zf2#5785.

`zendframework/zend-servicemanager` and `zendframework/zend-validator` are not soft dependencies of the Barcode component. If they are not installed, this is no possible to generate barcodes because `Zend\Barcode\ObjectPluginManager`, `Zend\Barcode\RendererPluginManager` and `Zend\Barcode\Object\AbstractObject` depend of them.
