### PR TITLE
[Soap/Server] add debug mode

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -76,7 +76,7 @@ class Server implements ZendServerServer
 
     /**
      * Informs if the soap server is in debug mode
-     * @var boolean
+     * @var bool
      */
     protected $debug = false;
 
@@ -934,7 +934,7 @@ class Server implements ZendServerServer
     /**
      * Set the debug mode.
      * In debug mode, all exceptions are send to the client.
-     * @param boolean $debug
+     * @param bool $debug
      */
     public function setDebugMode($debug = true)
     {
@@ -976,7 +976,7 @@ class Server implements ZendServerServer
      */
     public function isRegisteredAsFaultException($fault)
     {
-        if($this->debug) return true ;
+        if ($this->debug) return true;
 
         $ref        = new ReflectionClass($fault);
         $classNames = $ref->getName();

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -75,6 +75,12 @@ class Server implements ZendServerServer
     protected $object;
 
     /**
+     * Informs if the soap server is in debug mode
+     * @var boolean
+     */
+    protected $debug = false;
+
+    /**
      * Persistence mode; should be one of the SOAP persistence constants
      * @var int
      */
@@ -926,6 +932,15 @@ class Server implements ZendServerServer
     }
 
     /**
+     * Set the debug mode.
+     * In debug mode, all exceptions are send to the client.
+     * @param boolean $debug
+     */
+    public function setDebugMode($debug = true)
+    {
+        $this->debug = $debug;
+    }
+    /**
      * Validate and register fault exception
      *
      * @param  string|array $class Exception class or array of exception classes
@@ -961,6 +976,8 @@ class Server implements ZendServerServer
      */
     public function isRegisteredAsFaultException($fault)
     {
+        if($this->debug) return true ;
+
         $ref        = new ReflectionClass($fault);
         $classNames = $ref->getName();
         return in_array($classNames, $this->faultExceptions);

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -936,10 +936,12 @@ class Server implements ZendServerServer
      * In debug mode, all exceptions are send to the client.
      * @param bool $debug
      */
-    public function setDebugMode($debug = true)
+    public function setDebugMode($debug)
     {
         $this->debug = $debug;
+        return $this;
     }
+
     /**
      * Validate and register fault exception
      *

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -976,7 +976,9 @@ class Server implements ZendServerServer
      */
     public function isRegisteredAsFaultException($fault)
     {
-        if ($this->debug) return true;
+        if ($this->debug) {
+            return true;
+        }
 
         $ref        = new ReflectionClass($fault);
         $classNames = $ref->getName();

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -941,7 +941,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $server = new Server();
         $beforeDebug = $server->fault(new \Exception('test'));
-        $server->setDebugMode();
+        $server->setDebugMode(true);
         $afterDebug = $server->fault(new \Exception('test'));
 
         $this->assertEquals('Unknown error', $beforeDebug->getMessage());

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -937,4 +937,15 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Invalid XML', $response->getMessage());
     }
 
+    public function testDebugMode()
+    {
+        $server = new Server();
+        $beforeDebug = $server->fault(new \Exception('test'));
+        $server->setDebugMode();
+        $afterDebug = $server->fault(new \Exception('test'));
+
+        $this->assertEquals('Unknown error', $beforeDebug->getMessage());
+        $this->assertEquals('test', $afterDebug->getMessage());
+    }
+
 }


### PR DESCRIPTION
When an exception is raised the \Zend\Soap\Server catch it and check if this is an authorized exception. 
If not, and for security reason, it send an "Unknow error" message. 
And if in production its a sane behaviour, its really annoying during development & tests process.

So I propose to add a setDebugMode method, when activated, send all exceptions to the client.

The code is unit-tested.
