### PR TITLE
[Soap\Client\DotNet][FIX] Undefined property in void return

### DIFF
--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -216,7 +216,7 @@ class DotNet extends SOAPClient
     protected function _preProcessResult($result)
     {
         $resultProperty = $this->getLastMethod() . 'Result';
-        if (isset($result->$resultProperty)) {
+        if (property_exists($result, $resultProperty)) {
             return $result->$resultProperty;
         }
         return $result;

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -216,7 +216,10 @@ class DotNet extends SOAPClient
     protected function _preProcessResult($result)
     {
         $resultProperty = $this->getLastMethod() . 'Result';
-        return $result->$resultProperty;
+        if(isset($result->$resultProperty)){
+            return $result->resultProperty;
+        }
+        return $result;
     }
 
     /**

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -217,7 +217,7 @@ class DotNet extends SOAPClient
     {
         $resultProperty = $this->getLastMethod() . 'Result';
         if (isset($result->$resultProperty)) {
-            return $result->resultProperty;
+            return $result->$resultProperty;
         }
         return $result;
     }

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -216,7 +216,7 @@ class DotNet extends SOAPClient
     protected function _preProcessResult($result)
     {
         $resultProperty = $this->getLastMethod() . 'Result';
-        if(isset($result->$resultProperty)){
+        if (isset($result->$resultProperty)) {
             return $result->resultProperty;
         }
         return $result;


### PR DESCRIPTION
The dotNet soap implementation send the result in a [LastRequest]Result xml node, so the DotNet _preProcessResult return directly this node.

But in some case, when the method return nothing and if this behaviour is not defined in the ws defition (wsdl for example), a notice error is raised because the searched node does not exists.

So I have added an exists condition on the [LastRequest]Result xml node to avoid this error.

The code is not unit-tested because I don't know how to test this peculiar behaviour, but the modification is really really tiny.
