### PR TITLE
ServiceManager::canCreateFromAbstractFactory() missing foreach break after valid abstract factory found

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -730,6 +730,7 @@ class ServiceManager implements ServiceLocatorInterface
             if ($abstractFactory->canCreateServiceWithName($this, $cName, $rName)) {
                 $this->nestedContext[$cName] = $abstractFactory;
                 $result = true;
+                break;
             }
         }
         $this->checkNestedContextStop();

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -330,6 +330,28 @@ class ServiceManagerTest extends TestCase
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Bar', $this->serviceManager->get('bar'));
     }
 
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::create
+     */
+    public function testCreateTheSameServiceWithMultipleAbstractFactories()
+    {
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooFakeAbstractFactory');
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAbstractFactory');
+
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $this->serviceManager->get('foo'));
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::create
+     */
+    public function testCreateTheSameServiceWithMultipleAbstractFactoriesReversePriority()
+    {
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooAbstractFactory');
+        $this->serviceManager->addAbstractFactory('ZendTest\ServiceManager\TestAsset\FooFakeAbstractFactory');
+
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFake', $this->serviceManager->get('foo'));
+    }
+
     public function testCreateWithInitializerObject()
     {
         $this->serviceManager->addInitializer(new TestAsset\FooInitializer(array('foo' => 'bar')));

--- a/tests/ZendTest/ServiceManager/TestAsset/FooFake.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooFake.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+class FooFake
+{
+
+}

--- a/tests/ZendTest/ServiceManager/TestAsset/FooFakeAbstractFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/FooFakeAbstractFactory.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FooFakeAbstractFactory implements AbstractFactoryInterface
+{
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if ($name == 'foo') {
+            return true;
+        }
+    }
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        return new FooFake;
+    }
+}


### PR DESCRIPTION
It seems that in the ServiceManager::canCreateFromAbstractFactoryMethod() is missing foreach break after an abstract factory is found and assigned to the nestedContext.

Missing break after https://github.com/zendframework/zf2/blob/develop/library/Zend/ServiceManager/ServiceManager.php#L732

Now the issue is, that the first abstract factory if can create a service is always overridden with the last abstract factory that can create the same service, e.g. DiAbstractServiceFactory.

For example, I add an abstract factory to the service manager config AdapterAbstractServiceFactory and I configure the db adapter. When I want to inject that adapter with the Di, I have to configure the di instance alias. But, when the service manager is creating that db adapter new instance it continues over the AdapterAbstractServiceFactory to the DiAbstractServiceFactory, because of that missing foreach break. Thus db adapter instance can't be created,
