### PR TITLE
The 'for' attribute should not be a valid global attribute?

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -74,6 +74,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
         'dir'                => true,
         'draggable'          => true,
         'dropzone'           => true,
+        'for'                => true,
         'hidden'             => true,
         'id'                 => true,
         'lang'               => true,


### PR DESCRIPTION
The 'for' attribute should not be a valid global attribute?
