### PR TITLE
[Zend\Soap\Server] Add getException to get caught exceptions

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -58,6 +58,11 @@ class Server implements ZendServerServer
     protected $faultExceptions = array();
 
     /**
+     * Container for caught exception during business code execution
+     * @var \Exception
+     */
+    protected $caughtException = null;
+    /**
      * SOAP Server Features
      * @var int
      */
@@ -994,6 +999,15 @@ class Server implements ZendServerServer
     }
 
     /**
+     * Return caught exception during business code execution
+     * @return null|\Exception caught exception
+     */
+    public function getException()
+    {
+        return $this->caughtException;
+    }
+
+    /**
      * Generate a server fault
      *
      * Note that the arguments are reverse to those of SoapFault.
@@ -1009,6 +1023,8 @@ class Server implements ZendServerServer
      */
     public function fault($fault = null, $code = 'Receiver')
     {
+        $this->caughtException = (is_string($fault)) ? new \Exception($fault) : $fault;
+
         if ($fault instanceof \Exception) {
             if ($this->isRegisteredAsFaultException($fault)) {
                 $message = $fault->getMessage();

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -937,4 +937,15 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Invalid XML', $response->getMessage());
     }
 
+    public function testGetOriginalCaughtException()
+    {
+        $server = new Server();
+        $fault = $server->fault(new \Exception('test'));
+
+        $exception = $server->getException();
+        $this->assertInstanceOf('\Exception', $exception);
+        $this->assertEquals('test', $exception->getMessage());
+        $this->assertInstanceOf('\SoapFault', $fault);
+        $this->assertEquals('Unknown error', $fault->getMessage());
+    }
 }


### PR DESCRIPTION
If the Server class catch an Exception, the caught exception is hidden and the original exception is lost, this pull request adds a getException method to get the caught exception during business code execution.

Code Unit-tested
