### PR TITLE
[Zend\Soap\Server][NEW] add a getSoap method, return the internal instance

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -34,6 +34,11 @@ class Server implements ZendServerServer
     protected $class;
 
     /**
+     * Server instance
+     * @var \SoapServer
+     */
+    protected $server = null;
+    /**
      * Arguments to pass to {@link $class} constructor
      * @var array
      */
@@ -808,6 +813,10 @@ class Server implements ZendServerServer
      */
     protected function _getSoap()
     {
+        if ($this->server instanceof \SoapServer) {
+            return $this->server;
+        }
+
         $options = $this->getOptions();
         $server  = new SoapServer($this->wsdl, $options);
 
@@ -829,7 +838,18 @@ class Server implements ZendServerServer
             $server->setPersistence($this->persistence);
         }
 
-        return $server;
+        $this->server = $server;
+        return $this->server;
+    }
+
+    /**
+     * Proxy for _getSoap method
+     * @see _getSoap
+     * @return \SoapServer the soapServer instance
+     */
+    public function getSoap()
+    {
+        return $this->_getSoap();
     }
 
     /**

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -35,7 +35,7 @@ class Server implements ZendServerServer
 
     /**
      * Server instance
-     * @var \SoapServer
+     * @var SoapServer
      */
     protected $server = null;
     /**
@@ -813,7 +813,7 @@ class Server implements ZendServerServer
      */
     protected function _getSoap()
     {
-        if ($this->server instanceof \SoapServer) {
+        if ($this->server instanceof SoapServer) {
             return $this->server;
         }
 
@@ -845,7 +845,7 @@ class Server implements ZendServerServer
     /**
      * Proxy for _getSoap method
      * @see _getSoap
-     * @return \SoapServer the soapServer instance
+     * @return SoapServer the soapServer instance
      */
     public function getSoap()
     {

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -937,4 +937,13 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Invalid XML', $response->getMessage());
     }
 
+    public function testGetSoapInternalInstance()
+    {
+        $server = new Server();
+        $server->setOptions(array('location'=>'test://', 'uri'=>'http://framework.zend.com'));
+        $internalServer = $server->getSoap();
+        $this->assertInstanceOf('\SoapServer', $internalServer);
+        $this->assertSame($internalServer, $server->getSoap());
+    }
+
 }


### PR DESCRIPTION
Currently, we are no able to access of the internal SoapServer instance. But in certain case (especially when we need to send a soapfault with the setReturnResponse at true) we need an access to the internal instance.
So this pull request adds a proxy method getSoap() which returns the internal SoapServer instance.

Code is unit-tested
