### PR TITLE
Fixed the classmap autoloader to work under Windows in Phar files.

### DIFF
--- a/library/Zend/Loader/ClassMapAutoloader.php
+++ b/library/Zend/Loader/ClassMapAutoloader.php
@@ -197,11 +197,12 @@ class ClassMapAutoloader implements SplAutoloader
      */
     public static function realPharPath($path)
     {
-        if (strpos($path, 'phar:///') !== 0) {
+        if (!preg_match('|^phar:(/{2,3})|',$path, $match)) {
             return;
         }
 
-        $parts = explode('/', str_replace(array('/', '\\'), '/', substr($path, 8)));
+        $prefixLength  = 5 + strlen($match[1]);
+        $parts = explode('/', str_replace(array('/', '\\'), '/', substr($path, $prefixLength)));
         $parts = array_values(array_filter($parts, function ($p) {
             return ($p !== '' && $p !== '.');
         }));
@@ -213,7 +214,7 @@ class ClassMapAutoloader implements SplAutoloader
             }
         });
 
-        if (file_exists($realPath = 'phar:///' . implode('/', $parts))) {
+        if (file_exists($realPath = str_pad('phar:', $prefixLength, '/') . implode('/', $parts))) {
             return $realPath;
         }
     }


### PR DESCRIPTION
The following change makes it possible to use the classmap autoloader also under Windows in phar context.
(Example path: 'phar://D:/GDrive/zs-client.phar/module/Client/autoload_classmap.php')
