### PR TITLE
Fix validate non required fields in CollectionInputFilter

### DIFF
--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -174,7 +174,7 @@ class CollectionInputFilter extends InputFilter
             $this->data = $data;
             $this->populate();
 
-            if ($this->validateInputs($inputs)) {
+            if ($this->validateInputs($inputs, $data)) {
                 $this->collectionValidInputs[$key] = $this->validInputs;
             } else {
                 $this->collectionInvalidInputs[$key] = $this->invalidInputs;

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -433,6 +433,31 @@ class CollectionInputFilterTest extends TestCase
     public function testSetRequired()
     {
         $this->filter->setIsRequired(true);
-        $this->assertEquals(true,$this->filter->getIsRequired());
+        $this->assertEquals(true, $this->filter->getIsRequired());
+    }
+
+    public function testNonRequiredFieldsAreValidated()
+    {
+        $invalidCollectionData = array(
+            array(
+                'foo' => ' bazbattoolong ',
+                'bar' => '12345',
+                'baz' => 'baztoolong',
+                'nest' => array(
+                    'foo' => ' bazbat ',
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            )
+        );
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($invalidCollectionData);
+
+        $this->assertFalse($this->filter->isValid());
+
+        $this->assertCount(2, current($this->filter->getInvalidInput()));
+
+        $this->assertArrayHasKey('baz', current($this->filter->getMessages()));
     }
 }


### PR DESCRIPTION
Validators set on non required inputs were never executed.
The problem is with the missing `$data` parameter for the validateInputs method. BaseInputFilter needs the data to figure out if validation needs to be run.
In the unit test field `baz` has a `stringLength(1, 6)` validator, but was still valid even if you pass a string longer than 6 characters.
