### PR TITLE
Array overwriting in ArrayUtils::merge()

### DIFF
--- a/library/Zend/Stdlib/ArrayUtils.php
+++ b/library/Zend/Stdlib/ArrayUtils.php
@@ -259,7 +259,7 @@ abstract class ArrayUtils
         foreach ($b as $key => $value) {
             if (array_key_exists($key, $a)) {
                 if (is_int($key)) {
-                    $a[] = $value;
+                    $a[$key] = $value;
                 } elseif (is_array($value) && is_array($a[$key])) {
                     $a[$key] = static::merge($a[$key], $value);
                 } else {

--- a/tests/ZendTest/Stdlib/ArrayUtilsTest.php
+++ b/tests/ZendTest/Stdlib/ArrayUtilsTest.php
@@ -153,16 +153,15 @@ class ArrayUtilsTest extends TestCase
                     'baz',
                 ),
                 array(
-                    0     => 'foo',
+                    0     => 'baz',
                     3     => 'bar',
-                    'baz' => 'baz',
-                    4     => 'baz'
+                    'baz' => 'baz'
                 )
             ),
             'merge-arrays-recursively' => array(
                 array(
                     'foo' => array(
-                        'baz'
+                        'bar'
                     )
                 ),
                 array(
@@ -172,8 +171,7 @@ class ArrayUtilsTest extends TestCase
                 ),
                 array(
                     'foo' => array(
-                        0 => 'baz',
-                        1 => 'baz'
+                        0 => 'baz'
                     )
                 )
             ),


### PR DESCRIPTION
If you want to overwrite default value of _baz_ array:

``` php
'foo' => array(
    'bar' => array(
        'baz' => array(
            'dev',
        )
    ),
),
```

by this local version:

``` php
'foo' => array(
    'bar' => array(
        'baz' => array(
            'local',
        )
    ),
),
```

on default you get:

``` php
'foo' => array(
    'bar' => array(
        'baz' => array(
            0 => 'dev',
            1 => 'local',
        )
    ),
),
```

So the question is, how can I overwrite this value? Without this fix I can't, can I?
