### PR TITLE
Remove HTTP client restriction on cookies

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -260,10 +260,6 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setName($name)
     {
-        if ($name !== null && preg_match("/[=,; \t\r\n\013\014]/", $name)) {
-            throw new Exception\InvalidArgumentException("Cookie name cannot contain these characters: =,; \\t\\r\\n\\013\\014 ({$name})");
-        }
-
         $this->name = $name;
         return $this;
     }


### PR DESCRIPTION
Hi,

I've been encountering a strange issue today with Zend Http client. I was doing an OAuth authorization call to Stripe API (https://stripe.com/docs/connect/reference#post-token), but had the following error:

Zend\Http\Header\Exception\InvalidArgumentException:
Cookie name cannot contain these characters: =,; \t\r\n\013\014 (session=)

After lot of debugging, it appeared that Stripe sent three cookies: http://cl.ly/image/2E232m072h47

The first one is the problematic one because it uses "=". Removing the check make it works.

Please note that I couldn't find a clear documentation that stated that all those characters were not allowed. Furthermore, I tried the exact same call using another PHP client (Guzzle) and it worked without any issue, so I suppose they do not make this check. Lastly, this feature was not tested at all so I suppose it's safe to remove this check.

(I've tried to check on the Internet if other Stripe users had this problem in other languages, and couldn't find anything)
