### PR TITLE
[Zend\Filter\Compress] added PHP 5.4 support for strings in Bz2 and Gz decompress

### DIFF
--- a/library/Zend/Filter/Compress/Bz2.php
+++ b/library/Zend/Filter/Compress/Bz2.php
@@ -133,7 +133,9 @@ class Bz2 extends AbstractCompressionAlgorithm
     public function decompress($content)
     {
         $archive = $this->getArchive();
-        if (file_exists($content)) {
+
+        //check if there are null byte characters before doing a file_exists check
+        if (!strstr($content, "\0") && file_exists($content)) {
             $archive = $content;
         }
 

--- a/library/Zend/Filter/Compress/Gz.php
+++ b/library/Zend/Filter/Compress/Gz.php
@@ -165,7 +165,9 @@ class Gz extends AbstractCompressionAlgorithm
     {
         $archive = $this->getArchive();
         $mode    = $this->getMode();
-        if (file_exists($content)) {
+
+        //check if there are null byte characters before doing a file_exists check
+        if (!strstr($content, "\0") && file_exists($content)) {
             $archive = $content;
         }
 

--- a/tests/ZendTest/Filter/Compress/Bz2Test.php
+++ b/tests/ZendTest/Filter/Compress/Bz2Test.php
@@ -37,10 +37,6 @@ class Bz2Test extends \PHPUnit_Framework_TestCase
      */
     public function testBasicUsage()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $filter  = new Bz2Compression();
 
         $content = $filter->compress('compress me');

--- a/tests/ZendTest/Filter/Compress/GzTest.php
+++ b/tests/ZendTest/Filter/Compress/GzTest.php
@@ -37,10 +37,6 @@ class GzTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasicUsage()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $filter  = new GzCompression();
 
         $content = $filter->compress('compress me');

--- a/tests/ZendTest/Filter/Compress/GzTest.php
+++ b/tests/ZendTest/Filter/Compress/GzTest.php
@@ -160,10 +160,6 @@ class GzTest extends \PHPUnit_Framework_TestCase
      */
     public function testGzDeflate()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $filter  = new GzCompression(array('mode' => 'deflate'));
 
         $content = $filter->compress('compress me');

--- a/tests/ZendTest/Filter/CompressTest.php
+++ b/tests/ZendTest/Filter/CompressTest.php
@@ -37,10 +37,6 @@ class CompressTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasicUsage()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $filter  = new CompressFilter('bz2');
 
         $text     = 'compress me';

--- a/tests/ZendTest/Filter/DecompressTest.php
+++ b/tests/ZendTest/Filter/DecompressTest.php
@@ -37,10 +37,6 @@ class DecompressTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasicUsage()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $filter  = new DecompressFilter('bz2');
 
         $text       = 'compress me';

--- a/tests/ZendTest/Filter/Encrypt/BlockCipherTest.php
+++ b/tests/ZendTest/Filter/Encrypt/BlockCipherTest.php
@@ -200,10 +200,6 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
      */
     public function testEncryptionWithDecryptionAndCompressionMcrypt()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         if (!extension_loaded('bz2')) {
             $this->markTestSkipped('This adapter needs the bz2 extension');
         }

--- a/tests/ZendTest/Filter/Encrypt/OpensslTest.php
+++ b/tests/ZendTest/Filter/Encrypt/OpensslTest.php
@@ -274,10 +274,6 @@ bK22CwD/l7SMBOz4M9XH0Jb0OhNxLza4XMDu0ANMIpnkn1KOcmQ4gB8fmAbBt';
      */
     public function testEncryptionWithDecryptionAndCompressionWithPackagedKeys()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         if (!extension_loaded('bz2')) {
             $this->markTestSkipped('Bz2 extension for compression test needed');
         }


### PR DESCRIPTION
With this PR Zend\Filter\Compress\Bz2 and Zend\Filter\Compress\Gz are capable of decompressing Strings in PHP 5.4 without throwing a Warning like stated in #5788
In my research I found out, that the only problem are null byte characters, so we go for a check if there is a null byte char in the given content.
The skipped tests are working now in PHP >= 5.4
