### PR TITLE
Enabling the Request object to generate the correct scheme for SSL URI 

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -255,9 +255,8 @@ class Request extends HttpRequest
             || (!empty($this->serverParams['HTTP_X_FORWARDED_PROTO']) && $this->serverParams['HTTP_X_FORWARDED_PROTO'] == 'https')
         ) {
             $scheme = 'https';
-        }
-        else {
-	        $scheme = 'http';
+        } else {
+            $scheme = 'http';
         }
         $uri->setScheme($scheme);
 

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -251,8 +251,14 @@ class Request extends HttpRequest
         $uri = new HttpUri();
 
         // URI scheme
-        $scheme = (!empty($this->serverParams['HTTPS'])
-                   && $this->serverParams['HTTPS'] !== 'off') ? 'https' : 'http';
+        if ((!empty($this->serverParams['HTTPS']) && $this->serverParams['HTTPS'] !== 'off')
+            || (!empty($this->serverParams['HTTP_X_FORWARDED_PROTO']) && $this->serverParams['HTTP_X_FORWARDED_PROTO'] == 'https')
+        ) {
+            $scheme = 'https';
+        }
+        else {
+	        $scheme = 'http';
+        }
         $uri->setScheme($scheme);
 
         // URI host & port

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -387,6 +387,18 @@ class RequestTest extends TestCase
                 '443',
                 '/news',
             ),
+            // Test for HTTPS requests which are forwarded over a reverse proxy/load balancer
+            array(
+                array(
+                    'SERVER_NAME' => 'test.example.com',
+                    'SERVER_PORT' => '443',
+                    'HTTP_X_FORWARDED_PROTO' => 'https',
+                    'REQUEST_URI' => 'https://test.example.com/news',
+                ),
+                'test.example.com',
+                '443',
+                '/news',
+            ),
 
             //Test when url quert contains a full http url
             array(
@@ -415,6 +427,12 @@ class RequestTest extends TestCase
 
         $host = $request->getUri()->getHost();
         $this->assertEquals($expectedHost, $host);
+
+        $uriParts = parse_url($_SERVER['REQUEST_URI']);
+        if (isset($uriParts['scheme'])) {
+            $scheme = $request->getUri()->getScheme();
+            $this->assertEquals($uriParts['scheme'], $scheme);
+        }
 
         $port = $request->getUri()->getPort();
         $this->assertEquals($expectedPort, $port);


### PR DESCRIPTION
Enabling the Request object to generate the correct scheme for SSL URI  requests to a web server through an HTTP proxy or load balancer.

HTTP_X_FORWARDED_PROTO request header is sent by load balancers instead of HTTPS to indicate the URI was requested via a secure connection.

An example of this usage is Amazon Elastic Beanstalk applications which can sit behind a load balancer (when autoscaling)
