### PR TITLE
s/replace/provide/ in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "bin/pluginmap_generator.php",
         "bin/templatemap_generator.php"
     ],
-    "replace": {
+    "provide": {
         "zendframework/zend-authentication": "self.version",
         "zendframework/zend-barcode": "self.version",
         "zendframework/zend-cache": "self.version",


### PR DESCRIPTION
Based on http://blog.naderman.de/2014/02/17/replace-conflict-forks-explained/,
"replace" should be used only for forks of a package, and "provide" should be 
used when the current package provides an implementation of that package. 
Supposedly, using the "provide" key instead of "replace" should prevent forks 
published on Packagist (that update to use the "provide" key as well) from
being selected over the official packages.

I've tested this with the following composer.json:

``` javascript
{
    "repositories": [
        {
            "type": "vcs",
            "url": "file:///path/to/local/checkout/of/zf2/.git"
        }
    ],
    "require": {
        "zendframework/zend-http": "~2.2.0",
        "zendframework/zendframework": "~2.2.0"
    }
}
```

When I did this, composer accurately installed `zendframework/zendframework` only.
