### PR TITLE
Multiple identifiers in `In`

### DIFF
--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -89,7 +89,21 @@ class In implements PredicateInterface
     public function getExpressionData()
     {
         $values = $this->getValueSet();
+        $identifier = $this->getIdentifier();
         if ($values instanceof Select) {
+            if (is_array($identifier)) {
+                    $identifiers = $identifier;
+                    $specification = ' ( ' . implode(', ', array_fill(0, count($identifiers), '%s')) . ' ) ';
+                    $specification .= ' IN %s';
+                    $values = array_merge($identifiers, array($values)); 
+                    $types = array_fill(0, count($identifiers), self::TYPE_IDENTIFIER);
+                    $types[] = self::TYPE_VALUE;
+                    return array(array(
+                        $specification,
+                        $values,
+                        $types,
+                    ));
+            }
             $specification = $this->selectSpecification;
             $types = array(self::TYPE_VALUE);
             $values = array($values);
@@ -98,7 +112,6 @@ class In implements PredicateInterface
             $types = array_fill(0, count($values), self::TYPE_VALUE);
         }
 
-        $identifier = $this->getIdentifier();
         array_unshift($values, $identifier);
         array_unshift($types, self::TYPE_IDENTIFIER);
 

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -92,17 +92,17 @@ class In implements PredicateInterface
         $identifier = $this->getIdentifier();
         if ($values instanceof Select) {
             if (is_array($identifier)) {
-                    $identifiers = $identifier;
-                    $specification = ' ( ' . implode(', ', array_fill(0, count($identifiers), '%s')) . ' ) ';
-                    $specification .= ' IN %s';
-                    $values = array_merge($identifiers, array($values));
-                    $types = array_fill(0, count($identifiers), self::TYPE_IDENTIFIER);
-                    $types[] = self::TYPE_VALUE;
-                    return array(array(
-                        $specification,
-                        $values,
-                        $types,
-                    ));
+                $identifiers = $identifier;
+                $specification = ' ( ' . implode(', ', array_fill(0, count($identifiers), '%s')) . ' ) ';
+                $specification .= ' IN %s';
+                $values = array_merge($identifiers, array($values));
+                $types = array_fill(0, count($identifiers), self::TYPE_IDENTIFIER);
+                $types[] = self::TYPE_VALUE;
+                return array(array(
+                    $specification,
+                    $values,
+                    $types,
+                ));
             }
             $specification = $this->selectSpecification;
             $types = array(self::TYPE_VALUE);

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -23,8 +23,8 @@ class In implements PredicateInterface
     /**
      * Constructor
      *
-     * @param null|string $identifier
-     * @param array       $valueSet
+     * @param null|string|array $identifier
+     * @param null|array|Select $valueSet
      */
     public function __construct($identifier = null, $valueSet = null)
     {
@@ -39,7 +39,7 @@ class In implements PredicateInterface
     /**
      * Set identifier for comparison
      *
-     * @param  string $identifier
+     * @param  string|array $identifier
      * @return In
      */
     public function setIdentifier($identifier)
@@ -52,7 +52,7 @@ class In implements PredicateInterface
     /**
      * Get identifier of comparison
      *
-     * @return null|string
+     * @return null|string|array
      */
     public function getIdentifier()
     {
@@ -62,7 +62,7 @@ class In implements PredicateInterface
     /**
      * Set set of values for IN comparison
      *
-     * @param  array                              $valueSet
+     * @param  array|Select                       $valueSet
      * @throws Exception\InvalidArgumentException
      * @return In
      */
@@ -78,6 +78,11 @@ class In implements PredicateInterface
         return $this;
     }
 
+    /**
+     * Gets set of values in IN comparision
+     *
+     * @return array|Select
+     */
     public function getValueSet()
     {
         return $this->valueSet;

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -23,8 +23,8 @@ class In implements PredicateInterface
     /**
      * Constructor
      *
-     * @param  null|string $identifier
-     * @param  array $valueSet
+     * @param null|string $identifier
+     * @param array       $valueSet
      */
     public function __construct($identifier = null, $valueSet = null)
     {
@@ -45,6 +45,7 @@ class In implements PredicateInterface
     public function setIdentifier($identifier)
     {
         $this->identifier = $identifier;
+
         return $this;
     }
 
@@ -61,7 +62,7 @@ class In implements PredicateInterface
     /**
      * Set set of values for IN comparison
      *
-     * @param  array $valueSet
+     * @param  array                              $valueSet
      * @throws Exception\InvalidArgumentException
      * @return In
      */
@@ -73,6 +74,7 @@ class In implements PredicateInterface
             );
         }
         $this->valueSet = $valueSet;
+
         return $this;
     }
 
@@ -97,6 +99,7 @@ class In implements PredicateInterface
                 $specification .= ' IN %s';
                 $types = array_fill(0, count($identifiers), self::TYPE_IDENTIFIER);
                 $types[] = self::TYPE_VALUE;
+
                 return array(array(
                     $specification,
                     array_merge($identifiers, array($values)),

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -95,12 +95,11 @@ class In implements PredicateInterface
                 $identifiers = $identifier;
                 $specification = ' ( ' . implode(', ', array_fill(0, count($identifiers), '%s')) . ' ) ';
                 $specification .= ' IN %s';
-                $values = array_merge($identifiers, array($values));
                 $types = array_fill(0, count($identifiers), self::TYPE_IDENTIFIER);
                 $types[] = self::TYPE_VALUE;
                 return array(array(
                     $specification,
-                    $values,
+                    array_merge($identifiers, array($values)),
                     $types,
                 ));
             }

--- a/library/Zend/Db/Sql/Predicate/In.php
+++ b/library/Zend/Db/Sql/Predicate/In.php
@@ -95,7 +95,7 @@ class In implements PredicateInterface
                     $identifiers = $identifier;
                     $specification = ' ( ' . implode(', ', array_fill(0, count($identifiers), '%s')) . ' ) ';
                     $specification .= ' IN %s';
-                    $values = array_merge($identifiers, array($values)); 
+                    $values = array_merge($identifiers, array($values));
                     $types = array_fill(0, count($identifiers), self::TYPE_IDENTIFIER);
                     $types[] = self::TYPE_VALUE;
                     return array(array(

--- a/tests/ZendTest/Db/Sql/Predicate/InTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/InTest.php
@@ -68,4 +68,15 @@ class InTest extends TestCase
         ));
         $this->assertEquals($expected, $in->getExpressionData());
     }
+    
+    public function testGetExpressionDataWithSubselectAndArrayIdentifier()
+    {
+        $in = new In(array('foo', 'bar'), $select = new Select);
+        $expected = array(array(
+            ' ( %s, %s )  IN %s',
+            array('foo', 'bar', $select),
+            array($in::TYPE_IDENTIFIER, $in::TYPE_IDENTIFIER, $in::TYPE_VALUE)
+        ));
+        $this->assertEquals($expected, $in->getExpressionData());
+    }    
 }

--- a/tests/ZendTest/Db/Sql/Predicate/InTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/InTest.php
@@ -78,5 +78,5 @@ class InTest extends TestCase
             array($in::TYPE_IDENTIFIER, $in::TYPE_IDENTIFIER, $in::TYPE_VALUE)
         ));
         $this->assertEquals($expected, $in->getExpressionData());
-    }    
+    }
 }

--- a/tests/ZendTest/Db/Sql/Predicate/InTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/InTest.php
@@ -68,7 +68,7 @@ class InTest extends TestCase
         ));
         $this->assertEquals($expected, $in->getExpressionData());
     }
-    
+
     public function testGetExpressionDataWithSubselectAndArrayIdentifier()
     {
         $in = new In(array('foo', 'bar'), $select = new Select);


### PR DESCRIPTION
I have an SQL query like this:

`
SELECT * FROM data da 
INNER JOIN device_configuration d ON d.id = da.device_id 
WHERE (da.device_id, da.recorded_time) IN
(
        SELECT device_id, MAX(recorded_time) FROM data group BY device_id
)
AND d.parent_id IS NULL;`

Yes, you are right, it is not supported directly by Zend Framework 2.

With this PR, you can do something like:

``` php
$select->where->in(array('column1', 'column2'), $anotherSelect);
```

So, the above query can be written in Zend Framework 2 as:

``` php
$maxSelect->columns(array('device_id', new SqlExpression('MAX(recorded_time)')));
$maxSelect->group('device_id'); 
$select->where->in(array('device_id', 'recorded_time'), $maxSelect);
$select->join(
    'device_configuration',
    'device_configuration.id = data.device_id'
);
$select->where->isNull('parent_id');
$resultSet = $this->select($select); 
```
