### PR TITLE
Post/Redirect/Get should keep query parameters

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
+++ b/library/Zend/Mvc/Controller/Plugin/PostRedirectGet.php
@@ -95,7 +95,7 @@ class PostRedirectGet extends AbstractPlugin
     {
         $controller         = $this->getController();
         $params             = array();
-        $options            = array();
+        $options            = array('query' => $controller->params()->fromQuery());
         $reuseMatchedParams = false;
 
         if (null === $redirect) {

--- a/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/PostRedirectGetTest.php
@@ -18,6 +18,7 @@ use Zend\Mvc\Router\Http\Literal as LiteralRoute;
 use Zend\Mvc\Router\Http\Segment as SegmentRoute;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\SimpleRouteStack;
+use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Stdlib\Parameters;
 use ZendTest\Mvc\Controller\TestAsset\SampleController;
@@ -32,7 +33,7 @@ class PostRedirectGetTest extends TestCase
 
     public function setUp()
     {
-        $router = new SimpleRouteStack;
+        $router = new TreeRouteStack;
         $router->addRoute('home', LiteralRoute::factory(array(
             'route'    => '/',
             'defaults' => array(
@@ -217,6 +218,30 @@ class PostRedirectGetTest extends TestCase
         $this->assertInstanceOf('Zend\Http\Response', $prgResultRoute);
         $this->assertTrue($prgResultRoute->getHeaders()->has('Location'));
         $this->assertEquals($expects, $prgResultRoute->getHeaders()->get('Location')->getUri() , 'expects to redirect for the same url');
+        $this->assertEquals(303, $prgResultRoute->getStatusCode());
+    }
+
+    public function testKeepUrlQueryParameters()
+    {
+        $expects = '/ctl/sample';
+        $this->request->setMethod('POST');
+        $this->request->setUri($expects);
+        $this->request->setQuery(new Parameters(array(
+            'id' => '123',
+        )));
+
+        $routeMatch = $this->event->getRouter()->match($this->request);
+        $this->event->setRouteMatch($routeMatch);
+
+        $moduleRouteListener = new ModuleRouteListener;
+        $moduleRouteListener->onRoute($this->event);
+
+        $this->controller->dispatch($this->request, $this->response);
+        $prgResultRoute = $this->controller->prg();
+
+        $this->assertInstanceOf('Zend\Http\Response', $prgResultRoute);
+        $this->assertTrue($prgResultRoute->getHeaders()->has('Location'));
+        $this->assertEquals($expects . '?id=123', $prgResultRoute->getHeaders()->get('Location')->getUri() , 'expects to redirect for the same url');
         $this->assertEquals(303, $prgResultRoute->getStatusCode());
     }
 }


### PR DESCRIPTION
The Post Redirect Get Plugin should keep query parameters for redirects but I don't know if this is the right approach to do this.
