### PR TITLE
remove dependency on stdlib package

### DIFF
--- a/library/Zend/Dom/DOMXpath.php
+++ b/library/Zend/Dom/DOMXpath.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Dom;
+
+use ErrorException;
+
+/**
+ * Extends DOMXpath to throw ErrorExceptions instead of raising errors.
+ */
+class DOMXPath extends \DOMXPath
+{
+    /**
+     * A stack of ErrorExceptions created via addError()
+     * @var array
+     */
+    protected $errors = array(null);
+
+    /**
+     * Evaluates an XPath expression; throws an ErrorException instead of
+     * raising an error
+     *
+     * @param string $expression The XPath expression to evaluate.
+     * @return DOMNodeList
+     * @throws ErrorException
+     */
+    public function queryWithErrorException($expression)
+    {
+        $this->errors = array(null);
+
+        set_error_handler(array($this, 'addError'), \E_WARNING);
+        $nodeList = $this->query($expression);
+        restore_error_handler();
+
+        $exception = array_pop($this->errors);
+        if ($exception) {
+            throw $exception;
+        }
+
+        return $nodeList;
+    }
+
+    /**
+     * Adds an error to the stack of errors
+     *
+     * @param int    $errno
+     * @param string $errstr
+     * @param string $errfile
+     * @param int    $errline
+     * @return void
+     */
+    public function addError($errno, $errstr = '', $errfile = '', $errline = 0)
+    {
+        $last_error = $this->errors[count($this->errors) - 1];
+        $this->errors[] = new ErrorException(
+            $errstr,
+            0,
+            $errno,
+            $errfile,
+            $errline,
+            $last_error
+        );
+    }
+}

--- a/library/Zend/Dom/DOMXpath.php
+++ b/library/Zend/Dom/DOMXpath.php
@@ -17,6 +17,7 @@ class DOMXPath extends \DOMXPath
 {
     /**
      * A stack of ErrorExceptions created via addError()
+     *
      * @var array
      */
     protected $errors = array(null);
@@ -56,7 +57,7 @@ class DOMXPath extends \DOMXPath
      */
     public function addError($errno, $errstr = '', $errfile = '', $errline = 0)
     {
-        $last_error = $this->errors[count($this->errors) - 1];
+        $last_error = end($this->errors);
         $this->errors[] = new ErrorException(
             $errstr,
             0,

--- a/library/Zend/Dom/Document/Query.php
+++ b/library/Zend/Dom/Document/Query.php
@@ -9,9 +9,8 @@
 
 namespace Zend\Dom\Document;
 
-use DOMXPath;
+use Zend\Dom\DOMXPath;
 use Zend\Dom\Document;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * Query object executable in a Zend\Dom\Document
@@ -51,10 +50,7 @@ class Query
             ($xpathPhpfunctions === true) ? $xpath->registerPHPFunctions() : $xpath->registerPHPFunctions($xpathPhpfunctions);
         }
 
-        ErrorHandler::start();
-        $nodeList = $xpath->query($expression);
-        ErrorHandler::stop(true);
-
+        $nodeList = $xpath->queryWithErrorException($expression);
         return new NodeList($nodeList);
     }
 

--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -10,9 +10,7 @@
 namespace Zend\Dom;
 
 use DOMDocument;
-use DOMXPath;
-use ErrorException;
-use Zend\Stdlib\ErrorHandler;
+use Zend\Dom\DOMXPath;
 
 /**
  * Query DOM structures based on CSS selectors and/or XPath
@@ -317,10 +315,7 @@ class Query
         }
         $xpathQuery = (string) $xpathQuery;
 
-        ErrorHandler::start();
-        $nodeList = $xpath->query($xpathQuery);
-        ErrorHandler::stop(true);
-
+        $nodeList = $xpath->queryWithErrorException($xpathQuery);
         return $nodeList;
     }
 }

--- a/library/Zend/Dom/composer.json
+++ b/library/Zend/Dom/composer.json
@@ -13,8 +13,7 @@
     },
     "target-dir": "Zend/Dom",
     "require": {
-        "php": ">=5.3.3",
-        "zendframework/zend-stdlib": "self.version"
+        "php": ">=5.3.3"
     },
     "extra": {
         "branch-alias": {

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,4 +1,0 @@
-# Add here the vendor path to be whitelisted
-# Ex: for composer directory write here "!composer" (without quotes)
-!.gitignore
-*

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,0 +1,4 @@
+# Add here the vendor path to be whitelisted
+# Ex: for composer directory write here "!composer" (without quotes)
+!.gitignore
+*


### PR DESCRIPTION
This commit removes the dependency on the Stdlib package so that the Dom package can be used completely standalone. It does so by extending DOMXpath to wrap each raised error with an ErrorException with logic similar to that used in Stdlib ErrorHandler.
