### PR TITLE
Add processor support to the Logger options.

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -126,6 +126,7 @@ class Logger implements LoggerInterface
     public function __construct($options = null)
     {
         $this->writers = new SplPriorityQueue();
+        $this->processors = new SplPriorityQueue();
 
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
@@ -145,6 +146,20 @@ class Logger implements LoggerInterface
                     $this->addWriter($writer['name'], $priority, $writerOptions);
                 }
             }
+            if (isset($options['processors']) && is_array($options['processors'])) {
+                foreach ($options['processors'] as $processor) {
+
+                    if (!isset($processor['name'])) {
+                        throw new Exception\InvalidArgumentException('Options must contain a name for the processor');
+                    }
+
+                    $priority = (isset($processor['priority'])) ? $processor['priority'] : null;
+                    $processorOptions = (isset($processor['options'])) ? $processor['options'] : null;
+
+                    $this->addProcessor($processor['name'], $priority, $processorOptions);
+                }
+            }
+
 
             if (isset($options['exceptionhandler']) && $options['exceptionhandler'] === true) {
                 static::registerExceptionHandler($this);
@@ -158,7 +173,6 @@ class Logger implements LoggerInterface
             throw new Exception\InvalidArgumentException('Options must be an array or an object implementing \Traversable ');
         }
 
-        $this->processors = new SplPriorityQueue();
     }
 
     /**

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -298,6 +298,24 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $writers[0]->getLogSeparator());
     }
 
+    public function testOptionsWithMockAndProcessor()
+    {
+        $options = array('writers' => array(
+                             'first_writer' => array(
+                                 'name'     => 'mock',
+                             )
+                        ),
+                        'processors' => array(
+                            'first_processor' => array(
+                                'name'      => 'requestid',
+                            ),
+                        ));
+        $logger = new Logger($options);
+        $processors = $logger->getProcessors()->toArray();
+        $this->assertCount(1, $processors);
+        $this->assertInstanceOf('Zend\Log\Processor\RequestId', $processors[0]);
+    }
+
     public function testAddProcessor()
     {
         $processor = new Backtrace();


### PR DESCRIPTION
There currently is no means to easily add processors to Loggers.

As the functionality is baked into the Logger class, I added support for a `providers` key in the options following the `writers` key as a guide.
