### PR TITLE
Update NotEmpty validator to use bitmasking

### DIFF
--- a/library/Zend/Validator/NotEmpty.php
+++ b/library/Zend/Validator/NotEmpty.php
@@ -14,19 +14,19 @@ use Zend\Stdlib\ArrayUtils;
 
 class NotEmpty extends AbstractValidator
 {
-    const BOOLEAN       = 1;
-    const INTEGER       = 2;
-    const FLOAT         = 4;
-    const STRING        = 8;
-    const ZERO          = 16;
-    const EMPTY_ARRAY   = 32;
-    const NULL          = 64;
-    const PHP           = 127;
-    const SPACE         = 128;
-    const OBJECT        = 256;
-    const OBJECT_STRING = 512;
-    const OBJECT_COUNT  = 1024;
-    const ALL           = 2047;
+    const BOOLEAN       = 0x001;
+    const INTEGER       = 0x002;
+    const FLOAT         = 0x004;
+    const STRING        = 0x008;
+    const ZERO          = 0x010;
+    const EMPTY_ARRAY   = 0x020;
+    const NULL          = 0x040;
+    const PHP           = 0x07F;
+    const SPACE         = 0x080;
+    const OBJECT        = 0x100;
+    const OBJECT_STRING = 0x200;
+    const OBJECT_COUNT  = 0x400;
+    const ALL           = 0x7FF;
 
     const INVALID  = 'notEmptyInvalid';
     const IS_EMPTY = 'isEmpty';
@@ -128,9 +128,9 @@ class NotEmpty extends AbstractValidator
             $detected = 0;
             foreach ($type as $value) {
                 if (is_int($value)) {
-                    $detected += $value;
+                    $detected |= $value;
                 } elseif (in_array($value, $this->constants)) {
-                    $detected += array_search($value, $this->constants);
+                    $detected |= array_search($value, $this->constants);
                 }
             }
 
@@ -167,8 +167,7 @@ class NotEmpty extends AbstractValidator
         $object  = false;
 
         // OBJECT_COUNT (countable object)
-        if ($type >= self::OBJECT_COUNT) {
-            $type -= self::OBJECT_COUNT;
+        if ($type & self::OBJECT_COUNT) {
             $object = true;
 
             if (is_object($value) && ($value instanceof \Countable) && (count($value) == 0)) {
@@ -178,8 +177,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // OBJECT_STRING (object's toString)
-        if ($type >= self::OBJECT_STRING) {
-            $type -= self::OBJECT_STRING;
+        if ($type & self::OBJECT_STRING) {
             $object = true;
 
             if ((is_object($value) && (!method_exists($value, '__toString'))) ||
@@ -190,8 +188,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // OBJECT (object)
-        if ($type >= self::OBJECT) {
-            $type -= self::OBJECT;
+        if ($type & self::OBJECT) {
             // fall trough, objects are always not empty
         } elseif ($object === false) {
             // object not allowed but object given -> return false
@@ -202,8 +199,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // SPACE ('   ')
-        if ($type >= self::SPACE) {
-            $type -= self::SPACE;
+        if ($type & self::SPACE) {
             if (is_string($value) && (preg_match('/^\s+$/s', $value))) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -211,8 +207,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // NULL (null)
-        if ($type >= self::NULL) {
-            $type -= self::NULL;
+        if ($type & self::NULL) {
             if ($value === null) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -220,8 +215,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // EMPTY_ARRAY (array())
-        if ($type >= self::EMPTY_ARRAY) {
-            $type -= self::EMPTY_ARRAY;
+        if ($type & self::EMPTY_ARRAY) {
             if (is_array($value) && ($value == array())) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -229,8 +223,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // ZERO ('0')
-        if ($type >= self::ZERO) {
-            $type -= self::ZERO;
+        if ($type & self::ZERO) {
             if (is_string($value) && ($value == '0')) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -238,8 +231,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // STRING ('')
-        if ($type >= self::STRING) {
-            $type -= self::STRING;
+        if ($type & self::STRING) {
             if (is_string($value) && ($value == '')) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -247,8 +239,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // FLOAT (0.0)
-        if ($type >= self::FLOAT) {
-            $type -= self::FLOAT;
+        if ($type & self::FLOAT) {
             if (is_float($value) && ($value == 0.0)) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -256,8 +247,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // INTEGER (0)
-        if ($type >= self::INTEGER) {
-            $type -= self::INTEGER;
+        if ($type & self::INTEGER) {
             if (is_int($value) && ($value == 0)) {
                 $this->error(self::IS_EMPTY);
                 return false;
@@ -265,8 +255,7 @@ class NotEmpty extends AbstractValidator
         }
 
         // BOOLEAN (false)
-        if ($type >= self::BOOLEAN) {
-            $type -= self::BOOLEAN;
+        if ($type & self::BOOLEAN) {
             if (is_bool($value) && ($value == false)) {
                 $this->error(self::IS_EMPTY);
                 return false;

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -363,7 +363,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     public function testMultiConstantNotation()
     {
         $filter = new NotEmpty(
-            NotEmpty::ZERO + NotEmpty::STRING + NotEmpty::BOOLEAN
+            NotEmpty::ZERO | NotEmpty::STRING | NotEmpty::BOOLEAN
         );
 
         $this->assertFalse($filter->isValid(false));

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -719,51 +719,6 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-
-    /**
-     * Ensures that the validator follows expected behavior so if a string is specified more than once, it doesn't
-     * cause different validations to run
-     *
-     * @param string  $string   Array of string type values
-     * @param integer $expected Expected type setting value
-     *
-     * @return void
-     *
-     * @dataProvider duplicateStringSettingProvider
-     */
-    public function testStringNotationWithDuplicate($string, $expected)
-    {
-        $type = array($string, $string);
-        $this->validator->setType($type);
-
-        $this->assertEquals($expected, $this->validator->getType());
-    }
-
-    /**
-     * Data provider for testStringNotationWithDuplicate method. Provides a string which will be duplicated. The test
-     * ensures that setting a string value more than once only turns on the appropriate bit once
-     *
-     * @return array
-     */
-    public function duplicateStringSettingProvider()
-    {
-        return array(
-            array('boolean',      NotEmpty::BOOLEAN),
-            array('integer',      NotEmpty::INTEGER),
-            array('float',        NotEmpty::FLOAT),
-            array('string',       NotEmpty::STRING),
-            array('zero',         NotEmpty::ZERO),
-            array('array',        NotEmpty::EMPTY_ARRAY),
-            array('null',         NotEmpty::NULL),
-            array('php',          NotEmpty::PHP),
-            array('space',        NotEmpty::SPACE),
-            array('object',       NotEmpty::OBJECT),
-            array('objectstring', NotEmpty::OBJECT_STRING),
-            array('objectcount',  NotEmpty::OBJECT_COUNT),
-            array('all',          NotEmpty::ALL),
-        );
-    }
-
     /**
      * Ensures that the validator follows expected behavior
      *

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -679,30 +679,44 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
      * Ensures that the validator follows expected behavior so if a string is specified more than once, it doesn't
      * cause different validations to run
      *
+     * @param string  $string   Array of string type values
+     * @param integer $expected Expected type setting value
+     *
      * @return void
+     *
+     * @dataProvider duplicateStringSettingProvider
      */
-    public function testStringNotationWithDuplicate()
+    public function testStringNotationWithDuplicate($string, $expected)
     {
-        $filter = new NotEmpty(
-            array(
-                // Should only count as 'boolean'
-                'type' => array('boolean', 'boolean')
-            )
-        );
+        $type = array($string, $string);
+        $this->validator->setType($type);
 
-        $this->assertFalse($filter->isValid(false));
-        $this->assertTrue($filter->isValid(true));
-        $this->assertTrue($filter->isValid(0));
-        $this->assertTrue($filter->isValid(1));
-        $this->assertTrue($filter->isValid((float) 0.0));
-        $this->assertTrue($filter->isValid((float) 1.0));
-        $this->assertTrue($filter->isValid(''));
-        $this->assertTrue($filter->isValid('abc'));
-        $this->assertTrue($filter->isValid('0'));
-        $this->assertTrue($filter->isValid('1'));
-        $this->assertTrue($filter->isValid(array()));
-        $this->assertTrue($filter->isValid(array('xxx')));
-        $this->assertTrue($filter->isValid(null));
+        $this->assertEquals($expected, $this->validator->getType());
+    }
+
+    /**
+     * Data provider for testStringNotationWithDuplicate method. Provides a string which will be duplicated. The test
+     * ensures that setting a string value more than once only turns on the appropriate bit once
+     *
+     * @return array
+     */
+    public function duplicateStringSettingProvider()
+    {
+        return array(
+            array('boolean',      NotEmpty::BOOLEAN),
+            array('integer',      NotEmpty::INTEGER),
+            array('float',        NotEmpty::FLOAT),
+            array('string',       NotEmpty::STRING),
+            array('zero',         NotEmpty::ZERO),
+            array('array',        NotEmpty::EMPTY_ARRAY),
+            array('null',         NotEmpty::NULL),
+            array('php',          NotEmpty::PHP),
+            array('space',        NotEmpty::SPACE),
+            array('object',       NotEmpty::OBJECT),
+            array('objectstring', NotEmpty::OBJECT_STRING),
+            array('objectcount',  NotEmpty::OBJECT_COUNT),
+            array('all',          NotEmpty::ALL),
+        );
     }
 
     /**

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -51,9 +51,12 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             array(null, false),
             array(array(), false),
             array(array(5), true),
+            array(0.0, false),
+            array(1.0, true),
+            array(new stdClass(), true),
         );
         foreach ($valuesExpected as $i => $element) {
-            $this->assertEquals($element[1], $this->validator->isValid($element[0]),
+                $this->assertEquals($element[1], $this->validator->isValid($element[0]),
                 "Failed test #$i");
         }
     }
@@ -400,6 +403,37 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($filter->isValid(''));
         $this->assertTrue($filter->isValid('abc'));
         $this->assertFalse($filter->isValid('0'));
+        $this->assertTrue($filter->isValid('1'));
+        $this->assertTrue($filter->isValid(array()));
+        $this->assertTrue($filter->isValid(array('xxx')));
+        $this->assertTrue($filter->isValid(null));
+    }
+
+
+    /**
+     * Ensures that the validator follows expected behavior so if a string is specified more than once, it doesn't
+     * cause different validations to run
+     *
+     * @return void
+     */
+    public function testStringNotationWithDuplicate()
+    {
+        $filter = new NotEmpty(
+            array(
+                // Should only count as 'boolean'
+                'type' => array('boolean', 'boolean')
+            )
+        );
+
+        $this->assertFalse($filter->isValid(false));
+        $this->assertTrue($filter->isValid(true));
+        $this->assertTrue($filter->isValid(0));
+        $this->assertTrue($filter->isValid(1));
+        $this->assertTrue($filter->isValid((float) 0.0));
+        $this->assertTrue($filter->isValid((float) 1.0));
+        $this->assertTrue($filter->isValid(''));
+        $this->assertTrue($filter->isValid('abc'));
+        $this->assertTrue($filter->isValid('0'));
         $this->assertTrue($filter->isValid('1'));
         $this->assertTrue($filter->isValid(array()));
         $this->assertTrue($filter->isValid(array('xxx')));

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -414,30 +414,44 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
      * Ensures that the validator follows expected behavior so if a string is specified more than once, it doesn't
      * cause different validations to run
      *
+     * @param string  $string   Array of string type values
+     * @param integer $expected Expected type setting value
+     *
      * @return void
+     *
+     * @dataProvider duplicateStringSettingProvider
      */
-    public function testStringNotationWithDuplicate()
+    public function testStringNotationWithDuplicate($string, $expected)
     {
-        $filter = new NotEmpty(
-            array(
-                // Should only count as 'boolean'
-                'type' => array('boolean', 'boolean')
-            )
-        );
+        $type = array($string, $string);
+        $this->validator->setType($type);
 
-        $this->assertFalse($filter->isValid(false));
-        $this->assertTrue($filter->isValid(true));
-        $this->assertTrue($filter->isValid(0));
-        $this->assertTrue($filter->isValid(1));
-        $this->assertTrue($filter->isValid((float) 0.0));
-        $this->assertTrue($filter->isValid((float) 1.0));
-        $this->assertTrue($filter->isValid(''));
-        $this->assertTrue($filter->isValid('abc'));
-        $this->assertTrue($filter->isValid('0'));
-        $this->assertTrue($filter->isValid('1'));
-        $this->assertTrue($filter->isValid(array()));
-        $this->assertTrue($filter->isValid(array('xxx')));
-        $this->assertTrue($filter->isValid(null));
+        $this->assertEquals($expected, $this->validator->getType());
+    }
+
+    /**
+     * Data provider for testStringNotationWithDuplicate method. Provides a string which will be duplicated. The test
+     * ensures that setting a string value more than once only turns on the appropriate bit once
+     *
+     * @return array
+     */
+    public function duplicateStringSettingProvider()
+    {
+        return array(
+            array('boolean',      NotEmpty::BOOLEAN),
+            array('integer',      NotEmpty::INTEGER),
+            array('float',        NotEmpty::FLOAT),
+            array('string',       NotEmpty::STRING),
+            array('zero',         NotEmpty::ZERO),
+            array('array',        NotEmpty::EMPTY_ARRAY),
+            array('null',         NotEmpty::NULL),
+            array('php',          NotEmpty::PHP),
+            array('space',        NotEmpty::SPACE),
+            array('object',       NotEmpty::OBJECT),
+            array('objectstring', NotEmpty::OBJECT_STRING),
+            array('objectcount',  NotEmpty::OBJECT_COUNT),
+            array('all',          NotEmpty::ALL),
+        );
     }
 
     /**

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -67,6 +67,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             array(array(5), true),
             array(0.0, false),
             array(1.0, true),
+            array(new stdClass(), true),
         );
     }
 
@@ -587,6 +588,25 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensures that the validator follows expected behavior
+     *
+     * @param mixed $value Value to test
+     * @param boolean $valid Expected validity of value
+     *
+     * @return void
+     *
+     * @dataProvider multiConstantNotationProvider
+     */
+    public function testMultiConstantBooleanOrNotation($value, $valid)
+    {
+        $this->validator = new NotEmpty(
+            NotEmpty::ZERO | NotEmpty::STRING | NotEmpty::BOOLEAN
+        );
+
+        $this->checkValidationValue($value, $valid);
+    }
+
+    /**
      * Provides values and their expected validity for boolean empty
      *
      * @return array
@@ -652,6 +672,37 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
             array(array('xxx'), true),
             array(null, true),
         );
+    }
+
+
+    /**
+     * Ensures that the validator follows expected behavior so if a string is specified more than once, it doesn't
+     * cause different validations to run
+     *
+     * @return void
+     */
+    public function testStringNotationWithDuplicate()
+    {
+        $filter = new NotEmpty(
+            array(
+                // Should only count as 'boolean'
+                'type' => array('boolean', 'boolean')
+            )
+        );
+
+        $this->assertFalse($filter->isValid(false));
+        $this->assertTrue($filter->isValid(true));
+        $this->assertTrue($filter->isValid(0));
+        $this->assertTrue($filter->isValid(1));
+        $this->assertTrue($filter->isValid((float) 0.0));
+        $this->assertTrue($filter->isValid((float) 1.0));
+        $this->assertTrue($filter->isValid(''));
+        $this->assertTrue($filter->isValid('abc'));
+        $this->assertTrue($filter->isValid('0'));
+        $this->assertTrue($filter->isValid('1'));
+        $this->assertTrue($filter->isValid(array()));
+        $this->assertTrue($filter->isValid(array('xxx')));
+        $this->assertTrue($filter->isValid(null));
     }
 
     /**


### PR DESCRIPTION
This updates the NotEmpty validator to use bitmasks instead of adding and subtracting the values. While it may not seem like a big deal, there are bugs that can crop up if a user creates code that adds in the same value more than once. For instance, without this patch, setting the type to array('boolean', 'boolean') means that the validator will behave as though you'd set it to array('integer'). 

Additionally, there's no reason to subtract the value of the bit mask from the $type value since we can use bitwise math to determine which flags are set. Using |= instead of adding means that even if we set the same flag lots of times, the value still will be the same. I've added a new unit test which will fail with the current NotEmpty implementation but will work with the updated implementation.

The documentation needs to be updated as well since the NotEmpty docs talk about adding the values together which is not the correct way to use these flags.

The values for the flags have also been updated to hex as it makes it a little more clear what's actually happening. Each validation value is a number represented by a single bit (with the exception of the combined values like PHP and ALL). I did not updated the 493, but it should probably be commented or otherwise indicated the values that are being checked by default (boolean, float, string, empty array, null and space).

The only other test changed was to add 3 more checks to ensure the default setting treat 0.0 as invalid, 1.0 as valid and an empty stdClass object as valid.
