### PR TITLE
Logger register shut down

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -61,6 +61,13 @@ class Logger implements LoggerInterface
     protected static $registeredErrorHandler = false;
 
     /**
+     * Registered shutdown error handler
+     *
+     * @var bool
+     */
+    protected static $registeredFatalErrorShutdownFunction = false;
+
+    /**
      * Registered exception handler
      *
      * @var bool
@@ -152,6 +159,10 @@ class Logger implements LoggerInterface
 
             if (isset($options['errorhandler']) && $options['errorhandler'] === true) {
                 static::registerErrorHandler($this);
+            }
+
+            if (isset($options['fatal_error_shutdownfunction']) && $options['fatal_error_shutdownfunction'] === true) {
+                static::registerFatalErrorShutdownFunction($this);
             }
 
         } elseif ($options) {
@@ -553,6 +564,41 @@ class Logger implements LoggerInterface
         restore_error_handler();
         static::$registeredErrorHandler = false;
     }
+
+
+    /**
+     * Register a shutdown handler to log fatal errors
+     *
+     * @link http://www.php.net/manual/function.register-shutdown-function.php
+     * @param  Logger $logger
+     * @return bool
+     */
+    public static function registerFatalErrorShutdownFunction(Logger $logger)
+    {
+        // Only register once per instance
+        if (static::$registeredFatalErrorShutdownFunction) {
+            return false;
+        }
+
+        $errorPriorityMap = static::$errorPriorityMap;
+
+        register_shutdown_function(function () use ($logger, $errorPriorityMap) {
+            $error = error_get_last();
+            if (null !== $error && $error['type'] === E_ERROR) {
+                $logger->log($errorPriorityMap[E_ERROR],
+                    $error['message'],
+                    array(
+                        'file' => $error['file'],
+                        'line' => $error['line']
+                    )
+                );
+            }
+        });
+
+        static::$registeredFatalErrorShutdownFunction = true;
+        return true;
+    }
+
 
     /**
      * Register logging system as an exception handler to log PHP exceptions

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -410,4 +410,29 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('test', $contents);
         $this->assertContains('second', $contents);
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRegisterFatalShutdownFunction()
+    {
+        $writer = new MockWriter;
+        $this->logger->addWriter($writer);
+
+        $result = Logger::registerFatalErrorShutdownFunction($this->logger);
+        $this->assertTrue($result);
+
+        // check for single error handler instance
+        $this->assertFalse(Logger::registerFatalErrorShutdownFunction($this->logger));
+
+        $self = $this;
+        register_shutdown_function(function () use ($writer, $self) {
+            ini_set('display_errors', true);
+            $self->assertEquals($writer->events[0]['message'], 'Call to undefined method ZendTest\Log\LoggerTest::callToNonExistingMethod()');
+        });
+
+        // Temporary hide errors, because we don't want the fatal error to fail the test
+        ini_set('display_errors', false);
+        $this->callToNonExistingMethod();
+    }
 }

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -427,7 +427,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $self = $this;
         register_shutdown_function(function () use ($writer, $self) {
-            ini_set('display_errors', true);
             $self->assertEquals($writer->events[0]['message'], 'Call to undefined method ZendTest\Log\LoggerTest::callToNonExistingMethod()');
         });
 

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -432,7 +432,6 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         });
 
         // Temporary hide errors, because we don't want the fatal error to fail the test
-        ini_set('display_errors', false);
-        $this->callToNonExistingMethod();
+        @$this->callToNonExistingMethod();
     }
 }


### PR DESCRIPTION
Fatal runtime errors cause execution of the script to halt, so the registered error handler will not be called to log the error. This PR adds an option to the logger to register a shutdown function to fetch the last error. This error will be logged if it was a fatal runtime error (E_ERROR)
