### PR TITLE
Updated PhpArray to expand paths using __DIR__

### DIFF
--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -85,8 +85,10 @@ class PhpArray extends AbstractWriter
         );
 
         try {
-            $string = $this->toString($config);
-            $string = str_replace("'" . dirname($filename), "__DIR__ . '", $string);
+            $dirname = str_replace('\\', '\\\\', dirname($filename));
+
+            $string  = $this->toString($config);
+            $string  = str_replace("'" . $dirname, "__DIR__ . '", $string);
 
             file_put_contents($filename, $string, $flags);
         } catch (\Exception $e) {

--- a/library/Zend/Config/Writer/PhpArray.php
+++ b/library/Zend/Config/Writer/PhpArray.php
@@ -85,6 +85,7 @@ class PhpArray extends AbstractWriter
         );
 
         try {
+            // for Windows, paths are escaped.
             $dirname = str_replace('\\', '\\\\', dirname($filename));
 
             $string  = $this->toString($config);

--- a/tests/ZendTest/Config/Writer/PhpArrayTest.php
+++ b/tests/ZendTest/Config/Writer/PhpArrayTest.php
@@ -99,6 +99,23 @@ class PhpArrayTest extends AbstractWriterTestCase
         $this->assertEquals($expected, $configString);
     }
 
+    public function testWriteConvertsPathToDirWhenWritingBackToFile()
+    {
+        $filename = $this->getTestAssetFileName();
+        file_put_contents($filename, file_get_contents(__DIR__ . '/_files/array.php'));
+
+        $this->writer->toFile($filename, include $filename);
+
+        // Ensure file endings are same
+        $expected = trim(file_get_contents(__DIR__ . '/_files/array.php'));
+        $expected = preg_replace("~\r\n|\n|\r~", PHP_EOL, $expected);
+
+        $result = trim(file_get_contents($filename));
+        $result = preg_replace("~\r\n|\n|\r~", PHP_EOL, $result);
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testSetUseBracketArraySyntaxReturnsFluentInterface()
     {
         $this->assertSame($this->writer, $this->writer->setUseBracketArraySyntax(true));

--- a/tests/ZendTest/Config/Writer/_files/array.php
+++ b/tests/ZendTest/Config/Writer/_files/array.php
@@ -1,0 +1,4 @@
+<?php
+return array(
+    'dir' => __DIR__ . '/foobar.php',
+);


### PR DESCRIPTION
When using Apigility config files with `__DIR__` are var_exported causing the real path to be written instead. This is an issue for development/production setups where the directory may vary from server to server. This change just does a str_replace on the path of the file being written with the `__DIR__` constant.
