### PR TITLE
Allow setting formatter for Zend\Log\Writer\Db via config options

### DIFF
--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -307,6 +307,26 @@ abstract class AbstractWriter implements WriterInterface
     }
 
     /**
+     * Get formatter
+     *
+     * @return Formatter\FormatterInterface
+     */
+    public function getFormatter()
+    {
+        return $this->formatter;
+    }
+
+    /**
+     * Check if the writer has a formatter
+     *
+     * @return bool
+     */
+    public function hasFormatter()
+    {
+        return $this->formatter instanceof Formatter\FormatterInterface;
+    }
+
+    /**
      * Set convert write errors to exception flag
      *
      * @param bool $convertErrors

--- a/library/Zend/Log/Writer/Db.php
+++ b/library/Zend/Log/Writer/Db.php
@@ -12,7 +12,6 @@ namespace Zend\Log\Writer;
 use Traversable;
 use Zend\Db\Adapter\Adapter;
 use Zend\Log\Exception;
-use Zend\Log\Formatter;
 use Zend\Log\Formatter\Db as DbFormatter;
 
 class Db extends AbstractWriter

--- a/library/Zend/Log/Writer/Db.php
+++ b/library/Zend/Log/Writer/Db.php
@@ -87,7 +87,9 @@ class Db extends AbstractWriter
             $this->separator = $separator;
         }
 
-        $this->setFormatter(new DbFormatter());
+        if (!$this->hasFormatter()) {
+            $this->setFormatter(new DbFormatter());
+        }
     }
 
     /**

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -102,4 +102,34 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[1]);
         $this->assertEquals(3, $this->readAttribute($filters[1], 'priority'));
     }
+
+    /**
+     * @covers Zend\Log\Writer\AbstractWriter::getFormatter
+     */
+    public function testFormatterDefaultsToNull()
+    {
+        $this->assertNull($this->_writer->getFormatter());
+    }
+
+    /**
+     * @covers Zend\Log\Writer\AbstractWriter::getFormatter
+     * @covers Zend\Log\Writer\AbstractWriter::setFormatter
+     */
+    public function testCanSetFormatter()
+    {
+        $formatter = new SimpleFormatter;
+        $this->_writer->setFormatter($formatter);
+        $this->assertSame($formatter, $this->_writer->getFormatter());
+    }
+
+    /**
+     * @covers Zend\Log\Writer\AbstractWriter::hasFormatter
+     */
+    public function testHasFormatter()
+    {
+        $this->assertFalse($this->_writer->hasFormatter());
+
+        $this->_writer->setFormatter(new SimpleFormatter);
+        $this->assertTrue($this->_writer->hasFormatter());
+    }
 }

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -245,5 +245,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $registeredFormatter = self::readAttribute($writer, 'formatter');
         $this->assertSame($formatter, $registeredFormatter);
+
+        $registeredDb = self::readAttribute($writer, 'db');
+        $this->assertSame($this->db, $registeredDb);
     }
 }

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -242,5 +242,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $filters = self::readAttribute($writer, 'filters');
         $this->assertCount(1, $filters);
         $this->assertEquals($filter, $filters[0]);
+
+        $registeredFormatter = self::readAttribute($writer, 'formatter');
+        $this->assertSame($formatter, $registeredFormatter);
     }
 }


### PR DESCRIPTION
This PR fixes issue #5881 and makes it possible to set a formatter in `Zend\Log\Writer\Db` via the config options.

The last line in `Zend\Log\Writer\Db::__construct()` ([line 90](https://github.com/zendframework/zf2/blob/master/library/Zend/Log/Writer/Db.php#L90)) always sets the formatter like this:

``` php
$this->setFormatter(new DbFormatter());
```

This PR has an additional check to see if there already is a formatter set which is provided via the config options. If there already is a formatter, that formatter has precedence over the default formatter. If no formatter is provided via the config options the default formatter `Zend\Log\Formatter\Db` (`DbFormatter` in the code above) will be used.
