### PR TITLE
parametrized-locale-aware routing

### DIFF
--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -156,6 +156,10 @@ class Part extends TreeRouteStack implements RouteInterface
                 }
             }
 
+            if (isset($options['translator']) && null !== ($locale = $match->getParam('locale', null))) {
+                $options['locale'] = $locale;
+            }
+
             foreach ($this->routes as $name => $route) {
                 if (($subMatch = $route->match($request, $nextOffset, $options)) instanceof RouteMatch) {
                     if ($match->getLength() + $subMatch->getLength() + $pathOffset === $pathLength) {
@@ -187,7 +191,6 @@ class Part extends TreeRouteStack implements RouteInterface
         $options['has_child'] = (isset($options['name']));
 
         $path   = $this->route->assemble($params, $options);
-        $params = array_diff_key($params, array_flip($this->route->getAssembledParams()));
 
         if (!isset($options['name'])) {
             if (!$this->mayTerminate) {

--- a/library/Zend/Mvc/Router/Http/Part.php
+++ b/library/Zend/Mvc/Router/Http/Part.php
@@ -156,7 +156,7 @@ class Part extends TreeRouteStack implements RouteInterface
                 }
             }
 
-            if (isset($options['translator']) && null !== ($locale = $match->getParam('locale', null))) {
+            if (isset($options['translator']) && !isset($options['locale']) && null !== ($locale = $match->getParam('locale', null))) {
                 $options['locale'] = $locale;
             }
 
@@ -190,7 +190,12 @@ class Part extends TreeRouteStack implements RouteInterface
 
         $options['has_child'] = (isset($options['name']));
 
+        if (isset($options['translator']) && !isset($options['locale']) && isset($params['locale'])) {
+            $options['locale'] = $params['locale'];
+        }
+
         $path   = $this->route->assemble($params, $options);
+        $params = array_diff_key($params, array_flip($this->route->getAssembledParams()));
 
         if (!isset($options['name'])) {
             if (!$this->mayTerminate) {

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -277,7 +277,7 @@ class Segment implements RouteInterface
 
             $translator = $options['translator'];
             $textDomain = (isset($options['text_domain']) ? $options['text_domain'] : 'default');
-            $locale     = (isset($options['locale']) ? $options['locale'] : null);
+            $locale     = (isset($options['locale']) ? $options['locale'] : (isset($mergedParams['locale']) ? $mergedParams['locale'] : null));
         }
 
         $path      = '';

--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -277,7 +277,7 @@ class Segment implements RouteInterface
 
             $translator = $options['translator'];
             $textDomain = (isset($options['text_domain']) ? $options['text_domain'] : 'default');
-            $locale     = (isset($options['locale']) ? $options['locale'] : (isset($mergedParams['locale']) ? $mergedParams['locale'] : null));
+            $locale     = (isset($options['locale']) ? $options['locale'] : null);
         }
 
         $path      = '';

--- a/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
@@ -144,8 +144,7 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
         $this->assertEquals('/de/hauptseite', $stack->assemble(array('locale' => 'de'), array('name' => 'foo/index')));
         $this->assertEquals('/en/homepage',   $stack->assemble(array('locale' => 'en'), array('name' => 'foo/index')));
     }
-    
-    
+
     public function testMatchRouteWithParameterLocale()
     {
         $stack = new TranslatorAwareTreeRouteStack();

--- a/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
@@ -17,6 +17,45 @@ use Zend\Uri\Http as HttpUri;
 
 class TranslatorAwareTreeRouteStackTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    protected $testFilesDir;
+    
+    /**
+     * @var Translator
+     */
+    protected $translator;
+    
+    /**
+     * @var array
+     */
+    protected $fooRoute;
+
+    public function setUp()
+    {
+        $this->testFilesDir = __DIR__ . '/_files';
+
+        $this->translator = new Translator();
+        $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.en.php', 'route', 'en');
+        $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.de.php', 'route', 'de');
+        
+        $this->fooRoute = array(
+            'type' => 'Segment',
+            'options' => array(
+                'route' => '/:locale',
+            ),
+            'child_routes' => array(
+                'index' => array(
+                    'type' => 'Segment',
+                    'options' => array(
+                        'route' => '/{homepage}',
+                    ),
+                ),
+            ),
+        );
+    }
+
     public function testTranslatorAwareInterfaceImplementation()
     {
         $stack = new TranslatorAwareTreeRouteStack();
@@ -91,5 +130,36 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
         $stack->addRoute('test', $route);
 
         $stack->assemble(array(), array('name' => 'test', 'translator' => $translator, 'uri' => $uri));
+    }
+    
+    public function testAssembleRouteWithParameterLocale()
+    {
+        $stack = new TranslatorAwareTreeRouteStack();
+        $stack->setTranslator($this->translator, 'route');
+        $stack->addRoute(
+            'foo',
+            $this->fooRoute
+        );
+
+        $this->assertEquals('/de/hauptseite', $stack->assemble(array('locale' => 'de'), array('name' => 'foo/index')));
+        $this->assertEquals('/en/homepage',   $stack->assemble(array('locale' => 'en'), array('name' => 'foo/index')));
+    }
+    
+    
+    public function testMatchRouteWithParameterLocale()
+    {
+        $stack = new TranslatorAwareTreeRouteStack();
+        $stack->setTranslator($this->translator, 'route');
+        $stack->addRoute(
+            'foo',
+            $this->fooRoute
+        );
+
+        $request = new Request();
+        $request->setUri('http://example.com/de/hauptseite');
+
+        $match = $stack->match($request);
+        $this->assertNotNull($match);
+        $this->assertEquals('foo/index', $match->getMatchedRouteName());
     }
 }

--- a/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TranslatorAwareTreeRouteStackTest.php
@@ -21,12 +21,12 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
      * @var string
      */
     protected $testFilesDir;
-    
+
     /**
      * @var Translator
      */
     protected $translator;
-    
+
     /**
      * @var array
      */
@@ -39,7 +39,7 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
         $this->translator = new Translator();
         $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.en.php', 'route', 'en');
         $this->translator->addTranslationFile('phpArray', $this->testFilesDir . '/tokens.de.php', 'route', 'de');
-        
+
         $this->fooRoute = array(
             'type' => 'Segment',
             'options' => array(
@@ -131,7 +131,7 @@ class TranslatorAwareTreeRouteStackTest extends TestCase
 
         $stack->assemble(array(), array('name' => 'test', 'translator' => $translator, 'uri' => $uri));
     }
-    
+
     public function testAssembleRouteWithParameterLocale()
     {
         $stack = new TranslatorAwareTreeRouteStack();

--- a/tests/ZendTest/Mvc/Router/Http/_files/tokens.de.php
+++ b/tests/ZendTest/Mvc/Router/Http/_files/tokens.de.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+    'homepage' => 'hauptseite',
+);
+

--- a/tests/ZendTest/Mvc/Router/Http/_files/tokens.de.php
+++ b/tests/ZendTest/Mvc/Router/Http/_files/tokens.de.php
@@ -2,4 +2,3 @@
 return array(
     'homepage' => 'hauptseite',
 );
-

--- a/tests/ZendTest/Mvc/Router/Http/_files/tokens.en.php
+++ b/tests/ZendTest/Mvc/Router/Http/_files/tokens.en.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+    'homepage' => 'homepage',
+);
+

--- a/tests/ZendTest/Mvc/Router/Http/_files/tokens.en.php
+++ b/tests/ZendTest/Mvc/Router/Http/_files/tokens.en.php
@@ -2,4 +2,3 @@
 return array(
     'homepage' => 'homepage',
 );
-


### PR DESCRIPTION
For translation-aware routers, i.e. TranslatorAwareTreeRouteStack:

If parameter „locale“ is detected during routing (either matching or
assembling), the translator will use this locale instead of a default
one. By doing so, the following route is possible:

   /:locale/{NEWS}/{TODAY}

Which would match/assemble with/to:

   /en/news/today
   /de/neues/heute

with translations (excerpt for locale 'de': 'NEWS' => 'neues', 'TODAY' => 'heute').
