### PR TITLE
Hotfix/5640 for bug in nested Zend\Form\Element\Collection::extract() recursion

### DIFF
--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -714,13 +714,13 @@ class CollectionTest extends TestCase
             }
         };
     }
-    
+
     public function testNestedCollections()
     {
         // @see https://github.com/zendframework/zf2/issues/5640
         $addressesFieldeset = new \ZendTest\Form\TestAsset\AddressFieldset();
         $addressesFieldeset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
-    
+
         $form = new Form();
         $form->setHydrator(new ObjectPropertyHydrator());
         $form->add(array(
@@ -731,31 +731,31 @@ class CollectionTest extends TestCase
                 'count' => 2
             ),
         ));
-    
+
         $data = array(
             array('number' => '0000000001', 'street' => 'street1'),
             array('number' => '0000000002', 'street' => 'street2'),
         );
-    
+
         $phone1 = new Phone();
         $phone1->setNumber($data[0]['number']);
-    
+
         $phone2 = new Phone();
         $phone2->setNumber($data[1]['number']);
-    
+
         $address1 = new Address();
         $address1->setStreet($data[0]['street']);
         $address1->setPhones(array($phone1));
-    
+
         $address2 = new Address();
         $address2->setStreet($data[1]['street']);
         $address2->setPhones(array($phone2));
-    
+
         $customer = new stdClass();
         $customer->addresses = array($address1, $address2);
-    
+
         $form->bind($customer);
-    
+
         //test for object binding
         foreach ($form->get('addresses')->getFieldsets() as $_fieldset) {
             $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Address', $_fieldset->getObject());
@@ -772,7 +772,7 @@ class CollectionTest extends TestCase
                 }
             }
         }
-    
+
         //test for correct extract and populate
         $index = 0;
         foreach ($form->get('addresses') as $_addresses) {

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -23,6 +23,8 @@ use ZendTest\Form\TestAsset\ArrayModel;
 use ZendTest\Form\TestAsset\CustomCollection;
 use ZendTest\Form\TestAsset\Entity\Product;
 use ZendTest\Form\TestAsset\ProductFieldset;
+use ZendTest\Form\TestAsset\Entity\Address;
+use ZendTest\Form\TestAsset\Entity\Phone;
 
 class CollectionTest extends TestCase
 {
@@ -712,15 +714,12 @@ class CollectionTest extends TestCase
             }
         };
     }
-
+    
     public function testNestedCollections()
     {
         // @see https://github.com/zendframework/zf2/issues/5640
         $addressesFieldeset = new \ZendTest\Form\TestAsset\AddressFieldset();
         $addressesFieldeset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
-    
-        $phonesFieldset = new \ZendTest\Form\TestAsset\PhoneFieldset();
-        $phonesFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
     
         $form = new Form();
         $form->setHydrator(new ObjectPropertyHydrator());
@@ -733,23 +732,56 @@ class CollectionTest extends TestCase
             ),
         ));
     
+        $data = array(
+            array('number' => '0000000001', 'street' => 'street1'),
+            array('number' => '0000000002', 'street' => 'street2'),
+        );
+    
         $phone1 = new Phone();
-        $phone1->setNumber('0000000001');
+        $phone1->setNumber($data[0]['number']);
     
         $phone2 = new Phone();
-        $phone2->setNumber('0000000002');
+        $phone2->setNumber($data[1]['number']);
     
         $address1 = new Address();
-        $address1->setStreet('street');
+        $address1->setStreet($data[0]['street']);
         $address1->setPhones(array($phone1));
     
         $address2 = new Address();
-        $address2->setStreet('street');
+        $address2->setStreet($data[1]['street']);
         $address2->setPhones(array($phone2));
     
         $customer = new stdClass();
         $customer->addresses = array($address1, $address2);
     
         $form->bind($customer);
+    
+        //test for object binding
+        foreach ($form->get('addresses')->getFieldsets() as $_fieldset) {
+            $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Address', $_fieldset->getObject());
+            foreach ($_fieldset->getFieldsets() as $_childFieldsetName => $_childFieldset) {
+                switch ($_childFieldsetName) {
+                    case 'city':
+                        $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\City', $_childFieldset->getObject());
+                        break;
+                    case 'phones':
+                        foreach ($_childFieldset->getFieldsets() as $_phoneFieldset) {
+                            $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Phone', $_phoneFieldset->getObject());
+                        }
+                        break;
+                }
+            }
+        }
+    
+        //test for correct extract and populate
+        $index = 0;
+        foreach ($form->get('addresses') as $_addresses) {
+            $this->assertEquals($data[$index]['street'], $_addresses->get('street')->getValue());
+            //assuming data has just 1 phone entry
+            foreach ($_addresses->get('phones') as $phone) {
+                $this->assertEquals($data[$index]['number'], $phone->get('number')->getValue());
+            }
+            $index++;
+        }
     }
 }

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -712,4 +712,44 @@ class CollectionTest extends TestCase
             }
         };
     }
+
+    public function testNestedCollections()
+    {
+        // @see https://github.com/zendframework/zf2/issues/5640
+        $addressesFieldeset = new \ZendTest\Form\TestAsset\AddressFieldset();
+        $addressesFieldeset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+    
+        $phonesFieldset = new \ZendTest\Form\TestAsset\PhoneFieldset();
+        $phonesFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+    
+        $form = new Form();
+        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->add(array(
+            'name' => 'addresses',
+            'type' => 'Collection',
+            'options' => array(
+                'target_element' => $addressesFieldeset,
+                'count' => 2
+            ),
+        ));
+    
+        $phone1 = new Phone();
+        $phone1->setNumber('0000000001');
+    
+        $phone2 = new Phone();
+        $phone2->setNumber('0000000002');
+    
+        $address1 = new Address();
+        $address1->setStreet('street');
+        $address1->setPhones(array($phone1));
+    
+        $address2 = new Address();
+        $address2->setStreet('street');
+        $address2->setPhones(array($phone2));
+    
+        $customer = new stdClass();
+        $customer->addresses = array($address1, $address2);
+    
+        $form->bind($customer);
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/AddressFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/AddressFieldset.php
@@ -29,6 +29,16 @@ class AddressFieldset extends Fieldset implements InputFilterProviderInterface
 
         $this->add($street);
         $this->add($city);
+
+        $phones = new \Zend\Form\Element\Collection('phones');
+        $phones->setLabel('Phone numbers')
+               ->setOptions(array(
+                    'count'          => 2,
+                    'allow_add'      => true,
+                    'allow_remove'   => true,
+                    'target_element' => new PhoneFieldset(),
+               ));
+        $this->add($phones);
     }
 
     /**

--- a/tests/ZendTest/Form/TestAsset/Entity/Address.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Address.php
@@ -29,7 +29,7 @@ class Address
 
     /**
      * @param $street
-     * @return Address
+     * @return self
      */
     public function setStreet($street)
     {
@@ -47,7 +47,7 @@ class Address
 
     /**
      * @param City $city
-     * @return Address
+     * @return self
      */
     public function setCity(City $city)
     {
@@ -65,7 +65,7 @@ class Address
 
     /**
      * @param array $phones
-     * @return Address
+     * @return self
      */
     public function setPhones(array $phones)
     {

--- a/tests/ZendTest/Form/TestAsset/Entity/Address.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Address.php
@@ -21,6 +21,11 @@ class Address
      */
     protected $city;
 
+    /**
+     * @var array
+     */
+    protected $phones = array();
+
 
     /**
      * @param $street
@@ -56,5 +61,23 @@ class Address
     public function getCity()
     {
         return $this->city;
+    }
+
+    /**
+     * @param array $phones
+     * @return Address
+     */
+    public function setPhones(array $phones)
+    {
+        $this->phones = $phones;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPhones()
+    {
+        return $this->phones;
     }
 }

--- a/tests/ZendTest/Form/TestAsset/Entity/Phone.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Phone.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/tests/ZendTest/Form/TestAsset/Entity/Phone.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Phone.php
@@ -18,7 +18,7 @@ class Phone
 
     /**
      * @param string $number
-     * @return Phone
+     * @return self
      */
     public function setNumber($number)
     {

--- a/tests/ZendTest/Form/TestAsset/Entity/Phone.php
+++ b/tests/ZendTest/Form/TestAsset/Entity/Phone.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Entity;
+
+class Phone
+{
+    /**
+     * @var string
+     */
+    protected $number;
+
+    /**
+     * @param string $number
+     * @return Phone
+     */
+    public function setNumber($number)
+    {
+        $this->number = $number;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+}

--- a/tests/ZendTest/Form/TestAsset/PhoneFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/PhoneFieldset.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/tests/ZendTest/Form/TestAsset/PhoneFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/PhoneFieldset.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2013 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+
+use Zend\Form\Fieldset;
+use Zend\Form\Element;
+use Zend\Stdlib\Hydrator\ClassMethods as ClassMethodsHydrator;
+use ZendTest\Form\TestAsset\Entity\Phone;
+
+class PhoneFieldset extends Fieldset
+{
+    public function __construct()
+    {
+        parent::__construct('phones');
+
+        $this->setHydrator(new ClassMethodsHydrator)
+             ->setObject(new Phone());
+
+        $id = new Element\Hidden('id');
+        $this->add($id);
+
+        $number = new Element\Text('number');
+        $number->setLabel('Number')
+               ->setAttribute('class', 'form-control');
+        $this->add($number);
+    }
+}


### PR DESCRIPTION
This PR fixes a problem in "Recursively extract and populate values for nested fieldsets" for the use case of nested collections as described by #5640

Maybe this is not the definitive solution, but it includes a test for nested collections and a fix that solves the problem without breaking any other tested behaviours.
