### PR TITLE
Nicaraguan phone numbering plan

### DIFF
--- a/library/Zend/I18n/Validator/PhoneNumber/NI.php
+++ b/library/Zend/I18n/Validator/PhoneNumber/NI.php
@@ -13,7 +13,7 @@ return array(
         'national' => array(
             'general' => '/^[128]\\d{7}$/',
             'fixed' => '/^2\\d{7}$/',
-            'mobile' => '/^8\\d{7}$/',
+            'mobile' => '/^[78]\\d{7}$/',
             'tollfree' => '/^1800\\d{4}$/',
             'emergency' => '/^118$/',
         ),


### PR DESCRIPTION
Nicaraguan phone numbering plan now supports mobile numbers starting with 7
