### PR TITLE
Case-insensitive country for the PhoneNumber validator class

### DIFF
--- a/library/Zend/I18n/Validator/PhoneNumber.php
+++ b/library/Zend/I18n/Validator/PhoneNumber.php
@@ -151,7 +151,7 @@ class PhoneNumber extends AbstractValidator
      */
     public function setCountry($country)
     {
-        $this->country = $country;
+        $this->country = strtoupper($country);
 
         return $this;
     }


### PR DESCRIPTION
Recently, I have been working on some form validations and wanted to use the PhoneNumber validator class in my input filter.I realized that It would be awesome if we could set the country in a case-insensitive way :)
