### PR TITLE
Fix bug in json prettyprint

### DIFF
--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -369,10 +369,12 @@ class Json
             } else {
                 $result .= ($inLiteral ?  '' : $prefix) . $token;
 
+                //remove escaped backslash sequences causing false positives in next check
+                $token = str_replace('\\', '', $token);
                 // Count # of unescaped double-quotes in token, subtract # of
                 // escaped double-quotes and if the result is odd then we are
                 // inside a string literal
-                if ((substr_count($token, "\"")-substr_count($token, "\\\"")) % 2 != 0) {
+                if ((substr_count($token, '"')-substr_count($token, '\\"')) % 2 != 0) {
                     $inLiteral = !$inLiteral;
                 }
             }

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -868,6 +868,19 @@ EOB;
         $this->assertSame($expected, $pretty);
     }
 
+    public function testPrettyPrintDoublequoteFollowingEscapedBackslashShouldNotBeTreatedAsEscaped()
+    {
+        $this->assertEquals(
+            "[\n\t1,\n\t\"\\\\\",\n\t3\n]",
+            Json\Json::prettyPrint(Json\Json::encode(array(1, '\\', 3)))
+        );
+
+        $this->assertEquals(
+            "{\n\t\"a\":\"\\\\\"\n}",
+           Json\Json::prettyPrint(Json\Json::encode(array('a' => '\\')))
+        );
+    }
+
     /**
      * @group ZF-11167
      */


### PR DESCRIPTION
```
Fixes #5889
Double quote was erroneously treated as escaped if preceded by
escaped backslash sequence
```
