### PR TITLE
Added testcase for BlockCipher using 0 values

### DIFF
--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -149,6 +149,23 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testEncryptDecryptUsingZero()
+    {
+        $possibleValues = array(0, 0.0, '0');
+        $this->blockCipher->setKey('test');
+        $this->blockCipher->setKeyIteration(1000);
+        foreach ($this->blockCipher->getCipherSupportedAlgorithms() as $algo) {
+            $this->blockCipher->setCipherAlgorithm($algo);
+
+            foreach($passibleValues as $plaintext) {
+                $encrypted = $this->blockCipher->encrypt($plaintext);
+                $this->assertTrue(!empty($encrypted));
+                $decrypted = $this->blockCipher->decrypt($encrypted);
+                $this->assertEquals($decrypted, $plaintext);
+            }
+        }
+    }
+
     public function testDecryptAuthFail()
     {
         $this->blockCipher->setKey('test');


### PR DESCRIPTION
Tested against 0 (integer), 0.0 (float), and '0' (string). All 3 values should be accepted
