### PR TITLE
Allow merging text domains without plural rules

### DIFF
--- a/library/Zend/I18n/Translator/TextDomain.php
+++ b/library/Zend/I18n/Translator/TextDomain.php
@@ -26,6 +26,13 @@ class TextDomain extends ArrayObject
     protected $pluralRule;
 
     /**
+     * Default plural rule shared between instances.
+     *
+     * @var PluralRule
+     */
+    protected static $defaultPluralRule;
+
+    /**
      * Set the plural rule
      *
      * @param  PluralRule $rule
@@ -40,17 +47,40 @@ class TextDomain extends ArrayObject
     /**
      * Get the plural rule.
      *
-     * Lazy loads a default rule if none already registered
-     *
-     * @return PluralRule
+     * @param  bool $fallbackToDefaultRule
+     * @return PluralRule|null
      */
-    public function getPluralRule()
+    public function getPluralRule($fallbackToDefaultRule = true)
     {
-        if ($this->pluralRule === null) {
-            $this->setPluralRule(PluralRule::fromString('nplurals=2; plural=n != 1;'));
+        if ($this->pluralRule === null && $fallbackToDefaultRule) {
+            return self::getDefaultPluralRule();
         }
 
         return $this->pluralRule;
+    }
+
+    /**
+     * Checks whether the text domain has a plural rule.
+     *
+     * @return bool
+     */
+    public function hasPluralRule()
+    {
+        return ($this->pluralRule !== null);
+    }
+
+    /**
+     * Returns a shared default plural rule.
+     *
+     * @return PluralRule
+     */
+    public static function getDefaultPluralRule()
+    {
+        if (self::$defaultPluralRule === null) {
+            self::$defaultPluralRule = PluralRule::fromString('nplurals=2; plural=n != 1;');
+        }
+
+        return self::$defaultPluralRule;
     }
 
     /**
@@ -66,8 +96,12 @@ class TextDomain extends ArrayObject
      */
     public function merge(TextDomain $textDomain)
     {
-        if ($this->getPluralRule()->getNumPlurals() !== $textDomain->getPluralRule()->getNumPlurals()) {
-            throw new Exception\RuntimeException('Plural rule of merging text domain is not compatible with the current one');
+        if ($this->hasPluralRule() && $textDomain->hasPluralRule()) {
+            if ($this->getPluralRule()->getNumPlurals() !== $textDomain->getPluralRule()->getNumPlurals()) {
+                throw new Exception\RuntimeException('Plural rule of merging text domain is not compatible with the current one');
+            }
+        } elseif ($textDomain->hasPluralRule()) {
+            $this->setPluralRule($textDomain->getPluralRule());
         }
 
         $this->exchangeArray(

--- a/tests/ZendTest/I18n/Translator/TextDomainTest.php
+++ b/tests/ZendTest/I18n/Translator/TextDomainTest.php
@@ -60,8 +60,41 @@ class TextDomainTest extends TestCase
 
         $domainA = new TextDomain();
         $domainB = new TextDomain();
+        $domainA->setPluralRule(PluralRule::fromString('nplurals=3; plural=n'));
+        $domainB->setPluralRule(PluralRule::fromString('nplurals=2; plural=n'));
+
+        $domainA->merge($domainB);
+    }
+
+    public function testMergingTextDomainsWithPluralRules()
+    {
+        $domainA = new TextDomain();
+        $domainB = new TextDomain();
+
+        $domainA->merge($domainB);
+        $this->assertFalse($domainA->hasPluralRule());
+        $this->assertFalse($domainB->hasPluralRule());
+    }
+
+    public function testMergingTextDomainWithPluralRuleIntoTextDomainWithoutPluralRule()
+    {
+        $domainA = new TextDomain();
+        $domainB = new TextDomain();
         $domainB->setPluralRule(PluralRule::fromString('nplurals=3; plural=n'));
 
         $domainA->merge($domainB);
+        $this->assertEquals(3, $domainA->getPluralRule()->getNumPlurals());
+        $this->assertEquals(3, $domainB->getPluralRule()->getNumPlurals());
+    }
+
+    public function testMergingTextDomainWithoutPluralRuleIntoTextDomainWithPluralRule()
+    {
+        $domainA = new TextDomain();
+        $domainB = new TextDomain();
+        $domainA->setPluralRule(PluralRule::fromString('nplurals=3; plural=n'));
+
+        $domainA->merge($domainB);
+        $this->assertEquals(3, $domainA->getPluralRule()->getNumPlurals());
+        $this->assertFalse($domainB->hasPluralRule());
     }
 }


### PR DESCRIPTION
This pull request fixes the issue addressed by #5277 in a much cleaner way. Thus closes #5277.
