### PR TITLE
minor improvements to form labels

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -17,7 +17,7 @@ class Element implements
     ElementAttributeRemovalInterface,
     ElementInterface,
     InitializableInterface,
-    LabelOptionsAwareInterface
+    LabelAwareInterface
 {
     /**
      * @var array

--- a/library/Zend/Form/LabelAwareInterface.php
+++ b/library/Zend/Form/LabelAwareInterface.php
@@ -9,8 +9,23 @@
 
 namespace Zend\Form;
 
-interface LabelOptionsAwareInterface
+interface LabelAwareInterface
 {
+    /**
+     * Set the label (if any) used for this element
+     *
+     * @param  $label
+     * @return ElementInterface
+     */
+    public function setLabel($label);
+
+    /**
+     * Retrieve the label (if any) used for this element
+     *
+     * @return string
+     */
+    public function getLabel();
+
     /**
      * Set the attributes to use with the label
      *

--- a/library/Zend/Form/LabelAwareTrait.php
+++ b/library/Zend/Form/LabelAwareTrait.php
@@ -9,7 +9,9 @@
 
 namespace Zend\Form;
 
-class LabelAwareTrait
+use Traversable;
+
+trait LabelAwareTrait
 {
     /**
      * Label specific html attributes

--- a/library/Zend/Form/LabelAwareTrait.php
+++ b/library/Zend/Form/LabelAwareTrait.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Form;
 
-class LabelOptionsAwareTrait
+class LabelAwareTrait
 {
     /**
      * Label specific html attributes
@@ -29,7 +29,7 @@ class LabelOptionsAwareTrait
      * Set the attributes to use with the label
      *
      * @param array $labelAttributes
-     * @return LabelOptionsAwareInterface
+     * @return LabelAwareInterface
      */
     public function setLabelAttributes(array $labelAttributes)
     {

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -11,7 +11,7 @@ namespace Zend\Form\View\Helper;
 
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
-use Zend\Form\LabelOptionsAwareInterface;
+use Zend\Form\LabelAwareInterface;
 
 class FormButton extends FormInput
 {
@@ -93,7 +93,7 @@ class FormButton extends FormInput
             }
         }
 
-        if ($element instanceof LabelOptionsAwareInterface) {
+        if ($element instanceof LabelAwareInterface) {
             if (! $element->getLabelOption('disable_html_escape')) {
                 $escapeHtmlHelper = $this->getEscapeHtmlHelper();
                 $buttonContent = $escapeHtmlHelper($buttonContent);

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -93,11 +93,9 @@ class FormButton extends FormInput
             }
         }
 
-        if ($element instanceof LabelAwareInterface) {
-            if (! $element->getLabelOption('disable_html_escape')) {
-                $escapeHtmlHelper = $this->getEscapeHtmlHelper();
-                $buttonContent = $escapeHtmlHelper($buttonContent);
-            }
+        if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
+            $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+            $buttonContent = $escapeHtmlHelper($buttonContent);
         }
 
         return $openTag . $buttonContent . $this->closeTag();

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -15,7 +15,6 @@ use Zend\Form\ElementInterface;
 use Zend\Form\Element\Collection as CollectionElement;
 use Zend\Form\FieldsetInterface;
 use Zend\Form\LabelAwareInterface;
-use Zend\Form\LabelOptionsAwareInterface;
 use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
 
 class FormCollection extends AbstractHelper
@@ -103,7 +102,6 @@ class FormCollection extends AbstractHelper
             return '';
         }
 
-        $attributes       = $element->getAttributes();
         $markup           = '';
         $templateMarkup   = '';
         $elementHelper    = $this->getElementHelper();
@@ -125,10 +123,7 @@ class FormCollection extends AbstractHelper
         if ($this->shouldWrap) {
             $attributes = $element->getAttributes();
             unset($attributes['name']);
-            $attributesString = '';
-            if (count($attributes)) {
-                $attributesString = ' ' . $this->createAttributesString($attributes);
-            }
+            $attributesString = count($attributes) ? ' ' . $this->createAttributesString($attributes) : '';
 
             $label = $element->getLabel();
             $legend = '';

--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -14,6 +14,8 @@ use Zend\Form\Element;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\Collection as CollectionElement;
 use Zend\Form\FieldsetInterface;
+use Zend\Form\LabelAwareInterface;
+use Zend\Form\LabelOptionsAwareInterface;
 use Zend\View\Helper\AbstractHelper as BaseAbstractHelper;
 
 class FormCollection extends AbstractHelper
@@ -104,7 +106,6 @@ class FormCollection extends AbstractHelper
         $attributes       = $element->getAttributes();
         $markup           = '';
         $templateMarkup   = '';
-        $escapeHtmlHelper = $this->getEscapeHtmlHelper();
         $elementHelper    = $this->getElementHelper();
         $fieldsetHelper   = $this->getFieldsetHelper();
 
@@ -132,8 +133,6 @@ class FormCollection extends AbstractHelper
             $label = $element->getLabel();
             $legend = '';
 
-            $label = $element->getLabel();
-            $labelMarkup = '';
             if (!empty($label)) {
                 if (null !== ($translator = $this->getTranslator())) {
                     $label = $translator->translate(
@@ -142,9 +141,14 @@ class FormCollection extends AbstractHelper
                     );
                 }
 
+                if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
+                    $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+                    $label = $escapeHtmlHelper($label);
+                }
+
                 $legend = sprintf(
                     $this->labelWrapper,
-                    $escapeHtmlHelper($label)
+                    $label
                 );
             }
 

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -11,7 +11,7 @@ namespace Zend\Form\View\Helper;
 
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
-use Zend\Form\LabelOptionsAwareInterface;
+use Zend\Form\LabelAwareInterface;
 
 class FormLabel extends AbstractHelper
 {
@@ -64,7 +64,7 @@ class FormLabel extends AbstractHelper
                 );
             }
 
-            if ($element instanceof LabelOptionsAwareInterface) {
+            if ($element instanceof LabelAwareInterface) {
                 if (! $element->getLabelOption('disable_html_escape')) {
                     $escapeHtmlHelper = $this->getEscapeHtmlHelper();
                     $label = $escapeHtmlHelper($label);
@@ -127,7 +127,7 @@ class FormLabel extends AbstractHelper
         }
 
         $labelAttributes = array();
-        if ($attributesOrElement instanceof LabelOptionsAwareInterface) {
+        if ($attributesOrElement instanceof LabelAwareInterface) {
             $labelAttributes = $attributesOrElement->getLabelAttributes();
         }
 

--- a/library/Zend/Form/View/Helper/FormLabel.php
+++ b/library/Zend/Form/View/Helper/FormLabel.php
@@ -64,11 +64,9 @@ class FormLabel extends AbstractHelper
                 );
             }
 
-            if ($element instanceof LabelAwareInterface) {
-                if (! $element->getLabelOption('disable_html_escape')) {
-                    $escapeHtmlHelper = $this->getEscapeHtmlHelper();
-                    $label = $escapeHtmlHelper($label);
-                }
+            if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
+                $escapeHtmlHelper = $this->getEscapeHtmlHelper();
+                $label = $escapeHtmlHelper($label);
             }
         }
 

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -12,7 +12,7 @@ namespace Zend\Form\View\Helper;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\MultiCheckbox as MultiCheckboxElement;
 use Zend\Form\Exception;
-use Zend\Form\LabelOptionsAwareInterface;
+use Zend\Form\LabelAwareInterface;
 
 class FormMultiCheckbox extends FormInput
 {
@@ -156,7 +156,7 @@ class FormMultiCheckbox extends FormInput
         $globalLabelAttributes = array();
         $closingBracket   = $this->getInlineClosingBracket();
 
-        if ($element instanceof LabelOptionsAwareInterface) {
+        if ($element instanceof LabelAwareInterface) {
             $labelOptions = $element->getLabelOptions();
             $globalLabelAttributes = $element->getLabelAttributes();
         }
@@ -229,7 +229,7 @@ class FormMultiCheckbox extends FormInput
                 );
             }
 
-            if ($element instanceof LabelOptionsAwareInterface && !$element->getLabelOption('disable_html_escape')) {
+            if ($element instanceof LabelAwareInterface && !$element->getLabelOption('disable_html_escape')) {
                 $label = $escapeHtmlHelper($label);
             }
 

--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -149,7 +149,6 @@ class FormMultiCheckbox extends FormInput
         array $attributes)
     {
         $escapeHtmlHelper = $this->getEscapeHtmlHelper();
-        $labelOptions     = array();
         $labelHelper      = $this->getLabelHelper();
         $labelClose       = $labelHelper->closeTag();
         $labelPosition    = $this->getLabelPosition();
@@ -157,7 +156,6 @@ class FormMultiCheckbox extends FormInput
         $closingBracket   = $this->getInlineClosingBracket();
 
         if ($element instanceof LabelAwareInterface) {
-            $labelOptions = $element->getLabelOptions();
             $globalLabelAttributes = $element->getLabelAttributes();
         }
 
@@ -229,7 +227,7 @@ class FormMultiCheckbox extends FormInput
                 );
             }
 
-            if ($element instanceof LabelAwareInterface && !$element->getLabelOption('disable_html_escape')) {
+            if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
                 $label = $escapeHtmlHelper($label);
             }
 

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -12,7 +12,7 @@ namespace Zend\Form\View\Helper;
 use Zend\Form\Element\Button;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
-use Zend\Form\LabelOptionsAwareInterface;
+use Zend\Form\LabelAwareInterface;
 
 class FormRow extends AbstractHelper
 {
@@ -164,7 +164,7 @@ class FormRow extends AbstractHelper
             $labelOptions = array();
             $labelAttributes = array();
 
-            if ($element instanceof LabelOptionsAwareInterface) {
+            if ($element instanceof LabelAwareInterface) {
                 $labelOptions    = $element->getLabelOptions();
                 $labelAttributes = $element->getLabelAttributes();
 
@@ -189,7 +189,7 @@ class FormRow extends AbstractHelper
                 // Ensure element and label will be separated if element has an `id`-attribute.
                 // If element has label option `always_wrap` it will be nested in any case.
                 if ($element->hasAttribute('id')
-                    && ($element instanceof LabelOptionsAwareInterface && !$element->getLabelOption('always_wrap'))
+                    && ($element instanceof LabelAwareInterface && !$element->getLabelOption('always_wrap'))
                 ) {
                     $labelOpen = '';
                     $labelClose = '';
@@ -200,7 +200,7 @@ class FormRow extends AbstractHelper
                 }
 
                 if ($label !== '' && (!$element->hasAttribute('id'))
-                    || ($element instanceof LabelOptionsAwareInterface && $element->getLabelOption('always_wrap'))
+                    || ($element instanceof LabelAwareInterface && $element->getLabelOption('always_wrap'))
                 ) {
                     $label = '<span>' . $label . '</span>';
                 }

--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -161,16 +161,14 @@ class FormRow extends AbstractHelper
 
         if (isset($label) && '' !== $label) {
 
-            $labelOptions = array();
             $labelAttributes = array();
 
             if ($element instanceof LabelAwareInterface) {
-                $labelOptions    = $element->getLabelOptions();
                 $labelAttributes = $element->getLabelAttributes();
+            }
 
-                if (! $element->getLabelOption('disable_html_escape')) {
-                    $label = $escapeHtmlHelper($label);
-                }
+            if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
+                $label = $escapeHtmlHelper($label);
             }
 
             if (empty($labelAttributes)) {

--- a/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCollectionTest.php
@@ -363,4 +363,23 @@ class FormCollectionTest extends TestCase
         $this->assertAttributeEquals('foo', 'templateWrapper', $this->helper);
         $this->assertEquals('foo', $this->helper->getTemplateWrapper());
     }
+
+    public function testLabelIsEscapedByDefault()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('<strong>Some label</strong>');
+        $markup = $this->helper->render($collection);
+        $this->assertRegexp('#<fieldset(.*?)><legend>&lt;strong&gt;Some label&lt;/strong&gt;<\/legend>(.*?)<\/fieldset>#', $markup);
+    }
+
+    public function testCanDisableLabelHtmlEscape()
+    {
+        $form = $this->getForm();
+        $collection = $form->get('colors');
+        $collection->setLabel('<strong>Some label</strong>');
+        $collection->setLabelOptions(array('disable_html_escape' => true));
+        $markup = $this->helper->render($collection);
+        $this->assertRegexp('#<fieldset(.*?)><legend><strong>Some label</strong><\/legend>(.*?)<\/fieldset>#', $markup);
+    }
 }


### PR DESCRIPTION
the `LabelOptionsAwareInterface` was introduced in #4677 to preserve BC with 5.3.3, but since the whole functionality will make into 2.3 release and we're upping the minimum PHP version, some cleaning is due.

also minor cleanup subsequent to #5533 and reinstated #5539 new feature

it is important to merge this along with #4677 (which hasn't made yet into any release) before 2.3, otherwise this would become a bc break for the very PR it's trying to clean up. ;)
