### PR TITLE
Fix/5838 failing test

### DIFF
--- a/tests/ZendTest/Test/_files/Baz/src/Baz/Controller/IndexController.php
+++ b/tests/ZendTest/Test/_files/Baz/src/Baz/Controller/IndexController.php
@@ -50,7 +50,7 @@ class IndexController extends AbstractActionController
     public function customResponseAction()
     {
         $response = new Response();
-        $response->setStatusCode(999);
+        $response->setCustomStatusCode(999);
 
         return $response;
     }


### PR DESCRIPTION
#5838 test is failing because of an `InvalidArgumentException` thrown by `Response`. The test asset is not using the correct method for custom status codes: `setStatusCode()` only accepts valid HTTP codes since #5732.
