### PR TITLE
Hotfix/4785 csrf name conflicts

### DIFF
--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -121,7 +121,7 @@ class Csrf extends AbstractValidator
         $tokenId = $this->getTokenIdFromHash($value);
         $hash = $this->getValidationToken($tokenId);
 
-        if ($value !== $hash) {
+        if ($this->getTokenFromHash($value) !== $this->getTokenFromHash($hash)) {
             $this->error(self::NOT_SAME);
             return false;
         }

--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -74,6 +74,11 @@ class Csrf extends AbstractValidator
     protected $hashId;
 
     /**
+     * @var string
+     */
+    protected $format = '%s_%s';
+
+    /**
      * Constructor
      *
      * @param  array|Traversable $options
@@ -103,6 +108,9 @@ class Csrf extends AbstractValidator
                     break;
                 case 'timeout':
                     $this->setTimeout($value);
+                    break;
+                case 'format':
+                    $this->setFormat($value);
                     break;
                 default:
                     // ignore unknown options
@@ -321,7 +329,7 @@ class Csrf extends AbstractValidator
             $this->hash = md5($this->getSalt() . Rand::getBytes(32) .  $this->getName());
             static::$hashCache[$this->getSessionName()][$this->hashId] = $this->hash;
         }
-        $this->setValue(sprintf('%s_%s', $this->hashId, $this->hash));
+        $this->setValue(sprintf($this->getFormat(), $this->hashId, $this->hash));
         $this->initCsrfToken();
     }
 
@@ -330,6 +338,7 @@ class Csrf extends AbstractValidator
      *
      * Retrieve token from session, if it exists.
      *
+     * @param string $hashId
      * @return null|string
      */
     protected function getValidationToken($hashId = null)
@@ -339,5 +348,21 @@ class Csrf extends AbstractValidator
             return $session->hashList[$hashId];
         }
         return null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * @param string $format
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
     }
 }

--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -327,12 +327,11 @@ class Csrf extends AbstractValidator
         $session = $this->getSession();
 
         /**
-         * if no tokenId is passed we just grub the first one available.
-         * this handle validation of an old hash
+         * if no tokenId is passed we revert to the old behaviour
+         * @todo remove, here for BC
          */
-        if (! $tokenId && ! empty($session->tokenList)) {
-            $ids = array_keys($session->tokenList);
-            $tokenId = array_shift($ids);
+        if (! $tokenId && isset($session->hash)) {
+            return $session->hash;
         }
 
         if ($tokenId && isset($session->tokenList[$tokenId])) {

--- a/library/Zend/Validator/Csrf.php
+++ b/library/Zend/Validator/Csrf.php
@@ -216,14 +216,7 @@ class Csrf extends AbstractValidator
     public function getHash($regenerate = false)
     {
         if ((null === $this->hash) || $regenerate) {
-            if ($regenerate) {
-                $this->hash = null;
-            } else {
-                $this->hash = $this->getValidationToken($this->generateTokenId());
-            }
-            if (null === $this->hash) {
-                $this->generateHash();
-            }
+            $this->generateHash();
         }
         return $this->hash;
     }

--- a/tests/ZendTest/Form/FormElementManagerFactoryTest.php
+++ b/tests/ZendTest/Form/FormElementManagerFactoryTest.php
@@ -106,23 +106,14 @@ class FormElementManagerFactoryTest extends TestCase
     {
         $_SESSION = array();
         $formClass = 'ZendTest\Form\TestAsset\CustomForm';
-        $ref = new \ReflectionClass('Zend\Validator\Csrf');
-        $hashPropRef = $ref->getProperty('hash');
-        $hashPropRef->setAccessible(true);
-        $hashCache = $ref->getProperty('hashCache');
-        $hashCache->setAccessible(true);
-        $hashCache->setValue(new Csrf, array());
-        //check bare born
+
         $preForm = new $formClass;
         $preForm->prepare();
         $requestHash = $preForm->get('csrf')->getValue();
-        SessionContainer::setDefaultManager(null);
-        $hashCache->setValue(new Csrf, array());
 
         $postForm = $this->manager->get($formClass);
         $postCsrf = $postForm->get('csrf')->getCsrfValidator();
-        $storedHash = $postCsrf->getHash();
 
-        $this->assertEquals($requestHash, $storedHash, 'Test csrf validation');
+        $this->assertTrue($postCsrf->isValid($requestHash), 'Test csrf validation');
     }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -196,4 +196,16 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($validator->isValid($hash));
     }
+
+    public function testMultipleValidatorsDontConflict()
+    {
+        $validatorOne = new Csrf();
+        $validatorTwo = new Csrf();
+
+        $containerOne = $validatorOne->getSession();
+        $containerTwo = $validatorOne->getSession();
+
+        $this->assertSame($containerOne, $containerTwo);
+        $this->assertNotEquals($validatorOne->getHash() , $validatorTwo->getHash());
+    }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -249,4 +249,15 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->validator->isValid($hash));
     }
+
+    public function testCanValidateHasheWithoutId()
+    {
+        $method = new \ReflectionMethod(get_class($this->validator), 'getTokenFromHash');
+        $method->setAccessible(true);
+
+        $hash = $this->validator->getHash();
+        $bareToken = $method->invoke($this->validator, $hash);
+
+        $this->assertTrue($this->validator->isValid($bareToken));
+    }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -235,4 +235,18 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($validatorTwo->isValid($hashOne));
         $this->assertTrue($validatorTwo->isValid($hashTwo));
     }
+
+    public function testCannotReValidateAnExpiredHash()
+    {
+        $hash = $this->validator->getHash();
+
+        $this->assertTrue($this->validator->isValid($hash));
+
+        $this->sessionManager->getStorage()->setMetadata(
+            $this->validator->getSession()->getName(),
+            array('EXPIRE' => $_SERVER['REQUEST_TIME'] - 18600)
+        );
+
+        $this->assertFalse($this->validator->isValid($hash));
+    }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -187,4 +187,13 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $test        = $container->hash; // Doing this, as expiration hops are 1; have to grab on first access
         $this->assertEquals($hash, $test);
     }
+
+    public function testCanValidateWithOldBehaviour()
+    {
+        $hash = $this->validator->getHash();
+
+        $validator = new Csrf();
+
+        $this->assertTrue($validator->isValid($hash));
+    }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -206,6 +206,9 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $containerTwo = $validatorOne->getSession();
 
         $this->assertSame($containerOne, $containerTwo);
-        $this->assertNotEquals($validatorOne->getHash() , $validatorTwo->getHash());
+
+        $hashOne = $validatorOne->getHash();
+        $hashTwo = $validatorTwo->getHash();
+        $this->assertNotEquals($hashOne , $hashTwo);
     }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -188,7 +188,7 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($hash, $test);
     }
 
-    public function testMultipleValidatorsDontConflict()
+    public function testMultipleValidatorsSharingContainerGenerateDifferentHashes()
     {
         $validatorOne = new Csrf();
         $validatorTwo = new Csrf();
@@ -214,6 +214,25 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validatorOne->isValid($hashOne));
         $this->assertTrue($validatorOne->isValid($hashTwo));
         $this->assertTrue($validatorTwo->isValid($hashOne));
+        $this->assertTrue($validatorTwo->isValid($hashTwo));
+    }
+
+    public function testCannotValidateHashesOfOtherContainers()
+    {
+        $validatorOne = new Csrf();
+        $validatorTwo = new Csrf(array('name' => 'foo'));
+
+        $containerOne = $validatorOne->getSession();
+        $containerTwo = $validatorTwo->getSession();
+
+        $this->assertNotSame($containerOne, $containerTwo);
+
+        $hashOne = $validatorOne->getHash();
+        $hashTwo = $validatorTwo->getHash();
+
+        $this->assertTrue($validatorOne->isValid($hashOne));
+        $this->assertFalse($validatorOne->isValid($hashTwo));
+        $this->assertFalse($validatorTwo->isValid($hashOne));
         $this->assertTrue($validatorTwo->isValid($hashTwo));
     }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -203,7 +203,7 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($hashOne , $hashTwo);
     }
 
-    public function tesCanValidateOnlyHisOwnTokenWhenPlainHashIsSupplied()
+    public function testCanValidateAnyHashWithinTheSameContainer()
     {
         $validatorOne = new Csrf();
         $validatorTwo = new Csrf();
@@ -212,28 +212,8 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $hashTwo = $validatorTwo->getHash();
 
         $this->assertTrue($validatorOne->isValid($hashOne));
-        $this->assertFalse($validatorOne->isValid($hashTwo));
-        $this->assertFalse($validatorTwo->isValid($hashOne));
+        $this->assertTrue($validatorOne->isValid($hashTwo));
+        $this->assertTrue($validatorTwo->isValid($hashOne));
         $this->assertTrue($validatorTwo->isValid($hashTwo));
-    }
-
-    public function testCanValidateAnyTokenWhenCompositeValueIsSupplied()
-    {
-        $validatorOne = new Csrf();
-        $validatorTwo = new Csrf();
-
-        $hashOne = $validatorOne->getHash();
-        $hashTwo = $validatorTwo->getHash();
-
-        $hashIdOne = $this->readAttribute($validatorOne, 'hashId');
-        $hashIdTwo = $this->readAttribute($validatorTwo, 'hashId');
-
-        $valueOne = sprintf($validatorOne->getFormat(), $hashIdOne, $hashOne);
-        $valueTwo = sprintf($validatorTwo->getFormat(), $hashIdTwo, $hashTwo);
-
-        $this->assertTrue($validatorOne->isValid($valueOne));
-        $this->assertTrue($validatorOne->isValid($valueTwo));
-        $this->assertTrue($validatorTwo->isValid($valueOne));
-        $this->assertTrue($validatorTwo->isValid($valueTwo));
     }
 }

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -188,15 +188,6 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($hash, $test);
     }
 
-    public function testCanValidateWithOldBehaviour()
-    {
-        $hash = $this->validator->getHash();
-
-        $validator = new Csrf();
-
-        $this->assertTrue($validator->isValid($hash));
-    }
-
     public function testMultipleValidatorsDontConflict()
     {
         $validatorOne = new Csrf();

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -202,4 +202,38 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
         $hashTwo = $validatorTwo->getHash();
         $this->assertNotEquals($hashOne , $hashTwo);
     }
+
+    public function tesCanValidateOnlyHisOwnTokenWhenPlainHashIsSupplied()
+    {
+        $validatorOne = new Csrf();
+        $validatorTwo = new Csrf();
+
+        $hashOne = $validatorOne->getHash();
+        $hashTwo = $validatorTwo->getHash();
+
+        $this->assertTrue($validatorOne->isValid($hashOne));
+        $this->assertFalse($validatorOne->isValid($hashTwo));
+        $this->assertFalse($validatorTwo->isValid($hashOne));
+        $this->assertTrue($validatorTwo->isValid($hashTwo));
+    }
+
+    public function testCanValidateAnyTokenWhenCompositeValueIsSupplied()
+    {
+        $validatorOne = new Csrf();
+        $validatorTwo = new Csrf();
+
+        $hashOne = $validatorOne->getHash();
+        $hashTwo = $validatorTwo->getHash();
+
+        $hashIdOne = $this->readAttribute($validatorOne, 'hashId');
+        $hashIdTwo = $this->readAttribute($validatorTwo, 'hashId');
+
+        $valueOne = sprintf($validatorOne->getFormat(), $hashIdOne, $hashOne);
+        $valueTwo = sprintf($validatorTwo->getFormat(), $hashIdTwo, $hashTwo);
+
+        $this->assertTrue($validatorOne->isValid($valueOne));
+        $this->assertTrue($validatorOne->isValid($valueTwo));
+        $this->assertTrue($validatorTwo->isValid($valueOne));
+        $this->assertTrue($validatorTwo->isValid($valueTwo));
+    }
 }


### PR DESCRIPTION
this PR _should_ fix #4785

I'm not very sure about it, it is probably not very fancy, but I should have managed to fix the validator without adding any further state to it, actually even removing some, and maintain BC.

As far as I can tell, the only downside is that tokens are not statically cached any more and are regenerated each time a new validator instance is created (which may arguably be an improvement).

I had to edit `ZendTest\Form\FormElementManagerFactoryTest` because it was a bit of a mess. I didn't delve too much into it, but further cleaning is possible. I honestly don't know how much of a test I can change for this purpose. Also, it is failing in php `5.3.3` only, no clue why. I suppose it's not a problem since this issue was tagged for milestone 2.3.0.
