### PR TITLE
Default value for labelAttributes

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -24,14 +24,14 @@ class Element implements
     protected $attributes = array();
 
     /**
-     * @var string
+     * @var null|string
      */
     protected $label;
 
     /**
      * @var array
      */
-    protected $labelAttributes;
+    protected $labelAttributes = array();
 
     /**
      * @var array Validation error messages
@@ -308,7 +308,7 @@ class Element implements
     /**
      * Retrieve the label used for this element
      *
-     * @return string
+     * @return null|string
      */
     public function getLabel()
     {

--- a/tests/ZendTest/Form/ElementTest.php
+++ b/tests/ZendTest/Form/ElementTest.php
@@ -20,6 +20,12 @@ class ElementTest extends TestCase
         $this->assertEquals(array(), $element->getAttributes());
     }
 
+    public function testLabelAttributesAreEmptyByDefault()
+    {
+        $element = new Element();
+        $this->assertEquals(array(), $element->getLabelAttributes());
+    }
+
     public function testCanAddAttributesSingly()
     {
         $element = new Element();


### PR DESCRIPTION
Added a default value to labelAttributes. This makes it easier to use array_merge whenever you need to add more attributes. Also threw in a docblock fix for label.

Potential minimal BC break if anyone is using is_array or is_null on this already.
