### PR TITLE
FormRow generetes invalid HTML for MonthSelect

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -10,6 +10,7 @@
 namespace Zend\Form\View\Helper;
 
 use Zend\Form\Element\Button;
+use Zend\Form\Element\MonthSelect;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 
@@ -169,7 +170,9 @@ class FormRow extends AbstractHelper
             // Multicheckbox elements have to be handled differently as the HTML standard does not allow nested
             // labels. The semantic way is to group them inside a fieldset
             $type = $element->getAttribute('type');
-            if ($type === 'multi_checkbox' || $type === 'radio') {
+            if ($type === 'multi_checkbox'
+                || $type === 'radio'
+                || $element instanceof MonthSelect) {
                 $markup = sprintf(
                     '<fieldset><legend>%s</legend>%s</fieldset>',
                     $label,


### PR DESCRIPTION
FormRow renders invalid HTML for MonthSelect, DateSelect and DateTimeSelect. A label can only be assigned to a single input while the mentioned classes generates a group of inputs.

DateSelect and DateTimeSelect both extends MonthSelect. Hence only checking MonthSelect.

Would I need any tests for this? Should I test the output of FormRow? If so, then I'd also have to check for ext/intl in the test.
