### PR TITLE
Nicaraguan phone numbering plan once again

### DIFF
--- a/library/Zend/I18n/Validator/PhoneNumber/NI.php
+++ b/library/Zend/I18n/Validator/PhoneNumber/NI.php
@@ -13,7 +13,7 @@ return array(
         'national' => array(
             'general' => '/^[128]\\d{7}$/',
             'fixed' => '/^2\\d{7}$/',
-            'mobile' => '/^[78]\\d{7}$/',
+            'mobile' => '/^[578]\\d{7}$/',
             'tollfree' => '/^1800\\d{4}$/',
             'emergency' => '/^118$/',
         ),


### PR DESCRIPTION
I visited Movistar and Claro (Nicaraguan Telecommunication Providers) and there is a new number that made it to the list of mobile numbering plan.  The number 5. This number was introduce by Claro Nicargua
