### PR TITLE
Fix for missing required option for CollectionInputFilter

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -303,6 +303,9 @@ class Factory
             if (isset($inputFilterSpecification['count'])) {
                 $inputFilter->setCount($inputFilterSpecification['count']);
             }
+            if (isset($inputFilterSpecification['required'])) {
+                $inputFilter->setIsRequired($inputFilterSpecification['required']);
+            }
             return $inputFilter;
         }
 

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -439,12 +439,14 @@ class FactoryTest extends TestCase
 
         $inputFilter = $factory->createInputFilter(array(
             'type'        => 'Zend\InputFilter\CollectionInputFilter',
+            'required' => true,
             'inputfilter' => new InputFilter(),
             'count'       => 3
         ));
 
         $this->assertInstanceOf('Zend\InputFilter\CollectionInputFilter', $inputFilter);
         $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter->getInputFilter());
+        $this->assertTrue($inputFilter->getIsRequired());
         $this->assertEquals(3, $inputFilter->getCount());
     }
 


### PR DESCRIPTION
Since the CollectionInputFilter class has a $isRequired option defaulted to false, we need to have a required index in the factory array, so we can force validation on that element. Otherwise, it will always ignore the collection and return valid.
