### PR TITLE
Fixed notice on binding entity to form

### DIFF
--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -223,7 +223,7 @@ class DateTimeSelect extends DateSelect
         if (is_null($value)) {
             $value = new PhpDateTime();
         }
-        
+
         if ($value instanceof PhpDateTime) {
             $value = array(
                 'year'   => $value->format('Y'),

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -219,7 +219,7 @@ class DateTimeSelect extends DateSelect
                 throw new InvalidArgumentException('Value should be a parsable string or an instance of \DateTime');
             }
         }
-        
+
         if (is_null($value)) {
             $value = new PhpDateTime();
         }

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -219,7 +219,11 @@ class DateTimeSelect extends DateSelect
                 throw new InvalidArgumentException('Value should be a parsable string or an instance of \DateTime');
             }
         }
-
+        
+        if(is_null($value)) {
+            $value = new PhpDateTime();
+        }
+        
         if ($value instanceof PhpDateTime) {
             $value = array(
                 'year'   => $value->format('Y'),

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -220,7 +220,7 @@ class DateTimeSelect extends DateSelect
             }
         }
         
-        if(is_null($value)) {
+        if (is_null($value)) {
             $value = new PhpDateTime();
         }
         


### PR DESCRIPTION
Notice: Undefined index: year
Notice: Undefined index: month
Notice: Undefined index: day
Notice: Undefined index: hour
Notice: Undefined index: minute

When you bind a Entity, with a property set to NULL, to a form it then sets the element to NULL. This will break the generation of the DateTimeSelect
