### PR TITLE
Allow arbitrary error codes in JSON RPC server

### DIFF
--- a/library/Zend/Json/Server/Error.php
+++ b/library/Zend/Json/Server/Error.php
@@ -11,31 +11,18 @@ namespace Zend\Json\Server;
 
 class Error
 {
-    const ERROR_PARSE           = -32700;
+    const ERROR_PARSE = -32700;
     const ERROR_INVALID_REQUEST = -32600;
-    const ERROR_INVALID_METHOD  = -32601;
-    const ERROR_INVALID_PARAMS  = -32602;
-    const ERROR_INTERNAL        = -32603;
-    const ERROR_OTHER           = -32000;
-
-    /**
-     * Allowed error codes
-     * @var array
-     */
-    protected $allowedCodes = array(
-        self::ERROR_PARSE,
-        self::ERROR_INVALID_REQUEST,
-        self::ERROR_INVALID_METHOD,
-        self::ERROR_INVALID_PARAMS,
-        self::ERROR_INTERNAL,
-        self::ERROR_OTHER,
-    );
+    const ERROR_INVALID_METHOD = -32601;
+    const ERROR_INVALID_PARAMS = -32602;
+    const ERROR_INTERNAL = -32603;
+    const ERROR_OTHER = -32000;
 
     /**
      * Current code
      * @var int
      */
-    protected $code = -32000;
+    protected $code = self::ERROR_OTHER;
 
     /**
      * Error data
@@ -56,11 +43,14 @@ class Error
      * @param  int $code
      * @param  mixed $data
      */
-    public function __construct($message = null, $code = -32000, $data = null)
-    {
+    public function __construct(
+        $message = null,
+        $code = self::ERROR_OTHER,
+        $data = null
+    ) {
         $this->setMessage($message)
-             ->setCode($code)
-             ->setData($data);
+            ->setCode($code)
+            ->setData($data);
     }
 
     /**
@@ -71,16 +61,16 @@ class Error
      */
     public function setCode($code)
     {
-        if (!is_scalar($code)) {
+        if (!is_scalar($code) || is_bool($code) || is_float($code)) {
             return $this;
         }
 
-        $code = (int) $code;
-        if (in_array($code, $this->allowedCodes)) {
-            $this->code = $code;
-        } elseif (in_array($code, range(-32099, -32000))) {
-            $this->code = $code;
+        if (is_string($code) && !is_numeric($code)) {
+            return $this;
         }
+
+        $code = (int)$code;
+        $this->code = $code;
 
         return $this;
     }
@@ -107,7 +97,7 @@ class Error
             return $this;
         }
 
-        $this->message = (string) $message;
+        $this->message = (string)$message;
         return $this;
     }
 
@@ -151,9 +141,9 @@ class Error
     public function toArray()
     {
         return array(
-            'code'    => $this->getCode(),
+            'code' => $this->getCode(),
             'message' => $this->getMessage(),
-            'data'    => $this->getData(),
+            'data' => $this->getData(),
         );
     }
 

--- a/library/Zend/Json/Server/Error.php
+++ b/library/Zend/Json/Server/Error.php
@@ -11,12 +11,12 @@ namespace Zend\Json\Server;
 
 class Error
 {
-    const ERROR_PARSE = -32700;
+    const ERROR_PARSE           = -32700;
     const ERROR_INVALID_REQUEST = -32600;
-    const ERROR_INVALID_METHOD = -32601;
-    const ERROR_INVALID_PARAMS = -32602;
-    const ERROR_INTERNAL = -32603;
-    const ERROR_OTHER = -32000;
+    const ERROR_INVALID_METHOD  = -32601;
+    const ERROR_INVALID_PARAMS  = -32602;
+    const ERROR_INTERNAL        = -32603;
+    const ERROR_OTHER           = -32000;
 
     /**
      * Current code
@@ -43,14 +43,10 @@ class Error
      * @param  int $code
      * @param  mixed $data
      */
-    public function __construct(
-        $message = null,
-        $code = self::ERROR_OTHER,
-        $data = null
-    ) {
+    public function __construct($message = null, $code = self::ERROR_OTHER, $data = null) {
         $this->setMessage($message)
-            ->setCode($code)
-            ->setData($data);
+              ->setCode($code)
+              ->setData($data);
     }
 
     /**
@@ -69,7 +65,7 @@ class Error
             return $this;
         }
 
-        $code = (int)$code;
+        $code = (int) $code;
         $this->code = $code;
 
         return $this;
@@ -97,7 +93,7 @@ class Error
             return $this;
         }
 
-        $this->message = (string)$message;
+        $this->message = (string) $message;
         return $this;
     }
 
@@ -141,9 +137,9 @@ class Error
     public function toArray()
     {
         return array(
-            'code' => $this->getCode(),
+            'code'    => $this->getCode(),
             'message' => $this->getMessage(),
-            'data' => $this->getData(),
+            'data'    => $this->getData(),
         );
     }
 

--- a/library/Zend/Json/Server/Error.php
+++ b/library/Zend/Json/Server/Error.php
@@ -45,12 +45,14 @@ class Error
      */
     public function __construct($message = null, $code = self::ERROR_OTHER, $data = null) {
         $this->setMessage($message)
-              ->setCode($code)
-              ->setData($data);
+             ->setCode($code)
+             ->setData($data);
     }
 
     /**
-     * Set error code
+     * Set error code.
+     *
+     * If the error code is 0, it will be set to -32000 (ERROR_OTHER).
      *
      * @param  int $code
      * @return \Zend\Json\Server\Error
@@ -66,7 +68,12 @@ class Error
         }
 
         $code = (int) $code;
-        $this->code = $code;
+
+        if (0 === $code) {
+            $this->code = self::ERROR_OTHER;
+        } else {
+            $this->code = $code;
+        }
 
         return $this;
     }

--- a/tests/ZendTest/Json/Server/ErrorTest.php
+++ b/tests/ZendTest/Json/Server/ErrorTest.php
@@ -54,7 +54,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
 
     public function testCodeShouldBeLimitedToStandardIntegers()
     {
-        foreach (array(true, 'foo', array(), new \stdClass, 2.0, 25) as $code) {
+        foreach (array(null, true, 'foo', array(), new \stdClass, 2.0) as $code) {
             $this->error->setCode($code);
             $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
         }
@@ -63,6 +63,14 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange()
     {
         foreach (range(-32099, -32000) as $code) {
+            $this->error->setCode($code);
+            $this->assertEquals($code, $this->error->getCode());
+        }
+    }
+
+    public function testCodeShouldAllowArbitraryErrorCode()
+    {
+        foreach(array(1000, 404, -3000) as $code) {
             $this->error->setCode($code);
             $this->assertEquals($code, $this->error->getCode());
         }


### PR DESCRIPTION
Currently, the implementation of Zend\Json\Server\Error limits the range of custom error codes from -32000 to -32099. According to the spec (http://www.jsonrpc.org/specification#error_object), this range is "Reserved for implementation-defined server-errors".

The spec continues "The remainder of the space is available for application defined errors". But setting a custom error code (eg 1000) is not allowed by the current implementation and results in the error code being set to -32000.
For a statement of one of the authors of the JSON-RPC specification about usable custom error codes, see [this comment](https://groups.google.com/d/topic/json-rpc/3o2xWBr4FmI/discussion).

This PR aims to change the implementation to allow arbitrary error codes.
