### PR TITLE
Fix Zend\Mail\Headers::removeHeader is not removing every header matching header name

### DIFF
--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -237,18 +237,26 @@ class Headers implements Countable, Iterator
     /**
      * Remove a Header from the container
      *
-     * @param  string $fieldName
+     * @param  string|Header\HeaderInterface field name or specific header instance to remove
      * @return bool
      */
-    public function removeHeader($fieldName)
+    public function removeHeader($instanceOrFieldName)
     {
-        $key = $this->normalizeFieldName($fieldName);
-        $index = array_search($key, $this->headersKeys, true);
-        if ($index !== false) {
-            unset($this->headersKeys[$index]);
-            unset($this->headers[$index]);
+        if ($instanceOrFieldName instanceof Header\HeaderInterface) {
+            $indexes = array_keys($this->headers, $instanceOrFieldName, true);
+        } else {
+            $key = $this->normalizeFieldName($instanceOrFieldName);
+            $indexes = array_keys($this->headersKeys, $key, true);
+        }
+
+        if (!empty($indexes)) {
+            foreach ($indexes as $index) {
+                unset ($this->headersKeys[$index]);
+                unset ($this->headers[$index]);
+            }
             return true;
         }
+
         return false;
     }
 

--- a/tests/ZendTest/Mail/HeadersTest.php
+++ b/tests/ZendTest/Mail/HeadersTest.php
@@ -195,11 +195,34 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     {
         $headers = new Mail\Headers();
         $headers->addHeaders(array('Foo' => 'bar', 'Baz' => 'baz'));
-        $header = $headers->get('foo');
         $this->assertEquals(2, $headers->count());
-        $headers->removeHeader($header->getFieldName());
+        $headers->removeHeader('foo');
+        $this->assertEquals(1, $headers->count());
+        $this->assertFalse($headers->has('foo'));
+        $this->assertTrue($headers->has('baz'));
+    }
+
+    public function testRemoveHeaderWithFieldNameWillRemoveAllInstances()
+    {
+        $headers = new Mail\Headers();
+        $headers->addHeaders(array(array('Foo' => 'foo'), array('Foo' => 'bar'), 'Baz' => 'baz'));
+        $this->assertEquals(3, $headers->count());
+        $headers->removeHeader('foo');
         $this->assertEquals(1, $headers->count());
         $this->assertFalse($headers->get('foo'));
+        $this->assertTrue($headers->has('baz'));
+    }
+
+    public function testRemoveHeaderWithInstanceWillRemoveThatInstance()
+    {
+        $headers = new Mail\Headers();
+        $headers->addHeaders(array(array('Foo' => 'foo'), array('Foo' => 'bar'), 'Baz' => 'baz'));
+        $header = $headers->get('foo')->current();
+        $this->assertEquals(3, $headers->count());
+        $headers->removeHeader($header);
+        $this->assertEquals(2, $headers->count());
+        $this->assertTrue($headers->has('foo'));
+        $this->assertNotSame($header, $headers->get('foo'));
     }
 
     public function testHeadersCanClearAllHeaders()


### PR DESCRIPTION
Zend\Mail\Headers::removeHeader should remove all headers matching field
name instead of just first match.
