### PR TITLE
Zend\Db\Sql Allow MySQL to use limit when only offset was provided

### DIFF
--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -74,7 +74,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         }
         if ($driver) {
             $sql = $driver->formatParameterName('limit');
-            $parameterContainer->offsetSet('limit', (int) $this->limit, ParameterContainer::TYPE_INTEGER);
+            $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
             $sql = $this->limit;
         }
@@ -88,7 +88,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             return null;
         }
         if ($driver) {
-            $parameterContainer->offsetSet('offset', (int) $this->offset, ParameterContainer::TYPE_INTEGER);
+            $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
             return array($driver->formatParameterName('offset'));
         }
 

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -42,6 +42,9 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         foreach (get_object_vars($this->select) as $name => $value) {
             $this->{$name} = $value;
         }
+        if ($this->limit === null && $this->offset !== null) {
+            $this->specifications[self::LIMIT] = 'LIMIT 18446744073709551615';
+        }
         parent::prepareStatement($adapter, $statementContainer);
     }
 
@@ -55,11 +58,17 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         foreach (get_object_vars($this->select) as $name => $value) {
             $this->{$name} = $value;
         }
+        if ($this->limit === null && $this->offset !== null) {
+            $this->specifications[self::LIMIT] = 'LIMIT 18446744073709551615';
+        }
         return parent::getSqlString($platform);
     }
 
     protected function processLimit(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
     {
+        if ($this->limit === null && $this->offset !== null) {
+            return array('');
+        }
         if ($this->limit === null) {
             return null;
         }

--- a/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
@@ -85,9 +85,17 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $expectedParams1 = array('offset' => 10);
         $expectedSql1 = 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10';
 
+        // offset and limit are not type casted when injected into parameter container
+        $select2 = new Select;
+        $select2->from('foo')->limit('5')->offset('10');
+        $expectedPrepareSql2 = 'SELECT `foo`.* FROM `foo` LIMIT ? OFFSET ?';
+        $expectedParams2 = array('offset' => '10', 'limit' => '5');
+        $expectedSql2 = 'SELECT `foo`.* FROM `foo` LIMIT 5 OFFSET 10';
+
         return array(
             array($select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0),
             array($select1, $expectedPrepareSql1, $expectedParams1, $expectedSql1),
+            array($select2, $expectedPrepareSql2, $expectedParams2, $expectedSql2),
         );
     }
 

--- a/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
@@ -87,10 +87,10 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
 
         // offset and limit are not type casted when injected into parameter container
         $select2 = new Select;
-        $select2->from('foo')->limit('5')->offset('10');
+        $select2->from('foo')->limit('5')->offset('10000000000000000000');
         $expectedPrepareSql2 = 'SELECT `foo`.* FROM `foo` LIMIT ? OFFSET ?';
-        $expectedParams2 = array('offset' => '10', 'limit' => '5');
-        $expectedSql2 = 'SELECT `foo`.* FROM `foo` LIMIT 5 OFFSET 10';
+        $expectedParams2 = array('offset' => '10000000000000000000', 'limit' => '5');
+        $expectedSql2 = 'SELECT `foo`.* FROM `foo` LIMIT 5 OFFSET 10000000000000000000';
 
         return array(
             array($select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0),

--- a/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
@@ -78,8 +78,16 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $expectedParams0 = array('offset' => 10, 'limit' => 5);
         $expectedSql0 = 'SELECT `foo`.* FROM `foo` LIMIT 5 OFFSET 10';
 
+        // offset without limit
+        $select1 = new Select;
+        $select1->from('foo')->offset(10);
+        $expectedPrepareSql1 = 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET ?';
+        $expectedParams1 = array('offset' => 10);
+        $expectedSql1 = 'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10';
+
         return array(
             array($select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0),
+            array($select1, $expectedPrepareSql1, $expectedParams1, $expectedSql1),
         );
     }
 


### PR DESCRIPTION
This is a fix for #5642
And would supersede PR #5643 
