### PR TITLE
no cast to (int) on limit&offset at Zend\Db\Sql\Select.php

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -854,7 +854,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             return null;
         }
 
-        $limit = (int) $this->limit;
+        $limit = $this->limit;
 
         if ($driver) {
             $sql = $driver->formatParameterName('limit');
@@ -872,7 +872,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             return null;
         }
 
-        $offset = (int) $this->offset;
+        $offset = $this->offset;
 
         if ($driver) {
             $parameterContainer->offsetSet('offset', $offset, ParameterContainer::TYPE_INTEGER);

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -1195,6 +1195,19 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         $sqlStr46 = 'SELECT SOME_DB_FUNCTION_ONE() AS Expression1, SOME_DB_FUNCTION_TWO() AS "foo"';
         $params46 = array();
         $internalTests46 = array();
+
+        // limit with big offset and limit
+        $select47 = new Select;
+        $select47->from('foo')->limit("10000000000000000000")->offset("10000000000000000000");
+        $sqlPrep47 = 'SELECT "foo".* FROM "foo" LIMIT ? OFFSET ?';
+        $sqlStr47 = 'SELECT "foo".* FROM "foo" LIMIT \'10000000000000000000\' OFFSET \'10000000000000000000\'';
+        $params47 = array('limit' => 10000000000000000000, 'offset' => 10000000000000000000);
+        $internalTests47 = array(
+            'processSelect' => array(array(array('"foo".*')), '"foo"'),
+            'processLimit'  => array('?'),
+            'processOffset' => array('?')
+        );
+
         /**
          * $select = the select object
          * $sqlPrep = the sql as a result of preparation
@@ -1252,6 +1265,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select44, $sqlPrep44, array(),    $sqlStr44, $internalTests44),
             array($select45, $sqlPrep45, $params45,  $sqlStr45, $internalTests45),
             array($select46, $sqlPrep46, $params46,  $sqlStr46, $internalTests46),
+            array($select47, $sqlPrep47, $params47,  $sqlStr47, $internalTests47),
         );
     }
 }


### PR DESCRIPTION
based on #5940 , I think cast (int) in limit and offst at Zend\Db\Sql\Select.php should be removed too. /cc @ralphschindler
