### PR TITLE
Mvc\I18n\Translator -> setLocale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 install:
   - sudo apt-get install parallel
-  - composer install --dev
+  - composer install --dev --prefer-source
 
 before_script:
   - mkdir -p build/coverage

--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Service;
 
+use Traversable;
 use Zend\I18n\Translator\Translator;
 use Zend\Mvc\I18n\DummyTranslator;
 use Zend\Mvc\I18n\Translator as MvcTranslator;
@@ -27,19 +28,38 @@ class TranslatorServiceFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        // Assume that if a user has registered a service for the
+        // TranslatorInterface, it must be valid
         if ($serviceLocator->has('Zend\I18n\Translator\TranslatorInterface')) {
             return new MvcTranslator($serviceLocator->get('Zend\I18n\Translator\TranslatorInterface'));
         }
 
+        // If ext/intl is not loaded, return a dummy translator
+        if (!extension_loaded('intl')) {
+            return new MvcTranslator(new DummyTranslator());
+        }
+
+        // Load a translator from configuration, if possible
         if ($serviceLocator->has('Config')) {
             $config = $serviceLocator->get('Config');
-            if (isset($config['translator']) && !empty($config['translator'])) {
+
+            // 'translator' => false
+            if (array_key_exists('translator', $config) && $config['translator'] === false) {
+                return new MvcTranslator(new DummyTranslator());
+            }
+
+            // 'translator' => array( ... translator options ... )
+            if (array_key_exists('translator', $config)
+                && ((is_array($config['translator']) && !empty($config['translator']))
+                    || $config['translator'] instanceof Traversable)
+            ) {
                 $i18nTranslator = Translator::factory($config['translator']);
                 $serviceLocator->setService('Zend\I18n\Translator\TranslatorInterface', $i18nTranslator);
                 return new MvcTranslator($i18nTranslator);
             }
         }
 
-        return new MvcTranslator(new DummyTranslator());
+        // For BC purposes (pre-2.3.0), use the I18n Translator
+        return new MvcTranslator(new Translator());
     }
 }

--- a/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
@@ -44,6 +44,10 @@ class TranslatorServiceFactoryTest extends TestCase
 
     public function testReturnsMvcTranslatorWithI18nTranslatorComposedWhenNoTranslatorInterfaceOrConfigServicesPresent()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('This test will only run if ext/intl is present');
+        }
+
         $translator = $this->factory->createService($this->services);
         $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
         $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator->getTranslator());
@@ -51,6 +55,10 @@ class TranslatorServiceFactoryTest extends TestCase
 
     public function testReturnsTranslatorBasedOnConfigurationWhenNoTranslatorInterfaceServicePresent()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('This test will only run if ext/intl is present');
+        }
+
         $config = array('translator' => array(
             'locale' => 'en_US',
         ));

--- a/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
@@ -31,11 +31,22 @@ class TranslatorServiceFactoryTest extends TestCase
         $this->assertSame($i18nTranslator, $translator->getTranslator());
     }
 
-    public function testReturnsMvcTranslatorWithDummyTranslatorComposedWhenNoTranslatorInterfaceOrConfigServicesPresent()
+    public function testReturnsMvcTranslatorWithDummyTranslatorComposedWhenExtIntlIsNotAvailable()
     {
+        if (extension_loaded('intl')) {
+            $this->markTestSkipped('This test will only run if ext/intl is not present');
+        }
+
         $translator = $this->factory->createService($this->services);
         $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
         $this->assertInstanceOf('Zend\Mvc\I18n\DummyTranslator', $translator->getTranslator());
+    }
+
+    public function testReturnsMvcTranslatorWithI18nTranslatorComposedWhenNoTranslatorInterfaceOrConfigServicesPresent()
+    {
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator->getTranslator());
     }
 
     public function testReturnsTranslatorBasedOnConfigurationWhenNoTranslatorInterfaceServicePresent()
@@ -79,5 +90,14 @@ class TranslatorServiceFactoryTest extends TestCase
         $translator = $this->factory->createService($this->services);
         $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
         $this->assertSame($i18nTranslator, $translator->getTranslator());
+    }
+
+    public function testReturnsDummyTranslatorWhenTranslatorConfigIsBooleanFalse()
+    {
+        $config = array('translator' => false);
+        $this->services->setService('Config', $config);
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertInstanceOf('Zend\Mvc\I18n\DummyTranslator', $translator->getTranslator());
     }
 }


### PR DESCRIPTION
Hi,
   I have upgraded to 2.3 dev from 2.2.6 to test. It seems that the translator does not have the setLocale method anymore. Is this a known BC break?
Here is the error I got:

```
2014/03/11 04:01:45 [error] 1288#0: *1385 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught exception 'Zend\Mvc\Exception\BadMethodCallException' with message 'Unable to call method "setLocale"; does not exist in translator' in /vagrant/vendor/zendframework/zendframework/library/Zend/Mvc/I18n/Translator.php:47
Stack trace:
#0 /vagrant/module/BAppBase/Module.php(121): Zend\Mvc\I18n\Translator->__call('setLocale', Array)
#1 /vagrant/module/BAppBase/Module.php(121): Zend\Mvc\I18n\Translator->setLocale('en')
#2 [internal function]: BAppBase\Module->onBootstrap(Object(Zend\Mvc\MvcEvent))
#3 /vagrant/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php(468): call_user_func(Array, Object(Zend\Mvc\MvcEvent))
#4 /vagrant/vendor/zendframework/zendframework/library/Zend/EventManager/EventManager.php(207): Zend\EventManager\EventManager->triggerListeners('bootstrap', Object(Zend\Mvc\MvcEvent), Array)
```

Regards,
Norbert.
