### PR TITLE
Mysqli driver raise a lot of warning about Undefined property after connection closed

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Mysqli/Connection.php
@@ -237,7 +237,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         if ($this->resource instanceof \mysqli) {
             $this->resource->close();
         }
-        unset($this->resource);
+        $this->resource = null;
     }
 
     /**


### PR DESCRIPTION
The problem is in the Mysqli\Connection::Disconnect() that unset property but other methods check it and raise warning. So to fix it just add $this->resource=null; in the end of disconnect method: 

---

```
public function disconnect()
{
    if ($this->resource instanceof \mysqli) {
        $this->resource->close();
    }
    unset($this->resource);
    $this->resource=null; // +++ ADD this string
}
```

---
