### PR TITLE
move custom `listeners` inside `application` sub array

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -251,9 +251,9 @@ class Application implements
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();
 
-        $listenersFromAppConfig     = isset($configuration['listeners']) ? $configuration['listeners'] : array();
+        $listenersFromAppConfig     = isset($configuration['application']['listeners']) ? $configuration['application']['listeners'] : array();
         $config                     = $serviceManager->get('Config');
-        $listenersFromConfigService = isset($config['listeners']) ? $config['listeners'] : array();
+        $listenersFromConfigService = isset($config['application']['listeners']) ? $config['application']['listeners'] : array();
 
         $listeners = array_unique(array_merge($listenersFromConfigService, $listenersFromAppConfig));
 


### PR DESCRIPTION
We should be careful about taking over top level namespaces at this point. Could cause a lot of bc breaks for users.

We use the top level `listeners` configuration key to configure a custom event listener service locator in our internal library. I know, we probly should've prefixed it with a vendor name or placed it inside a sub array. But what's done is done I guess.

I figure since we already have `service_manager` it should be safe to take over `application` for internal use?
