### PR TITLE
Ability to attach/detach shared listeners from `AbstractListenerAggregate`

### DIFF
--- a/library/Zend/EventManager/AbstractListenerAggregate.php
+++ b/library/Zend/EventManager/AbstractListenerAggregate.php
@@ -36,19 +36,16 @@ abstract class AbstractListenerAggregate implements ListenerAggregateInterface
             }
         }
 
-        if (!empty($this->sharedListeners)) {
-            $sharedEvents = $events->getSharedManager();
+        $sharedEvents = $events->getSharedManager();
+        foreach ($this->sharedListeners as $id => $listeners) {
+            foreach ($listeners as $index => $callbacks) {
+                if (!is_array($callbacks)) {
+                    $this->sharedListeners[$id][$index] = $callbacks = array($callbacks);
+                }
 
-            foreach ($this->sharedListeners as $id => $listeners) {
-                foreach ($listeners as $index => $callbacks) {
-                    if (!is_array($callbacks)) {
-                        $this->sharedListeners[$id][$index] = $callbacks = array($callbacks);
-                    }
-
-                    foreach ($callbacks as $subIndex => $callback) {
-                        if ($sharedEvents->detach($id, $callback)) {
-                            unset($this->sharedListeners[$id][$index][$subIndex]);
-                        }
+                foreach ($callbacks as $subIndex => $callback) {
+                    if ($sharedEvents->detach($id, $callback)) {
+                        unset($this->sharedListeners[$id][$index][$subIndex]);
                     }
                 }
             }

--- a/library/Zend/EventManager/AbstractListenerAggregate.php
+++ b/library/Zend/EventManager/AbstractListenerAggregate.php
@@ -20,6 +20,9 @@ abstract class AbstractListenerAggregate implements ListenerAggregateInterface
      */
     protected $listeners = array();
 
+    /**
+     * @var array
+     */
     protected $sharedListeners = array();
 
     /**

--- a/library/Zend/EventManager/AbstractListenerAggregate.php
+++ b/library/Zend/EventManager/AbstractListenerAggregate.php
@@ -20,6 +20,8 @@ abstract class AbstractListenerAggregate implements ListenerAggregateInterface
      */
     protected $listeners = array();
 
+    protected $sharedListeners = array();
+
     /**
      * {@inheritDoc}
      */
@@ -28,6 +30,24 @@ abstract class AbstractListenerAggregate implements ListenerAggregateInterface
         foreach ($this->listeners as $index => $callback) {
             if ($events->detach($callback)) {
                 unset($this->listeners[$index]);
+            }
+        }
+
+        if (!empty($this->sharedListeners)) {
+            $sharedEvents = $events->getSharedManager();
+
+            foreach ($this->sharedListeners as $id => $listeners) {
+                foreach ($listeners as $index => $callbacks) {
+                    if (!is_array($callbacks)) {
+                        $this->sharedListeners[$id][$index] = $callbacks = array($callbacks);
+                    }
+
+                    foreach ($callbacks as $subIndex => $callback) {
+                        if ($sharedEvents->detach($id, $callback)) {
+                            unset($this->sharedListeners[$id][$index][$subIndex]);
+                        }
+                    }
+                }
             }
         }
     }

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -388,7 +388,7 @@ class EventManager implements EventManagerInterface
      * Retrieve all listeners for a given event
      *
      * @param  string $event
-     * @return PriorityQueue|CallbackHandler[]
+     * @return PriorityQueue
      */
     public function getListeners($event)
     {

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -388,7 +388,7 @@ class EventManager implements EventManagerInterface
      * Retrieve all listeners for a given event
      *
      * @param  string $event
-     * @return PriorityQueue
+     * @return PriorityQueue|CallbackHandler[]
      */
     public function getListeners($event)
     {

--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -57,7 +57,7 @@ class SharedEventManager implements
      * @param  string $event
      * @param  callable $callback PHP Callback
      * @param  int $priority Priority at which listener should execute
-     * @return CallbackHandler|array Either CallbackHandler or array of CallbackHandlers
+     * @return CallbackHandler|CallbackHandler[] Either CallbackHandler or array of CallbackHandlers
      */
     public function attach($id, $event, $callback, $priority = 1)
     {

--- a/library/Zend/EventManager/SharedEventManager.php
+++ b/library/Zend/EventManager/SharedEventManager.php
@@ -143,7 +143,7 @@ class SharedEventManager implements
      *
      * @param  string|int $id
      * @param  string|int $event
-     * @return false|PriorityQueue
+     * @return false|PriorityQueue|CallbackHandler[]
      */
     public function getListeners($id, $event)
     {

--- a/library/Zend/EventManager/SharedEventManagerInterface.php
+++ b/library/Zend/EventManager/SharedEventManagerInterface.php
@@ -33,7 +33,7 @@ interface SharedEventManagerInterface
      * @param  string $event
      * @param  callable $callback PHP Callback
      * @param  int $priority Priority at which listener should execute
-     * @return void
+     * @return CallbackHandler|CallbackHandler[] Either CallbackHandler or array of CallbackHandlers
      */
     public function attach($id, $event, $callback, $priority = 1);
 

--- a/library/Zend/Mvc/View/Http/CreateViewModelListener.php
+++ b/library/Zend/Mvc/View/Http/CreateViewModelListener.php
@@ -22,8 +22,10 @@ class CreateViewModelListener extends AbstractListenerAggregate
      */
     public function attach(Events $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'createViewModelFromArray'),  -80);
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'createViewModelFromNull'),   -80);
+        $sharedEvents = $events->getSharedManager();
+        $id = 'Zend\Stdlib\DispatchableInterface';
+        $this->sharedListeners[$id][] = $sharedEvents->attach($id, MvcEvent::EVENT_DISPATCH, array($this, 'createViewModelFromArray'), -80);
+        $this->sharedListeners[$id][] = $sharedEvents->attach($id, MvcEvent::EVENT_DISPATCH, array($this, 'createViewModelFromNull'), -80);
     }
 
     /**

--- a/library/Zend/Mvc/View/Http/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/Http/InjectTemplateListener.php
@@ -37,7 +37,9 @@ class InjectTemplateListener extends AbstractListenerAggregate
      */
     public function attach(Events $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'injectTemplate'), -90);
+        $sharedEvents = $events->getSharedManager();
+        $id = 'Zend\Stdlib\DispatchableInterface';
+        $this->sharedListeners[$id][] = $sharedEvents->attach($id, MvcEvent::EVENT_DISPATCH, array($this, 'injectTemplate'), -90);
     }
 
     /**

--- a/library/Zend/Mvc/View/Http/InjectViewModelListener.php
+++ b/library/Zend/Mvc/View/Http/InjectViewModelListener.php
@@ -29,9 +29,12 @@ class InjectViewModelListener extends AbstractListenerAggregate
      */
     public function attach(Events $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'injectViewModel'), -100);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'injectViewModel'), -100);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, array($this, 'injectViewModel'), -100);
+
+        $sharedEvents = $events->getSharedManager();
+        $id = 'Zend\Stdlib\DispatchableInterface';
+        $this->sharedListeners[$id][] = $sharedEvents->attach($id, MvcEvent::EVENT_DISPATCH, array($this, 'injectViewModel'), -100);
     }
 
     /**

--- a/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/Http/RouteNotFoundStrategy.php
@@ -55,6 +55,10 @@ class RouteNotFoundStrategy extends AbstractListenerAggregate
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'prepareNotFoundViewModel'), -90);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'detectNotFoundError'));
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'prepareNotFoundViewModel'));
+
+        $sharedEvents = $events->getSharedManager();
+        $id = 'Zend\Stdlib\DispatchableInterface';
+        $this->sharedListeners[$id][] = $sharedEvents->attach($id, MvcEvent::EVENT_DISPATCH, array($this, 'prepareNotFoundViewModel'), -90);
     }
 
     /**

--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -90,7 +90,7 @@ class ViewManager extends AbstractListenerAggregate
      * @param  $event
      * @return void
      */
-    public function onBootstrap(MvcEvent $event)
+    public function onBootstrap($event)
     {
         $application  = $event->getApplication();
         $services     = $application->getServiceManager();

--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -85,33 +85,17 @@ class ViewManager extends AbstractListenerAggregate
     }
 
     /**
-     * Detach aggregate listeners from the specified event manager
-     *
-     * @param  EventManagerInterface $events
-     * @return void
-     */
-    public function detach(EventManagerInterface $events)
-    {
-        foreach ($this->listeners as $index => $listener) {
-            if ($events->detach($listener)) {
-                unset($this->listeners[$index]);
-            }
-        }
-    }
-
-    /**
      * Prepares the view layer
      *
      * @param  $event
      * @return void
      */
-    public function onBootstrap($event)
+    public function onBootstrap(MvcEvent $event)
     {
         $application  = $event->getApplication();
         $services     = $application->getServiceManager();
         $config       = $services->get('Config');
         $events       = $application->getEventManager();
-        $sharedEvents = $events->getSharedManager();
 
         $this->config   = isset($config['view_manager']) && (is_array($config['view_manager']) || $config['view_manager'] instanceof ArrayAccess)
                         ? $config['view_manager']
@@ -131,15 +115,10 @@ class ViewManager extends AbstractListenerAggregate
 
         $events->attach($routeNotFoundStrategy);
         $events->attach($exceptionStrategy);
-        $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($injectViewModelListener, 'injectViewModel'), -100);
-        $events->attach(MvcEvent::EVENT_RENDER_ERROR, array($injectViewModelListener, 'injectViewModel'), -100);
         $events->attach($mvcRenderingStrategy);
-
-        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromArray'), -80);
-        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($routeNotFoundStrategy, 'prepareNotFoundViewModel'), -90);
-        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($createViewModelListener, 'createViewModelFromNull'), -80);
-        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($injectTemplateListener, 'injectTemplate'), -90);
-        $sharedEvents->attach('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH, array($injectViewModelListener, 'injectViewModel'), -100);
+        $events->attach($injectTemplateListener);
+        $events->attach($createViewModelListener);
+        $events->attach($injectViewModelListener);
     }
 
     /**

--- a/tests/ZendTest/Mvc/View/CreateViewModelListenerTest.php
+++ b/tests/ZendTest/Mvc/View/CreateViewModelListenerTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Mvc\View;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 use Zend\EventManager\EventManager;
+use Zend\EventManager\SharedEventManager;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\View\Http\CreateViewModelListener;
 use Zend\View\Model\ViewModel;
@@ -70,8 +71,10 @@ class CreateViewModelListenerTest extends TestCase
     public function testAttachesListenersAtExpectedPriority()
     {
         $events = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedManager($sharedEvents);
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+        $listeners = $sharedEvents->getListeners('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH);
 
         $expectedArrayCallback = array($this->listener, 'createViewModelFromArray');
         $expectedNullCallback  = array($this->listener, 'createViewModelFromNull');
@@ -98,11 +101,16 @@ class CreateViewModelListenerTest extends TestCase
     public function testDetachesListeners()
     {
         $events = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedManager($sharedEvents);
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+
+        $listeners = $sharedEvents->getListeners('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(2, count($listeners));
+
         $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+
+        $listeners = $sharedEvents->getListeners('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
     }
 

--- a/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Mvc\View;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\EventManager;
+use Zend\EventManager\SharedEventManager;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
@@ -303,8 +304,10 @@ class InjectTemplateListenerTest extends TestCase
     public function testAttachesListenerAtExpectedPriority()
     {
         $events = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedManager($sharedEvents);
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+        $listeners = $sharedEvents->getListeners('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH);
 
         $expectedCallback = array($this->listener, 'injectTemplate');
         $expectedPriority = -90;
@@ -324,11 +327,17 @@ class InjectTemplateListenerTest extends TestCase
     public function testDetachesListeners()
     {
         $events = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedManager($sharedEvents);
+
         $events->attachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+
+        $listeners = $sharedEvents->getListeners('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(1, count($listeners));
+
         $events->detachAggregate($this->listener);
-        $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
+
+        $listeners = $sharedEvents->getListeners('Zend\Stdlib\DispatchableInterface', MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
     }
 }

--- a/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
+++ b/tests/ZendTest/Mvc/View/RouteNotFoundStrategyTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Mvc\View;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\EventManager;
+use Zend\EventManager\SharedEventManager;
 use Zend\Http\Response;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
@@ -288,6 +289,8 @@ class RouteNotFoundStrategyTest extends TestCase
     public function testAttachesListenersAtExpectedPriorities()
     {
         $events = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedManager($sharedEvents);
         $events->attachAggregate($this->strategy);
 
         foreach (array(MvcEvent::EVENT_DISPATCH => -90, MvcEvent::EVENT_DISPATCH_ERROR => 1) as $event => $expectedPriority) {
@@ -325,14 +328,22 @@ class RouteNotFoundStrategyTest extends TestCase
     public function testDetachesListeners()
     {
         $events = new EventManager();
+        $sharedEvents = new SharedEventManager();
+        $events->setSharedManager($sharedEvents);
+
         $events->attachAggregate($this->strategy);
+
         $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(1, count($listeners));
+
         $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(2, count($listeners));
+
         $events->detachAggregate($this->strategy);
+
         $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
+
         $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH_ERROR);
         $this->assertEquals(0, count($listeners));
     }


### PR DESCRIPTION
Adding the ability to attach and detach shared event listeners by their id. Simply append the listener returned by the shared event manager to the `$sharedListeners` property:

``` php
<?php

use Zend\EventManager\AbstractListenerAggregate;
use Zend\EventManager\EventManagerInterface as Events;

class FooListener extends AbstractListenerAggregate
{
    public function attach(Events $events)
    {
        $this->listeners[] = $events->attach('foo', array($this, 'fooCallback'));

        $sharedEvents = $events->getSharedManager();
        $id = 'Zend\Stdlib\DispatchableInterface';
        $this->sharedListeners[$id][] = $sharedEvents->attach($id, 'foo.bar', array($this, 'fooBarCallback'));
    }
}
```

I've also cleaned up the `ViewManager` and moved the event listening logic to each individual listener's `attach()` method. This allows us to detach `RouteNotFoundStrategy` for example [without having to resort to hacks](http://stackoverflow.com/q/21490045/2257808).
