### PR TITLE
Fix console mixed case optional value params

### DIFF
--- a/library/Zend/Console/RouteMatcher/DefaultRouteMatcher.php
+++ b/library/Zend/Console/RouteMatcher/DefaultRouteMatcher.php
@@ -151,7 +151,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              */
             elseif (preg_match('/\G\[ *\<(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?)\> *\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
-                    'name'       => strtolower($m['name']),
+                    'name'       => $m['name'],
                     'literal'    => false,
                     'required'   => false,
                     'positional' => true,

--- a/tests/ZendTest/Console/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/tests/ZendTest/Console/RouteMatcher/DefaultRouteMatcherTest.php
@@ -845,6 +845,28 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
                     'something'   => null,
                 )
             ),
+            'value-optional-with-mixed-case' => array(
+                '[<mixedCaseParam>] [--bar=]',
+                array('aBc', '--bar','abc'),
+                array(
+                    'mixedCaseParam' => 'aBc',
+                    'foo'            => null,
+                    'bar'            => 'abc',
+                    'baz'            => null,
+                    'something'      => null,
+                )
+            ),
+            'value-optional-with-upper-case' => array(
+                '[<UPPERCASEPARAM>] [--bar=]',
+                array('aBc', '--bar', 'abc'),
+                array(
+                    'UPPERCASEPARAM' => 'aBc',
+                    'foo'            => null,
+                    'bar'            => 'abc',
+                    'baz'            => null,
+                    'something'      => null,
+                )
+            ),
             /**
              * @bug ZF2-5671
              * @link https://github.com/zendframework/zf2/issues/5671


### PR DESCRIPTION
This one slipped through.

When using optional value params in console routes, i.e.

```
do something [<withThisData>]
```

Given the following script invocation:

```
./zf2 do something "with foo"
```

We would receive the following route match:

``` php
// actual
[
  'withthisdata' => 'with foo'
]
```

Where it should be:

``` php
// expected
[
  'withThisData' => 'with foo'
]
```

Notice that `withThisData` parameter became lowercased `withthisdata`.

@weierophinney - we need to include a note on that in release notes, in case someone just ignored the bug and consumed all-lowercased parameter names.
