### PR TITLE
Add a missing way to set the HTML attributes of the fieldset tag

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -120,6 +120,7 @@ class FormRow extends AbstractHelper
         $elementHelper       = $this->getElementHelper();
         $elementErrorsHelper = $this->getElementErrorsHelper();
 
+        $attributes      = $element->getAttributes();
         $label           = $element->getLabel();
         $inputErrorClass = $this->getInputErrorClass();
 
@@ -171,7 +172,8 @@ class FormRow extends AbstractHelper
             $type = $element->getAttribute('type');
             if ($type === 'multi_checkbox' || $type === 'radio') {
                 $markup = sprintf(
-                    '<fieldset><legend>%s</legend>%s</fieldset>',
+                    '<fieldset %s><legend>%s</legend>%s</fieldset>',
+                    $this->createAttributesString($attributes),
                     $label,
                     $elementString);
             } else {


### PR DESCRIPTION
Add a missing way to set the HTML attributes of the fieldset tag as reported in https://github.com/zendframework/zf2/issues/5553
