### PR TITLE
Zend Db: Multiple nested selects - Zend Paginator with nested select bind parameters error

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -13,6 +13,7 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\StatementContainer;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 
 abstract class AbstractSql
 {
@@ -173,7 +174,14 @@ abstract class AbstractSql
             $subselect->processInfo['paramPrefix'] = 'subselect' . $subselect->processInfo['subselectCount'];
 
             // call subselect
-            $subselect->prepareStatement(new \Zend\Db\Adapter\Adapter($driver, $platform), $stmtContainer);
+            if ($this instanceof PlatformDecoratorInterface) {
+                /** @var Select|PlatformDecoratorInterface $subselectDecorator */
+                $subselectDecorator = clone $this;
+                $subselectDecorator->setSubject($subselect);
+                $subselectDecorator->prepareStatement(new \Zend\Db\Adapter\Adapter($driver, $platform), $stmtContainer);
+            } else {
+                $subselect->prepareStatement(new \Zend\Db\Adapter\Adapter($driver, $platform), $stmtContainer);
+            }
 
             // copy count
             $this->processInfo['subselectCount'] = $subselect->processInfo['subselectCount'];

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -745,7 +745,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 $joinName = ($joinName[1] ? $platform->quoteIdentifier($joinName[1]) . $platform->getIdentifierSeparator() : '') . $platform->quoteIdentifier($joinName[0]);
             } else {
                 if ($joinName instanceof Select) {
-                    $joinName = '(' . $joinName->processSubSelect($joinName, $platform, $driver, $parameterContainer) . ')';
+                    $joinName = '(' . $this->processSubSelect($joinName, $platform, $driver, $parameterContainer) . ')';
                 } else {
                     $joinName = $platform->quoteIdentifier($joinName);
                 }


### PR DESCRIPTION
Using 2.2.4 with mysqli.

Zend\Db\Sql\AbstractSql->processSubSelect

This method keeps track of the number of subselects and so parameter keys do not get overwritten. However when using the Zend Paginator you get a:

Warning: mysqli_stmt::bind_param(): Number of variables doesn't match number of parameters in prepared statement

The code to replicate this is at https://gist.github.com/nicklevett/7253154.

This what is produced by Zend\Db\Adapter\ParameterContainer->merge:

```
array(6) {
  'subselect1where1' =>
  string(4) "%AB%"
  'subselect1where2' =>
  int(4)
  'subselect1where3' =>
  int(1)
  'subselect1where4' =>
  int(2)
  'subselect1where5' =>
  int(1)
  'subselect1where6' =>
  bool(true)
}
```

But should be:

```
array(6) {
  'subselect1where1' =>
  int(1)
  'subselect1where2' =>
  int(4)
  'subselect1where3' =>
  int(1)
  'subselect1where4' =>
  int(2)
  'subselect1where5' =>
  int(1)
  'subselect1where6' =>
  bool(true)
  'subselect2where1' =>
  string(4) "%AB%"
}
```

The subselect is not incremented so subselect1where1 gets overwritten
