### PR TITLE
Prevent fatal error in JsonRpc-Client

### DIFF
--- a/library/Zend/Json/Server/Response.php
+++ b/library/Zend/Json/Server/Response.php
@@ -79,10 +79,14 @@ class Response
      *
      * @param  string $json
      * @return void
+     * @throws Exception\RuntimeException
      */
     public function loadJson($json)
     {
         $options = Json::decode($json, Json::TYPE_ARRAY);
+        if (!is_array($options)) {
+            throw new Exception\RuntimeException('json is not a valid response; array expected');
+        }
         $this->setOptions($options);
     }
 

--- a/tests/ZendTest/Json/Server/ClientTest.php
+++ b/tests/ZendTest/Json/Server/ClientTest.php
@@ -217,6 +217,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedUserAgent, $this->httpClient->getHeader('User-Agent'));
     }
 
+    public function testScalarServerResponseThrowsException()
+    {
+        $response = $this->makeHttpResponseFrom('false');
+        $this->httpAdapter->setResponse($response);
+        $this->setExpectedException('Zend\Json\Exception\ExceptionInterface');
+        $this->jsonClient->call('foo');
+    }
+
     // Helpers
     public function setServerResponseTo($nativeVars)
     {

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -173,6 +173,20 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->response->getId(), $test['id']);
     }
 
+    /**
+     * @dataProvider provideScalarJSONResponses
+     */
+    public function testLoadingScalarJSONResponseShouldThrowException($json)
+    {
+        $this->setExpectedException('Zend\Json\Server\Exception\RuntimeException');
+        $this->response->loadJson($json);
+    }
+
+    public function provideScalarJSONResponses()
+    {
+        return array(array(''), array('true'), array('null'), array('3'), array('"invalid"'));
+    }
+
     public function getOptions()
     {
         return array(


### PR DESCRIPTION
Zend\Server\Json\Response passes the json_decode()'d server response to its method setOptions(), which is type hinted as array. If the server response is anything but an array, this leads to a fatal error.

Maybe the Response class should be altogether more strict in its parsing of the response, but for now I just throw a RuntimeException, as pretty much anything is preferable to a fatal error.
