### PR TITLE
Issue - AbstractDiServiceFactory ,MvcTranslatorFactory throws Exception

### DIFF
--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -76,6 +76,7 @@ class ServiceListenerFactory implements FactoryInterface
             'ViewResolver'                   => 'Zend\Mvc\Service\ViewResolverFactory',
             'ViewTemplateMapResolver'        => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',
             'ViewTemplatePathStack'          => 'Zend\Mvc\Service\ViewTemplatePathStackFactory',
+            'Zend\I18n\Translator\TranslatorInterface' => 'Zend\I18n\Translator\TranslatorServiceFactory',
         ),
         'aliases' => array(
             'Configuration'                          => 'Config',

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -76,7 +76,6 @@ class ServiceListenerFactory implements FactoryInterface
             'ViewResolver'                   => 'Zend\Mvc\Service\ViewResolverFactory',
             'ViewTemplateMapResolver'        => 'Zend\Mvc\Service\ViewTemplateMapResolverFactory',
             'ViewTemplatePathStack'          => 'Zend\Mvc\Service\ViewTemplatePathStackFactory',
-            'Zend\I18n\Translator\TranslatorInterface' => 'Zend\I18n\Translator\TranslatorServiceFactory',
         ),
         'aliases' => array(
             'Configuration'                          => 'Config',

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -10,7 +10,6 @@
 namespace Zend\ServiceManager\Di;
 
 use Zend\Di\Di;
-use Zend\Di\Exception\RuntimeException as DiException;
 use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -52,25 +51,10 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        if ($this->instanceManager->hasSharedInstance($requestedName)
+        return $this->instanceManager->hasSharedInstance($requestedName)
             || $this->instanceManager->hasAlias($requestedName)
             || $this->instanceManager->hasConfig($requestedName)
             || $this->instanceManager->hasTypePreferences($requestedName)
-        ) {
-            return true;
-        }
-
-        if (! $this->definitions->hasClass($requestedName)) {
-            return false;
-        }
-
-        try {
-            $this->serviceLocator = $serviceLocator;
-            $this->get($requestedName);
-        } catch (DiException $e) {
-            return false;
-        }
-
-        return true;
+            || $this->definitions->hasClass($requestedName);
     }
 }

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\ServiceManager\Di;
 
 use Zend\Di\Di;
+use Zend\Di\Exception\RuntimeException as DiException;
 use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -51,10 +52,25 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        return $this->instanceManager->hasSharedInstance($requestedName)
+        if ($this->instanceManager->hasSharedInstance($requestedName)
             || $this->instanceManager->hasAlias($requestedName)
             || $this->instanceManager->hasConfig($requestedName)
             || $this->instanceManager->hasTypePreferences($requestedName)
-            || $this->definitions->hasClass($requestedName);
+        ) {
+            return true;
+        }
+
+        if (! $this->definitions->hasClass($requestedName)) {
+            return false;
+        }
+
+        try {
+            $this->serviceLocator = $serviceLocator;
+            $this->get($requestedName);
+        } catch (DiException $e) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -51,10 +51,18 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        return $this->instanceManager->hasSharedInstance($requestedName)
+        if ($this->instanceManager->hasSharedInstance($requestedName)
             || $this->instanceManager->hasAlias($requestedName)
             || $this->instanceManager->hasConfig($requestedName)
             || $this->instanceManager->hasTypePreferences($requestedName)
-            || $this->definitions->hasClass($requestedName);
+        ) {
+            return true;
+        }
+
+        if (! $this->definitions->hasClass($requestedName) || interface_exists($requestedName)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
@@ -20,7 +20,7 @@ class TranslatorServiceFactoryTest extends TestCase
     public function setUp()
     {
         $this->factory = new TranslatorServiceFactory();
-        $this->services = new ServiceManager(new ServiceManagerConfig());
+        $this->services = new ServiceManager();
     }
 
     public function testReturnsMvcTranslatorWithTranslatorInterfaceServiceComposedWhenPresent()
@@ -87,15 +87,16 @@ class TranslatorServiceFactoryTest extends TestCase
             'module_listener_options' => array(),
             'modules' => array(),
         );
-        $this->services->setService('ApplicationConfig', $applicationConfig);
-        $this->services->get('ModuleManager')->loadModules();
-        $this->services->get('Application')->bootstrap();
+        $serviceLocator = new ServiceManager(new ServiceManagerConfig());
+        $serviceLocator->setService('ApplicationConfig', $applicationConfig);
+        $serviceLocator->get('ModuleManager')->loadModules();
+        $serviceLocator->get('Application')->bootstrap();
 
         //enable to re-write Config
-        $ref = new \ReflectionObject($this->services);
+        $ref = new \ReflectionObject($serviceLocator);
         $prop = $ref->getProperty('allowOverride');
         $prop->setAccessible(true);
-        $prop->setValue($this->services, true);
+        $prop->setValue($serviceLocator, true);
 
         $config = array(
             'di' => array(),
@@ -104,13 +105,14 @@ class TranslatorServiceFactoryTest extends TestCase
             ),
         );
 
-        $this->services->setService('Config', $config);
+        $serviceLocator->setService('Config', $config);
 
+        //#5959
         //get any plugins with AbstractPluginManagerFactory
         $routePluginManagerFactory = new RoutePluginManagerFactory;
-        $routePluginManager = $routePluginManagerFactory->createService($this->services);
+        $routePluginManager = $routePluginManagerFactory->createService($serviceLocator);
 
-        $translator = $this->factory->createService($this->services);
+        $translator = $this->factory->createService($serviceLocator);
         $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
         $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator->getTranslator());
 

--- a/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
@@ -10,6 +10,8 @@
 namespace ZendTest\Mvc\Service;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Service\RoutePluginManagerFactory;
+use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\Mvc\Service\TranslatorServiceFactory;
 use Zend\ServiceManager\ServiceManager;
 
@@ -18,7 +20,7 @@ class TranslatorServiceFactoryTest extends TestCase
     public function setUp()
     {
         $this->factory = new TranslatorServiceFactory();
-        $this->services = new ServiceManager();
+        $this->services = new ServiceManager(new ServiceManagerConfig());
     }
 
     public function testReturnsMvcTranslatorWithTranslatorInterfaceServiceComposedWhenPresent()
@@ -72,6 +74,46 @@ class TranslatorServiceFactoryTest extends TestCase
             'translator' => $translator->getTranslator(),
             'services'   => $this->services,
         );
+    }
+
+    public function testReturnsTranslatorBasedOnConfigurationWhenNoTranslatorInterfaceServicePresentWithMinimumBootstrap()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('This test will only run if ext/intl is present');
+        }
+
+        //minimum bootstrap
+        $applicationConfig = array(
+            'module_listener_options' => array(),
+            'modules' => array(),
+        );
+        $this->services->setService('ApplicationConfig', $applicationConfig);
+        $this->services->get('ModuleManager')->loadModules();
+        $this->services->get('Application')->bootstrap();
+
+        //enable to re-write Config
+        $ref = new \ReflectionObject($this->services);
+        $prop = $ref->getProperty('allowOverride');
+        $prop->setAccessible(true);
+        $prop->setValue($this->services, true);
+
+        $config = array(
+            'di' => array(),
+            'translator' => array(
+                'locale' => 'en_US',
+            ),
+        );
+
+        $this->services->setService('Config', $config);
+
+        //get any plugins with AbstractPluginManagerFactory
+        $routePluginManagerFactory = new RoutePluginManagerFactory;
+        $routePluginManager = $routePluginManagerFactory->createService($this->services);
+
+        $translator = $this->factory->createService($this->services);
+        $this->assertInstanceOf('Zend\Mvc\I18n\Translator', $translator);
+        $this->assertInstanceOf('Zend\I18n\Translator\Translator', $translator->getTranslator());
+
     }
 
     /**


### PR DESCRIPTION
Minimum bootstrap with Di, If Di is enabled, $serviceLocator->get('MvcTranslator'); throws
Zend\Di\Exception\RuntimeException: Invalid instantiator of type "NULL" for "Zend\I18n\Translator\TranslatorInterface".

Relative:
https://github.com/zendframework/zf2/commit/239f7565e3869f49952c848c2aa52c11a2c13f7e#diff-0683436b236aeed3e48adbdbcfb17914
