### PR TITLE
Collection Input Filter fix messages

### DIFF
--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -193,9 +193,6 @@ class CollectionInputFilter extends InputFilter
             $this->collectionValues[$key] = $this->inputFilter->getValues();
             $this->collectionRawValues[$key] = $this->inputFilter->getRawValues();
 
-            if (!empty($messages)) {
-                $this->collectionMessages[$key] = $messages;
-            }
         }
 
         return $valid;

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -147,6 +146,7 @@ class CollectionInputFilter extends InputFilter
      */
     public function isValid()
     {
+        $inputFilter = $this->getInputFilter();
         $valid = true;
 
         if ($this->getCount() < 1) {
@@ -170,22 +170,22 @@ class CollectionInputFilter extends InputFilter
             if (!is_array($data)) {
                 $data = array();
             }
-            $this->getInputFilter()->setData($data);
+            $inputFilter->setData($data);
 
             if (null !== $this->validationGroup) {
-                $this->getInputFilter()->setValidationGroup($this->validationGroup[$key]);
+                $inputFilter->setValidationGroup($this->validationGroup[$key]);
             }
 
-            if ($this->getInputFilter()->isValid()) {
-                $this->validInputs[$key] = $this->getInputFilter()->getValidInput();
+            if ($inputFilter->isValid()) {
+                $this->validInputs[$key] = $inputFilter->getValidInput();
             } else {
                 $valid = false;
-                $this->collectionMessages[$key] = $this->getInputFilter()->getMessages();
-                $this->invalidInputs[$key] = $this->getInputFilter()->getInvalidInput();
+                $this->collectionMessages[$key] = $inputFilter->getMessages();
+                $this->invalidInputs[$key] = $inputFilter->getInvalidInput();
             }
 
-            $this->collectionValues[$key] = $this->getInputFilter()->getValues();
-            $this->collectionRawValues[$key] = $this->getInputFilter()->getRawValues();
+            $this->collectionValues[$key] = $inputFilter->getValues();
+            $this->collectionRawValues[$key] = $inputFilter->getRawValues();
         }
 
         return $valid;
@@ -250,5 +250,4 @@ class CollectionInputFilter extends InputFilter
     {
         return $this->collectionMessages;
     }
-
 }

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -211,7 +211,7 @@ class CollectionInputFilter extends InputFilter
         if (is_array($groups)) {
             foreach($groups as $group) {
                 $this->inputFilter->setValidationGroup($group);
-            } 
+            }
         }
     }
 

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -203,22 +203,6 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function getInvalidInput()
-    {
-        return (is_array($this->invalidInputs) ? $this->invalidInputs : array());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidInput()
-    {
-        return (is_array($this->validInputs) ? $this->validInputs : array());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getValues()
     {
         return $this->collectionValues;

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -80,7 +80,6 @@ class CollectionInputFilter extends InputFilter
         }
 
         $this->inputFilter = $inputFilter;
-        $this->inputs = $inputFilter->getInputs();
         return $this;
     }
 
@@ -181,37 +180,19 @@ class CollectionInputFilter extends InputFilter
             if (!is_array($data)) {
                 $data = array();
             }
-            $this->data = $data;
-            $this->populate();
-
-            if ($this->validateInputs($inputs, $data)) {
-                $this->collectionValidInputs[$key] = $this->validInputs;
+            $this->inputFilter->setData($data);
+            
+            if ($this->inputFilter->isValid()) {
+                $this->collectionValidInputs[$key] = $this->inputFilter->validInputs;
             } else {
-                $this->collectionInvalidInputs[$key] = $this->invalidInputs;
                 $valid = false;
+                $this->collectionMessages[$key] = $this->inputFilter->getMessages();
+                $this->collectionInvalidInputs[$key] = $this->inputFilter->invalidInputs;
             }
 
-            $values    = array();
-            $rawValues = array();
-            $messages = array();
-            foreach ($inputs as $name) {
-                $input = $this->inputs[$name];
-
-                if ($input instanceof InputFilterInterface) {
-                    $values[$name]    = $input->getValues();
-                    $rawValues[$name] = $input->getRawValues();
-                    continue;
-                }
-                $values[$name]    = $input->getValue($this->data);
-                $rawValues[$name] = $input->getRawValue();
-                $tmpMessages = $input->getMessages();
-                if (!empty($tmpMessages)) {
-                    $messages[$name] =  $tmpMessages;
-                }
-            }
-            $this->collectionValues[$key]    = $values;
-            $this->collectionRawValues[$key] = $rawValues;
-
+            $this->collectionValues[$key]    = $this->inputFilter->getValues();
+            $this->collectionRawValues[$key] = $this->inputFilter->getRawValues();
+            
             if (!empty($messages)) {
                 $this->collectionMessages[$key] = $messages;
             }

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -13,7 +14,6 @@ use Traversable;
 
 class CollectionInputFilter extends InputFilter
 {
-
     /*
      * @var bool
      */
@@ -66,6 +66,7 @@ class CollectionInputFilter extends InputFilter
         }
 
         $this->inputFilter = $inputFilter;
+
         return $this;
     }
 
@@ -79,6 +80,7 @@ class CollectionInputFilter extends InputFilter
         if (null === $this->inputFilter) {
             $this->setInputFilter(new InputFilter());
         }
+
         return $this->inputFilter;
     }
 
@@ -91,6 +93,7 @@ class CollectionInputFilter extends InputFilter
     public function setIsRequired($isRequired)
     {
         $this->isRequired = $isRequired;
+
         return $this;
     }
 
@@ -104,7 +107,6 @@ class CollectionInputFilter extends InputFilter
         return $this->isRequired;
     }
 
-
     /**
      * Set the count of data to validate
      *
@@ -114,6 +116,7 @@ class CollectionInputFilter extends InputFilter
     public function setCount($count)
     {
         $this->count = $count > 0 ? $count : 0;
+
         return $this;
     }
 
@@ -127,6 +130,7 @@ class CollectionInputFilter extends InputFilter
         if (null === $this->count) {
             $this->count = count($this->data);
         }
+
         return $this->count;
     }
 
@@ -158,6 +162,7 @@ class CollectionInputFilter extends InputFilter
         if (empty($this->data)) {
             $this->clearValues();
             $this->clearRawValues();
+
             return $valid;
         }
 
@@ -165,19 +170,22 @@ class CollectionInputFilter extends InputFilter
             if (!is_array($data)) {
                 $data = array();
             }
-            $this->inputFilter->setData($data);
+            $this->getInputFilter()->setData($data);
 
-            if ($this->inputFilter->isValid()) {
-                $this->validInputs[$key] = $this->inputFilter->getValidInput();
-            } else {
-                $valid = false;
-                $this->collectionMessages[$key] = $this->inputFilter->getMessages();
-                $this->invalidInputs[$key] = $this->inputFilter->getInvalidInput();
+            if (null !== $this->validationGroup) {
+                $this->getInputFilter()->setValidationGroup($this->validationGroup[$key]);
             }
 
-            $this->collectionValues[$key] = $this->inputFilter->getValues();
-            $this->collectionRawValues[$key] = $this->inputFilter->getRawValues();
+            if ($this->getInputFilter()->isValid()) {
+                $this->validInputs[$key] = $this->getInputFilter()->getValidInput();
+            } else {
+                $valid = false;
+                $this->collectionMessages[$key] = $this->getInputFilter()->getMessages();
+                $this->invalidInputs[$key] = $this->getInputFilter()->getInvalidInput();
+            }
 
+            $this->collectionValues[$key] = $this->getInputFilter()->getValues();
+            $this->collectionRawValues[$key] = $this->getInputFilter()->getRawValues();
         }
 
         return $valid;
@@ -190,14 +198,13 @@ class CollectionInputFilter extends InputFilter
     {
         if ($name === self::VALIDATE_ALL) {
             $this->validationGroup = null;
+
             return $this;
         }
 
-        if (is_array($name)) {
-            foreach($name as $group) {
-                $this->inputFilter->setValidationGroup($group);
-            }
-        }
+        $this->validationGroup = $name;
+
+        return $this;
     }
 
     /**
@@ -243,4 +250,5 @@ class CollectionInputFilter extends InputFilter
     {
         return $this->collectionMessages;
     }
+
 }

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -13,20 +13,6 @@ use Traversable;
 
 class CollectionInputFilter extends InputFilter
 {
-    /*
-     * @var array
-     */
-    protected $collectionData;
-
-    /*
-     * @var array
-     */
-    protected $collectionValidInputs;
-
-    /*
-     * @var array
-     */
-    protected $collectionInvalidInputs;
 
     /*
      * @var bool
@@ -139,7 +125,7 @@ class CollectionInputFilter extends InputFilter
     public function getCount()
     {
         if (null === $this->count) {
-            $this->count = count($this->collectionData);
+            $this->count = count($this->data);
         }
         return $this->count;
     }
@@ -149,7 +135,7 @@ class CollectionInputFilter extends InputFilter
      */
     public function setData($data)
     {
-        $this->collectionData = $data;
+        $this->data = $data;
     }
 
     /**
@@ -165,29 +151,28 @@ class CollectionInputFilter extends InputFilter
             }
         }
 
-        if (count($this->collectionData) < $this->getCount()) {
+        if (count($this->data) < $this->getCount()) {
             $valid = false;
         }
 
-        if (empty($this->collectionData)) {
+        if (empty($this->data)) {
             $this->clearValues();
             $this->clearRawValues();
             return $valid;
         }
 
-        $inputs = $this->validationGroup ?: array_keys($this->inputFilter->getInputs());
-        foreach ($this->collectionData as $key => $data) {
+        foreach ($this->data as $key => $data) {
             if (!is_array($data)) {
                 $data = array();
             }
             $this->inputFilter->setData($data);
 
             if ($this->inputFilter->isValid()) {
-                $this->collectionValidInputs[$key] = $this->inputFilter->getValidInput();
+                $this->validInputs[$key] = $this->inputFilter->getValidInput();
             } else {
                 $valid = false;
                 $this->collectionMessages[$key] = $this->inputFilter->getMessages();
-                $this->collectionInvalidInputs[$key] = $this->inputFilter->getInvalidInput();
+                $this->invalidInputs[$key] = $this->inputFilter->getInvalidInput();
             }
 
             $this->collectionValues[$key] = $this->inputFilter->getValues();
@@ -201,15 +186,15 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function setValidationGroup($groups)
+    public function setValidationGroup($name)
     {
-        if ($groups === self::VALIDATE_ALL) {
+        if ($name === self::VALIDATE_ALL) {
             $this->validationGroup = null;
             return $this;
         }
 
-        if (is_array($groups)) {
-            foreach($groups as $group) {
+        if (is_array($name)) {
+            foreach($name as $group) {
                 $this->inputFilter->setValidationGroup($group);
             }
         }
@@ -220,7 +205,7 @@ class CollectionInputFilter extends InputFilter
      */
     public function getInvalidInput()
     {
-        return (is_array($this->collectionInvalidInputs) ? $this->collectionInvalidInputs : array());
+        return (is_array($this->invalidInputs) ? $this->invalidInputs : array());
     }
 
     /**
@@ -228,7 +213,7 @@ class CollectionInputFilter extends InputFilter
      */
     public function getValidInput()
     {
-        return (is_array($this->collectionValidInputs) ? $this->collectionValidInputs : array());
+        return (is_array($this->validInputs) ? $this->validInputs : array());
     }
 
     /**

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -175,7 +175,7 @@ class CollectionInputFilter extends InputFilter
             return $valid;
         }
 
-        $inputs = $this->validationGroup ?: array_keys($this->inputs);
+        $inputs = $this->validationGroup ?: array_keys($this->inputFilter->getInputs());
         foreach ($this->collectionData as $key => $data) {
             if (!is_array($data)) {
                 $data = array();
@@ -183,11 +183,11 @@ class CollectionInputFilter extends InputFilter
             $this->inputFilter->setData($data);
 
             if ($this->inputFilter->isValid()) {
-                $this->collectionValidInputs[$key] = $this->inputFilter->validInputs;
+                $this->collectionValidInputs[$key] = $this->inputFilter->getValidInput();
             } else {
                 $valid = false;
                 $this->collectionMessages[$key] = $this->inputFilter->getMessages();
-                $this->collectionInvalidInputs[$key] = $this->inputFilter->invalidInputs;
+                $this->collectionInvalidInputs[$key] = $this->inputFilter->getInvalidInput();
             }
 
             $this->collectionValues[$key] = $this->inputFilter->getValues();

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -181,7 +181,7 @@ class CollectionInputFilter extends InputFilter
                 $data = array();
             }
             $this->inputFilter->setData($data);
-            
+
             if ($this->inputFilter->isValid()) {
                 $this->collectionValidInputs[$key] = $this->inputFilter->validInputs;
             } else {
@@ -190,9 +190,9 @@ class CollectionInputFilter extends InputFilter
                 $this->collectionInvalidInputs[$key] = $this->inputFilter->invalidInputs;
             }
 
-            $this->collectionValues[$key]    = $this->inputFilter->getValues();
+            $this->collectionValues[$key] = $this->inputFilter->getValues();
             $this->collectionRawValues[$key] = $this->inputFilter->getRawValues();
-            
+
             if (!empty($messages)) {
                 $this->collectionMessages[$key] = $messages;
             }

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -204,22 +204,18 @@ class CollectionInputFilter extends InputFilter
     /**
      * {@inheritdoc}
      */
-    public function setValidationGroup($name)
+    public function setValidationGroup($groups)
     {
-        if ($name === self::VALIDATE_ALL) {
+        if ($groups === self::VALIDATE_ALL) {
             $this->validationGroup = null;
             return $this;
         }
 
-        if (is_array($name)) {
-            // Best effort check if the validation group was set by a form for BC
-            if (count($name) == count($this->collectionData) && is_array(reset($name))) {
-                return parent::setValidationGroup(reset($name));
-            }
-            return parent::setValidationGroup($name);
+        if (is_array($groups)) {
+            foreach($groups as $group) {
+                $this->inputFilter->setValidationGroup($group);
+            } 
         }
-
-        return parent::setValidationGroup(func_get_args());
     }
 
     /**

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -327,6 +327,16 @@ class CollectionInputFilterTest extends TestCase
                     'baz' => '',
                 ),
             ),
+            array(
+                'foo' => ' bazbat ',
+                'bar' => '12345',
+                'baz' => '',
+                'nest' => array(
+                    // missing 'foo' here
+                    'bar' => '12345',
+                    'baz' => '',
+                ),
+            ),
         );
 
         $this->filter->setInputFilter($this->getBaseInputFilter());
@@ -334,19 +344,21 @@ class CollectionInputFilterTest extends TestCase
 
         $this->assertFalse($this->filter->isValid());
 
-        $this->assertCount(2, $this->filter->getInvalidInput());
+        $this->assertCount(3, $this->filter->getInvalidInput());
         foreach ($this->filter->getInvalidInput() as $invalidInputs) {
             $this->assertCount(1, $invalidInputs);
         }
 
         $messages = $this->filter->getMessages();
-
-        $this->assertCount(2, $messages);
+        
+        $this->assertCount(3, $messages);
         $this->assertArrayHasKey('foo', $messages[0]);
         $this->assertArrayHasKey('bar', $messages[1]);
+        $this->assertArrayHasKey('nest', $messages[2]);
 
         $this->assertCount(1, $messages[0]['foo']);
         $this->assertCount(1, $messages[1]['bar']);
+        $this->assertCount(1, $messages[2]['nest']);
     }
 
     public function testSetValidationGroupUsingFormStyle()

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -350,7 +350,7 @@ class CollectionInputFilterTest extends TestCase
         }
 
         $messages = $this->filter->getMessages();
-        
+
         $this->assertCount(3, $messages);
         $this->assertArrayHasKey('foo', $messages[0]);
         $this->assertArrayHasKey('bar', $messages[1]);

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -109,17 +109,6 @@ class CollectionInputFilterTest extends TestCase
         $this->assertInstanceOf('Zend\InputFilter\BaseInputFilter', $this->filter->getInputFilter());
     }
 
-    public function testInputFilterInputsAppliedToCollection()
-    {
-        if (!extension_loaded('intl')) {
-            $this->markTestSkipped('ext/intl not enabled');
-        }
-
-        $this->filter->setInputFilter($this->getBaseInputFilter());
-
-        $this->assertCount(4, $this->filter->getInputs());
-    }
-
     public function testGetDefaultInputFilter()
     {
         $this->assertInstanceOf('Zend\InputFilter\BaseInputFilter', $this->filter->getInputFilter());

--- a/tests/ZendTest/InputFilter/InputFilterTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterTest.php
@@ -51,9 +51,13 @@ class InputFilterTest extends TestCase
      */
     public function testCountZeroValidateInternalInputWithCollectionInputFilter()
     {
+        $inputFilter = new InputFilter();
+        $inputFilter->add(new Input(), 'name');
+        
         $collection = new CollectionInputFilter();
-        $collection->setCount(0)
-                   ->add(new Input(), 'name');
+        $collection->setInputFilter($inputFilter);
+        $collection->setCount(0);
+                   
         $this->filter->add($collection, 'people');
 
         $data = array(

--- a/tests/ZendTest/InputFilter/InputFilterTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterTest.php
@@ -53,11 +53,11 @@ class InputFilterTest extends TestCase
     {
         $inputFilter = new InputFilter();
         $inputFilter->add(new Input(), 'name');
-        
+
         $collection = new CollectionInputFilter();
         $collection->setInputFilter($inputFilter);
         $collection->setCount(0);
-                   
+
         $this->filter->add($collection, 'people');
 
         $data = array(


### PR DESCRIPTION
All CollectionInputFilter messages are returning as a empty arrays instead of an array of messages.

Also modified the class behavior. Previously it was copying the inputs from its Inputfilter and validating the InputFilter in CollectionInputFilter, which is not necessary since it can already be done in the InputFilter itself. 

To make sure this is necessary, I updated testGetDefaultInputFilter, so it can fail when there is a error in the nested CollectionInputFilter. It is failing in current master, but it will work with this hotfix.

The CollectionInputFilter should only get each element data and setting it to the InputFilter it contains, get back the validation and messages and return in its own methods.

Special thanks to @danizord, who is always helping me with those issues.
