### PR TITLE
Fix tablegateway query with selectWith alias

### DIFF
--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -216,7 +216,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected function executeSelect(Select $select)
     {
         $selectState = $select->getRawState();
-        if ($selectState['table'] != $this->table) {
+        if ($selectState['table'] != $this->table && (is_array($selectState['table']) && end($selectState['table']) != $this->table)) {
             throw new Exception\RuntimeException('The table name of the provided select object must match that of the table');
         }
 


### PR DESCRIPTION
Fixed this error:

$tableGateway = new \Zend\Db\TableGateway\TableGateway('main_table', $adapter);
$select = new \Zend\Db\Sql\Select(array('MT' => 'main_table'));

// Joins...group...etc...

$result = $tableGateway->selectWith($select);//Exception thrown here...
//Msg: The table name of the provided select object must match that of the table
