### PR TITLE
Rbac::getRole() : check object->getName()

### DIFF
--- a/library/Zend/Permissions/Rbac/AbstractIterator.php
+++ b/library/Zend/Permissions/Rbac/AbstractIterator.php
@@ -13,7 +13,13 @@ use RecursiveIterator;
 
 abstract class AbstractIterator implements RecursiveIterator
 {
+    /**
+     * @var int
+     */
     protected $index    = 0;
+    /**
+     * @var array
+     */
     protected $children = array();
 
     /**
@@ -42,7 +48,7 @@ abstract class AbstractIterator implements RecursiveIterator
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Return the key of the current element
      * @link http://php.net/manual/en/iterator.key.php
-     * @return scalar scalar on success, or null on failure.
+     * @return int|null scalar on success, or null on failure.
      */
     public function key()
     {

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -110,8 +110,10 @@ class Rbac extends AbstractIterator
 
         $it = new RecursiveIteratorIterator($this, RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($it as $leaf) {
-            /* @var RoleInterface $leaf */
-            if ((is_string($objectOrName) && $leaf->getName() == $objectOrName) || $leaf == $objectOrName) {
+            /** @var RoleInterface $leaf */
+            if ((is_string($objectOrName) && $leaf->getName() == $objectOrName)
+                || (is_object($objectOrName) && $leaf->getName() == $objectOrName->getName())
+            ) {
                 return $leaf;
             }
         }

--- a/library/Zend/Permissions/Rbac/Rbac.php
+++ b/library/Zend/Permissions/Rbac/Rbac.php
@@ -108,12 +108,16 @@ class Rbac extends AbstractIterator
             );
         }
 
+        if (is_object($objectOrName)) {
+            $requiredRole = $objectOrName->getName();
+        } else {
+            $requiredRole = $objectOrName;
+        }
+
         $it = new RecursiveIteratorIterator($this, RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($it as $leaf) {
             /** @var RoleInterface $leaf */
-            if ((is_string($objectOrName) && $leaf->getName() == $objectOrName)
-                || (is_object($objectOrName) && $leaf->getName() == $objectOrName->getName())
-            ) {
+            if ($leaf->getName() == $requiredRole) {
                 return $leaf;
             }
         }

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -82,16 +82,30 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $this->rbac->isGranted('bar', 'can.baz'));
     }
 
+    /**
+     * @covers Zend\Permissions\Rbac\Rbac::hasRole()
+     */
     public function testHasRole()
     {
         $foo = new Rbac\Role('foo');
+        $snafu = new TestAsset\RoleTest('snafu');
 
         $this->rbac->addRole('bar');
         $this->rbac->addRole($foo);
+        $this->rbac->addRole('snafu');
 
-        $this->assertEquals(true, $this->rbac->hasRole($foo));
-        $this->assertEquals(true, $this->rbac->hasRole('bar'));
-        $this->assertEquals(false, $this->rbac->hasRole('baz'));
+        // check that the container has the same object $foo
+        $this->assertTrue($this->rbac->hasRole($foo));
+
+        // check that the container has the same string "bar"
+        $this->assertTrue($this->rbac->hasRole('bar'));
+
+        // check that the container do not have the string "baz"
+        $this->assertFalse($this->rbac->hasRole('baz'));
+
+        // check that we can compare two different objects with same name
+        $this->assertNotEquals($this->rbac->getRole('snafu'), $snafu);
+        $this->assertTrue($this->rbac->hasRole($snafu));
     }
 
     public function testAddRoleFromString()

--- a/tests/ZendTest/Permissions/Rbac/TestAsset/RoleTest.php
+++ b/tests/ZendTest/Permissions/Rbac/TestAsset/RoleTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Permissions\Rbac\TestAsset;
+
+use Zend\Permissions\Rbac\AbstractRole;
+
+class RoleTest extends AbstractRole
+{
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
We know that `$objectOrName`, can only be `string` or `RoleInterface`.

So if it's an object, we can check with `getName()` method.

If found it usefull for some unit tests which did not pass because `$leaf` and `$objectOrName` were not the same when `$objectOrName` was a mock. 

In this case, the test `$leaf == $objectOrName` was false when it should be true because the two objects had the same name property, even if the rest of the objects were different.
