### PR TITLE
Fix BC break in TranslatorServiceFactory

### DIFF
--- a/library/Zend/Mvc/Service/TranslatorServiceFactory.php
+++ b/library/Zend/Mvc/Service/TranslatorServiceFactory.php
@@ -34,11 +34,6 @@ class TranslatorServiceFactory implements FactoryInterface
             return new MvcTranslator($serviceLocator->get('Zend\I18n\Translator\TranslatorInterface'));
         }
 
-        // If ext/intl is not loaded, return a dummy translator
-        if (!extension_loaded('intl')) {
-            return new MvcTranslator(new DummyTranslator());
-        }
-
         // Load a translator from configuration, if possible
         if ($serviceLocator->has('Config')) {
             $config = $serviceLocator->get('Config');
@@ -57,6 +52,11 @@ class TranslatorServiceFactory implements FactoryInterface
                 $serviceLocator->setService('Zend\I18n\Translator\TranslatorInterface', $i18nTranslator);
                 return new MvcTranslator($i18nTranslator);
             }
+        }
+
+        // If ext/intl is not loaded, return a dummy translator
+        if (!extension_loaded('intl')) {
+            return new MvcTranslator(new DummyTranslator());
         }
 
         // For BC purposes (pre-2.3.0), use the I18n Translator

--- a/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/TranslatorServiceFactoryTest.php
@@ -55,10 +55,6 @@ class TranslatorServiceFactoryTest extends TestCase
 
     public function testReturnsTranslatorBasedOnConfigurationWhenNoTranslatorInterfaceServicePresent()
     {
-        if (!extension_loaded('intl')) {
-            $this->markTestSkipped('This test will only run if ext/intl is present');
-        }
-
         $config = array('translator' => array(
             'locale' => 'en_US',
         ));


### PR DESCRIPTION
Fix for issue #5978. The check for the `intl` extension must be done after checking for the `translator` config key, not before. The test for this was deactivated, this PR also reactivates that test again.
