### PR TITLE
Remove unused uses that are causing check-cs to fail

### DIFF
--- a/tests/ZendTest/Barcode/Object/TestCommon.php
+++ b/tests/ZendTest/Barcode/Object/TestCommon.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Barcode\Object;
 
-use ZendTest\Barcode\Object\TestAsset;
 use Zend\Barcode;
 use Zend\Config;
 

--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Code\Generator;
 
-use Exception;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\FileGenerator;
 use Zend\Code\Reflection\FileReflection;

--- a/tests/ZendTest/Code/Generator/TestAsset/ClassWithUses.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/ClassWithUses.php
@@ -10,7 +10,6 @@
 
 namespace ZendTest\Code\Generator\TestAsset;
 
-use ZendTest\Code\Generator\TestAsset\ClassWithNamespace;
 
 class ClassWithUses
 {

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass8.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass8.php
@@ -9,9 +9,7 @@
 
 namespace ZendTest\Code\Reflection\TestAsset;
 
-use Zend\Config as ZendConfig;
 use FooBar\Foo\Bar;
-use One\Two\Three\Four\Five as ottff;
 
 
 class TestSampleClass8

--- a/tests/ZendTest/Filter/BaseNameTest.php
+++ b/tests/ZendTest/Filter/BaseNameTest.php
@@ -9,7 +9,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\BaseName as BaseNameFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group Zend_Filter

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\Digits as DigitsFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\Int as IntFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/RealPathTest.php
+++ b/tests/ZendTest/Filter/RealPathTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\RealPath as RealPathFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\StringToLower as StringToLowerFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\StringToUpper as StringToUpperFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Filter;
 
 use Zend\Filter\StripTags as StripTagsFilter;
-use Zend\Stdlib\ErrorHandler;
 
 /**
  * @group      Zend_Filter

--- a/tests/ZendTest/Mvc/Controller/Plugin/TestAsset/InputFilterProviderFieldset.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/TestAsset/InputFilterProviderFieldset.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Mvc\Controller\Plugin\TestAsset;
 
-use Zend\Form\Element;
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
 

--- a/tests/ZendTest/Mvc/Router/SimpleRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/SimpleRouteStackTest.php
@@ -14,7 +14,6 @@ use ArrayIterator;
 use Zend\Stdlib\Request;
 use Zend\Mvc\Router\RoutePluginManager;
 use Zend\Mvc\Router\SimpleRouteStack;
-use ZendTest\Mvc\Router\FactoryTester;
 
 class SimpleRouteStackTest extends TestCase
 {

--- a/tests/ZendTest/Permissions/Acl/Assertion/AssertionAggregateTest.php
+++ b/tests/ZendTest/Permissions/Acl/Assertion/AssertionAggregateTest.php
@@ -9,7 +9,6 @@
 namespace ZendTest\Permissions\Acl\Assertion;
 
 use Zend\Permissions\Acl\Assertion\AssertionAggregate;
-use ZendTest\Permissions\Acl\TestAsset\MockAssertion;
 use Zend\Di\Exception\UndefinedReferenceException;
 
 class AssertionAggregateTest extends \PHPUnit_Framework_TestCase

--- a/tests/ZendTest/Permissions/Rbac/RbacTest.php
+++ b/tests/ZendTest/Permissions/Rbac/RbacTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Permissions\Rbac;
 
 use Zend\Permissions\Rbac;
-use ZendTest\Permissions\Rbac\TestAsset;
 
 /**
  * @group      Zend_Rbac

--- a/tests/ZendTest/Tag/Cloud/CloudTest.php
+++ b/tests/ZendTest/Tag/Cloud/CloudTest.php
@@ -11,10 +11,7 @@ namespace ZendTest\Tag\Cloud;
 
 use stdClass;
 use Zend\Tag;
-use Zend\Tag\Cloud;
 use Zend\Tag\Cloud\DecoratorPluginManager;
-use Zend\Tag\Exception\InvalidArgumentException;
-use ZendTest\Tag\Cloud\TestAsset;
 
 /**
  * @group      Zend_Tag

--- a/tests/ZendTest/Validator/ExplodeTest.php
+++ b/tests/ZendTest/Validator/ExplodeTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Validator;
 
 use Zend\Validator\Explode;
-use Zend\Validator\EmailAddress;
 use Zend\Validator\Regex;
 
 /**


### PR DESCRIPTION
Remove all unused uses causing check-cs to fail

EDIT: I Didn't notice the unused uses fixer wasn't enabled for the tests folder, so the problem is cs-check-cs.sh itself.

@Maks3w Some of the tests, i guess is the second one, is showing up this message "Loaded config from "/var/www/zf2/./tests/.php_cs"", which makes the check-cs.sh think there is an error. As you're working with that checker, could you please take a look at that? All PR's are failing in Travis, even with no errors.
