### PR TITLE
Bug fix: Removes length limit (of TLD) when validating a hostname

### DIFF
--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -522,7 +522,7 @@ class Hostname extends AbstractValidator
             do {
                 // First check TLD
                 $matches = array();
-                if (preg_match('/([^.]{2,10})$/iu', end($domainParts), $matches)
+                if (preg_match('/([^.]{2,})$/iu', end($domainParts), $matches)
                     || (array_key_exists(end($domainParts), $this->validIdns))) {
                     reset($domainParts);
 

--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -522,7 +522,7 @@ class Hostname extends AbstractValidator
             do {
                 // First check TLD
                 $matches = array();
-                if (preg_match('/([^.]{2,})$/iu', end($domainParts), $matches)
+                if (preg_match('/([^.]{2,63})$/iu', end($domainParts), $matches)
                     || (array_key_exists(end($domainParts), $this->validIdns))) {
                     reset($domainParts);
 

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -49,7 +49,7 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
         $valuesExpected = array(
             array(Hostname::ALLOW_IP, true, array('1.2.3.4', '10.0.0.1', '255.255.255.255')),
             array(Hostname::ALLOW_IP, false, array('1.2.3.4.5', '0.0.0.256')),
-            array(Hostname::ALLOW_DNS, true, array('example.com', 'example.museum', 'd.hatena.ne.jp')),
+            array(Hostname::ALLOW_DNS, true, array('example.com', 'example.museum', 'd.hatena.ne.jp', 'example.photography')),
             array(Hostname::ALLOW_DNS, false, array('localhost', 'localhost.localdomain', '1.2.3.4', 'domain.invalid')),
             array(Hostname::ALLOW_LOCAL, true, array('localhost', 'localhost.localdomain', 'example.com')),
             array(Hostname::ALLOW_ALL, true, array('localhost', 'example.com', '1.2.3.4')),


### PR DESCRIPTION
The regular expression matching a tld in a hostname was limited to 2 to 10 chars.
This limit was reached with new gTLDs like .photography. Added this use case to
tests and removed length limit of 10 chars to allow new TLDs like .photography.
