### PR TITLE
less "quoted-printable" overhead

### DIFF
--- a/library/Zend/Mail/Header/HeaderWrap.php
+++ b/library/Zend/Mail/Header/HeaderWrap.php
@@ -47,7 +47,7 @@ abstract class HeaderWrap
     protected static function wrapUnstructuredHeader($value, HeaderInterface $header)
     {
         $encoding = $header->getEncoding();
-        if ($encoding == 'ASCII') {
+        if ($encoding == 'ASCII' or !preg_match('/[^\x00-\x7f]/', $value)) {
             return wordwrap($value, 78, Headers::FOLDING);
         }
         return static::mimeEncodeValue($value, $encoding, 78);


### PR DESCRIPTION
@Zend/Mail: now no transcoding if header value is already US-ASCII. It would be "quoted-printable" if encoding property of message object has been set to "UTF-8"
https://github.com/zendframework/zf2/issues/5987
