### PR TITLE
Update segment route to TranslatorInterface

### DIFF
--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -10,7 +10,7 @@
 namespace Zend\Mvc\Router\Http;
 
 use Traversable;
-use Zend\I18n\Translator\Translator;
+use Zend\I18n\Translator\TranslatorInterface as Translator;
 use Zend\Mvc\Router\Exception;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\RequestInterface as Request;


### PR DESCRIPTION
Fix for issue #5965 where the translation of segment routes is broken due to `Zend\I18n\Translator\Translator` instead of `Zend\I18n\Translator\TranslatorInterface`
