### PR TITLE
[proposal] Cache item : set lifetime of an item

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -661,6 +661,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      *
      * @param  string $key
      * @param  mixed  $value
+     * @param  int  $ttl Lifetime for this item
      * @return bool
      * @throws Exception\ExceptionInterface
      *
@@ -668,7 +669,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @triggers setItem.post(PostEvent)
      * @triggers setItem.exception(ExceptionEvent)
      */
-    public function setItem($key, $value)
+    public function setItem($key, $value, $ttl = 0)
     {
         if (!$this->getOptions()->getWritable()) {
             return false;
@@ -702,7 +703,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    abstract protected function internalSetItem(& $normalizedKey, & $value);
+    abstract protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0);
 
     /**
      * Store multiple items.

--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -661,7 +661,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      *
      * @param  string $key
      * @param  mixed  $value
-     * @param  int  $ttl Lifetime for this item
+     * @param  int    $ttl    Lifetime for this item
      * @return bool
      * @throws Exception\ExceptionInterface
      *

--- a/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
@@ -163,11 +163,11 @@ abstract class AbstractZendServer extends AbstractAdapter
      * Internal method to store an item.
      *
      * @param  string $normalizedKey
-     * @param  mixed  $value
+     * @param  mixed $value
+     * @param int $ttl
      * @return bool
-     * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractZendServer.php
@@ -163,8 +163,8 @@ abstract class AbstractZendServer extends AbstractAdapter
      * Internal method to store an item.
      *
      * @param  string $normalizedKey
-     * @param  mixed $value
-     * @param int $ttl
+     * @param  mixed  $value
+     * @param int     $ttl
      * @return bool
      */
     protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -400,7 +400,7 @@ class Apc extends AbstractAdapter implements
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+        $ttl         = $ttl ? $ttl : $options->getTtl();
 
         if (!apc_store($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);

--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -394,7 +394,7 @@ class Apc extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/BlackHole.php
+++ b/library/Zend/Cache/Storage/Adapter/BlackHole.php
@@ -58,7 +58,7 @@ class BlackHole implements
     /**
      * Constructor
      *
-     * @param  null|array|Traversable|AdapterOptions $options
+     * @param  null|array|\Traversable|AdapterOptions $options
      */
     public function __construct($options = null)
     {
@@ -70,7 +70,7 @@ class BlackHole implements
     /**
      * Set options.
      *
-     * @param array|Traversable|Adapter\AdapterOptions $options
+     * @param array|\Traversable|AdapterOptions $options
      * @return StorageInterface Fluent interface
      */
     public function setOptions($options)
@@ -92,7 +92,7 @@ class BlackHole implements
     /**
      * Get options
      *
-     * @return Adapter\AdapterOptions
+     * @return AdapterOptions
      */
     public function getOptions()
     {
@@ -428,7 +428,7 @@ class BlackHole implements
     /**
      * Get the storage iterator
      *
-     * @return KeyIterator
+     * @return KeyListIterator
      */
     public function getIterator()
     {

--- a/library/Zend/Cache/Storage/Adapter/BlackHole.php
+++ b/library/Zend/Cache/Storage/Adapter/BlackHole.php
@@ -175,8 +175,8 @@ class BlackHole implements
      * Store an item.
      *
      * @param  string $key
-     * @param  mixed $value
-     * @param int $ttl
+     * @param  mixed  $value
+     * @param int     $ttl
      * @return bool
      */
     public function setItem($key, $value, $ttl = 0)

--- a/library/Zend/Cache/Storage/Adapter/BlackHole.php
+++ b/library/Zend/Cache/Storage/Adapter/BlackHole.php
@@ -175,10 +175,11 @@ class BlackHole implements
      * Store an item.
      *
      * @param  string $key
-     * @param  mixed  $value
+     * @param  mixed $value
+     * @param int $ttl
      * @return bool
      */
-    public function setItem($key, $value)
+    public function setItem($key, $value, $ttl = 0)
     {
         return false;
     }

--- a/library/Zend/Cache/Storage/Adapter/Dba.php
+++ b/library/Zend/Cache/Storage/Adapter/Dba.php
@@ -370,7 +370,7 @@ class Dba extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -758,13 +758,13 @@ class Filesystem extends AbstractAdapter implements
      * @triggers setItem.post(PostEvent)
      * @triggers setItem.exception(ExceptionEvent)
      */
-    public function setItem($key, $value)
+    public function setItem($key, $value, $ttl = 0)
     {
         $options = $this->getOptions();
         if ($options->getWritable() && $options->getClearStatCache()) {
             clearstatcache();
         }
-        return parent::setItem($key, $value);
+        return parent::setItem($key, $value, $ttl);
     }
 
     /**
@@ -882,7 +882,7 @@ class Filesystem extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $filespec = $this->getFileSpec($normalizedKey);
         $this->prepareDirectoryStructure($filespec);

--- a/library/Zend/Cache/Storage/Adapter/Memcache.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcache.php
@@ -354,7 +354,7 @@ class Memcache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $memc       = $this->getMemcacheResource();
         $expiration = $this->expirationTime();

--- a/library/Zend/Cache/Storage/Adapter/Memcache.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcache.php
@@ -357,7 +357,7 @@ class Memcache extends AbstractAdapter implements
     protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $memc       = $this->getMemcacheResource();
-        $expiration = $this->expirationTime();
+        $expiration = $ttl ? $ttl : $this->expirationTime();
         $flag       = $this->getWriteFlag($value);
 
         if (!$memc->set($this->namespacePrefix . $normalizedKey, $value, $flag, $expiration)) {

--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -375,10 +375,10 @@ class Memcached extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $memc       = $this->getMemcachedResource();
-        $expiration = $this->expirationTime();
+        $expiration = $ttl ? $ttl : $this->expirationTime();
         if (!$memc->set($this->namespacePrefix . $normalizedKey, $value, $expiration)) {
             throw $this->getExceptionByResultCode($memc->getResultCode());
         }

--- a/library/Zend/Cache/Storage/Adapter/Memory.php
+++ b/library/Zend/Cache/Storage/Adapter/Memory.php
@@ -441,7 +441,7 @@ class Memory extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $options = $this->getOptions();
 

--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -220,7 +220,7 @@ class Redis extends AbstractAdapter implements
     protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $redis = $this->getRedisResource();
-        $ttl = $this->getOptions()->getTtl();
+        $ttl = $ttl ? $ttl : $this->getOptions()->getTtl();
 
         try {
             if ($ttl) {

--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -217,7 +217,7 @@ class Redis extends AbstractAdapter implements
      * @return bool
      * @throws Exception\RuntimeException
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $redis = $this->getRedisResource();
         $ttl = $this->getOptions()->getTtl();

--- a/library/Zend/Cache/Storage/Adapter/Session.php
+++ b/library/Zend/Cache/Storage/Adapter/Session.php
@@ -264,7 +264,7 @@ class Session extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -235,7 +235,7 @@ class WinCache extends AbstractAdapter implements
         $namespace   = $options->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+        $ttl         = $ttl ? $ttl : $options->getTtl();
 
         if (!wincache_ucache_set($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);

--- a/library/Zend/Cache/Storage/Adapter/WinCache.php
+++ b/library/Zend/Cache/Storage/Adapter/WinCache.php
@@ -229,7 +229,7 @@ class WinCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/XCache.php
+++ b/library/Zend/Cache/Storage/Adapter/XCache.php
@@ -342,7 +342,7 @@ class XCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/library/Zend/Cache/Storage/Adapter/XCache.php
+++ b/library/Zend/Cache/Storage/Adapter/XCache.php
@@ -348,7 +348,7 @@ class XCache extends AbstractAdapter implements
         $namespace   = $options->getNamespace();
         $prefix      = ($options === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
-        $ttl         = $options->getTtl();
+        $ttl         = $ttl ? $ttl : $options->getTtl();
 
         if (!xcache_set($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);

--- a/library/Zend/Cache/Storage/StorageInterface.php
+++ b/library/Zend/Cache/Storage/StorageInterface.php
@@ -92,11 +92,11 @@ interface StorageInterface
      * Store an item.
      *
      * @param  string $key
-     * @param  mixed  $value
+     * @param  mixed $value
+     * @param int $ttl Lifetime for this item
      * @return bool
-     * @throws \Zend\Cache\Exception\ExceptionInterface
      */
-    public function setItem($key, $value);
+    public function setItem($key, $value, $ttl = 0);
 
     /**
      * Store multiple items.

--- a/library/Zend/Cache/Storage/StorageInterface.php
+++ b/library/Zend/Cache/Storage/StorageInterface.php
@@ -92,9 +92,10 @@ interface StorageInterface
      * Store an item.
      *
      * @param  string $key
-     * @param  mixed $value
-     * @param int $ttl Lifetime for this item
+     * @param  mixed  $value
+     * @param int     $ttl     Lifetime for this item
      * @return bool
+     * @throws \Zend\Cache\Exception\ExceptionInterface
      */
     public function setItem($key, $value, $ttl = 0);
 

--- a/tests/ZendTest/Cache/Storage/TestAsset/MockAdapter.php
+++ b/tests/ZendTest/Cache/Storage/TestAsset/MockAdapter.php
@@ -18,7 +18,7 @@ class MockAdapter extends AbstractAdapter
     {
     }
 
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem(& $normalizedKey, & $value, $ttl = 0)
     {
     }
 


### PR DESCRIPTION
This PR add the possibility to set a time to live **per item**.

It's not perfect : 
- there is a BC break in `/Zend/Cache/Storage/StorageInterface::setItem` prototype
- not all adapters can use this parameter

What to you think of it ?

Usecase : i needed to set a ttl for a doctrine result cache using [DoctrineModule/Cache/ZendStorageCache](https://github.com/doctrine/DoctrineModule/blob/master/src/DoctrineModule/Cache/ZendStorageCache.php#L75) with a memcached adapter
