### PR TITLE
Form\Element\Select multiple is always required

### DIFF
--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -51,6 +51,16 @@ class Select extends Element implements InputProviderInterface
     protected $valueOptions = array();
 
     /**
+     * @var bool
+     */
+    protected $useHiddenElement = false;
+
+    /**
+     * @var string
+     */
+    protected $unselectedValue = '';
+
+    /**
      * @return array
      */
     public function getValueOptions()
@@ -126,6 +136,14 @@ class Select extends Element implements InputProviderInterface
 
         if (isset($this->options['disable_inarray_validator'])) {
             $this->setDisableInArrayValidator($this->options['disable_inarray_validator']);
+        }
+
+        if (isset($options['use_hidden_element'])) {
+            $this->setUseHiddenElement($options['use_hidden_element']);
+        }
+
+        if (isset($options['unselected_value'])) {
+            $this->setUnselectedValue($options['unselected_value']);
         }
 
         return $this;
@@ -206,10 +224,7 @@ class Select extends Element implements InputProviderInterface
                 'strict'   => false
             ));
 
-            $multiple = (isset($this->attributes['multiple']))
-                      ? $this->attributes['multiple'] : null;
-
-            if (true === $multiple || 'multiple' === $multiple) {
+            if ($this->isMultiple()) {
                 $validator = new ExplodeValidator(array(
                     'validator'      => $validator,
                     'valueDelimiter' => null, // skip explode if only one value
@@ -222,9 +237,52 @@ class Select extends Element implements InputProviderInterface
     }
 
     /**
-     * Provide default input rules for this element
+     * Do we render hidden element?
      *
-     * Attaches the captcha as a validator.
+     * @param  bool $useHiddenElement
+     * @return Select
+     */
+    public function setUseHiddenElement($useHiddenElement)
+    {
+        $this->useHiddenElement = (bool) $useHiddenElement;
+
+        return $this;
+    }
+
+    /**
+     * Do we render hidden element?
+     *
+     * @return bool
+     */
+    public function useHiddenElement()
+    {
+        return $this->useHiddenElement;
+    }
+
+    /**
+     * Set the value if the select is not selected
+     *
+     * @param string $unselectedValue
+     * @return Select
+     */
+    public function setUnselectedValue($unselectedValue)
+    {
+        $this->unselectedValue = (string) $unselectedValue;
+        return $this;
+    }
+
+    /**
+     * Get the value when the select is not selected
+     *
+     * @return string
+     */
+    public function getUnselectedValue()
+    {
+        return $this->unselectedValue;
+    }
+
+    /**
+     * Provide default input rules for this element
      *
      * @return array
      */
@@ -234,6 +292,24 @@ class Select extends Element implements InputProviderInterface
             'name' => $this->getName(),
             'required' => true,
         );
+
+        if ($this->useHiddenElement() && $this->isMultiple()) {
+            $unselectedValue = $this->getUnselectedValue();
+
+            $spec['allow_empty'] = true;
+            $spec['continue_if_empty'] = true;
+            $spec['filters'] = array(array(
+                'name'    => 'Callback',
+                'options' => array(
+                    'callback' => function ($value) use ($unselectedValue) {
+                        if ($value === $unselectedValue) {
+                            $value = array();
+                        }
+                        return $value;
+                    }
+                )
+            ));
+        }
 
         if ($validator = $this->getValidator()) {
             $spec['validators'] = array(
@@ -269,5 +345,14 @@ class Select extends Element implements InputProviderInterface
     protected function getOptionValue($key, $optionSpec)
     {
         return is_array($optionSpec) ? $optionSpec['value'] : $key;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isMultiple()
+    {
+        return isset($this->attributes['multiple'])
+            && ($this->attributes['multiple'] === true || $this->attributes['multiple'] === 'multiple');
     }
 }

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -245,7 +245,6 @@ class Select extends Element implements InputProviderInterface
     public function setUseHiddenElement($useHiddenElement)
     {
         $this->useHiddenElement = (bool) $useHiddenElement;
-
         return $this;
     }
 
@@ -348,7 +347,9 @@ class Select extends Element implements InputProviderInterface
     }
 
     /**
-     * @return boolean
+     * Element has the multiple attribute
+     *
+     * @return bool
      */
     public function isMultiple()
     {

--- a/library/Zend/Form/View/Helper/FormSelect.php
+++ b/library/Zend/Form/View/Helper/FormSelect.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Form\View\Helper;
 
+use Zend\Form\Element\Hidden;
 use Zend\Form\ElementInterface;
 use Zend\Form\Element\Select as SelectElement;
 use Zend\Form\Exception;
@@ -67,6 +68,11 @@ class FormSelect extends AbstractHelper
     );
 
     /**
+     * @var FromHidden|null
+     */
+    protected $formHiddenHelper;
+
+    /**
      * Invoke helper as functor
      *
      * Proxies to {@link render()}.
@@ -123,11 +129,22 @@ class FormSelect extends AbstractHelper
         }
         $this->validTagAttributes = $this->validSelectAttributes;
 
-        return sprintf(
+        $rendered = sprintf(
             '<select %s>%s</select>',
             $this->createAttributesString($attributes),
             $this->renderOptions($options, $value)
         );
+
+        // Render hidden element
+        $useHiddenElement = method_exists($element, 'useHiddenElement')
+            && method_exists($element, 'getUnselectedValue')
+            && $element->useHiddenElement();
+
+        if ($useHiddenElement) {
+            $rendered = $this->renderHiddenElement($element) . $rendered;
+        }
+
+        return $rendered;
     }
 
     /**
@@ -277,5 +294,31 @@ class FormSelect extends AbstractHelper
         }
 
         return $value;
+    }
+
+    protected function renderHiddenElement(ElementInterface $element)
+    {
+        $hiddenElement = new Hidden($element->getName());
+        $hiddenElement->setValue($element->getUnselectedValue());
+
+        return $this->getFormHiddenHelper()->__invoke($hiddenElement);
+    }
+
+    /**
+     * @return FormHidden
+     */
+    protected function getFormHiddenHelper()
+    {
+        if (!$this->formHiddenHelper) {
+            if (method_exists($this->view, 'plugin')) {
+                $this->formHiddenHelper = $this->view->plugin('formhidden');
+            }
+
+            if (!$this->formHiddenHelper instanceof FormHidden) {
+                $this->formHiddenHelper = new FormHidden();
+            }
+        }
+
+        return $this->formHiddenHelper;
     }
 }

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -235,4 +235,38 @@ class SelectTest extends TestCase
         $this->assertArrayNotHasKey('Option Undefined', $valueOptions);
     }
 
+    public function testSetOptionsToSelectMultiple()
+    {
+        $element = new SelectElement(null, array(
+            'label' => 'Importance',
+            'use_hidden_element' => true,
+            'unselected_value' => 'empty',
+            'value_options' => array(
+                'foo' => 'Foo',
+                'bar' => 'Bar'
+            ),
+        ));
+        $element->setAttributes(array('multiple' => 'multiple'));
+
+        $this->assertTrue($element->isMultiple());
+        $this->assertTrue($element->useHiddenElement());
+        $this->assertEquals('empty', $element->getUnselectedValue());
+    }
+
+    public function testProvidesInputSpecificationForMultipleSelectWithUseHiddenElement()
+    {
+        $element = new SelectElement();
+        $element
+            ->setUseHiddenElement(true)
+            ->setAttributes(array(
+                'multiple' => true,
+            ));
+
+        $inputSpec = $element->getInputSpecification();
+
+        $this->assertArrayHasKey('allow_empty', $inputSpec);
+        $this->assertTrue($inputSpec['allow_empty']);
+        $this->assertArrayHasKey('continue_if_empty', $inputSpec);
+        $this->assertTrue($inputSpec['continue_if_empty']);
+    }
 }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1907,9 +1907,20 @@ class FormTest extends TestCase
     }
 
     /**
+     * @param bool $expectedIsValid
+     * @param array $expectedFormData
+     * @param array $data
+     * @param string $unselectedValue
+     * @param bool $useHiddenElement
      * @dataProvider formWithSelectMultipleAndEmptyUnselectedValueDataProvider
      */
-    public function testFormWithSelectMultipleAndEmptyUnselectedValue($isValid, array $data = array(), $unselectedValue = '', $useHiddenElement = true)
+    public function testFormWithSelectMultipleAndEmptyUnselectedValue(
+        $expectedIsValid,
+        array $expectedFormData,
+        array $data,
+        $unselectedValue,
+        $useHiddenElement
+    )
     {
         $this->form->add(array(
             'name' => 'multipleSelect',
@@ -1926,9 +1937,11 @@ class FormTest extends TestCase
             ),
         ));
 
-        $actual = $this->form->setData($data)->isValid();
+        $actualIsValid = $this->form->setData($data)->isValid();
+        $this->assertEquals($expectedIsValid, $actualIsValid);
 
-        $this->assertEquals($isValid, $actual);
+        $formData = $this->form->getData();
+        $this->assertEquals($expectedFormData, $formData);
     }
 
     /**
@@ -1939,23 +1952,45 @@ class FormTest extends TestCase
         return array(
             array(
                 true,
-                array('multipleSelect' => ''),
+                array('multipleSelect' => array('foo')),
+                array('multipleSelect' => array('foo')),
+                '',
+                true
             ),
             array(
                 true,
+                array('multipleSelect' => array()),
+                array('multipleSelect' => ''),
+                '',
+                true
+            ),
+            array(
+                true,
+                array('multipleSelect' => array()),
                 array('multipleSelect' => 'empty'),
                 'empty',
+                true
             ),
             array(
                 false,
                 array('multipleSelect' => ''),
+                array('multipleSelect' => ''),
                 'empty',
+                true
             ),
             array(
                 false,
+                array('multipleSelect' => ''),
                 array('multipleSelect' => ''),
                 '',
                 false
+            ),
+            array(
+                true,
+                array('multipleSelect' => array()),
+                array('multipleSelect' => 'foo'),
+                'foo',
+                true
             ),
         );
     }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1906,6 +1906,60 @@ class FormTest extends TestCase
         $this->assertTrue($this->form->isValid());
     }
 
+    /**
+     * @dataProvider formWithSelectMultipleAndEmptyUnselectedValueDataProvider
+     */
+    public function testFormWithSelectMultipleAndEmptyUnselectedValue($isValid, array $data = array(), $unselectedValue = '', $useHiddenElement = true)
+    {
+        $this->form->add(array(
+            'name' => 'multipleSelect',
+            'type'  => 'Zend\Form\Element\Select',
+            'attributes' => array('multiple' => 'multiple'),
+            'options' => array(
+                'label' => 'Importance',
+                'use_hidden_element' => $useHiddenElement,
+                'unselected_value' => $unselectedValue,
+                'value_options' => array(
+                    'foo' => 'Foo',
+                    'bar' => 'Bar'
+                ),
+            ),
+        ));
+
+        $actual = $this->form->setData($data)->isValid();
+
+        $this->assertEquals($isValid, $actual);
+    }
+
+    /**
+     * @return array
+     */
+    public function formWithSelectMultipleAndEmptyUnselectedValueDataProvider()
+    {
+        return array(
+            array(
+                true,
+                array('multipleSelect' => ''),
+            ),
+            array(
+                true,
+                array('multipleSelect' => 'empty'),
+                'empty',
+            ),
+            array(
+                false,
+                array('multipleSelect' => ''),
+                'empty',
+            ),
+            array(
+                false,
+                array('multipleSelect' => ''),
+                '',
+                false
+            ),
+        );
+    }
+
     public function testCanSetUseInputFilterDefaultsViaArray()
     {
         $spec = array(

--- a/tests/ZendTest/Form/View/Helper/FormSelectTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormSelectTest.php
@@ -384,6 +384,16 @@ class FormSelectTest extends CommonTestCase
         $this->assertContains('<option value="0" selected="selected">label0</option>', $markup);
     }
 
+    public function testHiddenElementWhenAttributeMultipleIsSet()
+    {
+        $element = new SelectElement('foo');
+        $element->setUseHiddenElement(true);
+        $element->setUnselectedValue('empty');
+
+        $markup = $this->helper->render($element);
+        $this->assertContains('<input type="hidden" name="foo" value="empty"><select', $markup);
+    }
+
     public function testRenderInputNotSelectElementRaisesException()
     {
         $element = new Element\Text('foo');


### PR DESCRIPTION
The Select Element is always required. The Validation fails (required) if the multiple select is unselected. It is not possible to send an empty list.

I added the option for an hidden element. If nothing is selected the empty hidden field is send (required). 

Select Element has the new Option 'use_hidden_element' and 'unselected_value'.
The FormSelect Helper generates an hidden element before the select element.

Reference to other Issues.
#4750, #5842, https://github.com/doctrine/DoctrineModule/issues/215
