### PR TITLE
less "quoted-printable" overhead

### DIFF
--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -115,6 +115,7 @@ abstract class AbstractAddressList implements HeaderInterface
 
                 if ($format == HeaderInterface::FORMAT_ENCODED
                     && 'ASCII' !== $encoding
+                    && preg_match('/[^\x00-\x7f]/', $name)
                 ) {
                     $name = HeaderWrap::mimeEncodeValue($name, $encoding);
                 }

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -142,6 +142,9 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
 
     public function getEncoding()
     {
+        if(!preg_match('/[^\x00-\x7f]/', $this->getFieldValue())){
+          return "ASCII";
+        }
         return $this->encoding;
     }
 

--- a/library/Zend/Mail/Header/HeaderWrap.php
+++ b/library/Zend/Mail/Header/HeaderWrap.php
@@ -47,7 +47,7 @@ abstract class HeaderWrap
     protected static function wrapUnstructuredHeader($value, HeaderInterface $header)
     {
         $encoding = $header->getEncoding();
-        if ($encoding == 'ASCII' or !preg_match('/[^\x00-\x7f]/', $value)) {
+        if ($encoding == 'ASCII') {
             return wordwrap($value, 78, Headers::FOLDING);
         }
         return static::mimeEncodeValue($value, $encoding, 78);

--- a/library/Zend/Mail/Header/HeaderWrap.php
+++ b/library/Zend/Mail/Header/HeaderWrap.php
@@ -47,7 +47,7 @@ abstract class HeaderWrap
     protected static function wrapUnstructuredHeader($value, HeaderInterface $header)
     {
         $encoding = $header->getEncoding();
-        if ($encoding == 'ASCII') {
+        if ($encoding == 'ASCII' or !preg_match('/[^\x00-\x7f]/', $value)) {
             return wordwrap($value, 78, Headers::FOLDING);
         }
         return static::mimeEncodeValue($value, $encoding, 78);

--- a/library/Zend/Mail/Header/Subject.php
+++ b/library/Zend/Mail/Header/Subject.php
@@ -64,6 +64,9 @@ class Subject implements UnstructuredInterface
 
     public function getEncoding()
     {
+        if(!preg_match('/[^\x00-\x7f]/', $this->getFieldValue())){
+          return "ASCII";
+        }
         return $this->encoding;
     }
 


### PR DESCRIPTION
@Zend/Mail: now no transcoding to ASCII throught "quoted-printable" if header value is already US-ASCII.
Header would be re re-encoded to "quoted-printable" if encoding property of message object has been set to "UTF-8"
