### PR TITLE
Missed variable, renamed to one which exists.

### DIFF
--- a/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
+++ b/library/Zend/ServiceManager/Di/DiAbstractServiceFactory.php
@@ -43,7 +43,7 @@ class DiAbstractServiceFactory extends DiServiceFactory implements AbstractFacto
             return $this->get($requestedName, array());
         }
 
-        return $this->get($serviceName, array());
+        return $this->get($name, array());
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/Di/DiAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/ServiceManager/Di/DiAbstractServiceFactoryTest.php
@@ -55,6 +55,17 @@ class DiAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\ServiceManager\Di\DiAbstractServiceFactory', $instance);
     }
 
+
+    /**
+     * @covers Zend\ServiceManager\Di\DiAbstractServiceFactory::createServiceWithName
+     * @covers Zend\ServiceManager\Di\DiAbstractServiceFactory::get
+     */
+    public function testCreateServiceWithNameAndWithoutRequestName()
+    {
+        $foo = $this->diAbstractServiceFactory->createServiceWithName($this->mockServiceLocator, 'foo', null);
+        $this->assertEquals($this->fooInstance, $foo);
+    }
+
     /**
      * @covers Zend\ServiceManager\Di\DiAbstractServiceFactory::createServiceWithName
      * @covers Zend\ServiceManager\Di\DiAbstractServiceFactory::get


### PR DESCRIPTION
I guess this variable has been misspelled by mistake.
