### PR TITLE
Parameter generator backslash escaping

### DIFF
--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -398,7 +398,7 @@ class ValueGenerator extends AbstractGenerator
      */
     public static function escape($input, $quote = true)
     {
-        $output = addcslashes($input, "'");
+        $output = addcslashes($input, "\\'");
 
         // adds quoting strings
         if ($quote) {

--- a/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ParameterGeneratorTest.php
@@ -227,4 +227,20 @@ class ParameterGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('\OtherNamespace\ParameterClass', $param->getType());
     }
+
+    /**
+     * @group 6023
+     *
+     * @coversNothing
+     */
+    public function testGeneratedParametersHaveEscapedDefaultValues()
+    {
+        $parameter = new ParameterGenerator();
+
+        $parameter->setName('foo');
+        $parameter->setDefaultValue("\\'");
+        $parameter->setType('stdClass');
+
+        $this->assertSame("stdClass \$foo = '\\\\\\''", $parameter->generate());
+    }
 }

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -14,6 +14,8 @@ use Zend\Code\Generator\ValueGenerator;
 /**
  * @group Zend_Code_Generator
  * @group Zend_Code_Generator_Php
+ *
+ * @covers \Zend\Code\Generator\ValueGenerator
  */
 class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -141,17 +143,25 @@ EOS;
 
     /**
      * @group 6023
+     *
+     * @dataProvider getEscapedParameters
      */
-    public function testEscapesBackslash()
+    public function testEscaping($input, $expectedEscapedValue)
     {
-        $this->assertSame('\\\\', ValueGenerator::escape('\\', false));
+        $this->assertSame($expectedEscapedValue, ValueGenerator::escape($input, false));
     }
 
     /**
-     * @group 6023
+     * Data provider for escaping tests
+     *
+     * @return string[][]
      */
-    public function testEscapesQuotes()
+    public function getEscapedParameters()
     {
-        $this->assertSame('\\\'', ValueGenerator::escape('\'', false));
+        return array(
+            array('\\', '\\\\'),
+            array("'", "\\'"),
+            array("\\'", "\\\\\\'"),
+        );
     }
 }

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -138,4 +138,14 @@ EOS;
 
         $this->assertEquals($expectedSource, $valueGenerator->generate());
     }
+
+    public function testEscapesBackslash()
+    {
+        $this->assertSame('\\\\', ValueGenerator::escape('\\', false));
+    }
+
+    public function testEscapesQuotes()
+    {
+        $this->assertSame('\\\'', ValueGenerator::escape('\'', false));
+    }
 }

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -139,11 +139,17 @@ EOS;
         $this->assertEquals($expectedSource, $valueGenerator->generate());
     }
 
+    /**
+     * @group 6023
+     */
     public function testEscapesBackslash()
     {
         $this->assertSame('\\\\', ValueGenerator::escape('\\', false));
     }
 
+    /**
+     * @group 6023
+     */
     public function testEscapesQuotes()
     {
         $this->assertSame('\\\'', ValueGenerator::escape('\'', false));


### PR DESCRIPTION
Found while trying different default parameters for methods. Currently, `Zend\Code` is not able to produce valid code when following is being done:

``` php
$generator = new Zend\Code\Generator\ParameterGenerator();

$generator->setType('Foo');
$generator->setDefaultValue('\\');
$generator->setName('bar');

var_dump($generator->generator());
```

Produces

``` php
Foo $bar = '\'
```

Which is obviously going to break method signature if used as a method parameter.
