### PR TITLE
Dispatch error should be preventable

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -306,7 +306,6 @@ class Application implements
             if ($event->getError()) {
                 return $this->completeRequest($event);
             }
-            return $this;
         }
         if ($event->getError()) {
             return $this->completeRequest($event);

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -679,6 +679,76 @@ class ApplicationTest extends TestCase
         $this->assertEquals(1, count($listeners));
     }
 
+    public function testFailedRoutingShouldBePreventable()
+    {
+        $this->application->bootstrap();
+
+        $response     = $this->getMock('Zend\Stdlib\ResponseInterface');
+        $finishMock   = $this->getMock('stdClass', array('__invoke'));
+        $routeMock    = $this->getMock('stdClass', array('__invoke'));
+        $dispatchMock = $this->getMock('stdClass', array('__invoke'));
+
+        $routeMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
+            $event->stopPropagation(true);
+            $event->setRouteMatch(new Router\RouteMatch(array()));
+        }));
+        $dispatchMock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->will($this->returnCallback(function (MvcEvent $event) use ($response) {
+                return $response;
+            }));
+        $finishMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
+            $event->stopPropagation(true);
+        }));
+
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_ROUTE, $routeMock, 100);
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, $dispatchMock, 100);
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_FINISH, $finishMock, 100);
+
+        $this->application->run();
+        $this->assertSame($response, $this->application->getMvcEvent()->getResponse());
+    }
+
+    public function testCanRecoverFromApplicationError()
+    {
+        $this->application->bootstrap();
+
+        $response     = $this->getMock('Zend\Stdlib\ResponseInterface');
+        $errorMock    = $this->getMock('stdClass', array('__invoke'));
+        $finishMock   = $this->getMock('stdClass', array('__invoke'));
+        $routeMock    = $this->getMock('stdClass', array('__invoke'));
+        $dispatchMock = $this->getMock('stdClass', array('__invoke'));
+
+        $errorMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
+            $event->stopPropagation(true);
+            $event->setRouteMatch(new Router\RouteMatch(array()));
+            $event->setError('');
+        }));
+        $routeMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
+            $event->stopPropagation(true);
+            $event->setError(Application::ERROR_ROUTER_NO_MATCH);
+            return $event->getApplication()->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event)->last();
+        }));
+        $dispatchMock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->will($this->returnCallback(function (MvcEvent $event) use ($response) {
+                return $response;
+            }));
+        $finishMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
+            $event->stopPropagation(true);
+        }));
+
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH_ERROR, $errorMock, 100);
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_ROUTE, $routeMock, 100);
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, $dispatchMock, 100);
+        $this->application->getEventManager()->attach(MvcEvent::EVENT_FINISH, $finishMock, 100);
+
+        $this->application->run();
+        $this->assertSame($response, $this->application->getMvcEvent()->getResponse());
+    }
+
     public function eventPropagation()
     {
         return array(

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -692,12 +692,7 @@ class ApplicationTest extends TestCase
             $event->stopPropagation(true);
             $event->setRouteMatch(new Router\RouteMatch(array()));
         }));
-        $dispatchMock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->will($this->returnCallback(function (MvcEvent $event) use ($response) {
-                return $response;
-            }));
+        $dispatchMock->expects($this->once())->method('__invoke')->will($this->returnValue($response));
         $finishMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
             $event->stopPropagation(true);
         }));
@@ -730,12 +725,7 @@ class ApplicationTest extends TestCase
             $event->setError(Application::ERROR_ROUTER_NO_MATCH);
             return $event->getApplication()->getEventManager()->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event)->last();
         }));
-        $dispatchMock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->will($this->returnCallback(function (MvcEvent $event) use ($response) {
-                return $response;
-            }));
+        $dispatchMock->expects($this->once())->method('__invoke')->will($this->returnValue($response));
         $finishMock->expects($this->once())->method('__invoke')->will($this->returnCallback(function (MvcEvent $event) {
             $event->stopPropagation(true);
         }));


### PR DESCRIPTION
Please see the tests.

It is currently impossible for a listener of `Zend\Mvc\MvcEvent::EVENT_DISPATCH_ERROR` to do following:

``` php
$event->setError(''); // resetting app state (not an error)
$event->setRouteMatch(...); // setting a route match (allows for redirecting to a controller in case of routing failure)
$event->stopPropagation();
```

This PR fixes that
