### PR TITLE
Service Manager initializers improvements

### DIFF
--- a/library/Zend/ServiceManager/Config.php
+++ b/library/Zend/ServiceManager/Config.php
@@ -149,8 +149,15 @@ class Config implements ConfigInterface
             $serviceManager->setAlias($alias, $nameOrAlias);
         }
 
-        foreach ($this->getInitializers() as $key => $initializer) {
-            $serviceManager->addInitializer($initializer, true, ((is_string($key)) ? $key : null));
+        foreach ($this->getInitializers() as $initializer) {
+            $serviceName = null;
+            if (is_array($initializer) && isset($initializer['initializer'])) { //Service initializer?
+                if (isset($initializer['serviceName'])) {
+                    $serviceName = $initializer['serviceName'];
+                }
+                $initializer = $initializer['initializer'];
+            }
+            $serviceManager->addInitializer($initializer, true, $serviceName);
         }
 
         foreach ($this->getShared() as $name => $isShared) {

--- a/library/Zend/ServiceManager/Config.php
+++ b/library/Zend/ServiceManager/Config.php
@@ -149,8 +149,8 @@ class Config implements ConfigInterface
             $serviceManager->setAlias($alias, $nameOrAlias);
         }
 
-        foreach ($this->getInitializers() as $initializer) {
-            $serviceManager->addInitializer($initializer);
+        foreach ($this->getInitializers() as $key => $initializer) {
+            $serviceManager->addInitializer($initializer, true, ((is_string($key)) ? $key : null));
         }
 
         foreach ($this->getShared() as $name => $isShared) {

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -352,11 +352,11 @@ class ServiceManager implements ServiceLocatorInterface
      *
      * @param  callable|InitializerInterface $initializer
      * @param  bool                          $topOfStack
-     * @param  string                        $classOrServiceName Specific, fully qualified class type or service name for which this initializer should run.
+     * @param  string|null          $className Specific, fully qualified class name for which this initializer should run.
      * @return ServiceManager
      * @throws Exception\InvalidArgumentException
      */
-    public function addInitializer($initializer, $topOfStack = true, $classOrServiceName = null)
+    public function addInitializer($initializer, $topOfStack = true, $className = null)
     {
         if (!($initializer instanceof InitializerInterface || is_callable($initializer))) {
             if (is_string($initializer)) {
@@ -368,8 +368,8 @@ class ServiceManager implements ServiceLocatorInterface
             }
         }
 
-        if ($classOrServiceName) {
-            $initializer = array($classOrServiceName => $initializer);
+        if ($className) {
+            $initializer = array($initializer, $className);
         } 
         
         if ($topOfStack) {
@@ -642,12 +642,12 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         foreach ($this->initializers as $initializer) {
-            if (is_array($initializer) && is_string($classOrServiceName = key($initializer))) { //Specific class/service name binding?
-                if (!$classOrServiceName == $rName && !$instance instanceof $classOrServiceName) {
-                    continue; //Skip
+            if (is_array($initializer)) { //Specific class/service name binding?
+                if (!$instance instanceof $initializer[1]) {
+                    continue;
                 }
                 
-                $initializer = $initializer[$classOrServiceName];
+                $initializer = $initializer[0];
             }
             
             if ($initializer instanceof InitializerInterface) {


### PR DESCRIPTION
Functionality for binding service manager initializers to specific services or class types, so that they can be executed only for objects "of interest". For example:

``` php
$serviceManager->addInitializer('My\Initializer', true, 'FooService');
```

or when targeting class types:

``` php
$serviceManager->addInitializer('My\Initializer', true, 'Foo\SomeServiceAwareInterface');
```
