### PR TITLE
decompress() Zend/Filter/Compress/Zip fix

### DIFF
--- a/library/Zend/Filter/Compress/Zip.php
+++ b/library/Zend/Filter/Compress/Zip.php
@@ -189,7 +189,7 @@ class Zip extends AbstractCompressionAlgorithm
         if (empty($archive) || !file_exists($archive)) {
             throw new Exception\RuntimeException('ZIP Archive not found');
         }
-        
+
         $zip     = new ZipArchive();
         $res     = $zip->open($archive);
 

--- a/library/Zend/Filter/Compress/Zip.php
+++ b/library/Zend/Filter/Compress/Zip.php
@@ -184,13 +184,12 @@ class Zip extends AbstractCompressionAlgorithm
      */
     public function decompress($content)
     {
-        $archive = $this->getArchive();
+        $archive = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, realpath($content));
 
         if (empty($archive) || !file_exists($archive)) {
             throw new Exception\RuntimeException('ZIP Archive not found');
         }
-
-        $archive = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, realpath($content));
+        
         $zip     = new ZipArchive();
         $res     = $zip->open($archive);
 

--- a/tests/ZendTest/Filter/Compress/ZipTest.php
+++ b/tests/ZendTest/Filter/Compress/ZipTest.php
@@ -297,7 +297,7 @@ class ZipTest extends \PHPUnit_Framework_TestCase
         $content = file_get_contents($this->tmp . '/_compress');
         $this->assertEquals('compress me', $content);
     }
-    
+
     public function testDecompressWhenNoArchieveInClass()
     {
         if (!constant('TESTS_ZEND_FILTER_COMPRESS_ZIP_ENABLED')) {

--- a/tests/ZendTest/Filter/Compress/ZipTest.php
+++ b/tests/ZendTest/Filter/Compress/ZipTest.php
@@ -299,29 +299,29 @@ class ZipTest extends \PHPUnit_Framework_TestCase
     }
     
     public function testDecompressWhenNoArchieveInClass()
-	{
-		if (!constant('TESTS_ZEND_FILTER_COMPRESS_ZIP_ENABLED')) {
-			$this->markTestSkipped('ZIP compression tests are currently disabled');
-		}
+    {
+        if (!constant('TESTS_ZEND_FILTER_COMPRESS_ZIP_ENABLED')) {
+            $this->markTestSkipped('ZIP compression tests are currently disabled');
+        }
 
-		$filter  = new ZipCompression(
-			array(
-				'archive' => $this->tmp . '/compressed.zip',
-				'target'  => $this->tmp . '/_compress'
-			)
-		);
+        $filter  = new ZipCompression(
+            array(
+                'archive' => $this->tmp . '/compressed.zip',
+                'target'  => $this->tmp . '/_compress'
+            )
+        );
 
-		$content = $filter->compress('compress me');
-		$this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $content = $filter->compress('compress me');
+        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
-		$filter  = new ZipCompression(
-			array(
-				'target'  => $this->tmp . '/_compress'
-			)
-		);
-		$content = $filter->decompress($content);
-		$this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
-		$content = file_get_contents($this->tmp . '/_compress');
-		$this->assertEquals('compress me', $content);
-	}
+        $filter  = new ZipCompression(
+            array(
+                'target'  => $this->tmp . '/_compress'
+            )
+        );
+        $content = $filter->decompress($content);
+        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $content = file_get_contents($this->tmp . '/_compress');
+        $this->assertEquals('compress me', $content);
+    }
 }

--- a/tests/ZendTest/Filter/Compress/ZipTest.php
+++ b/tests/ZendTest/Filter/Compress/ZipTest.php
@@ -297,4 +297,31 @@ class ZipTest extends \PHPUnit_Framework_TestCase
         $content = file_get_contents($this->tmp . '/_compress');
         $this->assertEquals('compress me', $content);
     }
+    
+    public function testDecompressWhenNoArchieveInClass()
+	{
+		if (!constant('TESTS_ZEND_FILTER_COMPRESS_ZIP_ENABLED')) {
+			$this->markTestSkipped('ZIP compression tests are currently disabled');
+		}
+
+		$filter  = new ZipCompression(
+			array(
+				'archive' => $this->tmp . '/compressed.zip',
+				'target'  => $this->tmp . '/_compress'
+			)
+		);
+
+		$content = $filter->compress('compress me');
+		$this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+
+		$filter  = new ZipCompression(
+			array(
+				'target'  => $this->tmp . '/_compress'
+			)
+		);
+		$content = $filter->decompress($content);
+		$this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+		$content = file_get_contents($this->tmp . '/_compress');
+		$this->assertEquals('compress me', $content);
+	}
 }


### PR DESCRIPTION
decompress didn't work when a valid parameter was given. It relied on archive that was stored in class.
This fixes it.
