### PR TITLE
Allow empty response strings in \Zend\Http\Response::fromStream

### DIFF
--- a/library/Zend/Http/Response/Stream.php
+++ b/library/Zend/Http/Response/Stream.php
@@ -157,7 +157,11 @@ class Stream extends Response
         $headerComplete = false;
         $headersString  = '';
 
-        $responseArray = explode("\n", $responseString);
+        if ($responseString) {
+            $responseArray = explode("\n", $responseString);
+        } else {
+            $responseArray = array();
+        }
 
         while (count($responseArray)) {
             $nextLine        = array_shift($responseArray);

--- a/tests/ZendTest/Http/Response/ResponseStreamTest.php
+++ b/tests/ZendTest/Http/Response/ResponseStreamTest.php
@@ -26,6 +26,17 @@ class ResponseStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Foo Bar\r\nBar Foo", $response->getBody());
     }
 
+    public function testResponseFactoryFromEmptyStringCreatesValidResponse()
+    {
+        $stream = fopen('php://temp','rb+');
+        fwrite($stream, 'HTTP/1.0 200 OK' . "\r\n\r\n".'Foo Bar'."\r\n".'Bar Foo');
+        rewind($stream);
+
+        $response = Stream::fromStream('', $stream);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("Foo Bar\r\nBar Foo", $response->getBody());
+    }
+
     public function testGzipResponse()
     {
         $stream = fopen(__DIR__ . '/../_files/response_gzip','rb');


### PR DESCRIPTION
If the [explode](http://us2.php.net/explode) function is only passed 2 parameters, it will always return an array of size 1 or greater, which means that $headerComplete will be set to true whether or not there was actually any data in the response string. This causes \Zend\Http\Response::fromStream to fail without reason.

For example, if you wanted to proxy the English Wikipedia's main page, you might say:

```
public function indexAction() {
    $socket = fsockopen('en.wikipedia.org', 80);
    fwrite($socket, "GET /wiki/Main_Page\nHost: en.wikipedia.org\n\n");
    $ret = \Zend\Http\Response\Stream::fromStream('', $socket);
    return $ret;
}
```

In the current version of Zend Framework, this example results in the following error:

```
Zend\Http\Exception\InvalidArgumentException
vendor/zendframework/zendframework/library/Zend/Http/Response.php:184
A valid response status line was not found in the provided string
```

There is no good reason to produce an error here. With my attached code, the request is honored and processed normally.
