### PR TITLE
Method getValue should check the type of input inside InputFilter

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -462,6 +462,11 @@ class BaseInputFilter implements
             ));
         }
         $input = $this->inputs[$name];
+
+        if ($input instanceof InputFilterInterface) {
+            return $input->getValues();
+        }
+
         return $input->getValue();
     }
 

--- a/tests/ZendTest/InputFilter/InputFilterTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterTest.php
@@ -46,6 +46,25 @@ class InputFilterTest extends TestCase
         $this->assertInstanceOf('Zend\InputFilter\InputInterface', $foo);
     }
 
+    public function testInputFilterDoesNotHandleNestedInputFilters()
+    {
+        $inputFilter = new InputFilter();
+        $inputFilter->add(new Input(), 'name');
+
+        $this->filter->add($inputFilter, 'people');
+
+        $data = array(
+            'people' => array(
+                 'name' => 'Wanderson'
+            )
+        );
+
+        $this->filter->setData($data);
+        $this->assertTrue($this->filter->isValid());
+
+        $this->assertInternalType('array', $this->filter->getValue('people'));
+    }
+
     /**
      * @group ZF2-5648
      */

--- a/tests/ZendTest/InputFilter/InputFilterTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterTest.php
@@ -46,7 +46,7 @@ class InputFilterTest extends TestCase
         $this->assertInstanceOf('Zend\InputFilter\InputInterface', $foo);
     }
 
-    public function testInputFilterDoesNotHandleNestedInputFilters()
+    public function testGetValueReturnsArrayIfNestedInputFilters()
     {
         $inputFilter = new InputFilter();
         $inputFilter->add(new Input(), 'name');


### PR DESCRIPTION
InputFilter::getValue works incorrect and finishes with error (Missing argument 1 for Zend\InputFilter\BaseInputFilter::getValue()) when InputFilter has nested InputFilters.
