### PR TITLE
Fixed charset support for Pdo_Pgsql.

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -301,7 +301,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                     if (isset($port)) {
                         $dsn[] = "port={$port}";
                     }
-                    if (isset($charset)) {
+                    if (isset($charset) && $pdoDriver != 'pgsql') {
                         $dsn[] = "charset={$charset}";
                     }
                     break;
@@ -319,6 +319,9 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         try {
             $this->resource = new \PDO($dsn, $username, $password, $options);
             $this->resource->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+            if (isset($charset) && $pdoDriver == 'pgsql') {
+                $this->resource->exec('SET NAMES ' . $this->resource->quote($charset));
+            }
             $this->driverName = strtolower($this->resource->getAttribute(\PDO::ATTR_DRIVER_NAME));
         } catch (\PDOException $e) {
             $code = $e->getCode();


### PR DESCRIPTION
Starting with Release 2.3, the "charset"  option is passed to PDO. This is not supported for all PDO drivers. In particular, The pgsql driver throws an exception if the DSN contains the "charset" option.

I created a workaround for Pdo_Pgsql. Please note that the quoting of $charset is not 100% secure if the charset is not already set. Either set the encoding to a default charset before setting the final charset, validate the string to be plain ASCII, or document that the value cannot be trusted in regards to possible SQL injection.

For uniform charset handling, other drivers (PDO and non-PDO) may need special treatment as well.
