### PR TITLE
Convert only if exactly one

### DIFF
--- a/library/Zend/Authentication/Adapter/Ldap.php
+++ b/library/Zend/Authentication/Adapter/Ldap.php
@@ -426,10 +426,10 @@ class Ldap extends AbstractAdapter
                 // skip attributes marked to be omitted
                 continue;
             }
+            
+            $returnObject->$attr = $value;
             if (is_array($value)) {
-                $returnObject->$attr = (count($value) > 1) ? $value : $value[0];
-            } else {
-                $returnObject->$attr = $value;
+                $returnObject->$attr = (count($value) === 1) ? $value[0] : $value;
             }
         }
         return $returnObject;


### PR DESCRIPTION
I copied this function out for another use and i had there some entries, where the value was "array" without any values.

This generates warnings, since `$value[0]` is then not accessible
