### PR TITLE
Hotfix : Zend\Test trace error flag

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -87,12 +87,13 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
 
     /**
      * Set the trace error flag
-     * @param  bool $traceError
+     * @param  bool                       $traceError
      * @return AbstractControllerTestCase
      */
     public function setTraceError($traceError)
     {
         $this->traceError = $traceError;
+
         return $this;
     }
 
@@ -107,12 +108,13 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
 
     /**
      * Set the usage of the console router or not
-     * @param  bool $boolean
+     * @param  bool                       $boolean
      * @return AbstractControllerTestCase
      */
     public function setUseConsoleRequest($boolean)
     {
         $this->useConsoleRequest = (bool) $boolean;
+
         return $this;
     }
 
@@ -127,7 +129,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
 
     /**
      * Set the application config
-     * @param  array $applicationConfig
+     * @param  array                      $applicationConfig
      * @return AbstractControllerTestCase
      * @throws LogicException
      */
@@ -144,6 +146,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
             $applicationConfig['module_listener_options']['config_cache_enabled'] = false;
         }
         $this->applicationConfig = $applicationConfig;
+
         return $this;
     }
 
@@ -196,9 +199,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Set the request URL
      *
-     * @param  string $url
-     * @param  string|null $method
-     * @param  array|null $params
+     * @param  string                     $url
+     * @param  string|null                $method
+     * @param  array|null                 $params
      * @return AbstractControllerTestCase
      */
     public function url($url, $method = HttpRequest::METHOD_GET, $params = array())
@@ -208,6 +211,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
             preg_match_all('/(--\S+[= ]"\S*\s*\S*")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
             $params = str_replace(array(' "', '"'), array('=', ''), $matches[0]);
             $request->params()->exchangeArray($params);
+
             return $this;
         }
 
@@ -256,9 +260,9 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
      *
      * The URL provided set the request URI in the request object.
      *
-     * @param  string $url
+     * @param  string      $url
      * @param  string|null $method
-     * @param  array|null $params
+     * @param  array|null  $params
      * @throws \Exception
      */
     public function dispatch($url, $method = null, $params = array(), $isXmlHttpRequest = false)
@@ -309,7 +313,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Trigger an application event
      *
-     * @param  string $eventName
+     * @param  string                                $eventName
      * @return \Zend\EventManager\ResponseCollection
      */
     public function triggerApplicationEvent($eventName)
@@ -357,7 +361,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert modules were not loaded with the module manager
      *
-     * @param  array $modules
+     * @param array $modules
      */
     public function assertNotModulesLoaded(array $modules)
     {
@@ -388,13 +392,14 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         if (null === $match) {
             $match = 0;
         }
+
         return $match;
     }
 
     /**
      * Assert response status code
      *
-     * @param  int $code
+     * @param int $code
      */
     public function assertResponseStatusCode($code)
     {
@@ -418,7 +423,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert not response status code
      *
-     * @param  int $code
+     * @param int $code
      */
     public function assertNotResponseStatusCode($code)
     {
@@ -472,13 +477,14 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
         $controllerIdentifier = $routeMatch->getParam('controller');
         $controllerManager    = $this->getApplicationServiceLocator()->get('ControllerManager');
         $controllerClass      = $controllerManager->get($controllerIdentifier);
+
         return get_class($controllerClass);
     }
 
     /**
      * Assert that the application route match used the given module
      *
-     * @param  string $module
+     * @param string $module
      */
     public function assertModuleName($module)
     {
@@ -498,7 +504,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used NOT the given module
      *
-     * @param  string $module
+     * @param string $module
      */
     public function assertNotModuleName($module)
     {
@@ -518,7 +524,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used the given controller class
      *
-     * @param  string $controller
+     * @param string $controller
      */
     public function assertControllerClass($controller)
     {
@@ -538,7 +544,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used NOT the given controller class
      *
-     * @param  string $controller
+     * @param string $controller
      */
     public function assertNotControllerClass($controller)
     {
@@ -558,7 +564,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used the given controller name
      *
-     * @param  string $controller
+     * @param string $controller
      */
     public function assertControllerName($controller)
     {
@@ -578,7 +584,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used NOT the given controller name
      *
-     * @param  string $controller
+     * @param string $controller
      */
     public function assertNotControllerName($controller)
     {
@@ -598,7 +604,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used the given action
      *
-     * @param  string $action
+     * @param string $action
      */
     public function assertActionName($action)
     {
@@ -618,7 +624,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used NOT the given action
      *
-     * @param  string $action
+     * @param string $action
      */
     public function assertNotActionName($action)
     {
@@ -638,7 +644,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used the given route name
      *
-     * @param  string $route
+     * @param string $route
      */
     public function assertMatchedRouteName($route)
     {
@@ -658,7 +664,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that the application route match used NOT the given route name
      *
-     * @param  string $route
+     * @param string $route
      */
     public function assertNotMatchedRouteName($route)
     {
@@ -678,7 +684,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
      * Assert template name
      * Assert that a template was used somewhere in the view model tree
      *
-     * @param  string $templateName
+     * @param string $templateName
      */
     public function assertTemplateName($templateName)
     {
@@ -690,7 +696,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
      * Assert not template name
      * Assert that a template was not used somewhere in the view model tree
      *
-     * @param  string $templateName
+     * @param string $templateName
      */
     public function assertNotTemplateName($templateName)
     {
@@ -701,18 +707,19 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Recursively search a view model and it's children for the given templateName
      *
-     * @param ViewModel $viewModel
-     * @param string $templateName
+     * @param  ViewModel $viewModel
+     * @param  string    $templateName
      * @return boolean
      */
     protected function searchTemplates($viewModel, $templateName)
     {
-        if ($viewModel->getTemplate($templateName) == $templateName){
+        if ($viewModel->getTemplate($templateName) == $templateName) {
             return true;
         }
-        foreach ($viewModel->getChildren() as $child){
+        foreach ($viewModel->getChildren() as $child) {
             return $this->searchTemplates($child, $templateName);
         }
+
         return false;
     }
 }

--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -65,6 +65,15 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         Console::overrideIsConsole($this->usedConsoleBackup);
+
+        if (true !== $this->traceError) {
+            return;
+        }
+
+        $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
+        if ($exception instanceof \Exception) {
+            throw $exception;
+        }
     }
 
     /**
@@ -270,15 +279,6 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
 
         $this->url($url, $method, $params);
         $this->getApplication()->run();
-
-        if (true !== $this->traceError) {
-            return;
-        }
-
-        $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
-        if ($exception instanceof \Exception) {
-            throw $exception;
-        }
     }
 
     /**

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -26,6 +26,8 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
             include __DIR__ . '/../../_files/application.config.php'
         );
         parent::setUp();
+
+        $this->setTraceError(true);
     }
 
     public function testUseOfRouter()

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -636,6 +636,18 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertApplicationException('RuntimeException');
     }
 
+    public function testGetErrorWithTraceErrorEnabled()
+    {
+        $this->dispatch('/exception');
+        $this->assertResponseStatusCode(500);
+
+        $exception = $this->getApplication()->getMvcEvent()->getParam('exception');
+        $this->assertInstanceOf('RuntimeException', $exception);
+
+        // set to null to avoid the throwing of the exception
+        $this->getApplication()->getMvcEvent()->setParam('exception', null);
+    }
+
     /**
      * Sample tests on MvcEvent
      */

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -26,8 +26,6 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
             include __DIR__ . '/../../_files/application.config.php'
         );
         parent::setUp();
-
-        $this->setTraceError(true);
     }
 
     public function testUseOfRouter()
@@ -627,6 +625,8 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
     public function testAssertExceptionInAction()
     {
+        $this->setTraceError(true);
+
         $this->dispatch('/exception');
         $this->assertResponseStatusCode(500);
         $this->assertApplicationException('RuntimeException', 'Foo error');


### PR DESCRIPTION
Current behavior is annoying because exception are automatically thrown ... currently, you can't assert application exception and debug your application
