### PR TITLE
Service manager and canonicalization

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -124,6 +124,30 @@ class ServiceManager implements ServiceLocatorInterface
      */
     public function __construct(ConfigInterface $config = null)
     {
+        $defaultConfig = new Config(
+            array(
+                'invokables'         => $this->invokableClasses,
+                'factories'          => $this->factories,
+                'abstract_factories' => $this->abstractFactories,
+                'services'           => $this->instances,
+                'aliases'            => $this->aliases,
+                'initializers'       => $this->initializers,
+                'shared'             => $this->shared,
+                'delegators'         => $this->delegators,
+            )
+        );
+
+        $this->invokableClasses = array();
+        $this->factories = array();
+        $this->abstractFactories = array();
+        $this->instances = array();
+        $this->aliases = array();
+        $this->initializers = array();
+        $this->shared = array();
+        $this->delegators = array();
+
+        $defaultConfig->configureServiceManager($this);
+
         if ($config) {
             $config->configureServiceManager($this);
         }

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -195,6 +195,14 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testCanonicalizationWithKeyOverriddenByPluginManager()
     {
         $pluginManager = new OverrideKeysPluginManager();
+
+        $foo = $pluginManager->get('foo-invokable');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $foo);
+
+        $foo = $pluginManager->get('foo-factory');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\Foo', $foo);
+
         $foo = $pluginManager->get('foo');
+        $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFake', $foo);
     }
 }

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -16,6 +16,7 @@ use Zend\ServiceManager\Config;
 
 use ZendTest\ServiceManager\TestAsset\FooPluginManager;
 use ZendTest\ServiceManager\TestAsset\MockSelfReturningDelegatorFactory;
+use ZendTest\ServiceManager\TestAsset\OverrideKeysPluginManager;
 
 class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -189,5 +190,11 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('stdClass', array_shift($fooDelegator->instances));
         $this->assertSame($fooDelegator, array_shift($barDelegator->instances));
 
+    }
+
+    public function testCanonicalizationWithKeyOverriddenByPluginManager()
+    {
+        $pluginManager = new OverrideKeysPluginManager();
+        $foo = $pluginManager->get('foo');
     }
 }

--- a/tests/ZendTest/ServiceManager/TestAsset/OverrideKeysPluginManager.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/OverrideKeysPluginManager.php
@@ -17,7 +17,21 @@ class OverrideKeysPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $invokableClasses = array(
-        'FOO' => 'ZendTest\ServiceManager\TestAsset\Foo',
+        'FOOINVOKABLE' => 'ZendTest\ServiceManager\TestAsset\Foo',
+    );
+
+    /**
+     * @var array
+     */
+    protected $factories = array(
+        'FOOFACTORY' => 'ZendTest\ServiceManager\TestAsset\FooFactory',
+    );
+
+    /**
+     * @var array
+     */
+    protected $abstractFactories = array(
+        'FOO' => 'ZendTest\ServiceManager\TestAsset\FooFakeAbstractFactory',
     );
 
     /**

--- a/tests/ZendTest/ServiceManager/TestAsset/OverrideKeysPluginManager.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/OverrideKeysPluginManager.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use Zend\ServiceManager\AbstractPluginManager;
+
+class OverrideKeysPluginManager extends AbstractPluginManager
+{
+    /**
+     * @var array
+     */
+    protected $invokableClasses = array(
+        'FOO' => 'ZendTest\ServiceManager\TestAsset\Foo',
+    );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        return;
+    }
+}


### PR DESCRIPTION
With my custom plugin manager :

``` php
class OverrideKeysPluginManager extends AbstractPluginManager
{
    protected $invokableClasses = array(
        'FOO' => 'Foo',
    );
}
```

Because 'foo' use upper case, I can't get my service with the key 'foo', because overridden keys does not use the canonicalization.
