### PR TITLE
Fix for issue 6048

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -131,6 +131,8 @@ class Filesystem extends AbstractAdapter implements
      * Remove expired items
      *
      * @return bool
+     * 
+     * @triggers clearExpired.exception(ExceptionEvent)
      */
     public function clearExpired()
     {
@@ -161,7 +163,10 @@ class Filesystem extends AbstractAdapter implements
         }
         $error = ErrorHandler::stop();
         if ($error) {
-            throw new Exception\RuntimeException("Failed to clear expired items", 0, $error);
+            $e = new Exception\RuntimeException("Failed to clear expired items", 0, $error);
+            $result = false;
+            $args = new \ArrayObject();
+            return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
 
         return true;

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -131,7 +131,7 @@ class Filesystem extends AbstractAdapter implements
      * Remove expired items
      *
      * @return bool
-     * 
+     *
      * @triggers clearExpired.exception(ExceptionEvent)
      */
     public function clearExpired()
@@ -163,10 +163,13 @@ class Filesystem extends AbstractAdapter implements
         }
         $error = ErrorHandler::stop();
         if ($error) {
-            $e = new Exception\RuntimeException("Failed to clear expired items", 0, $error);
             $result = false;
-            $args = new \ArrayObject();
-            return $this->triggerException(__FUNCTION__, $args, $result, $e);
+            return $this->triggerException(
+                __FUNCTION__,
+                null,
+                $result,
+                new Exception\RuntimeException("Failed to clear expired items", 0, $error)
+            );
         }
 
         return true;

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -25,6 +25,7 @@ use Zend\Cache\Storage\OptimizableInterface;
 use Zend\Cache\Storage\TaggableInterface;
 use Zend\Cache\Storage\TotalSpaceCapableInterface;
 use Zend\Stdlib\ErrorHandler;
+use ArrayObject;
 
 class Filesystem extends AbstractAdapter implements
     AvailableSpaceCapableInterface,
@@ -166,7 +167,7 @@ class Filesystem extends AbstractAdapter implements
             $result = false;
             return $this->triggerException(
                 __FUNCTION__,
-                null,
+                new ArrayObject(),
                 $result,
                 new Exception\RuntimeException("Failed to clear expired items", 0, $error)
             );

--- a/library/Zend/Cache/Storage/Plugin/ExceptionHandler.php
+++ b/library/Zend/Cache/Storage/Plugin/ExceptionHandler.php
@@ -55,6 +55,9 @@ class ExceptionHandler extends AbstractPlugin
 
         $this->listeners[] = $events->attach('decrementItem.exception', $callback, $priority);
         $this->listeners[] = $events->attach('decrementItems.exception', $callback, $priority);
+        
+        // utility
+        $this->listeners[] = $events->attach('clearExpired.exception', $callback, $priority);
     }
 
     /**

--- a/library/Zend/Cache/Storage/Plugin/ExceptionHandler.php
+++ b/library/Zend/Cache/Storage/Plugin/ExceptionHandler.php
@@ -55,7 +55,7 @@ class ExceptionHandler extends AbstractPlugin
 
         $this->listeners[] = $events->attach('decrementItem.exception', $callback, $priority);
         $this->listeners[] = $events->attach('decrementItems.exception', $callback, $priority);
-        
+
         // utility
         $this->listeners[] = $events->attach('clearExpired.exception', $callback, $priority);
     }

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -10,6 +10,8 @@
 namespace ZendTest\Cache\Storage\Adapter;
 
 use Zend\Cache;
+use Zend\Cache\Storage\Plugin\ExceptionHandler;
+use Zend\Cache\Storage\Plugin\PluginOptions;
 
 /**
  * @group      Zend_Cache
@@ -292,8 +294,8 @@ class FilesystemTest extends CommonAdapterTest
         }
         chmod($dirs[0], 0500); //make directory rx, unlink should fail
         sleep(1); //wait for the entry to expire
-        $plugin = new \Zend\Cache\Storage\Plugin\ExceptionHandler();
-        $options = new Cache\Storage\Plugin\PluginOptions(array('throw_exceptions' => true));
+        $plugin = new ExceptionHandler();
+        $options = new PluginOptions(array('throw_exceptions' => false));
         $plugin->setOptions($options);
         $this->_storage->addPlugin($plugin);
         $this->_storage->clearExpired();

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -287,8 +287,7 @@ class FilesystemTest extends CommonAdapterTest
         $this->_options->setTtl(0.1);
         $this->_storage->setItem('k', 'v');
         $dirs = glob($this->_tmpCacheDir . '/*');
-        if(count($dirs) === 0)
-        {
+        if(count($dirs) === 0) {
             $this->fail('Could not find cache dir');
         }
         chmod($dirs[0], 0500); //make directory rx, unlink should fail

--- a/tests/ZendTest/Cache/Storage/Plugin/ExceptionHandlerTest.php
+++ b/tests/ZendTest/Cache/Storage/Plugin/ExceptionHandlerTest.php
@@ -71,7 +71,7 @@ class ExceptionHandlerTest extends CommonPluginTest
 
             'decrementItem.exception'  => 'onException',
             'decrementItems.exception' => 'onException',
-            
+
             'clearExpired.exception' => 'onException',
         );
         foreach ($expectedListeners as $eventName => $expectedCallbackMethod) {

--- a/tests/ZendTest/Cache/Storage/Plugin/ExceptionHandlerTest.php
+++ b/tests/ZendTest/Cache/Storage/Plugin/ExceptionHandlerTest.php
@@ -71,6 +71,8 @@ class ExceptionHandlerTest extends CommonPluginTest
 
             'decrementItem.exception'  => 'onException',
             'decrementItems.exception' => 'onException',
+            
+            'clearExpired.exception' => 'onException',
         );
         foreach ($expectedListeners as $eventName => $expectedCallbackMethod) {
             $listeners = $this->_adapter->getEventManager()->getListeners($eventName);


### PR DESCRIPTION
Allow ExceptionHandler plugin to suppress exceptions from Filesystem::clearExpired, by having FileSystem::clearExpired trigger an exception event that ExceptionHandler will listen for.
