### PR TITLE
Correction for SMTP transport class

### DIFF
--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -211,8 +211,8 @@ class Smtp implements TransportInterface
         // Prepare message
         $from       = $this->prepareFromAddress($message);
         $recipients = $this->prepareRecipients($message);
-        $headers    = $this->prepareHeaders($message);
         $body       = $this->prepareBody($message);
+        $headers    = $this->prepareHeaders($message);
 
         if ((count($recipients) == 0) && (!empty($headers) || !empty($body))) {
             throw new Exception\RuntimeException(  // Per RFC 2821 3.3 (page 18)


### PR DESCRIPTION
If "headers" are generated before "body" important header keys are not included in the headers and the final message (MIME-Version, Content-Type and Content-Transfer-Encoding). Look at Sendmail transport class method "send" - there is correct order of method calls...
