### PR TITLE
Added Hydrator's dependency

### DIFF
--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -18,12 +18,14 @@
     "require-dev": {
         "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-serializer": "self.version",
-        "zendframework/zend-servicemanager": "self.version"
+        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-filter": "self.version"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
         "zendframework/zend-serializer": "Zend\\Serializer component",
-        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage",
+        "zendframework/zend-filter": "self.version"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
When using Hydrator\ClassMethods::extract the class Filter is missing and must be added manually on composer.json.
