### PR TITLE
fix for issue 6076. avoid GlobIterator globbing to directories which it ...

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -189,7 +189,7 @@ class Filesystem extends AbstractAdapter implements
         $flags = GlobIterator::SKIP_DOTS | GlobIterator::CURRENT_AS_PATHNAME;
         $path = $options->getCacheDir()
             . str_repeat(DIRECTORY_SEPARATOR . $prefix . '*', $options->getDirLevel())
-            . DIRECTORY_SEPARATOR . $prefix . '*';
+            . DIRECTORY_SEPARATOR . $prefix . '*.*';
         $glob = new GlobIterator($path, $flags);
 
         ErrorHandler::start();
@@ -227,7 +227,7 @@ class Filesystem extends AbstractAdapter implements
         $flags = GlobIterator::SKIP_DOTS | GlobIterator::CURRENT_AS_PATHNAME;
         $path = $options->getCacheDir()
             . str_repeat(DIRECTORY_SEPARATOR . $nsPrefix . '*', $options->getDirLevel())
-            . DIRECTORY_SEPARATOR . $nsPrefix . $prefix . '*';
+            . DIRECTORY_SEPARATOR . $nsPrefix . $prefix . '*.*';
         $glob = new GlobIterator($path, $flags);
 
         ErrorHandler::start();

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -227,7 +227,7 @@ class Filesystem extends AbstractAdapter implements
         $flags = GlobIterator::SKIP_DOTS | GlobIterator::CURRENT_AS_PATHNAME;
         $path = $options->getCacheDir()
             . str_repeat(DIRECTORY_SEPARATOR . $nsPrefix . '*', $options->getDirLevel())
-            . DIRECTORY_SEPARATOR . $nsPrefix . $prefix . '*';
+            . DIRECTORY_SEPARATOR . $nsPrefix . $prefix . '*.*';
         $glob = new GlobIterator($path, $flags);
 
         ErrorHandler::start();

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -227,7 +227,7 @@ class Filesystem extends AbstractAdapter implements
         $flags = GlobIterator::SKIP_DOTS | GlobIterator::CURRENT_AS_PATHNAME;
         $path = $options->getCacheDir()
             . str_repeat(DIRECTORY_SEPARATOR . $nsPrefix . '*', $options->getDirLevel())
-            . DIRECTORY_SEPARATOR . $nsPrefix . $prefix . '*.*';
+            . DIRECTORY_SEPARATOR . $nsPrefix . $prefix . '*';
         $glob = new GlobIterator($path, $flags);
 
         ErrorHandler::start();

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -281,4 +281,14 @@ class FilesystemTest extends CommonAdapterTest
         $expectedAtime = fileatime($meta['filespec'] . '.dat');
         $this->assertEquals($expectedAtime, $meta['atime']);
     }
+    
+    public function testClearByNamespaceWithUnexpectedDirectory()
+    {
+        // create cache items at 2 different directory levels
+        $this->_storage->getOptions()->setDirLevel(2);
+        $this->_storage->setItem('a_key', 'a_value');
+        $this->_storage->getOptions()->setDirLevel(1);
+        $this->_storage->setItem('b_key', 'b_value');
+        $this->_storage->clearByNamespace($this->_storage->getOptions()->getNamespace());
+    }
 }

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -291,4 +291,17 @@ class FilesystemTest extends CommonAdapterTest
         $this->_storage->setItem('b_key', 'b_value');
         $this->_storage->clearByNamespace($this->_storage->getOptions()->getNamespace());
     }
+
+    public function testClearByPrefixWithUnexpectedDirectory()
+    {
+        // create cache items at 2 different directory levels
+        $this->_storage->getOptions()->setDirLevel(2);
+        $this->_storage->setItem('a_key', 'a_value');
+        $this->_storage->getOptions()->setDirLevel(1);
+        $this->_storage->setItem('b_key', 'b_value');
+        $glob = glob($this->_tmpCacheDir.'/*');
+        //contrived prefix which will collide with an existing directory
+        $prefix = substr(md5('a_key'), 2, 2);
+        $this->_storage->clearByPrefix($prefix);
+    }
 }

--- a/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/FilesystemTest.php
@@ -281,7 +281,7 @@ class FilesystemTest extends CommonAdapterTest
         $expectedAtime = fileatime($meta['filespec'] . '.dat');
         $this->assertEquals($expectedAtime, $meta['atime']);
     }
-    
+
     public function testClearByNamespaceWithUnexpectedDirectory()
     {
         // create cache items at 2 different directory levels


### PR DESCRIPTION
...will subsequently fail to unlink() by appending _._ instead of just \* to path in clearByNamespace() and clearByPrefix(). _._ will glob to both .dat and .tag extensions
