### PR TITLE
NumberOfParameterFilter correctly handles argument count greater than 0.

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
@@ -26,7 +26,7 @@ class NumberOfParameterFilter implements FilterInterface
      */
     public function __construct($numberOfParameters = 0)
     {
-        $this->numberOfParameters = 0;
+        $this->numberOfParameters = (int) $numberOfParameters;
     }
 
     /**

--- a/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/NumberOfParameterFilter.php
@@ -44,10 +44,6 @@ class NumberOfParameterFilter implements FilterInterface
             );
         }
 
-        if ($reflectionMethod->getNumberOfParameters() !== $this->numberOfParameters) {
-            return false;
-        }
-
-        return true;
+        return $reflectionMethod->getNumberOfParameters() === $this->numberOfParameters;
     }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/Filter/NumberOfParameterFilterTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Filter/NumberOfParameterFilterTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\Filter;
+
+use Zend\Stdlib\Hydrator\Filter\NumberOfParameterFilter;
+
+/**
+ * Unit tests for {@see \Zend\Stdlib\Hydrator\Filter\NumberOfParameterFilter}
+ *
+ * @covers \Zend\Stdlib\Hydrator\Filter\NumberOfParameterFilter
+ * @group Zend_Stdlib
+ */
+class NumberOfParameterFilterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testArityZero()
+    {
+        $filter = new NumberOfParameterFilter();
+        $this->assertTrue($filter->filter(__CLASS__ . '::methodWithNoParameters'));
+        $this->assertFalse($filter->filter(__CLASS__ . '::methodWithOptionalParameters'));
+    }
+
+    public function testArityOne()
+    {
+        $filter = new NumberOfParameterFilter(1);
+        $this->assertFalse($filter->filter(__CLASS__ . '::methodWithNoParameters'));
+        $this->assertTrue($filter->filter(__CLASS__ . '::methodWithOptionalParameters'));
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithOptionalParameters($parameter = 'foo')
+    {
+    }
+
+    /**
+     * Test asset method
+     */
+    public function methodWithNoParameters()
+    {
+    }
+}


### PR DESCRIPTION
The NumberOfParameterFilter used to have a constructor argument for the number of parameters to filter by, but this was ignored and always set to 0.  Luckily, the use case for the filter was restricting the getter, is, has, etc. filters to 0-arity functions so this was OK.  This pull request fixes the class to handle any number of arguments as shown in testArityOne().
