### PR TITLE
Restore ArrayObject protectedProperties on unserialize.

### DIFF
--- a/library/Zend/Stdlib/ArrayObject.php
+++ b/library/Zend/Stdlib/ArrayObject.php
@@ -420,6 +420,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
                     $this->setIteratorClass($v);
                     break;
                 case 'protectedProperties':
+                    $this->protectedProperties = $v;
                     continue;
                 default:
                     $this->__set($k, $v);

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -319,6 +319,18 @@ class ArrayObjectTest extends TestCase
         $this->assertSame('foo', $ar['bar']);
     }
 
+    public function testPhpSerializeUnserialize()
+    {
+        $ar = new ArrayObject();
+        $ar->foo = 'bar';
+        $ar['bar'] = 'foo';
+        $serialized = serialize($ar);
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($ar, $unserialized);
+    }
+
     public function testUasort()
     {
         $function = function ($a, $b) {


### PR DESCRIPTION
Oh well, this is strange, the tests pass on Travis but on my development machine I had problems with:

``` php
$ar = new Zend\Stdlib\ArrayObject();
$serialized = serialize($ar);
var_dump(unserialize($serialized));
```
