### PR TITLE
Hotfix for #6089 - ArrayObject serialization doesn't restore `protectedProperties`

### DIFF
--- a/library/Zend/Stdlib/ArrayObject.php
+++ b/library/Zend/Stdlib/ArrayObject.php
@@ -404,10 +404,13 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      */
     public function unserialize($data)
     {
-        $ar = unserialize($data);
+        $ar                        = unserialize($data);
+        $this->protectedProperties = array_keys(get_object_vars($this));
+
         $this->setFlags($ar['flag']);
         $this->exchangeArray($ar['storage']);
         $this->setIteratorClass($ar['iteratorClass']);
+
         foreach ($ar as $k => $v) {
             switch ($k) {
                 case 'flag':

--- a/tests/ZendTest/Stdlib/ArrayObjectTest.php
+++ b/tests/ZendTest/Stdlib/ArrayObjectTest.php
@@ -351,4 +351,15 @@ class ArrayObjectTest extends TestCase
         $this->assertSame($sorted, $ar->getArrayCopy());
     }
 
+    /**
+     * @group 6089
+     */
+    public function testSerializationRestoresProperties()
+    {
+        $ar        = new ArrayObject();
+        $ar->foo   = 'bar';
+        $ar['bar'] = 'foo';
+
+        $this->assertEquals($ar, unserialize(serialize($ar)));
+    }
 }


### PR DESCRIPTION
This is a hotfix for #6089
