### PR TITLE
Fix undefined classes, constants and methods

### DIFF
--- a/library/Zend/Barcode/Object/Identcode.php
+++ b/library/Zend/Barcode/Object/Identcode.php
@@ -40,7 +40,7 @@ class Identcode extends Code25interleaved
      * Check allowed characters
      * @param  string $value
      * @return string
-     * @throws  Exception
+     * @throws Exception\BarcodeValidationException
      */
     public function validateText($value)
     {

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -1599,7 +1599,7 @@ class Filesystem extends AbstractAdapter implements
      *
      * @param string $file
      * @return void
-     * @throws RuntimeException
+     * @throws Exception\RuntimeException
      */
     protected function unlink($file)
     {

--- a/library/Zend/Cache/Storage/Adapter/MemcacheOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcacheOptions.php
@@ -197,7 +197,7 @@ class MemcacheOptions extends AdapterOptions
     /**
      * Set compress threshold
      *
-     * @param  int|string|array|ArrayAccess|null $threshold
+     * @param  int|string|array|\ArrayAccess|null $threshold
      * @return MemcacheOptions
      */
     public function setAutoCompressThreshold($threshold)

--- a/library/Zend/Cache/Storage/Adapter/MemcacheResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcacheResourceManager.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
+use ArrayAccess;
 use Memcache as MemcacheResource;
 use Traversable;
 use Zend\Cache\Exception;

--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -12,6 +12,7 @@ namespace Zend\Cache\Storage\Adapter;
 use Redis as RedisResource;
 use RedisException as RedisResourceException;
 use stdClass;
+use Traversable;
 use Zend\Cache\Exception;
 use Zend\Cache\Storage\Capabilities;
 use Zend\Cache\Storage\FlushableInterface;

--- a/library/Zend/Code/Reflection/FileReflection.php
+++ b/library/Zend/Code/Reflection/FileReflection.php
@@ -49,7 +49,7 @@ class FileReflection implements ReflectionInterface
     protected $requiredFiles = array();
 
     /**
-     * @var ReflectionClass[]
+     * @var ClassReflection[]
      */
     protected $classes = array();
 

--- a/library/Zend/Db/Adapter/Driver/Pdo/Feature/OracleRowCounter.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Feature/OracleRowCounter.php
@@ -64,7 +64,7 @@ class OracleRowCounter extends AbstractFeature
 
     /**
      * @param $context
-     * @return closure
+     * @return \Closure
      */
     public function getRowCountClosure($context)
     {

--- a/library/Zend/Db/Adapter/Driver/Pdo/Feature/SqliteRowCounter.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Feature/SqliteRowCounter.php
@@ -64,7 +64,7 @@ class SqliteRowCounter extends AbstractFeature
 
     /**
      * @param $context
-     * @return closure
+     * @return \Closure
      */
     public function getRowCountClosure($context)
     {

--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -301,7 +301,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
      * Update
      *
      * @param  array $set
-     * @param  string|array|closure $where
+     * @param  string|array|\Closure $where
      * @return int
      */
     public function update($set, $where = null)

--- a/library/Zend/Di/Definition/Builder/InjectionMethod.php
+++ b/library/Zend/Di/Definition/Builder/InjectionMethod.php
@@ -106,7 +106,7 @@ class InjectionMethod
                     return Di::METHOD_IS_OPTIONAL;
                     break;
                 case "constructor":
-                    return Di::MEHTOD_IS_CONSTRUCTOR;
+                    return Di::METHOD_IS_CONSTRUCTOR;
                     break;
                 case "instantiator":
                     return Di::METHOD_IS_INSTANTIATOR;

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -551,7 +551,7 @@ class Di implements DependencyInjectionInterface
      * @param  string                                $method
      * @param  array                                 $callTimeUserParams
      * @param  string                                $alias
-     * @param  int|bolean                            $methodRequirementType
+     * @param  int|boolean                           $methodRequirementType
      * @param  bool                                  $isInstantiator
      * @throws Exception\MissingPropertyException
      * @throws Exception\CircularDependencyException

--- a/library/Zend/Dom/DOMXPath.php
+++ b/library/Zend/Dom/DOMXPath.php
@@ -27,7 +27,7 @@ class DOMXPath extends \DOMXPath
      * raising an error
      *
      * @param string $expression The XPath expression to evaluate.
-     * @return DOMNodeList
+     * @return \DOMNodeList
      * @throws ErrorException
      */
     public function queryWithErrorException($expression)

--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -298,7 +298,7 @@ class Query
      * @param  DOMDocument $document
      * @param  string|array $xpathQuery
      * @return array
-     * @throws ErrorException If query cannot be executed
+     * @throws \ErrorException If query cannot be executed
      */
     protected function getNodeList($document, $xpathQuery)
     {

--- a/library/Zend/Feed/Reader/Reader.php
+++ b/library/Zend/Feed/Reader/Reader.php
@@ -266,7 +266,7 @@ class Reader
      * HTTP client implementations.
      *
      * @param  string $uri
-     * @param  Http\Client $client
+     * @param  Http\ClientInterface $client
      * @return self
      * @throws Exception\RuntimeException if response is not an Http\ResponseInterface
      */

--- a/library/Zend/Feed/Writer/ExtensionManager.php
+++ b/library/Zend/Feed/Writer/ExtensionManager.php
@@ -60,7 +60,7 @@ class ExtensionManager implements ExtensionManagerInterface
      * Get the named extension
      *
      * @param  string $name
-     * @return Extension\AbstractEntry|Extension\AbstractFeed
+     * @return Extension\AbstractRenderer
      */
     public function get($name)
     {

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -23,7 +23,7 @@ class DateTimeFormatter extends AbstractFilter
     /**
      * Sets filter options
      *
-     * @param array|Traversable $options
+     * @param array|\Traversable $options
      */
     public function __construct($options = null)
     {

--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -10,6 +10,7 @@
 namespace Zend\Filter;
 
 use Countable;
+use Traversable;
 use Zend\Stdlib\PriorityQueue;
 
 class FilterChain extends AbstractFilter implements Countable
@@ -52,7 +53,7 @@ class FilterChain extends AbstractFilter implements Countable
      */
     public function setOptions($options)
     {
-        if (!is_array($options) && !$options instanceof \Traversable) {
+        if (!is_array($options) && !$options instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Expected array or Traversable; received "%s"',
                 (is_object($options) ? get_class($options) : gettype($options))

--- a/library/Zend/Filter/Inflector.php
+++ b/library/Zend/Filter/Inflector.php
@@ -217,7 +217,7 @@ class Inflector extends AbstractFilter
     /**
      * Set Target Reference
      *
-     * @param  reference $target
+     * @param  string $target
      * @return self
      */
     public function setTargetReference(&$target)

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -11,6 +11,7 @@ namespace Zend\Form;
 
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\InitializableInterface;
 
@@ -153,7 +154,7 @@ class FormElementManager extends AbstractPluginManager
      * @param  string $canonicalName
      * @param  string $requestedName
      * @return null|\stdClass
-     * @throws Exception\ServiceNotCreatedException If resolved class does not exist
+     * @throws ServiceNotCreatedException If resolved class does not exist
      */
     protected function createFromInvokable($canonicalName, $requestedName)
     {

--- a/library/Zend/Form/InputFilterProviderFieldset.php
+++ b/library/Zend/Form/InputFilterProviderFieldset.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Form;
 
+use Traversable;
 use Zend\InputFilter\InputFilterProviderInterface;
 
 class InputFilterProviderFieldset extends Fieldset implements InputFilterProviderInterface

--- a/library/Zend/Form/LabelAwareInterface.php
+++ b/library/Zend/Form/LabelAwareInterface.php
@@ -46,7 +46,7 @@ interface LabelAwareInterface
      *
      * Implementation will decide if this will overwrite or merge.
      *
-     * @param  array|Traversable $arrayOrTraversable
+     * @param  array|\Traversable $arrayOrTraversable
      * @return self
      */
     public function setLabelOptions($arrayOrTraversable);

--- a/library/Zend/Http/Headers.php
+++ b/library/Zend/Http/Headers.php
@@ -24,7 +24,7 @@ use Zend\Loader\PluginClassLocator;
 class Headers implements Countable, Iterator
 {
     /**
-     * @var PluginClassLoader
+     * @var PluginClassLocator
      */
     protected $pluginClassLoader = null;
 

--- a/library/Zend/Ldap/Attribute.php
+++ b/library/Zend/Ldap/Attribute.php
@@ -37,13 +37,13 @@ class Attribute
         $valArray   = array();
         if (is_array($value) || ($value instanceof \Traversable)) {
             foreach ($value as $v) {
-                $v = static::valueToLdap($v);
+                $v = self::valueToLdap($v);
                 if ($v !== null) {
                     $valArray[] = $v;
                 }
             }
         } elseif ($value !== null) {
-            $value = static::valueToLdap($value);
+            $value = self::valueToLdap($value);
             if ($value !== null) {
                 $valArray[] = $value;
             }
@@ -76,14 +76,14 @@ class Attribute
             }
             $retArray = array();
             foreach ($data[$attribName] as $v) {
-                $retArray[] = static::valueFromLdap($v);
+                $retArray[] = self::valueFromLdap($v);
             }
             return $retArray;
         } elseif (is_int($index)) {
             if (!isset($data[$attribName])) {
                 return null;
             } elseif ($index >= 0 && $index < count($data[$attribName])) {
-                return static::valueFromLdap($data[$attribName][$index]);
+                return self::valueFromLdap($data[$attribName][$index]);
             } else {
                 return null;
             }
@@ -295,13 +295,13 @@ class Attribute
         $convertedValues = array();
         if (is_array($value) || ($value instanceof \Traversable)) {
             foreach ($value as $v) {
-                $v = static::valueToLdapDateTime($v, $utc);
+                $v = self::valueToLdapDateTime($v, $utc);
                 if ($v !== null) {
                     $convertedValues[] = $v;
                 }
             }
         } elseif ($value !== null) {
-            $value = static::valueToLdapDateTime($value, $utc);
+            $value = self::valueToLdapDateTime($value, $utc);
             if ($value !== null) {
                 $convertedValues[] = $value;
             }
@@ -336,13 +336,13 @@ class Attribute
         $values = static::getAttribute($data, $attribName, $index);
         if (is_array($values)) {
             for ($i = 0, $count = count($values); $i < $count; $i++) {
-                $newVal = static::valueFromLdapDateTime($values[$i]);
+                $newVal = self::valueFromLdapDateTime($values[$i]);
                 if ($newVal !== null) {
                     $values[$i] = $newVal;
                 }
             }
         } else {
-            $newVal = static::valueFromLdapDateTime($values);
+            $newVal = self::valueFromLdapDateTime($values);
             if ($newVal !== null) {
                 $values = $newVal;
             }

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -67,7 +67,6 @@ abstract class AbstractWriter implements WriterInterface
      * - formatter: formatter for this writer
      *
      * @param  array|Traversable $options
-     * @return Logger
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($options = null)

--- a/library/Zend/Mail/Storage/Writable/Maildir.php
+++ b/library/Zend/Mail/Storage/Writable/Maildir.php
@@ -426,7 +426,7 @@ class Maildir extends Folder\Maildir implements WritableInterface
     /**
      * append a new message to mail storage
      *
-     * @param   string|stream                              $message message as string or stream resource
+     * @param   string|resource                            $message message as string or stream resource
      * @param   null|string|\Zend\Mail\Storage\Folder      $folder  folder for new message, else current folder is taken
      * @param   null|array                                 $flags   set flags for new message, else a default set is used
      * @param   bool                                       $recent  handle this mail as if recent flag has been set,

--- a/library/Zend/Mime/Part.php
+++ b/library/Zend/Mime/Part.php
@@ -68,7 +68,7 @@ class Part
      * reading the content. very useful for large file attachments.
      *
      * @param string $EOL
-     * @return stream
+     * @return resource
      * @throws Exception\RuntimeException if not a stream or unable to append filter
      */
     public function getEncodedStream($EOL = Mime::LINEEND)

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -174,7 +174,7 @@ class ModuleManager implements ModuleManagerInterface
 
     /**
      * Load a module with the name
-     * @param  Zend\EventManager\EventInterface $event
+     * @param  \Zend\EventManager\EventInterface $event
      * @return mixed                            module instance
      * @throws Exception\RuntimeException
      */

--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -18,12 +18,12 @@ class Translator implements
     ValidatorTranslatorInterface
 {
     /**
-     * @var I18nTranslator
+     * @var I18nTranslatorInterface
      */
     protected $translator;
 
     /**
-     * @param I18nTranslator $translator
+     * @param I18nTranslatorInterface $translator
      */
     public function __construct(I18nTranslatorInterface $translator)
     {

--- a/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TranslatorAwareTreeRouteStack.php
@@ -11,6 +11,7 @@ namespace Zend\Mvc\Router\Http;
 
 use Zend\I18n\Translator\TranslatorInterface as Translator;
 use Zend\I18n\Translator\TranslatorAwareInterface;
+use Zend\Mvc\Router\Exception;
 use Zend\Stdlib\RequestInterface as Request;
 
 /**

--- a/library/Zend/Navigation/Page/AbstractPage.php
+++ b/library/Zend/Navigation/Page/AbstractPage.php
@@ -260,7 +260,7 @@ abstract class AbstractPage extends AbstractContainer
     /**
      * Add static factory for self::factory function
      *
-     * @param type $callback Any callable variable
+     * @param callable $callback Any callable variable
      */
     public static function addFactory($callback)
     {

--- a/library/Zend/Navigation/Page/Uri.php
+++ b/library/Zend/Navigation/Page/Uri.php
@@ -123,7 +123,7 @@ class Uri extends AbstractPage
      * Sets request for assembling URLs
      *
      * @param Request $request
-     * @return Fluent interface, returns self
+     * @return self Fluent interface, returns self
      */
     public function setRequest(Request $request = null)
     {

--- a/library/Zend/Permissions/Acl/Assertion/AssertionAggregate.php
+++ b/library/Zend/Permissions/Acl/Assertion/AssertionAggregate.php
@@ -95,7 +95,7 @@ class AssertionAggregate implements AssertionInterface
      *
      * @param string $mode
      *            indicates how assertion chain result should interpreted (either 'all' or 'at_least_one')
-     * @throws Exception
+     * @throws InvalidArgumentException
      *
      * @return self
      */

--- a/library/Zend/Serializer/Serializer.php
+++ b/library/Zend/Serializer/Serializer.php
@@ -18,7 +18,7 @@ abstract class Serializer
      *
      * @var null|AdapterPluginManager
      */
-    private static $adapters = null;
+    protected static $adapters = null;
 
     /**
      * The default adapter.

--- a/library/Zend/Session/SaveHandler/MongoDB.php
+++ b/library/Zend/Session/SaveHandler/MongoDB.php
@@ -51,7 +51,7 @@ class MongoDB implements SaveHandlerInterface
      *
      * @param Mongo|MongoClient $mongo
      * @param MongoDBOptions $options
-     * @throws Zend\Session\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct($mongo, MongoDBOptions $options)
     {

--- a/library/Zend/Session/Service/StorageFactory.php
+++ b/library/Zend/Session/Service/StorageFactory.php
@@ -12,7 +12,7 @@ namespace Zend\Session\Service;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\Session\Storage\Exception as SessionException;
+use Zend\Session\Exception\ExceptionInterface as SessionException;
 use Zend\Session\Storage\Factory;
 use Zend\Session\Storage\StorageInterface;
 

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -720,7 +720,7 @@ class Server implements ZendServerServer
      * - stdClass; if so, calls __toString() and verifies XML
      * - string; if so, verifies XML
      *
-     * @param  DOMDocument|DOMNode|SimpleXMLElement|stdClass|string $request
+     * @param  DOMDocument|DOMNode|SimpleXMLElement|\stdClass|string $request
      * @return self
      * @throws Exception\InvalidArgumentException
      */
@@ -880,7 +880,7 @@ class Server implements ZendServerServer
      * If no request is passed, pulls request using php:://input (for
      * cross-platform compatibility purposes).
      *
-     * @param  DOMDocument|DOMNode|SimpleXMLElement|stdClass|string $request Optional request
+     * @param  DOMDocument|DOMNode|SimpleXMLElement|\stdClass|string $request Optional request
      * @return void|string
      */
     public function handle($request = null)
@@ -999,7 +999,7 @@ class Server implements ZendServerServer
     /**
      * Checks if provided fault name is registered as valid in this server.
      *
-     * @param $fault Name of a fault class
+     * @param string $fault Name of a fault class
      * @return bool
      */
     public function isRegisteredAsFaultException($fault)

--- a/library/Zend/Stdlib/Hydrator/Filter/OptionalParametersFilter.php
+++ b/library/Zend/Stdlib/Hydrator/Filter/OptionalParametersFilter.php
@@ -25,7 +25,7 @@ class OptionalParametersFilter implements FilterInterface
      *
      * @var bool[]
      */
-    private static $propertiesCache = array();
+    protected static $propertiesCache = array();
 
     /**
      * {@inheritDoc}

--- a/library/Zend/Stdlib/PriorityList.php
+++ b/library/Zend/Stdlib/PriorityList.php
@@ -244,7 +244,7 @@ class PriorityList implements Iterator, Countable
     /**
      * Return list as array
      *
-     * @param type $raw
+     * @param int $flag
      * @return array
      */
     public function toArray($flag = self::EXTR_DATA)

--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -707,7 +707,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     /**
      * Recursively search a view model and it's children for the given templateName
      *
-     * @param  ViewModel $viewModel
+     * @param  \Zend\View\Model\ModelInterface $viewModel
      * @param  string    $templateName
      * @return boolean
      */

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -365,7 +365,7 @@ abstract class AbstractStandalone extends AbstractHelper implements
     /**
      * IteratorAggregate: get Iterator
      *
-     * @return Iterator
+     * @return \Iterator
      */
     public function getIterator()
     {


### PR DESCRIPTION
This pull request fixes undefined classes in phpDoc and one undefined class constant. In addition, the visibility for some methods was increased to `protected` as those methods were called with `static`.
