### PR TITLE
Prevent ArrayObject recursion in 5.6

### DIFF
--- a/library/Zend/Stdlib/Parameters.php
+++ b/library/Zend/Stdlib/Parameters.php
@@ -83,7 +83,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      */
     public function offsetGet($name)
     {
-        if (isset($this[$name])) {
+          if ($this->offsetExists($name)) {
             return parent::offsetGet($name);
         }
         return null;
@@ -96,7 +96,7 @@ class Parameters extends PhpArrayObject implements ParametersInterface
      */
     public function get($name, $default = null)
     {
-        if (isset($this[$name])) {
+        if ($this->offsetExists($name)) {
             return parent::offsetGet($name);
         }
         return $default;


### PR DESCRIPTION
In PHP 5.6(next), calling `isset()` on an instance of `ArrayObject` will invoke both `offsetExists()` and `offsetGet()`. Adding an `isset()` inside `offsetGet()` will therefore result in an infinite recursion; this is related to [php-src/614](https://github.com/php/php-src/pull/614).

It causes `tests/ZendTest/StdLib/ParametersTest.php` to fail.

This patch addresses the above issue in a backward compatible manner.
