### PR TITLE
Validator\Ip should not allow newlines in any case.

### DIFF
--- a/library/Zend/Validator/Ip.php
+++ b/library/Zend/Validator/Ip.php
@@ -97,15 +97,15 @@ class Ip extends AbstractValidator
      */
     protected function validateIPv4($value)
     {
-        if (preg_match('/^([01]{8}.){3}[01]{8}$/i', $value)) {
+        if (preg_match('/^([01]{8}.){3}[01]{8}\z/i', $value)) {
             // binary format  00000000.00000000.00000000.00000000
             $value = bindec(substr($value, 0, 8)) . '.' . bindec(substr($value, 9, 8)) . '.'
                    . bindec(substr($value, 18, 8)) . '.' . bindec(substr($value, 27, 8));
-        } elseif (preg_match('/^([0-9]{3}.){3}[0-9]{3}$/i', $value)) {
+        } elseif (preg_match('/^([0-9]{3}.){3}[0-9]{3}\z/i', $value)) {
             // octet format 777.777.777.777
             $value = (int) substr($value, 0, 3) . '.' . (int) substr($value, 4, 3) . '.'
                    . (int) substr($value, 8, 3) . '.' . (int) substr($value, 12, 3);
-        } elseif (preg_match('/^([0-9a-f]{2}.){3}[0-9a-f]{2}$/i', $value)) {
+        } elseif (preg_match('/^([0-9a-f]{2}.){3}[0-9a-f]{2}\z/i', $value)) {
             // hex format ff.ff.ff.ff
             $value = hexdec(substr($value, 0, 2)) . '.' . hexdec(substr($value, 3, 2)) . '.'
                    . hexdec(substr($value, 6, 2)) . '.' . hexdec(substr($value, 9, 2));

--- a/tests/ZendTest/Validator/IpTest.php
+++ b/tests/ZendTest/Validator/IpTest.php
@@ -283,6 +283,12 @@ class IpTest extends \PHPUnit_Framework_TestCase
             'a0.b0.c0.d0'                            => true,
             'g0.00.00.00'                            => false,
             'g0.00.00.00:80'                         => false,
+
+            // new lines should not accept
+            "00000001.00000010.00000011.00000100\n"  => false,
+            "001.002.003.004\n"                      => false,
+            "a0.b0.c0.d0\n"                          => false,
+
         );
 
         foreach ($ips as $ip => $expectedOutcome) {


### PR DESCRIPTION
``` php
<?php
use Zend\Validator\Ip;

var_dump((new Ip)->isValid("127.000.000.001"));  // true (expected)
var_dump((new Ip)->isValid("127.000.000.001\n")); // true (Unexpected)
var_dump((new Ip)->isValid("127.0.0.1\n")); //false (expected)
```

This issue was caused by ZF-10621
https://github.com/zendframework/zf2/commit/29516d4#diff-1f6ffee384d80d41af718d92b4b7ea76R144

related fix http://framework.zend.com/issues/browse/ZF-8640
