### PR TITLE
Zend\Test Enable trace error by default

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -48,7 +48,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
      * Trace error when exception is throwed in application
      * @var bool
      */
-    protected $traceError = false;
+    protected $traceError = true;
 
     /**
      * Reset the application for isolation

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -639,6 +639,21 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertApplicationException('RuntimeException', 'Foo error');
     }
 
+    public function testTraceErrorEnableByDefault()
+    {
+        $this->dispatch('/exception');
+        $this->assertResponseStatusCode(500);
+
+        try {
+            // force exception throwing
+            parent::tearDown();
+        } catch(\Exception $e) {
+            $this->getApplication()->getMvcEvent()->setParam('exception', null);
+            $this->setExpectedException('RuntimeException', 'Foo error');
+            throw $e;
+        }
+    }
+
     public function testGetErrorWithTraceErrorEnabled()
     {
         $this->dispatch('/exception');


### PR DESCRIPTION
I wanted to change this for a long time but I Had to wait for https://github.com/zendframework/zf2/pull/6041, but now it's ok, we can enable trace error by default, it will be better for developer.

It's not a BC because if test is broken now, it's because the developer had an exception he didn't see, so it's better :)
