### PR TITLE
Allow session garbage collection to use an index

### DIFF
--- a/library/Zend/Session/SaveHandler/DbTableGateway.php
+++ b/library/Zend/Session/SaveHandler/DbTableGateway.php
@@ -164,10 +164,9 @@ class DbTableGateway implements SaveHandlerInterface
     public function gc($maxlifetime)
     {
         $platform = $this->tableGateway->getAdapter()->getPlatform();
-        return (bool) $this->tableGateway->delete(sprintf('%s + %s < %d',
+        return (bool) $this->tableGateway->delete(sprintf('%s < %d',
             $platform->quoteIdentifier($this->options->getModifiedColumn()),
-            $platform->quoteIdentifier($this->options->getLifetimeColumn()),
-            time()
+            (time() - $this->lifetime)
         ));
     }
 }


### PR DESCRIPTION
Performing arithmetic in the where clause prevents MySQL from using an index. The garbage collection becomes increasingly more expensive to run as traffic grows.
