### PR TITLE
Mail transfer encoding binary

### DIFF
--- a/library/Zend/Mail/Header/ContentTransferEncoding.php
+++ b/library/Zend/Mail/Header/ContentTransferEncoding.php
@@ -22,9 +22,9 @@ class ContentTransferEncoding implements HeaderInterface
         '8bit',
         'quoted-printable',
         'base64',
+        'binary',
         /*
          * not implemented:
-         * 'binary',
          * x-token: 'X-'
          */
     );

--- a/tests/ZendTest/Mail/Header/ContentTransferEncodingTest.php
+++ b/tests/ZendTest/Mail/Header/ContentTransferEncodingTest.php
@@ -16,18 +16,41 @@ use Zend\Mail\Header\ContentTransferEncoding;
  */
 class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
 {
-
-    public function testContentTransferEncodingFromStringCreatesValidContentTransferEncodingHeader()
+    public function dataValidEncodings()
     {
-        $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: 7bit');
+        return array(
+            array('7bit'),
+            array('8bit'),
+            array('quoted-printable'),
+        );
+    }
+
+    public function dataInvalidEncodings()
+    {
+        return array(
+            array('9bit'),
+            array('binary'),
+            array('x-something'),
+        );
+    }
+
+    /**
+     * @dataProvider dataValidEncodings
+     */
+    public function testContentTransferEncodingFromStringCreatesValidContentTransferEncodingHeader($encoding)
+    {
+        $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: '.$encoding);
         $this->assertInstanceOf('Zend\Mail\Header\HeaderInterface', $contentTransferEncodingHeader);
         $this->assertInstanceOf('Zend\Mail\Header\ContentTransferEncoding', $contentTransferEncodingHeader);
     }
 
-    public function testContentTransferEncodingFromStringCreateExcaption()
+    /**
+     * @dataProvider dataInvalidEncodings
+     */
+    public function testContentTransferEncodingFromStringCreateExcaption($encoding)
     {
         $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
-        $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: 9bit');
+        $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: '.$encoding);
     }
 
     public function testContentTransferEncodingGetFieldNameReturnsHeaderName()
@@ -36,34 +59,33 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Content-Transfer-Encoding', $contentTransferEncodingHeader->getFieldName());
     }
 
-    public function testContentTransferEncodingGetFieldValueReturnsProperValue()
+    /**
+     * @dataProvider dataValidEncodings
+     */
+    public function testContentTransferEncodingGetFieldValueReturnsProperValue($encoding)
     {
         $contentTransferEncodingHeader = new ContentTransferEncoding();
-        $contentTransferEncodingHeader->setTransferEncoding('7bit');
-        $this->assertEquals('7bit', $contentTransferEncodingHeader->getFieldValue());
+        $contentTransferEncodingHeader->setTransferEncoding($encoding);
+        $this->assertEquals($encoding, $contentTransferEncodingHeader->getFieldValue());
     }
 
-    public function testContentTransferEncodingHandlesCaseInsensitivity()
-    {
-        $encoding = new ContentTransferEncoding();
-        $encoding->setTransferEncoding('quOtED-printAble');
-        $this->assertEquals('quoted-printable', strtolower($encoding->getFieldValue()));
-    }
-
-    public function testContentTransferEncodingToStringReturnsHeaderFormattedString()
-    {
-        $contentTransferEncodingHeader = new ContentTransferEncoding();
-        $contentTransferEncodingHeader->setTransferEncoding('8bit');
-        $this->assertEquals("Content-Transfer-Encoding: 8bit", $contentTransferEncodingHeader->toString());
-    }
-
-    public function testProvidingParametersIntroducesHeaderFolding()
+    /**
+     * @dataProvider dataValidEncodings
+     */
+    public function testContentTransferEncodingHandlesCaseInsensitivity($encoding)
     {
         $header = new ContentTransferEncoding();
-        $header->setTransferEncoding('quoted-printable');
-        $string = $header->toString();
-
-        $this->assertContains("Content-Transfer-Encoding: quoted-printable", $string);
+        $header->setTransferEncoding(strtoupper(substr($encoding, 0, 4)).substr($encoding, 4));
+        $this->assertEquals(strtolower($encoding), strtolower($header->getFieldValue()));
     }
 
+    /**
+     * @dataProvider dataValidEncodings
+     */
+    public function testContentTransferEncodingToStringReturnsHeaderFormattedString($encoding)
+    {
+        $contentTransferEncodingHeader = new ContentTransferEncoding();
+        $contentTransferEncodingHeader->setTransferEncoding($encoding);
+        $this->assertEquals("Content-Transfer-Encoding: ".$encoding, $contentTransferEncodingHeader->toString());
+    }
 }

--- a/tests/ZendTest/Mail/Header/ContentTransferEncodingTest.php
+++ b/tests/ZendTest/Mail/Header/ContentTransferEncodingTest.php
@@ -21,6 +21,7 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
         return array(
             array('7bit'),
             array('8bit'),
+            array('binary'),
             array('quoted-printable'),
         );
     }
@@ -29,7 +30,6 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('9bit'),
-            array('binary'),
             array('x-something'),
         );
     }


### PR DESCRIPTION
I can't see a reason why ContentTransferEncoding would disallow `binary`.
Real emails get sent with this encoding and it seems to just work if we allow it.
