### PR TITLE
Elements and Fieldsets within a Collection are not validated

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -798,7 +798,13 @@ class Form extends Fieldset implements FormInterface
             }
         }
 
-        foreach ($fieldset->getFieldsets() as $childFieldset) {
+        if ($fieldset instanceof Collection && $fieldset->getTargetElement() instanceof FieldsetInterface) {
+            $childFieldsets = $fieldset->getTargetElement()->getFieldsets();
+        } else {
+            $childFieldsets = $fieldset->getFieldsets();
+        }
+
+        foreach ($childFieldsets as $childFieldset) {
             $name = $childFieldset->getName();
 
             if (!$childFieldset instanceof InputFilterProviderInterface) {
@@ -808,8 +814,8 @@ class Form extends Fieldset implements FormInterface
                     if ($childFieldset->getObject() instanceof InputFilterAwareInterface) {
                         $inputFilter->add($childFieldset->getObject()->getInputFilter(), $name);
                     } else {
-                        if ($fieldset instanceof Collection && $inputFilter instanceof CollectionInputFilter) {
-                            continue;
+                        if ($childFieldset instanceof Collection) {
+                            $inputFilter->add(new CollectionInputFilter(), $name);
                         } else {
                             $inputFilter->add(new InputFilter(), $name);
                         }

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -193,7 +193,6 @@ class CollectionInputFilter extends InputFilter
 
             $values    = array();
             $rawValues = array();
-            $messages = array();
             foreach ($inputs as $name) {
                 $input = $this->inputs[$name];
 
@@ -204,17 +203,10 @@ class CollectionInputFilter extends InputFilter
                 }
                 $values[$name]    = $input->getValue($this->data);
                 $rawValues[$name] = $input->getRawValue();
-                $tmpMessages = $input->getMessages();
-                if (!empty($tmpMessages)) {
-                    $messages[$name] =  $tmpMessages;
-                }
             }
             $this->collectionValues[$key]    = $values;
             $this->collectionRawValues[$key] = $rawValues;
 
-            if (!empty($messages)) {
-                $this->collectionMessages[$key] = $messages;
-            }
         }
 
         return $valid;
@@ -298,6 +290,13 @@ class CollectionInputFilter extends InputFilter
      */
     public function getMessages()
     {
-        return $this->collectionMessages;
+        $messages = array();
+        foreach ($this->getInvalidInput() as $iteration => $inputFields) {
+            foreach ($inputFields as $name => $field) {
+                $messages[$iteration][$name] = $field->getMessages();
+            }
+        }
+
+        return $messages;
     }
 }

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1123,6 +1123,75 @@ class FormTest extends TestCase
         $this->assertEquals('foo[fieldsets][0][field]', $form->get('fieldsets')->get('0')->get('field')->getName());
     }
 
+    public function testCanValidateFieldsetWithinCollection()
+    {
+        $form = new \ZendTest\Form\TestAsset\FormCollection();
+        $form->prepare();
+
+        $form->setData(array(
+            'colors' => array(
+                '#00FF00',
+                '#FF00FF',
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'pass',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'pass',
+                    ),
+                ),
+                array(
+                    'field' => 'pass',
+                    'nested_fieldset' => array(
+                        'anotherField' => null, // Fail; bad must not be empty
+                    ),
+                ),
+            )
+        ));
+
+        $this->assertFalse( $form->isValid() );
+
+        $messages = $form->getMessages();
+        $this->assertCount( 1, $messages['fieldsets'] );
+        $this->assertCount( 1, $messages['fieldsets'][1] );
+        $this->assertCount( 1, $messages['fieldsets'][1]['nested_fieldset'] );
+    }
+
+    public function testCanValidateElementWithinCollection()
+    {
+        $form = new \ZendTest\Form\TestAsset\FormCollection();
+        $form->prepare();
+
+        $form->setData(array(
+            'colors' => array(
+                '#00FF00',
+                'ZZZZZZZ', // Fail; bad data
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'pass',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'pass',
+                    ),
+                ),
+                array(
+                    'field' => 'pass',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'pass',
+                    ),
+                ),
+            )
+        ));
+
+        $this->markTestSkipped('Bug: Cannot successfully validate Element direction under a Collection');
+
+        $this->assertFalse( $form->isValid() );
+
+        $messages = $form->getMessages();
+        $this->assertCount( 1, $messages['colors'] );
+        $this->assertCount( 1, $messages['colors'][1] );
+    }
+
     public function testUnsetValuesNotBound()
     {
         $model = new stdClass;


### PR DESCRIPTION
Currently member items of a Collection (Fieldset or Element) are never validated when isValid() is called on a form.

This PR fixes \Zend\Form\Form to instantiate a CollectionInputFilter, causing Fieldsets to be be validated.
This PR does NOT fix the issue of Elements under a Collection not being validated, but I have added a skipped test which would otherwise fail, for this case.
This PR also modifies the CollectionInputFilter to not collate the error messages on isValid, but instead when getMessages is called. This is more akin to the actions of BaseInputFilter.
