### PR TITLE
Extra fieldsets are created when calling form bind multiple times

### DIFF
--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -422,6 +422,30 @@ class CollectionTest extends TestCase
         $this->assertNotSame($categories[1], $cat2);
     }
 
+    public function testCreateExtraCollectionFieldsetOnMultipleBind()
+    {
+        $form = new \Zend\Form\Form();
+        $this->productFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());
+        $form->add($this->productFieldset);
+        $form->setHydrator(new \Zend\Stdlib\Hydrator\ObjectProperty());
+
+        $product = new Product();
+        $categories = array(new \ZendTest\Form\TestAsset\Entity\Category(), new \ZendTest\Form\TestAsset\Entity\Category());
+        $product->setCategories($categories);
+
+        $market = new \StdClass();
+        $market->product = $product;
+
+        // this will pass the test
+        $form->bind($market);
+        $this->assertSame(count($categories), iterator_count($form->get('product')->get('categories')->getIterator()));
+
+        // this won't pass, but must
+        $form->bind($market);
+        $this->assertSame(count($categories), iterator_count($form->get('product')->get('categories')->getIterator()));
+
+    }
+
     public function testExtractDefaultIsEmptyArray()
     {
         $collection = $this->form->get('fieldsets');

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -422,7 +422,7 @@ class CollectionTest extends TestCase
         $this->assertNotSame($categories[1], $cat2);
     }
 
-    public function testCreateExtraCollectionFieldsetOnMultipleBind()
+    public function testDoNotCreateExtraFieldsetOnMultipleBind()
     {
         $form = new \Zend\Form\Form();
         $this->productFieldset->setHydrator(new \Zend\Stdlib\Hydrator\ClassMethods());


### PR DESCRIPTION
Yet another test to demonstrate regression since #5636

Ref to #6074 #6100
Removing changes in #5093 fixes this
