### PR TITLE
Mail: Require Zend\Validator

### DIFF
--- a/library/Zend/Mail/composer.json
+++ b/library/Zend/Mail/composer.json
@@ -17,15 +17,14 @@
         "zendframework/zend-crypt": "self.version",
         "zendframework/zend-loader": "self.version",
         "zendframework/zend-mime": "self.version",
-        "zendframework/zend-stdlib": "self.version"
-    },
-    "require-dev": {
-        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-validator": "self.version"
     },
+    "require-dev": {
+        "zendframework/zend-servicemanager": "self.version"
+    },
     "suggest": {
-        "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
-        "zendframework/zend-validator": "Zend\\Validator component"
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Since the `AbstractProtocol` in the Zend\Mail namespace uses Zend\Validator, the component is required in almost all cases.
