### PR TITLE
Tiny typo fix in docblock

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -230,7 +230,7 @@ abstract class AbstractRestfulController extends AbstractController
     }
 
     /**
-     * Modify a resource collection withou completely replacing it
+     * Modify a resource collection without completely replacing it
      *
      * Not marked as abstract, as that would introduce a BC break
      * (introduced in 2.2.0); instead, raises an exception if not implemented.


### PR DESCRIPTION
My first little addition to the perfection of the ZF2 Framework.

Fixed a tiny little typo in a docblock in the AbstractRestfulController.
