### PR TITLE
FormElementManager: Only initialize a shared element once

### DIFF
--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -83,6 +83,7 @@ class FormElementManager extends AbstractPluginManager
         parent::__construct($configuration);
 
         $this->addInitializer(array($this, 'injectFactory'));
+        $this->addInitializer(array($this, 'injectInitializable'), false);
     }
 
     /**
@@ -106,6 +107,18 @@ class FormElementManager extends AbstractPluginManager
     }
 
     /**
+     * Call init() on any element that implements InitializableInterface
+     *
+     * @param $element
+     */
+    public function injectInitializable($element)
+    {
+        if ($element instanceof InitializableInterface) {
+            $element->init();
+        }
+    }
+
+    /**
      * Validate the plugin
      *
      * Checks that the element is an instance of ElementInterface
@@ -116,20 +129,6 @@ class FormElementManager extends AbstractPluginManager
      */
     public function validatePlugin($plugin)
     {
-        // Hook to perform various initialization, when the element is not created through the factory
-        if ($plugin instanceof InitializableInterface) {
-            $pluginName = $this->canonicalizeName(get_class($plugin));
-            // If $plugin is shared, we only want to initialize it once.
-            if (array_key_exists($pluginName, $this->shared) && $this->shared[$pluginName] == true) {
-                if (!in_array($pluginName, $this->initializedPlugins)) {
-                    $plugin->init();
-                    $this->initializedPlugins[] = $pluginName;
-                }
-            } else {
-                $plugin->init();
-            }
-        }
-
         if ($plugin instanceof ElementInterface) {
             return; // we're okay
         }

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -63,12 +63,6 @@ class FormElementManager extends AbstractPluginManager
     );
 
     /**
-     * Keep track of which plugins have been intizalied
-     * @var array
-     */
-    protected $initializedPlugins = array();
-
-    /**
      * Don't share form elements by default
      *
      * @var bool
@@ -83,7 +77,7 @@ class FormElementManager extends AbstractPluginManager
         parent::__construct($configuration);
 
         $this->addInitializer(array($this, 'injectFactory'));
-        $this->addInitializer(array($this, 'injectInitializable'), false);
+        $this->addInitializer(array($this, 'callElementInit'), false);
     }
 
     /**
@@ -109,9 +103,9 @@ class FormElementManager extends AbstractPluginManager
     /**
      * Call init() on any element that implements InitializableInterface
      *
-     * @param $element
+     * @internal param $element
      */
-    public function injectInitializable($element)
+    public function callElementInit($element)
     {
         if ($element instanceof InitializableInterface) {
             $element->init();

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -120,7 +120,7 @@ class FormElementManager extends AbstractPluginManager
         if ($plugin instanceof InitializableInterface) {
             $pluginName = $this->canonicalizeName(get_class($plugin));
             // If $plugin is shared, we only want to initialize it once.
-            if (in_array($pluginName, $this->shared) && $this->shared[$pluginName] == true) {
+            if (array_key_exists($pluginName, $this->shared) && $this->shared[$pluginName] == true) {
                 if (!in_array($pluginName, $this->initializedPlugins)) {
                     $plugin->init();
                     $this->initializedPlugins[] = $pluginName;

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -66,7 +66,7 @@ class FormElementManager extends AbstractPluginManager
      * Keep track of which plugins have been intizalied
      * @var array
      */
-    protected $initializedPlugins;
+    protected $initializedPlugins = array();
 
     /**
      * Don't share form elements by default

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -116,11 +116,18 @@ class FormElementManager extends AbstractPluginManager
      */
     public function validatePlugin($plugin)
     {
-        $objectHash = spl_object_hash($plugin);
         // Hook to perform various initialization, when the element is not created through the factory
-        if ($plugin instanceof InitializableInterface && !in_array($objectHash, $this->initializedPlugins)) {
-            $plugin->init();
-            $this->initializedPlugins[] = $objectHash;
+        if ($plugin instanceof InitializableInterface) {
+            $pluginName = $this->canonicalizeName(get_class($plugin));
+            // If $plugin is shared, we only want to initialize it once.
+            if (in_array($pluginName, $this->shared) && $this->shared[$pluginName] == true) {
+                if (!in_array($pluginName, $this->initializedPlugins)) {
+                    $plugin->init();
+                    $this->initializedPlugins[] = $pluginName;
+                }
+            } else {
+                $plugin->init();
+            }
         }
 
         if ($plugin instanceof ElementInterface) {

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -63,6 +63,12 @@ class FormElementManager extends AbstractPluginManager
     );
 
     /**
+     * Keep track of which plugins have been intizalied
+     * @var array
+     */
+    protected $initializedPlugins;
+
+    /**
      * Don't share form elements by default
      *
      * @var bool
@@ -110,9 +116,11 @@ class FormElementManager extends AbstractPluginManager
      */
     public function validatePlugin($plugin)
     {
+        $objectHash = spl_object_hash($plugin);
         // Hook to perform various initialization, when the element is not created through the factory
-        if ($plugin instanceof InitializableInterface) {
+        if ($plugin instanceof InitializableInterface && !in_array($objectHash, $this->initializedPlugins)) {
             $plugin->init();
+            $this->initializedPlugins[] = $objectHash;
         }
 
         if ($plugin instanceof ElementInterface) {


### PR DESCRIPTION
If you call $formElementManager->get('My\Element'); several times, My\Element->init() is called each time.
This is correct if the element is not shared, but if the element is shared it should only be called once.
