### PR TITLE
InputFilter\Factory can't handle config with null input

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -310,6 +310,9 @@ class Factory
         }
 
         foreach ($inputFilterSpecification as $key => $value) {
+            if (null === $value) {
+                continue;
+            }
 
             if (($value instanceof InputInterface)
                 || ($value instanceof InputFilterInterface)

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -583,4 +583,25 @@ class FactoryTest extends TestCase
 
         $this->assertFalse($factory->createInput(array('break_on_failure' => false))->breakOnFailure());
     }
+
+    public function testCanCreateInputFilterWithNullInputs()
+    {
+        $factory = new Factory();
+
+        $inputFilter = $factory->createInputFilter(array(
+            'foo' => array(
+                'name' => 'foo',
+            ),
+            'bar' => null,
+            'baz' => array(
+                'name' => 'baz',
+            ),
+        ));
+
+        $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
+        $this->assertEquals(2, count($inputFilter));
+        $this->assertTrue($inputFilter->has('foo'));
+        $this->assertFalse($inputFilter->has('bar'));
+        $this->assertTrue($inputFilter->has('baz'));
+    }
 }


### PR DESCRIPTION
Same issue as with https://github.com/zendframework/zf2/pull/4971

InputFilter\Factory should handle null value, when we want to cancel the input filter input statically (by config).

I'm ready to send a PR.
