### PR TITLE
Don't check for error if event is not stopped

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -303,10 +303,10 @@ class Application implements
                 $this->response = $response;
                 return $this;
             }
-        }
 
-        if ($event->getError()) {
-            return $this->completeRequest($event);
+            if ($event->getError()) {
+                return $this->completeRequest($event);
+            }
         }
 
         // Trigger dispatch event


### PR DESCRIPTION
It's a very minor improvement, related to https://github.com/zendframework/zf2/commit/26bc1ea6da647d92a6a57bc1d71a0d5cb3177dbe.

Since `$shortCircuit` is:

``` php
$shortCircuit = function ($r) use ($event) {
    if ($r instanceof ResponseInterface) {
        return true;
    }
    if ($event->getError()) {
        return true;
    }
    return false;
};
```

We can assume that if the event is not stopped, then there's no error in `MvcEvent`.
