### PR TITLE
Fix: No need to prefix imports

### DIFF
--- a/library/Zend/Http/Header/Origin.php
+++ b/library/Zend/Http/Header/Origin.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Http\Header;
 
-use \Zend\Uri\UriFactory;
+use Zend\Uri\UriFactory;
 
 /**
  * @throws Exception\InvalidArgumentException

--- a/tests/ZendTest/Db/Adapter/AdapterAwareTraitTest.php
+++ b/tests/ZendTest/Db/Adapter/AdapterAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Db\Adapter;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\Db\Adapter\Adapter;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Db\Adapter\Adapter;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/EventManager/EventManagerAwareTraitTest.php
+++ b/tests/ZendTest/EventManager/EventManagerAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\EventManager;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\EventManager\EventManager;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\EventManager\EventManager;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/Form/FormFactoryAwareTraitTest.php
+++ b/tests/ZendTest/Form/FormFactoryAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Form;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\Form\Factory;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Factory;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/I18n/Translator/TranslatorAwareTraitTest.php
+++ b/tests/ZendTest/I18n/Translator/TranslatorAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\I18n\Translator;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\I18n\Translator\Translator;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\I18n\Translator\Translator;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/InputFilter/InputFilterAwareTraitTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\InputFilter;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\InputFilter\InputFilter;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\InputFilter\InputFilter;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/Log/LoggerAwareTraitTest.php
+++ b/tests/ZendTest/Log/LoggerAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\Log;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\Log\Logger;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Log\Logger;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/ServiceManager/ServiceLocatorAwareTraitTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceLocatorAwareTraitTest.php
@@ -9,8 +9,8 @@
 
 namespace ZendTest\ServiceManager;
 
-use \PHPUnit_Framework_TestCase as TestCase;
-use \Zend\ServiceManager\ServiceManager;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * @requires PHP 5.4

--- a/tests/ZendTest/Stdlib/Hydrator/HydratorAwareTraitTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/HydratorAwareTraitTest.php
@@ -10,7 +10,7 @@
 
 namespace ZendTest\Stdlib\Hydrator;
 
-use \PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit_Framework_TestCase as TestCase;
 
 /**
  * @requires PHP 5.4


### PR DESCRIPTION
There's no need to prefix FQCNs with `\` in `use` statements.

Stumbled upon this when having a look at https://github.com/zendframework/zf2/pull/5029.
