### PR TITLE
Zend\Log\Formatter\Xml improvement to handle extra data array

### DIFF
--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -185,11 +185,7 @@ class Xml implements FormatterInterface
                 } elseif ($key == "extra" && empty($value)) {
                     continue;
                 } elseif ($key == "extra" && (is_array($value) || $value instanceof Traversable)) {
-                    $extraElement = $dom->createElement('extra');
-                    foreach ($value as $extraKey => $extraValue) {
-                        $extraElement->appendChild(new DOMElement($extraKey, (string) $extraValue));
-                    }
-                    $elt->appendChild($extraElement);
+                    $elt->appendChild($this->_buildElementTree($dom, $dom->createElement('extra'), $value));
                     continue;
                 }
                 $elt->appendChild(new DOMElement($key, (string) $value));
@@ -197,9 +193,56 @@ class Xml implements FormatterInterface
         }
 
         $xml = $dom->saveXML();
+
         $xml = preg_replace('/<\?xml version="1.0"( encoding="[^\"]*")?\?>\n/u', '', $xml);
 
         return $xml . PHP_EOL;
+    }
+
+    /**
+     * Recursion function to crete a xml tree structure out of array structure
+     * @param DomDocument $doc - DomDocument where the current nodes will be generated
+     * @param DomElement $domElement - Element where there
+     * @param $mixedData array|Traversable - mixedData
+     * @return DomElement with appended child nodes
+     */
+    protected function _buildElementTree(DOMDocument $doc, DOMElement $domElement, $mixedData)
+    {
+        if (is_array($mixedData) || $mixedData instanceof Traversable) {
+
+            foreach ($mixedData as $key => $value) {
+
+                // key is numeric and switch is not possible, numeric values are not valid node names
+                if (is_numeric($key) && (is_numeric($value) || empty($value))) {
+                    continue;
+                }
+
+                if (is_array($value) || $value instanceof Traversable) {
+                    // current value is an array, start recursion
+                    $domElement->appendChild($this->_buildElementTree($doc, $doc->createElement($key), $value));
+                    continue;
+                }
+
+                if (is_object($value) && !method_exists($value, '__toString')) {
+
+                    // object does not support __toString() method, manually convert the value
+                    $value = $this->getEscaper()->escapeHtml(
+                        '"Object" of type ' . get_class($value) . " does not support __toString() method"
+                    );
+                }
+
+                if (is_numeric($key)) {
+                    // xml does not allow numeric values, switch the value and the key
+                    $key = (string)$value;
+                    $value = null;
+                }
+
+                $domElement->appendChild(new DOMElement($key, (!empty($value)) ? (string) $value : null));
+
+            }
+        }
+
+        return $domElement;
     }
 
     /**

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -185,7 +185,7 @@ class Xml implements FormatterInterface
                 } elseif ($key == "extra" && empty($value)) {
                     continue;
                 } elseif ($key == "extra" && (is_array($value) || $value instanceof Traversable)) {
-                    $extraElement = $dom->appendChild(new DOMElement('extra'));
+                    $extraElement = $dom->createElement('extra');
                     foreach ($value as $extraKey => $extraValue) {
                         $extraElement->appendChild(new DOMElement($extraKey, (string) $extraValue));
                     }

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -177,14 +177,14 @@ class Xml implements FormatterInterface
         foreach ($dataToInsert as $key => $value) {
             if (empty($value)
                 || is_scalar($value)
-                || ((is_array($value) || $value instanceof \Traversable) && $key == "extra")
+                || ((is_array($value) || $value instanceof Traversable) && $key == "extra")
                 || (is_object($value) && method_exists($value, '__toString'))
             ) {
                 if ($key == "message") {
                     $value = $escaper->escapeHtml($value);
                 } elseif ($key == "extra" && empty($value)) {
                     continue;
-                } elseif ($key == "extra" && (is_array($value) || $value instanceof \Traversable)) {
+                } elseif ($key == "extra" && (is_array($value) || $value instanceof Traversable)) {
                     $extraElement = $dom->appendChild(new DOMElement('extra'));
                     foreach ($value as $extraKey => $extraValue) {
                         $extraElement->appendChild(new DOMElement($extraKey, (string) $extraValue));

--- a/library/Zend/Log/Formatter/Xml.php
+++ b/library/Zend/Log/Formatter/Xml.php
@@ -177,11 +177,19 @@ class Xml implements FormatterInterface
         foreach ($dataToInsert as $key => $value) {
             if (empty($value)
                 || is_scalar($value)
+                || ((is_array($value) || $value instanceof \Traversable) && $key == "extra")
                 || (is_object($value) && method_exists($value, '__toString'))
             ) {
                 if ($key == "message") {
                     $value = $escaper->escapeHtml($value);
                 } elseif ($key == "extra" && empty($value)) {
+                    continue;
+                } elseif ($key == "extra" && (is_array($value) || $value instanceof \Traversable)) {
+                    $extraElement = $dom->appendChild(new DOMElement('extra'));
+                    foreach ($value as $extraKey => $extraValue) {
+                        $extraElement->appendChild(new DOMElement($extraKey, (string) $extraValue));
+                    }
+                    $elt->appendChild($extraElement);
                     continue;
                 }
                 $elt->appendChild(new DOMElement($key, (string) $value));

--- a/tests/ZendTest/Log/Formatter/XmlTest.php
+++ b/tests/ZendTest/Log/Formatter/XmlTest.php
@@ -183,14 +183,74 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $formatter = new XmlFormatter;
         $d = new DateTime('2001-01-01T12:00:00-06:00');
         $event = array(
-            'timestamp'    =>  $d,
+            'timestamp'    => $d,
             'message'      => 'test',
             'priority'     => 1,
             'priorityName' => 'CRIT',
-            'extra' => array()
+            'extra'        => array()
         );
         $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName></logEntry>';
         $expected .= PHP_EOL . PHP_EOL;
         $this->assertEquals($expected, $formatter->format($event));
     }
+
+    public function testFormatWillAcceptSimpleArrayFromExtra()
+    {
+        $formatter = new XmlFormatter;
+        $d = new DateTime('2001-01-01T12:00:00-06:00');
+        $event = array(
+            'timestamp'    => $d,
+            'message'      => 'test',
+            'priority'     => 1,
+            'priorityName' => 'CRIT',
+            'extra'        => array(
+                'test' => 'one',
+                'bar'  => 'foo',
+                'wrong message' => 'dasdasd'
+            )
+        );
+
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test>one</test><bar>foo</bar></extra></logEntry>';
+        $expected .= PHP_EOL . PHP_EOL;
+        $this->assertEquals($expected, $formatter->format($event));
+    }
+
+    public function testFormatWillAcceptNestedArrayFromExtraEvent()
+    {
+        $formatter = new XmlFormatter;
+
+        $d = new DateTime('2001-01-01T12:00:00-06:00');
+
+        $event = array(
+            'timestamp'    => $d,
+            'message'      => 'test',
+            'priority'     => 1,
+            'priorityName' => 'CRIT',
+            'extra'        => array(
+                'test'  => array(
+                    'one',
+                    'two' => array(
+                        'three' => array(
+                            'four' => 'four'
+                        ),
+                        'five'  => array('')
+                    )
+                ),
+                '1111'                => '2222',
+                'test_null'           => null,
+                'test_int'            => 14,
+                'test_object'         => new \stdClass(),
+                new SerializableObject(),
+                'serializable_object' => new SerializableObject(),
+                null,
+                'test_empty_array'    => array(),
+                'bar'                 => 'foo',
+                'foobar'
+            )
+        );
+        $expected = '<logEntry><timestamp>2001-01-01T12:00:00-06:00</timestamp><message>test</message><priority>1</priority><priorityName>CRIT</priorityName><extra><test><one/><two><three><four>four</four></three><five/></two></test><test_null/><test_int>14</test_int><test_object>"Object" of type stdClass does not support __toString() method</test_object><serializable_object>ZendTest\Log\TestAsset\SerializableObject</serializable_object><test_empty_array/><bar>foo</bar><foobar/></extra></logEntry>';
+        $expected .= PHP_EOL . PHP_EOL;
+        $this->assertEquals($expected, $formatter->format($event));
+    }
+
 }


### PR DESCRIPTION
I found out, that the \Zend\Log\Formatter\Xml doesn´t support  "extra" information, when its a extra data is an array. I made an example to show my little change.

Hope its useful.

Example-Code:

``` php
$stream = new \Zend\Log\Writer\Stream('data/log/application.log');
$stream->setFormatter(new \Zend\Log\Formatter\Xml());
$logger = new \Zend\Log\Logger();
$logger->addProcessor(new \Zend\Log\Processor\Backtrace());
$logger->addWriter($stream);

$logger->info('wrong stuff');
```

before:

``` xml
<logEntry>
   <timestamp>2014-04-14T23:40:17+02:00</timestamp>
   <priority>6</priority>
   <priorityName>INFO</priorityName>
   <message>wrong stuff</message>
</logEntry>
```

after:

``` xml
<logEntry>
  <timestamp>2014-04-14T23:40:17+02:00</timestamp>
  <priority>6</priority>
  <priorityName>INFO</priorityName>
  <message>wrong stuff</message>
  <extra>
      <file>/home/project/module/App/src/App/Controller/ConsoleController.php</file>        <line>51</line>
      <class>App\Controller\ConsoleController</class>
      <function>loggerTestAction</function>
  </extra>
</logEntry>
```
