### PR TITLE
Fix: Test name

### DIFF
--- a/tests/ZendTest/Config/AbstractConfigFactoryTest.php
+++ b/tests/ZendTest/Config/AbstractConfigFactoryTest.php
@@ -16,9 +16,9 @@ use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\ServiceManager;
 
 /**
- * Class AbstractFactoryTest
+ * Class AbstractConfigFactoryTest
  */
-class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
+class AbstractConfigFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Zend\Mvc\Application


### PR DESCRIPTION
Following the naming convention (say: 1-to-1 mapping), it should probably be `AbstractConfigFactoryTest` instead of `AbstractFactoryTest`.
