### PR TITLE
Fix: Indentation in array initialization, trailing commas

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -31,7 +31,7 @@ class Socket implements HttpAdapter, StreamInterface
         'ssl'   => STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
         'sslv2' => STREAM_CRYPTO_METHOD_SSLv2_CLIENT,
         'sslv3' => STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
-        'tls'   => STREAM_CRYPTO_METHOD_TLS_CLIENT
+        'tls'   => STREAM_CRYPTO_METHOD_TLS_CLIENT,
     );
 
     /**
@@ -69,7 +69,7 @@ class Socket implements HttpAdapter, StreamInterface
         'sslcafile'             => null,
         'sslcapath'             => null,
         'sslallowselfsigned'    => false,
-        'sslusecontext'         => false
+        'sslusecontext'         => false,
     );
 
     /**

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -28,10 +28,10 @@ class Socket implements HttpAdapter, StreamInterface
      * @var array
      */
     protected static $sslCryptoTypes = array(
-            'ssl'   => STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
-            'sslv2' => STREAM_CRYPTO_METHOD_SSLv2_CLIENT,
-            'sslv3' => STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
-            'tls'   => STREAM_CRYPTO_METHOD_TLS_CLIENT
+        'ssl'   => STREAM_CRYPTO_METHOD_SSLv23_CLIENT,
+        'sslv2' => STREAM_CRYPTO_METHOD_SSLv2_CLIENT,
+        'sslv3' => STREAM_CRYPTO_METHOD_SSLv3_CLIENT,
+        'tls'   => STREAM_CRYPTO_METHOD_TLS_CLIENT
     );
 
     /**


### PR DESCRIPTION
This PR
- fixes indentation of an array initialization
- adds trailing commas in array initializations
