### PR TITLE
Support shorthand Priority filter in Log\AbstractWriter

### DIFF
--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -78,11 +78,11 @@ abstract class AbstractWriter implements WriterInterface
         if (is_array($options)) {
             if (isset($options['filters'])) {
                 $filters = $options['filters'];
-                if (is_string($filters) || $filters instanceof Filter\FilterInterface) {
+                if (is_int($filters) || is_string($filters) || $filters instanceof Filter\FilterInterface) {
                     $this->addFilter($filters);
                 } elseif (is_array($filters)) {
                     foreach ($filters as $filter) {
-                        if (is_string($filter) || $filter instanceof Filter\FilterInterface) {
+                        if (is_int($filter) || is_string($filter) || $filter instanceof Filter\FilterInterface) {
                             $this->addFilter($filter);
                         } elseif (is_array($filter)) {
                             if (!isset($filter['name'])) {

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -104,6 +104,39 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $this->readAttribute($filters[1], 'priority'));
     }
 
+    public function testConstructorWithPriorityFilter()
+    {
+        $options = array('filters' => 3);
+
+        $writer = new ConcreteWriter($options);
+
+        $filters = $this->readAttribute($writer, 'filters');
+        $this->assertCount(1, $filters);
+
+        $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
+        $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
+    }
+
+    public function testConstructorWithPriorityFilterArray()
+    {
+        $options = array('filters' => array(
+                             3,
+                             array(
+                                 'name' => 'mock'
+                             )
+                       )
+                   );
+
+        $writer = new ConcreteWriter($options);
+
+        $filters = $this->readAttribute($writer, 'filters');
+        $this->assertCount(2, $filters);
+
+        $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
+        $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
+        $this->assertInstanceOf('Zend\Log\Filter\Mock', $filters[1]);
+    }
+
     /**
      * @covers Zend\Log\Writer\AbstractWriter::getFormatter
      */

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -106,32 +106,19 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorWithPriorityFilter()
     {
-        $options = array('filters' => 3);
-
-        $writer = new ConcreteWriter($options);
-
+        // Accept an int as a PriorityFilter
+        $writer = new ConcreteWriter(array('filters' => 3));
         $filters = $this->readAttribute($writer, 'filters');
         $this->assertCount(1, $filters);
-
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
         $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
-    }
 
-    public function testConstructorWithPriorityFilterArray()
-    {
-        $options = array('filters' => array(
-                             3,
-                             array(
-                                 'name' => 'mock'
-                             )
-                       )
-                   );
+        // Accept an int in an array of filters as a PriorityFilter
+        $options = array('filters' => array(3, array('name' => 'mock')));
 
         $writer = new ConcreteWriter($options);
-
         $filters = $this->readAttribute($writer, 'filters');
         $this->assertCount(2, $filters);
-
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
         $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
         $this->assertInstanceOf('Zend\Log\Filter\Mock', $filters[1]);


### PR DESCRIPTION
Update the AbstractWriter constructor to accept an int filter as supported by addFilter.
