### PR TITLE
add support number of string in __construct of Priority

### DIFF
--- a/library/Zend/Log/Filter/Priority.php
+++ b/library/Zend/Log/Filter/Priority.php
@@ -42,14 +42,14 @@ class Priority implements FilterInterface
             $operator = isset($priority['operator']) ? $priority['operator'] : null;
             $priority = isset($priority['priority']) ? $priority['priority'] : null;
         }
-        if (!is_int($priority)) {
+        if (!is_int($priority) && !is_numeric($priority)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Priority must be an integer; received "%s"',
                 gettype($priority)
             ));
         }
 
-        $this->priority = $priority;
+        $this->priority = intval($priority);
         $this->operator = $operator === null ? '<=' : $operator;
     }
 

--- a/tests/ZendTest/Log/Filter/PriorityTest.php
+++ b/tests/ZendTest/Log/Filter/PriorityTest.php
@@ -41,4 +41,15 @@ class PriorityTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'must be an integer');
         new Priority('foo');
     }
+
+    public function testComparisonStringSupport()
+    {
+        // accept at or below priority '2'
+        $filter = new Priority('2');
+
+        $this->assertTrue($filter->filter(array('priority' => 2)));
+        $this->assertTrue($filter->filter(array('priority' => 1)));
+        $this->assertFalse($filter->filter(array('priority' => 3)));
+    }
+
 }


### PR DESCRIPTION
I create a zend_logger from a  config.ini, bug it just support return string type. So I add support string in __construct of Priority
