### PR TITLE
Collection validation with element as target element

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -760,7 +760,7 @@ class Form extends Fieldset implements FormInterface
             $elements = $fieldset->getElements();
         }
 
-        if (!$fieldset instanceof Collection || $inputFilter instanceof CollectionInputFilter) {
+        if (!$fieldset instanceof Collection || !$fieldset->getTargetElement() instanceof FieldsetInterface || $inputFilter instanceof CollectionInputFilter) {
             foreach ($elements as $element) {
                 $name = $element->getName();
 

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -178,6 +178,35 @@ class CollectionTest extends TestCase
         $this->assertArrayHasKey('colors', $messages);
     }
 
+    public function testCannotValidateFormWithCollectionWithBadFieldsetField()
+    {
+        $this->form->setData(array(
+            'colors' => array(
+                '#ffffff',
+                '#ffffff'
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'oneValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                ),
+                array(
+                    'field' => 'twoValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => null,
+                    )
+                )
+            )
+        ));
+
+        $this->assertEquals(false, $this->form->isValid());
+        $messages = $this->form->getMessages();
+        $this->assertCount(1, $messages);
+        $this->assertArrayHasKey('fieldsets', $messages);
+    }
+
     public function testCanValidateFormWithCollectionWithTemplate()
     {
         $collection = $this->form->get('colors');

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -174,6 +174,8 @@ class CollectionTest extends TestCase
         ));
 
         $this->assertEquals(false, $this->form->isValid());
+        $messages = $this->form->getMessages();
+        $this->assertArrayHasKey('colors', $messages);
     }
 
     public function testCanValidateFormWithCollectionWithTemplate()

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -150,6 +150,32 @@ class CollectionTest extends TestCase
         $this->assertEquals(true, $this->form->isValid());
     }
 
+    public function testCannotValidateFormWithCollectionWithBadColor()
+    {
+        $this->form->setData(array(
+            'colors' => array(
+                '#ffffff',
+                '123465'
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'oneValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                ),
+                array(
+                    'field' => 'twoValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                )
+            )
+        ));
+
+        $this->assertEquals(false, $this->form->isValid());
+    }
+
     public function testCanValidateFormWithCollectionWithTemplate()
     {
         $collection = $this->form->get('colors');


### PR DESCRIPTION
When we use element as target element, there is a validation problem.
See fail test case to understand.

This PR is a response to https://github.com/zendframework/zf2/pull/6115
