### PR TITLE
Session validation listeners may return `null`, erroneously causing validation to fail

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -332,7 +332,7 @@ class SessionManager extends AbstractManager
     {
         $validator = $this->getValidatorChain();
         $responses = $validator->triggerUntil('session.validate', $this, array($this), function ($test) {
-            return !$test;
+            return false === $test;
         });
         if ($responses->stopped()) {
             // If execution was halted, validation failed

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -22,6 +22,9 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
 
     public $cookieDateFormat = 'D, d-M-y H:i:s e';
 
+    /**
+     * @var SessionManager
+     */
     protected $manager;
 
     public function setUp()
@@ -535,4 +538,17 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($_SESSION['__ZF'], $metaData);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionValidationDoesNotHaltOnNoopListener()
+    {
+        $validator = $this->getMock('stdClass', array('__invoke'));
+
+        $validator->expects($this->once())->method('__invoke');
+
+        $this->manager->getValidatorChain()->attach('session.validate', $validator);
+
+        $this->assertTrue($this->manager->isValid());
+    }
 }


### PR DESCRIPTION
Ping @mwillbanks
