### PR TITLE
Oracle incorrect SELECT FROM decoration with table alias when using nested selects

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -189,7 +189,13 @@ abstract class AbstractSql
             $parameterContainer->merge($stmtContainer->getParameterContainer()->getNamedArray());
             $sql = $stmtContainer->getSql();
         } else {
-            $sql = $subselect->getSqlString($platform);
+            if ($this instanceof PlatformDecoratorInterface) {
+                $subselectDecorator = clone $this;
+                $subselectDecorator->setSubject($subselect);
+                $sql = $subselectDecorator->getSqlString($platform);
+            } else {
+                $sql = $subselect->getSqlString($platform);
+            }
         }
         return $sql;
     }

--- a/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
@@ -16,12 +16,47 @@ use Zend\Db\Adapter\Platform\Oracle as OraclePlatform;
 
 class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
-     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper from alias sql statement
+     * @testdox integration test: Testing SelectDecorator will use Select to produce properly Oracle dialect prepared sql
+     * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::prepareStatement
+     * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::processLimitOffset
+     * @dataProvider dataProvider
+     */
+    public function testPrepareStatement(Select $select, $expectedSql, $expectedParams, $notUsed, $expectedFormatParamCount)
+    {
+        $driver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $driver->expects($this->exactly($expectedFormatParamCount))->method('formatParameterName')->will($this->returnValue('?'));
+
+        // test
+        $adapter = $this->getMock(
+            'Zend\Db\Adapter\Adapter',
+            null,
+            array(
+                $driver,
+                new OraclePlatform()
+            )
+        );
+
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $statement->expects($this->once())->method('setSql')->with($expectedSql);
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $selectDecorator->prepareStatement($adapter, $statement);
+
+        $this->assertEquals($expectedParams, $parameterContainer->getNamedArray());
+    }
+
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select to produce properly Oracle dialect sql statements
      * @covers Zend\Db\Sql\Platform\Oracle\SelectDecorator::getSqlString
      * @dataProvider dataProvider
      */
-    public function testGetSqlString(Select $select, $expectedSql)
+    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
@@ -42,9 +77,17 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $select0 = new Select;
         $select0->from(array('x' => 'foo'));
         $expectedSql0 = 'SELECT "x".* FROM "foo" "x"';
+        $expectedFormatParamCount0 = 0;
+
+        $select1a = new Select('test');
+        $select1b = new Select(array('a' => $select1a));
+        $select1 = new Select(array('b' => $select1b));
+        $expectedSql1 = 'SELECT "b".* FROM (SELECT "a".* FROM (SELECT "test".* FROM "test") "a") "b"';
+        $expectedFormatParamCount1 = 0;
 
         return array(
-            array($select0, $expectedSql0),
+            array($select0, $expectedSql0, array(), $expectedSql0, $expectedFormatParamCount0),
+            array($select1, $expectedSql1, array(), $expectedSql1, $expectedFormatParamCount1),
         );
     }
 


### PR DESCRIPTION
Using the Oracle adapter, creating a SELECT query with more than 1 nested sub-select, like this:

``` php
$sql = new \Zend\Db\Sql\Sql($adapter);

$select = $sql->select()
    ->from('test');

$select = $sql->select()
    ->from(array('a' => $select));

$select = $sql->select()
    ->from(array('b' => $select));

$sql->prepareStatementForSqlObject($select);
```

results in the following SQL:

``` sql
SELECT "b".* FROM (SELECT "a".* FROM (SELECT "test".* FROM "test") AS "a") "b"
```

The expected SQL for Oracle is:

``` sql
SELECT "b".* FROM (SELECT "a".* FROM (SELECT "test".* FROM "test") "a") "b"
```

Oracle only allows the use of AS for aliasing columns - not tables.

This bug is similar to #4069.
