### PR TITLE
Properly pass context to input filter

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -189,10 +189,11 @@ class BaseInputFilter implements
     /**
      * Is the data set valid?
      *
+     * @param  mixed|null $context
      * @throws Exception\RuntimeException
      * @return bool
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         $data = $this->getRawValues();
         if (null === $data) {
@@ -203,17 +204,18 @@ class BaseInputFilter implements
         }
 
         $inputs = $this->validationGroup ?: array_keys($this->inputs);
-        return $this->validateInputs($inputs, $data);
+        return $this->validateInputs($inputs, $data, $context);
     }
 
     /**
      * Validate a set of inputs against the current data
      *
-     * @param  array $inputs
-     * @param  array $data
+     * @param  array      $inputs
+     * @param  array      $data
+     * @param  mixed|null $context
      * @return bool
      */
-    protected function validateInputs(array $inputs, array $data = array())
+    protected function validateInputs(array $inputs, array $data = array(), $context = null)
     {
         // backwards compatibility
         if (empty($data)) {
@@ -328,7 +330,7 @@ class BaseInputFilter implements
 
             // Validate an input filter
             if ($input instanceof InputFilterInterface) {
-                if (!$input->isValid()) {
+                if (!$input->isValid($context)) {
                     $this->invalidInputs[$name] = $input;
                     $valid = false;
                     continue;
@@ -339,7 +341,9 @@ class BaseInputFilter implements
 
             // Validate an input
             if ($input instanceof InputInterface) {
-                if (!$input->isValid($data)) {
+                $inputContext = $context ?: $data;
+
+                if (!$input->isValid($inputContext)) {
                     // Validation failure
                     $this->invalidInputs[$name] = $input;
                     $valid = false;
@@ -530,6 +534,7 @@ class BaseInputFilter implements
                 $values[$name] = $input->getRawValues();
                 continue;
             }
+
             $values[$name] = $input->getRawValue();
         }
         return $values;

--- a/tests/ZendTest/InputFilter/InputFilterTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterTest.php
@@ -18,6 +18,11 @@ use Zend\InputFilter\InputFilter;
 
 class InputFilterTest extends TestCase
 {
+    /**
+     * @var InputFilter
+     */
+    protected $filter;
+
     public function setUp()
     {
         $this->filter = new InputFilter();
@@ -95,5 +100,19 @@ class InputFilterTest extends TestCase
 
         $this->assertTrue($this->filter->isvalid());
         $this->assertSame($data, $this->filter->getValues());
+    }
+
+    public function testCanUseContextPassedToInputFilter()
+    {
+        $context = new \stdClass();
+
+        $input = $this->getMock('Zend\InputFilter\InputInterface');
+        $input->expects($this->once())->method('isValid')->with($context)->will($this->returnValue(true));
+        $input->expects($this->any())->method('getRawValue')->will($this->returnValue('Mwop'));
+
+        $this->filter->add($input, 'username');
+        $this->filter->setData(array('username' => 'Mwop'));
+
+        $this->filter->isValid($context);
     }
 }


### PR DESCRIPTION
Hi,

I was quite surprised to see this bug. Basically, the "isValid" method of input filter did not allow to pass any context, which in hence could not be transfered to various validators, that made it impossible to use some validators that relied on context.

The problem is that input filter actually considered the whole array data as context, and pass it to various inputs.

To avoid any BC, I just checked if a context was explicitly given in the input filter. If that's the case, this context is preferred over the data as array.

Thanks!
