### PR TITLE
Fix for #6151 - Filter breaks on non-alpha characters

### DIFF
--- a/library/Zend/Filter/Word/SeparatorToCamelCase.php
+++ b/library/Zend/Filter/Word/SeparatorToCamelCase.php
@@ -30,8 +30,8 @@ class SeparatorToCamelCase extends AbstractSeparator
 
         if (StringUtils::hasPcreUnicodeSupport()) {
             $patterns = array(
-                '#(' . $pregQuotedSeparator.')(\p{L}{1})#u',
-                '#(^\p{Ll}{1})#u',
+                '#(' . $pregQuotedSeparator.')(\P{Z}{1})#u',
+                '#(^\P{Z}{1})#u',
             );
             if (!extension_loaded('mbstring')) {
                 $replacements = array(
@@ -54,8 +54,8 @@ class SeparatorToCamelCase extends AbstractSeparator
             }
         } else {
             $patterns = array(
-                '#(' . $pregQuotedSeparator.')([A-Za-z]{1})#',
-                '#(^[A-Za-z]{1})#',
+                '#(' . $pregQuotedSeparator.')([\S]{1})#',
+                '#(^[\S]{1})#',
             );
             $replacements = array(
                 function ($matches) {

--- a/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToCamelCaseTest.php
@@ -73,6 +73,19 @@ class SeparatorToCamelCaseTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group 6151
+     */
+    public function testFilterSeparatesCamelCasedNonAlphaWordsWithProvidedSeparator()
+    {
+        $string   = 'user_2_user';
+        $filter   = new SeparatorToCamelCaseFilter('_');
+        $filtered = $filter($string);
+
+        $this->assertNotEquals($string, $filtered);
+        $this->assertEquals('User2User', $filtered);
+    }
+
+    /**
      * @return void
      */
     public function testFilterSupportArray()


### PR DESCRIPTION
Fix for #6151 - Match patterns now look for any non-whitespace character after the separator.
