### PR TITLE
Fixes #5962

### DIFF
--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -107,8 +107,12 @@ class Message
     public function generateMessage($EOL = Mime::LINEEND)
     {
         if (!$this->isMultiPart()) {
-            $part = current($this->parts);
-            $body = $part->getContent($EOL);
+            if (!empty($this->parts)) {
+                $part = current($this->parts);
+                $body = $part->getContent($EOL);
+            } else {
+                return '';
+            }
         } else {
             $mime = $this->getMime();
 

--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -107,12 +107,11 @@ class Message
     public function generateMessage($EOL = Mime::LINEEND)
     {
         if (!$this->isMultiPart()) {
-            if (!empty($this->parts)) {
-                $part = current($this->parts);
-                $body = $part->getContent($EOL);
-            } else {
+            if (empty($this->parts)) {
                 return '';
             }
+            $part = current($this->parts);
+            $body = $part->getContent($EOL);
         } else {
             $mime = $this->getMime();
 

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -683,4 +683,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $restoredMessage = Message::fromString($serialized);
         $this->assertEquals($serialized, $restoredMessage->toString());
     }
+
+    /**
+     * @group ZF2-5962
+     */
+    public function testPassEmptyArrayIntoSetPartsOfMimeMessageShouldReturnEmptyBodyString()
+    {
+        $mimeMessage = new MimeMessage();
+        $mimeMessage->setParts(array());
+
+        $this->message->setBody($mimeMessage);
+        $this->assertEquals('', $this->message->getBodyText());
+    }
 }

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Mime;
 
 use Zend\Mime;
+use Zend\Mail;
 
 /**
  * @group      Zend_Mime
@@ -123,5 +124,21 @@ EOD;
         $parts = $message->getParts();
         $test  = current($parts);
         $this->assertSame($part, $test);
+    }
+
+    /**
+     * @group ZF2-5962
+     */
+    public function testPassEmptyArrayIntoSetPartsShouldReturnEmptyString()
+    {
+        $mailMessage = new Mail\Message();
+        $mimeMessage = new Mime\Message();
+        $mimeMessage->setParts(array());
+
+        $mailMessage->setBody($mimeMessage);
+        $mailMessage->getBodyText();
+
+        $this->assertEquals('', $mimeMessage->generateMessage());
+        $this->assertEquals('', $mailMessage->getBodyText());
     }
 }

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Mime;
 
 use Zend\Mime;
-use Zend\Mail;
 
 /**
  * @group      Zend_Mime
@@ -131,13 +130,9 @@ EOD;
      */
     public function testPassEmptyArrayIntoSetPartsShouldReturnEmptyString()
     {
-        $mailMessage = new Mail\Message();
         $mimeMessage = new Mime\Message();
         $mimeMessage->setParts(array());
 
-        $mailMessage->setBody($mimeMessage);
-
         $this->assertEquals('', $mimeMessage->generateMessage());
-        $this->assertEquals('', $mailMessage->getBodyText());
     }
 }

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -136,7 +136,6 @@ EOD;
         $mimeMessage->setParts(array());
 
         $mailMessage->setBody($mimeMessage);
-        $mailMessage->getBodyText();
 
         $this->assertEquals('', $mimeMessage->generateMessage());
         $this->assertEquals('', $mailMessage->getBodyText());


### PR DESCRIPTION
Fixes #5962 . Based on Zend\Mime\Message::generateMessage() comment description, If no part had been added, an empty string is returned.
