### PR TITLE
CollectionInputFilter->getCount() gives wrong count on consecutive setData() calls

### DIFF
--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -127,7 +127,7 @@ class CollectionInputFilter extends InputFilter
     public function getCount()
     {
         if (null === $this->count) {
-            $this->count = count($this->data);
+            return count($this->data);
         }
 
         return $this->count;

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -149,6 +149,23 @@ class CollectionInputFilterTest extends TestCase
         $this->assertEquals(3, $this->filter->getCount());
     }
 
+    public function testGetCountReturnsRightCountOnConsecutiveCallsWithDifferentData()
+    {
+        $collectionData1 = array(
+            array('foo' => 'bar'),
+            array('foo' => 'baz')
+        );
+
+        $collectionData2 = array(
+            array('foo' => 'bar')
+        );
+
+        $this->filter->setData($collectionData1);
+        $this->assertEquals(2, $this->filter->getCount());
+        $this->filter->setData($collectionData2);
+        $this->assertEquals(1, $this->filter->getCount());
+    }
+
     public function testCanValidateValidData()
     {
         if (!extension_loaded('intl')) {


### PR DESCRIPTION
If no count is explicitly set using setCount() on CollectionInputFilter, evaluated count($this->data) is saved and then served across different data set by setData() even if it it's valid no more. This patch makes it not to save temporary value across different data.
