### PR TITLE
Fix: Add missing throws tags

### DIFF
--- a/library/Zend/InputFilter/ArrayInput.php
+++ b/library/Zend/InputFilter/ArrayInput.php
@@ -18,6 +18,7 @@ class ArrayInput extends Input
 
     /**
      * @param  array $value
+     * @throws Exception\InvalidArgumentException
      * @return Input
      */
     public function setValue($value)

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -369,6 +369,7 @@ class BaseInputFilter implements
      * each specifying a single input.
      *
      * @param  mixed $name
+     * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
     public function setValidationGroup($name)

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -47,6 +47,7 @@ class CollectionInputFilter extends InputFilter
      * Set the input filter to use when looping the data
      *
      * @param BaseInputFilter|array|Traversable $inputFilter
+     * @throws Exception\RuntimeException
      * @return CollectionInputFilter
      */
     public function setInputFilter($inputFilter)

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -10,6 +10,7 @@
 namespace Zend\InputFilter;
 
 use Traversable;
+use Zend\Filter\Exception;
 use Zend\Filter\FilterChain;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorInterface;
@@ -331,6 +332,7 @@ class Factory
     /**
      * @param  FilterChain       $chain
      * @param  array|Traversable $filters
+     * @throws Exception\RuntimeException
      * @return void
      */
     protected function populateFilters(FilterChain $chain, $filters)
@@ -366,6 +368,7 @@ class Factory
     /**
      * @param  ValidatorChain    $chain
      * @param  array|Traversable $validators
+     * @throws Exception\RuntimeException
      * @return void
      */
     protected function populateValidators(ValidatorChain $chain, $validators)


### PR DESCRIPTION
This PR adds a few missing `@throws` tags in the `Zend\InputFilter` namespace.
