### PR TITLE
Math\Rand::getInteger returns no values for the given range

### DIFF
--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -136,8 +136,9 @@ abstract class Rand
         // calculate number of bits required to store range on this machine
         $r = $range;
         $bits = 0;
-        while ($r >>= 1) {
+        while ($r) {
             $bits++;
+            $r >>= 1;
         }
 
         $bits   = (int) max($bits, 1);

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -43,6 +43,44 @@ class RandTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider dataProviderForTestRandIntegerRangeTest
+     */
+    public function testRandIntegerRangeTest($min, $max, $cycles)
+    {
+        $counter = array();
+        for ($i = $min; $i <= $max; $i++) {
+            $counter[$i] = 0;
+        }
+
+        for ($j = 0; $j < $cycles; $j++) {
+            $value = Rand::getInteger($min, $max);
+            $this->assertInternalType('integer', $value);
+            $this->assertGreaterThanOrEqual($min, $value);
+            $this->assertLessThanOrEqual($max, $value);
+            $counter[$value]++;
+        }
+
+        foreach ($counter as $value => $count) {
+            $this->assertGreaterThan(0, $count, sprintf('The bucket for value %d is empty.', $value));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestRandIntegerRangeTest()
+    {
+        return array(
+            array(0, 100, 10000),
+            array(-100, 100, 10000),
+            array(-100, 50, 10000),
+            array(0, 63, 10000),
+            array(0, 64, 10000),
+            array(0, 65, 10000),
+        );
+    }
+
+    /**
      * A Monte Carlo test that generates $cycles numbers from 0 to $tot
      * and test if the numbers are above or below the line y=x with a
      * frequency range of [$min, $max]


### PR DESCRIPTION
The function returns no values for the given range.

mt_rand(0-99) --> 0-99
Rand::getInteger(0-99) --> 0-63

There's a Bug in the Bitcount function for integers.
100 = 1100100 = 7 Bits (not 6)
