### PR TITLE
[BUGFIX] missing Zend XML-RPC support library

### DIFF
--- a/library/Zend/XmlRpc/composer.json
+++ b/library/Zend/XmlRpc/composer.json
@@ -17,7 +17,8 @@
         "zendframework/zend-http": "self.version",
         "zendframework/zend-math": "self.version",
         "zendframework/zend-server": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zendxml": "1.*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Required package `zendxml` is missing for Zend\XmlRpc component.
