### PR TITLE
Join ON clause in Oracle - bad quotes

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -161,7 +161,7 @@ class Oracle implements PlatformInterface
         if ($this->quoteIdentifiers === false) {
             return $identifier;
         }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $parts = preg_split('#('[^']*'|[\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         if ($safeWords) {
             $safeWords = array_flip($safeWords);
             $safeWords = array_change_key_case($safeWords, CASE_LOWER);
@@ -180,7 +180,7 @@ class Oracle implements PlatformInterface
                 case 'as':
                     break;
                 default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
+                    $parts[$i] = (preg_match("#^'.*'$#", $part)) ? $part : '"' . str_replace('"', '\\' . '"', $part) . '"';
             }
         }
         return implode('', $parts);


### PR DESCRIPTION
When I try to make a join:
$select->join("A", "A.A_ID = B.B_A_ID AND A.A_S = '1'");
result query is: 
INNER JOIN "A" ON "A"."A_ID" = "B"."B_A_ID" AND "A"."A_S" = "'""1""'"
it should be:
INNER JOIN "A" ON "A"."A_ID" = "B"."B_A_ID" AND "A"."A_S" = '1'
