### PR TITLE
JOIN empty columns

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -258,7 +258,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                 sprintf("join() expects '%s' as an array is a single element associative array", array_shift($name))
             );
         }
-        if (!is_array($columns)) {
+        if (empty($columns)) {
+            $columns = array();
+        }
+        else if (!is_array($columns)) {
             $columns = array($columns);
         }
         $this->joins[] = array(


### PR DESCRIPTION
If I make a join and don't want any columns to be fetched I should be able to pass null or empty string. Now if You do this, query will look like You tried to get an column, without its name.

$select->from("B");
$select->join("A", "A.A_ID = B.B_A_ID", null);

SELECT "B".*, "A". AS "" FROM "B" INNER JOIN "A" ON "A"."A_ID" = "B"."B_A_ID"
