### PR TITLE
Fix: C/P error when creating ProcessorPluginManager

### DIFF
--- a/library/Zend/Log/ProcessorPluginManager.php
+++ b/library/Zend/Log/ProcessorPluginManager.php
@@ -14,7 +14,7 @@ use Zend\ServiceManager\AbstractPluginManager;
 class ProcessorPluginManager extends AbstractPluginManager
 {
     /**
-     * Default set of writers
+     * Default set of processors
      *
      * @var array
      */
@@ -24,7 +24,7 @@ class ProcessorPluginManager extends AbstractPluginManager
     );
 
     /**
-     * Allow many writers of the same type
+     * Allow many processors of the same type
      *
      * @var bool
      */


### PR DESCRIPTION
`writer` should probably be `processor` instead.
