### PR TITLE
Fix: Indentation of array initialization, missing trailing comma

### DIFF
--- a/tests/ZendTest/Log/Processor/RequestIdTest.php
+++ b/tests/ZendTest/Log/Processor/RequestIdTest.php
@@ -26,7 +26,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             'priority'     => 1,
             'priorityName' => 'ALERT',
             'message'      => 'foo',
-            'extra'        => array()
+            'extra'        => array(),
         );
 
         $eventA = $processor->process($event);

--- a/tests/ZendTest/Log/Processor/RequestIdTest.php
+++ b/tests/ZendTest/Log/Processor/RequestIdTest.php
@@ -22,11 +22,11 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
         $processor = new RequestId();
 
         $event = array(
-                'timestamp'    => '',
-                'priority'     => 1,
-                'priorityName' => 'ALERT',
-                'message'      => 'foo',
-                'extra'        => array()
+            'timestamp'    => '',
+            'priority'     => 1,
+            'priorityName' => 'ALERT',
+            'message'      => 'foo',
+            'extra'        => array()
         );
 
         $eventA = $processor->process($event);


### PR DESCRIPTION
This PR fixes indentation of an array initialization in a unit test and adds a missing trailing comma.
