### PR TITLE
Enhancement: Do not overwrite requestId if extra already has one

### DIFF
--- a/library/Zend/Log/Processor/RequestId.php
+++ b/library/Zend/Log/Processor/RequestId.php
@@ -21,7 +21,7 @@ class RequestId implements ProcessorInterface
     protected $identifier;
 
     /**
-     * Adds an identifier for the request to the log.
+     * Adds an identifier for the request to the log, unless one has already been set.
      *
      * This enables to filter the log for messages belonging to a specific request
      *
@@ -30,6 +30,10 @@ class RequestId implements ProcessorInterface
      */
     public function process(array $event)
     {
+        if (isset($event['extra']['requestId'])) {
+            return $event;
+        }
+
         if (!isset($event['extra'])) {
             $event['extra'] = array();
         }

--- a/tests/ZendTest/Log/Processor/RequestIdTest.php
+++ b/tests/ZendTest/Log/Processor/RequestIdTest.php
@@ -37,4 +37,26 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($eventA['extra']['requestId'], $eventB['extra']['requestId']);
     }
+
+    public function testProcessDoesNotOverwriteExistingRequestId()
+    {
+        $processor = new RequestId();
+
+        $requestId = 'bar';
+
+        $event = array(
+            'timestamp'    => '',
+            'priority'     => 1,
+            'priorityName' => 'ALERT',
+            'message'      => 'foo',
+            'extra'        => array(
+                'requestId' => $requestId,
+            ),
+        );
+
+        $processedEvent = $processor->process($event);
+
+        $this->assertArrayHasKey('requestId', $processedEvent['extra']);
+        $this->assertSame($requestId, $processedEvent['extra']['requestId']);
+    }
 }


### PR DESCRIPTION
This PR updates the `Processor\RequestId` so it does not overwrite a value for `requestId` in the `extra` array.

The reason I'm proposing this change is because I want to be able to pass on the `requestId` identifier, for example, to a `Gearman` worker, so I can identify log entries related to the request that started a background job.
