### PR TITLE
Fix: Indentation, missing trailing commas, extra empty lines in Log\Logger

### DIFF
--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -594,7 +594,6 @@ class Logger implements LoggerInterface
         static::$registeredErrorHandler = false;
     }
 
-
     /**
      * Register a shutdown handler to log fatal errors
      *
@@ -627,7 +626,6 @@ class Logger implements LoggerInterface
         static::$registeredFatalErrorShutdownFunction = true;
         return true;
     }
-
 
     /**
      * Register logging system as an exception handler to log PHP exceptions

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -344,9 +344,9 @@ class Logger implements LoggerInterface
         }
         if (!$plugins instanceof ProcessorPluginManager) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'processor plugin manager must extend %s\ProcessorPluginManager; received %s',
-                    __NAMESPACE__,
-                    is_object($plugins) ? get_class($plugins) : gettype($plugins)
+                'processor plugin manager must extend %s\ProcessorPluginManager; received %s',
+                __NAMESPACE__,
+                is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }
 
@@ -381,8 +381,8 @@ class Logger implements LoggerInterface
             $processor = $this->processorPlugin($processor, $options);
         } elseif (!$processor instanceof Processor\ProcessorInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'Processor must implement Zend\Log\ProcessorInterface; received "%s"',
-                    is_object($processor) ? get_class($processor) : gettype($processor)
+                'Processor must implement Zend\Log\ProcessorInterface; received "%s"',
+                is_object($processor) ? get_class($processor) : gettype($processor)
             ));
         }
         $this->processors->insert($processor, $priority);

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -449,7 +449,7 @@ class Logger implements LoggerInterface
             'priority'     => (int) $priority,
             'priorityName' => $this->priorities[$priority],
             'message'      => (string) $message,
-            'extra'        => $extra
+            'extra'        => $extra,
         );
 
         foreach ($this->processors->toArray() as $processor) {
@@ -617,7 +617,7 @@ class Logger implements LoggerInterface
                     $error['message'],
                     array(
                         'file' => $error['file'],
-                        'line' => $error['line']
+                        'line' => $error['line'],
                     )
                 );
             }


### PR DESCRIPTION
This PR
- fixes indentation when throwing exceptions and `sprintf`ing
- removes extra empty lines
- adds trailing commas in array initializations 

in `Zend\Log\Logger`.
