### PR TITLE
Fix: Fix PHP-CS-Fixer to a working version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ircmaxell/random-lib": "dev-master",
         "ircmaxell/security-lib": "dev-master",
         "mikey179/vfsStream": "1.2.*",
-        "fabpot/php-cs-fixer": "*@dev",
+        "fabpot/php-cs-fixer": "dev-master#2f1df1d",
         "phpunit/PHPUnit": "3.7.*",
         "satooshi/php-coveralls": "dev-master",
         "sebastianbergmann/phpcov": "1.1.0"


### PR DESCRIPTION
Follows https://github.com/zendframework/zf2/pull/6172#issuecomment-41189933.

Unfortunately a change I proposed in `fabpot/php-cs-fixer` results in failing builds on Travis.

See https://github.com/fabpot/PHP-CS-Fixer/pull/342.
