### PR TITLE
Enhancement: Introduce ReferenceId processor

### DIFF
--- a/library/Zend/Log/Processor/ReferenceId.php
+++ b/library/Zend/Log/Processor/ReferenceId.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log\Processor;
+
+class ReferenceId extends RequestId implements ProcessorInterface
+{
+    /**
+     * Adds an identifier for the request to the log.
+     *
+     * This enables to filter the log for messages belonging to a specific request
+     *
+     * @param array $event event data
+     * @return array event data
+     */
+    public function process(array $event)
+    {
+        if (isset($event['extra']['referenceId'])) {
+            return $event;
+        }
+
+        if (!isset($event['extra'])) {
+            $event['extra'] = array();
+        }
+
+        $event['extra']['referenceId'] = $this->getIdentifier();
+
+        return $event;
+    }
+
+    /**
+     * Sets identifier.
+     *
+     * @param string $identifier
+     * @return self
+     */
+    public function setReferenceId($identifier)
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
+    /**
+     * Returns identifier.
+     *
+     * @return string
+     */
+    public function getReferenceId()
+    {
+        return $this->getIdentifier();
+    }
+}

--- a/library/Zend/Log/ProcessorPluginManager.php
+++ b/library/Zend/Log/ProcessorPluginManager.php
@@ -20,6 +20,7 @@ class ProcessorPluginManager extends AbstractPluginManager
      */
     protected $invokableClasses = array(
         'backtrace' => 'Zend\Log\Processor\Backtrace',
+        'referenceid' => 'Zend\Log\Processor\ReferenceId',
         'requestid' => 'Zend\Log\Processor\RequestId',
     );
 

--- a/tests/ZendTest/Log/Processor/ReferenceIdTest.php
+++ b/tests/ZendTest/Log/Processor/ReferenceIdTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log\Processor;
+
+use Zend\Log\Processor\ReferenceId;
+
+/**
+ * @group      Zend_Log
+ */
+class ReferenceIdTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessMixesInReferenceId()
+    {
+        $processor = new ReferenceId();
+
+        $event = array(
+            'timestamp' => '',
+            'priority' => 1,
+            'priorityName' => 'ALERT',
+            'message' => 'foo',
+        );
+
+        $processedEvent = $processor->process($event);
+
+        $this->assertArrayHasKey('extra', $processedEvent);
+        $this->assertInternalType('array', $processedEvent['extra']);
+        $this->assertArrayHasKey('referenceId', $processedEvent['extra']);
+
+        $this->assertNotNull($processedEvent['extra']['referenceId']);
+    }
+
+    public function testProcessDoesNotOverwriteReferenceId()
+    {
+        $processor = new ReferenceId();
+
+        $referenceId = 'bar';
+
+        $event = array(
+            'timestamp' => '',
+            'priority' => 1,
+            'priorityName' => 'ALERT',
+            'message' => 'foo',
+            'extra' => array(
+                'referenceId' => $referenceId,
+            ),
+        );
+
+        $processedEvent = $processor->process($event);
+
+        $this->assertArrayHasKey('extra', $processedEvent);
+        $this->assertInternalType('array', $processedEvent['extra']);
+        $this->assertArrayHasKey('referenceId', $processedEvent['extra']);
+
+        $this->assertSame($referenceId, $processedEvent['extra']['referenceId']);
+    }
+
+    public function testCanSetAndGetReferenceId()
+    {
+        $processor = new ReferenceId();
+
+        $referenceId = 'foo';
+
+        $processor->setReferenceId($referenceId);
+
+        $this->assertSame($referenceId, $processor->getReferenceId());
+    }
+
+    public function testProcessUsesSetReferenceId()
+    {
+        $referenceId = 'foo';
+
+        $processor = new ReferenceId();
+        $processor->setReferenceId($referenceId);
+
+        $event = array(
+            'timestamp' => '',
+            'priority' => 1,
+            'priorityName' => 'ALERT',
+            'message' => 'foo',
+        );
+
+        $processedEvent = $processor->process($event);
+
+        $this->assertArrayHasKey('extra', $processedEvent);
+        $this->assertInternalType('array', $processedEvent['extra']);
+        $this->assertArrayHasKey('referenceId', $processedEvent['extra']);
+
+        $this->assertSame($referenceId, $processedEvent['extra']['referenceId']);
+    }
+}


### PR DESCRIPTION
This PR introduces a `Log\Processor\ReferenceId` processor that 
- mixes in a `referenceId` into the `extra` array (i.e., event context)
- allows for setting / retrieving said identifier 

Follows https://github.com/zendframework/zf2/pull/6178#issuecomment-41212314.
