### PR TITLE
Fix mongo handler

### DIFF
--- a/library/Zend/Session/SaveHandler/MongoDBOptions.php
+++ b/library/Zend/Session/SaveHandler/MongoDBOptions.php
@@ -38,7 +38,7 @@ class MongoDBOptions extends AbstractOptions
      * @see http://php.net/manual/en/mongocollection.save.php
      * @var string
      */
-    protected $saveOptions = array('safe' => true);
+    protected $saveOptions = array('w' => 1);
 
     /**
      * Name field

--- a/tests/ZendTest/Session/SaveHandler/MongoDBOptionsTest.php
+++ b/tests/ZendTest/Session/SaveHandler/MongoDBOptionsTest.php
@@ -22,7 +22,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
         $options = new MongoDBOptions();
         $this->assertNull($options->getDatabase());
         $this->assertNull($options->getCollection());
-        $this->assertEquals(array('safe' => true), $options->getSaveOptions());
+        $this->assertEquals(array('w' => true), $options->getSaveOptions());
         $this->assertEquals('name', $options->getNameField());
         $this->assertEquals('data', $options->getDataField());
         $this->assertEquals('lifetime', $options->getLifetimeField());
@@ -34,7 +34,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
         $options = new MongoDBOptions(array(
             'database' => 'testDatabase',
             'collection' => 'testCollection',
-            'saveOptions' => array('safe' => 2),
+            'saveOptions' => array('w' => 2),
             'nameField' => 'testName',
             'dataField' => 'testData',
             'lifetimeField' => 'testLifetime',
@@ -43,7 +43,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('testDatabase', $options->getDatabase());
         $this->assertEquals('testCollection', $options->getCollection());
-        $this->assertEquals(array('safe' => 2), $options->getSaveOptions());
+        $this->assertEquals(array('w' => 2), $options->getSaveOptions());
         $this->assertEquals('testName', $options->getNameField());
         $this->assertEquals('testData', $options->getDataField());
         $this->assertEquals('testLifetime', $options->getLifetimeField());
@@ -55,7 +55,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
         $options = new MongoDBOptions();
         $options->setDatabase('testDatabase')
                 ->setCollection('testCollection')
-                ->setSaveOptions(array('safe' => 2))
+                ->setSaveOptions(array('w' => 2))
                 ->setNameField('testName')
                 ->setDataField('testData')
                 ->setLifetimeField('testLifetime')
@@ -63,7 +63,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('testDatabase', $options->getDatabase());
         $this->assertEquals('testCollection', $options->getCollection());
-        $this->assertEquals(array('safe' => 2), $options->getSaveOptions());
+        $this->assertEquals(array('w' => 2), $options->getSaveOptions());
         $this->assertEquals('testName', $options->getNameField());
         $this->assertEquals('testData', $options->getDataField());
         $this->assertEquals('testLifetime', $options->getLifetimeField());


### PR DESCRIPTION
Hello,

First of all, tests pass :

```
php run-tests.php Session
> OK, but incomplete or skipped tests!
> Tests: 568, Assertions: 781, Skipped: 1
```

This fix is about the last version of php-mongo driver, where safe option is deprecated.
More informations here : http://www.php.net/manual/fr/mongo.writeconcerns.php#mongo.writeconcerns.options

On my dev environnement (archlinux), a lot of "deprecated" messages are present without this fix.
