### PR TITLE
Enable passing namespace to FlashMessenger::hasMessages()

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
+++ b/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
@@ -246,11 +246,15 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
      *
      * @return bool
      */
-    public function hasMessages()
+    public function hasMessages($namespace = null)
     {
         $this->getMessagesFromContainer();
 
-        return isset($this->messages[$this->getNamespace()]);
+        if (null === $namespace) {
+        	$namespace = $this->getNamespace();
+        }
+        
+        return isset($this->messages[$namespace]);
     }
 
     /**


### PR DESCRIPTION
This allows to call hasMessages with specifying a namespace without having to call every dedicated method. Those ones set the according namespace.
