### PR TITLE
Added possibility to render view with short reference (added RelativeFallbackResolver).

### DIFF
--- a/library/Zend/Mvc/Service/ViewResolverFactory.php
+++ b/library/Zend/Mvc/Service/ViewResolverFactory.php
@@ -27,8 +27,8 @@ class ViewResolverFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $resolver = new ViewResolver\AggregateResolver();
-        $resolver->attach($serviceLocator->get('ViewTemplateMapResolver'));
-        $resolver->attach($serviceLocator->get('ViewTemplatePathStack'));
+        $resolver->attach(new ViewResolver\RelativeFallbackResolver($serviceLocator->get('ViewTemplateMapResolver')));
+        $resolver->attach(new ViewResolver\RelativeFallbackResolver($serviceLocator->get('ViewTemplatePathStack')));
         return $resolver;
     }
 }

--- a/library/Zend/Mvc/Service/ViewResolverFactory.php
+++ b/library/Zend/Mvc/Service/ViewResolverFactory.php
@@ -27,9 +27,13 @@ class ViewResolverFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $resolver = new ViewResolver\AggregateResolver();
-        $resolver->attach($serviceLocator->get('ViewTemplateMapResolver'));
-        $resolver->attach($serviceLocator->get('ViewTemplatePathStack'));
-        $resolver->attach(new ViewResolver\RelativeFallbackResolver($resolver));
+        $mapResolver = $serviceLocator->get('ViewTemplateMapResolver');
+        $pathResolver = $serviceLocator->get('ViewTemplatePathStack');
+        $resolver->attach($mapResolver)
+                 ->attach($pathResolver)
+                 ->attach(new ViewResolver\RelativeFallbackResolver($mapResolver))
+                 ->attach(new ViewResolver\RelativeFallbackResolver($pathResolver))
+        ;
         return $resolver;
     }
 }

--- a/library/Zend/Mvc/Service/ViewResolverFactory.php
+++ b/library/Zend/Mvc/Service/ViewResolverFactory.php
@@ -27,6 +27,8 @@ class ViewResolverFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $resolver = new ViewResolver\AggregateResolver();
+        $resolver->attach($serviceLocator->get('ViewTemplateMapResolver'));
+        $resolver->attach($serviceLocator->get('ViewTemplatePathStack'));
         $resolver->attach(new ViewResolver\RelativeFallbackResolver($serviceLocator->get('ViewTemplateMapResolver')));
         $resolver->attach(new ViewResolver\RelativeFallbackResolver($serviceLocator->get('ViewTemplatePathStack')));
         return $resolver;

--- a/library/Zend/Mvc/Service/ViewResolverFactory.php
+++ b/library/Zend/Mvc/Service/ViewResolverFactory.php
@@ -29,8 +29,7 @@ class ViewResolverFactory implements FactoryInterface
         $resolver = new ViewResolver\AggregateResolver();
         $resolver->attach($serviceLocator->get('ViewTemplateMapResolver'));
         $resolver->attach($serviceLocator->get('ViewTemplatePathStack'));
-        $resolver->attach(new ViewResolver\RelativeFallbackResolver($serviceLocator->get('ViewTemplateMapResolver')));
-        $resolver->attach(new ViewResolver\RelativeFallbackResolver($serviceLocator->get('ViewTemplatePathStack')));
+        $resolver->attach(new ViewResolver\RelativeFallbackResolver($resolver));
         return $resolver;
     }
 }

--- a/library/Zend/View/Resolver/AggregateResolver.php
+++ b/library/Zend/View/Resolver/AggregateResolver.php
@@ -81,27 +81,6 @@ class AggregateResolver implements Countable, IteratorAggregate, ResolverInterfa
     }
 
     /**
-     * Loop over queue of resolvers
-     *
-     * @param string $name
-     * @param null|Renderer $renderer
-     * @return false|string
-     */
-    protected function findResourceInQueue($name, Renderer $renderer = null)
-    {
-        foreach ($this->queue as $resolver) {
-            $resource = $resolver->resolve($name, $renderer);
-            if ($resource) {
-                // Resource found; return it
-                $this->lastSuccessfulResolver = $resolver;
-                return $resource;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Resolve a template/pattern name to a resource the renderer can consume
      *
      * @param  string $name
@@ -118,22 +97,12 @@ class AggregateResolver implements Countable, IteratorAggregate, ResolverInterfa
             return false;
         }
 
-        $resource = $this->findResourceInQueue($name, $renderer);
-        if ($resource) {
-            return $resource;
-        }
-
-        // Here we look in the same name space (folder)
-        if ($renderer !== null) {
-            $helper = $renderer->plugin('view_model');
-            $currentTemplate = $helper->getCurrent()->getTemplate();
-            $pos = strrpos($currentTemplate, '/');
-            if ($pos > 0) {
-                $fullName = substr($currentTemplate, 0, $pos) . '/' . $name;
-                $resource = $this->findResourceInQueue($fullName, $renderer);
-                if ($resource) {
-                    return $resource;
-                }
+        foreach ($this->queue as $resolver) {
+            $resource = $resolver->resolve($name, $renderer);
+            if ($resource) {
+                // Resource found; return it
+                $this->lastSuccessfulResolver = $resolver;
+                return $resource;
             }
         }
 

--- a/library/Zend/View/Resolver/AggregateResolver.php
+++ b/library/Zend/View/Resolver/AggregateResolver.php
@@ -80,6 +80,20 @@ class AggregateResolver implements Countable, IteratorAggregate, ResolverInterfa
         return $this;
     }
 
+    private function findResourceInQueue($name, Renderer $renderer = null)
+    {
+        foreach ($this->queue as $resolver) {
+            $resource = $resolver->resolve($name, $renderer);
+            if ($resource) {
+                // Resource found; return it
+                $this->lastSuccessfulResolver = $resolver;
+                return $resource;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Resolve a template/pattern name to a resource the renderer can consume
      *
@@ -97,16 +111,23 @@ class AggregateResolver implements Countable, IteratorAggregate, ResolverInterfa
             return false;
         }
 
-        foreach ($this->queue as $resolver) {
-            $resource = $resolver->resolve($name, $renderer);
-            if (!$resource) {
-                // No resource found; try next resolver
-                continue;
-            }
-
-            // Resource found; return it
-            $this->lastSuccessfulResolver = $resolver;
+        $resource = $this->findResourceInQueue($name, $renderer);
+        if ($resource) {
             return $resource;
+        }
+
+        // Here we look in the same name space (folder)
+        if ($renderer !== null) {
+            $helper = $renderer->plugin('view_model');
+            $currentTemplate = $helper->getCurrent()->getTemplate();
+            $pos = strrpos($currentTemplate, '/');
+            if ($pos > 0) {
+                $fullName = substr($currentTemplate, 0, $pos) . '/' . $name;
+                $resource = $this->findResourceInQueue($fullName, $renderer);
+                if ($resource) {
+                    return $resource;
+                }
+            }
         }
 
         $this->lastLookupFailure = static::FAILURE_NOT_FOUND;

--- a/library/Zend/View/Resolver/AggregateResolver.php
+++ b/library/Zend/View/Resolver/AggregateResolver.php
@@ -80,7 +80,14 @@ class AggregateResolver implements Countable, IteratorAggregate, ResolverInterfa
         return $this;
     }
 
-    private function findResourceInQueue($name, Renderer $renderer = null)
+    /**
+     * Loop over queue of resolvers
+     *
+     * @param string $name
+     * @param null|Renderer $renderer
+     * @return false|string
+     */
+    protected function findResourceInQueue($name, Renderer $renderer = null)
     {
         foreach ($this->queue as $resolver) {
             $resource = $resolver->resolve($name, $renderer);

--- a/library/Zend/View/Resolver/RelativeFallbackResolver.php
+++ b/library/Zend/View/Resolver/RelativeFallbackResolver.php
@@ -31,9 +31,9 @@ class RelativeFallbackResolver implements ResolverInterface
      * Set wrapped resolver
      *
      */
-    public function __construct(Resolver $relover)
+    public function __construct(Resolver $resolver)
     {
-        $this->resolver = $relover;
+        $this->resolver = $resolver;
     }
 
     /**

--- a/library/Zend/View/Resolver/RelativeFallbackResolver.php
+++ b/library/Zend/View/Resolver/RelativeFallbackResolver.php
@@ -57,8 +57,7 @@ class RelativeFallbackResolver implements ResolverInterface
         $position = strrpos($currentTemplate, self::NS_SEPARATOR);
         if ($position > 0) {
             $absoluteName = substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name;
-            $resource = $this->resolver->resolve($absoluteName, $renderer);
-            return $resource;
+            return $this->resolver->resolve($absoluteName, $renderer);
         }
 
         return false;

--- a/library/Zend/View/Resolver/RelativeFallbackResolver.php
+++ b/library/Zend/View/Resolver/RelativeFallbackResolver.php
@@ -46,15 +46,11 @@ class RelativeFallbackResolver implements ResolverInterface
      */
     public function resolve($name, Renderer $renderer = null)
     {
-        // It may sense only in context of view
-        if ($renderer === null) {
-            return false;
-        }
-
         // There should exists view model to get template name
         if (!is_callable(array($renderer, 'plugin'))) {
             return false;
         }
+
         // Try to get it from the same name space (folder)
         $helper = $renderer->plugin('view_model');
         $currentTemplate = $helper->getCurrent()->getTemplate();

--- a/library/Zend/View/Resolver/RelativeFallbackResolver.php
+++ b/library/Zend/View/Resolver/RelativeFallbackResolver.php
@@ -21,7 +21,7 @@ class RelativeFallbackResolver implements ResolverInterface
     const NS_SEPARATOR = '/';
 
     /**
-     * @var Resolve
+     * @var Resolver
      */
     protected $resolver;
 
@@ -48,14 +48,13 @@ class RelativeFallbackResolver implements ResolverInterface
     {
         // It may sense only in context of view
         if ($renderer === null) {
-            return $this->resolver->resolve($name);
+            return false;
         }
 
-        $resource = $this->resolver->resolve($name, $renderer);
-        if ($resource) {
-            return $resource;
+        // There should exists view model to get template name
+        if (!is_callable(array($renderer, 'plugin'))) {
+            return false;
         }
-
         // Try to get it from the same name space (folder)
         $helper = $renderer->plugin('view_model');
         $currentTemplate = $helper->getCurrent()->getTemplate();
@@ -63,8 +62,9 @@ class RelativeFallbackResolver implements ResolverInterface
         if ($position > 0) {
             $absoluteName = substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name;
             $resource = $this->resolver->resolve($absoluteName, $renderer);
+            return $resource;
         }
 
-        return $resource;
+        return false;
     }
 }

--- a/library/Zend/View/Resolver/RelativeFallbackResolver.php
+++ b/library/Zend/View/Resolver/RelativeFallbackResolver.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Resolver;
+
+use Zend\View\Renderer\RendererInterface as Renderer;
+use Zend\View\Resolver\ResolverInterface as Resolver;
+
+/**
+ * Resolve addition
+ * Allow refering to view script
+ */
+class RelativeFallbackResolver implements ResolverInterface
+{
+    const NS_SEPARATOR = '/';
+
+    /**
+     * @var Resolve
+     */
+    protected $resolver;
+
+    /**
+     * Constructor
+     *
+     * Set wrapped resolver
+     *
+     */
+    public function __construct(Resolver $relover)
+    {
+        $this->resolver = $relover;
+    }
+
+    /**
+     * Resolve a template/pattern name to a resource the renderer can consume
+     *
+     * @param  string $name
+     * @param  null|Renderer $renderer
+     * @return false|string
+     */
+    public function resolve($name, Renderer $renderer = null)
+    {
+        // It may sense only in context of view
+        if ($renderer === null) {
+            return $this->resolver->resolve($name);
+        }
+
+        $resource = $this->resolver->resolve($name, $renderer);
+        if ($resource) {
+            return $resource;
+        }
+
+        // Try to get it from the same name space (folder)
+        $helper = $renderer->plugin('view_model');
+        $currentTemplate = $helper->getCurrent()->getTemplate();
+        $position = strrpos($currentTemplate, self::NS_SEPARATOR);
+        if ($position > 0) {
+            $absoluteName = substr($currentTemplate, 0, $position) . self::NS_SEPARATOR . $name;
+            $resource = $this->resolver->resolve($absoluteName, $renderer);
+        }
+
+        return $resource;
+    }
+}

--- a/library/Zend/View/Resolver/RelativeFallbackResolver.php
+++ b/library/Zend/View/Resolver/RelativeFallbackResolver.php
@@ -30,6 +30,7 @@ class RelativeFallbackResolver implements ResolverInterface
      *
      * Set wrapped resolver
      *
+     * @param \Zend\View\Resolver\ResolverInterface $resolver
      */
     public function __construct(Resolver $resolver)
     {

--- a/tests/ZendTest/View/Resolver/AggregateResolverTest.php
+++ b/tests/ZendTest/View/Resolver/AggregateResolverTest.php
@@ -10,8 +10,6 @@
 namespace ZendTest\View\Resolver;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\View\Model\ViewModel;
-use Zend\View\Renderer\PhpRenderer;
 use Zend\View\Resolver;
 
 class AggregateResolverTest extends TestCase
@@ -69,57 +67,6 @@ class AggregateResolverTest extends TestCase
         $test = $resolver->resolve('bar');
         $this->assertEquals('baz', $test);
         $this->assertSame($barResolver, $resolver->getLastSuccessfulResolver());
-    }
-
-    public function testReturnsResourceFromTheSameNameSpaceWithMapResolver()
-    {
-        $resolver = new Resolver\AggregateResolver();
-        $resolver->attach(new Resolver\TemplateMapResolver(array(
-            'foo/bar' => 'foo/baz',
-        )));
-        $renderer = new PhpRenderer();
-        $view = new ViewModel();
-        $view->setTemplate('foo/zaz');
-        $helper = $renderer->plugin('view_model');
-        $helper->setCurrent($view);
-
-        $test = $resolver->resolve('bar', $renderer);
-        $this->assertEquals('foo/baz', $test);
-    }
-
-    public function testReturnsResourceFromTheSameNameSpaceWithPathStack()
-    {
-        $resolver = new Resolver\AggregateResolver();
-        $pathStack = new Resolver\TemplatePathStack();
-        $pathStack->addPath(__DIR__ . '/../_templates');
-        $resolver->attach($pathStack);
-        $renderer = new PhpRenderer();
-        $view = new ViewModel();
-        $view->setTemplate('name-space/any-view');
-        $helper = $renderer->plugin('view_model');
-        $helper->setCurrent($view);
-
-        $test = $resolver->resolve('bar', $renderer);
-        $this->assertEquals(realpath(__DIR__ . '/../_templates/name-space/bar.phtml'), $test);
-    }
-
-    public function testReturnsResourceFromTopLevelIfExistsInsteadOfTheSameNameSpace()
-    {
-        $resolver = new Resolver\AggregateResolver();
-        $resolver->attach(new Resolver\TemplateMapResolver(array(
-            'foo/bar' => 'foo/baz',
-        )));
-        $resolver->attach(new Resolver\TemplateMapResolver(array(
-            'bar' => 'baz',
-        )));
-        $renderer = new PhpRenderer();
-        $view = new ViewModel();
-        $view->setTemplate('foo/zaz');
-        $helper = $renderer->plugin('view_model');
-        $helper->setCurrent($view);
-
-        $test = $resolver->resolve('bar', $renderer);
-        $this->assertEquals('baz', $test);
     }
 
     public function testReturnsFalseWhenNoResolverSucceeds()

--- a/tests/ZendTest/View/Resolver/RelativeFallbackResolverTest.php
+++ b/tests/ZendTest/View/Resolver/RelativeFallbackResolverTest.php
@@ -53,7 +53,9 @@ class RelativeFallbackResolverTest extends TestCase
             'foo/bar' => 'foo/baz',
             'bar' => 'baz',
         ));
-        $resolver = new Resolver\RelativeFallbackResolver($tplMapResolver);
+        $resolver = new Resolver\AggregateResolver();
+        $resolver->attach($tplMapResolver);
+        $resolver->attach(new Resolver\RelativeFallbackResolver($tplMapResolver));
         $renderer = new PhpRenderer();
         $view = new ViewModel();
         $view->setTemplate('foo/zaz');

--- a/tests/ZendTest/View/Resolver/RelativeFallbackResolverTest.php
+++ b/tests/ZendTest/View/Resolver/RelativeFallbackResolverTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Resolver;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\View\Model\ViewModel;
+use Zend\View\Renderer\PhpRenderer;
+use Zend\View\Resolver;
+
+class RelativeFallbackResolverTest extends TestCase
+{
+    public function testReturnsResourceFromTheSameNameSpaceWithMapResolver()
+    {
+        $tplMapResolver = new Resolver\TemplateMapResolver(array(
+            'foo/bar' => 'foo/baz',
+        ));
+        $resolver = new Resolver\RelativeFallbackResolver($tplMapResolver);
+        $renderer = new PhpRenderer();
+        $view = new ViewModel();
+        $view->setTemplate('foo/zaz');
+        $helper = $renderer->plugin('view_model');
+        $helper->setCurrent($view);
+
+        $test = $resolver->resolve('bar', $renderer);
+        $this->assertEquals('foo/baz', $test);
+    }
+
+    public function testReturnsResourceFromTheSameNameSpaceWithPathStack()
+    {
+        $pathStack = new Resolver\TemplatePathStack();
+        $pathStack->addPath(__DIR__ . '/../_templates');
+        $resolver = new Resolver\RelativeFallbackResolver($pathStack);
+        $renderer = new PhpRenderer();
+        $view = new ViewModel();
+        $view->setTemplate('name-space/any-view');
+        $helper = $renderer->plugin('view_model');
+        $helper->setCurrent($view);
+
+        $test = $resolver->resolve('bar', $renderer);
+        $this->assertEquals(realpath(__DIR__ . '/../_templates/name-space/bar.phtml'), $test);
+    }
+
+    public function testReturnsResourceFromTopLevelIfExistsInsteadOfTheSameNameSpace()
+    {
+        $tplMapResolver = new Resolver\TemplateMapResolver(array(
+            'foo/bar' => 'foo/baz',
+            'bar' => 'baz',
+        ));
+        $resolver = new Resolver\RelativeFallbackResolver($tplMapResolver);
+        $renderer = new PhpRenderer();
+        $view = new ViewModel();
+        $view->setTemplate('foo/zaz');
+        $helper = $renderer->plugin('view_model');
+        $helper->setCurrent($view);
+
+        $test = $resolver->resolve('bar', $renderer);
+        $this->assertEquals('baz', $test);
+    }
+}

--- a/tests/ZendTest/View/_templates/name-space/bar.phtml
+++ b/tests/ZendTest/View/_templates/name-space/bar.phtml
@@ -1,0 +1,1 @@
+View to test rendering from the same name space


### PR DESCRIPTION
It makes add rendering view the same as php include file which contains
in the same folder.

Now possible use short form to look up in the same folder. If we are in view with template name `'very-long-view-top-name/very-long-view-top-name2/any-name'` we can use:

``` php
$this->render('bar');   // like include 'bar.phtml';
// instead of
// $this->render('very-long-view-top-name/very-long-view-top-name2/bar');
```

should exist map resolver: 

``` php
     'very-long-view-top-name/very-long-view-top-name2/bar' => 'foo/baz',
```

or the same path resolver.
