### PR TITLE
Added array map naming strategy

### DIFF
--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -14,59 +14,22 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
     /**
      * @var string[]
      */
-    protected $hydrationMap = array();
+    protected $extractionMap = array();
 
     /**
      * @var string[]
      */
-    protected $extractionMap = array();
+    protected $hydrationMap = array();
 
     /**
      * Constructor
      *
      * @param array $extractionMap
-     * @param array $hydrationMap
      */
-    public function __construct(array $extractionMap = array(), array $hydrationMap = array())
-    {
-        $this->setExtractionMap($extractionMap, false);
-        $this->setHydrationMap($hydrationMap, false);
-    }
-
-    /**
-     * Sets hydrationMap
-     *
-     * @param  array $hydrationMap
-     * @param  bool  $bidirectional
-     * @return self
-     */
-    public function setHydrationMap(array $hydrationMap, $bidirectional = true)
-    {
-        $this->hydrationMap = $hydrationMap;
-
-        if ($bidirectional) {
-            $this->setExtractionMap(array_flip($hydrationMap), false);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Sets extractionMap
-     *
-     * @param  array $extractionMap
-     * @param  bool  $bidirectional
-     * @return self
-     */
-    public function setExtractionMap(array $extractionMap, $bidirectional = true)
+    public function __construct(array $extractionMap)
     {
         $this->extractionMap = $extractionMap;
-
-        if ($bidirectional) {
-            $this->setHydrationMap(array_flip($extractionMap), false);
-        }
-
-        return $this;
+        $this->hydrationMap  = array_flip($extractionMap);
     }
 
     /**

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -37,11 +37,7 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      */
     public function hydrate($name)
     {
-        if (isset($this->hydrationMap[$name])) {
-            return $this->hydrationMap[$name];
-        }
-
-        return $name;
+        return isset($this->hydrationMap[$name]) ? $this->hydrationMap[$name] : $name;
     }
 
     /**
@@ -49,10 +45,6 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      */
     public function extract($name)
     {
-        if (isset($this->extractionMap[$name])) {
-            return $this->extractionMap[$name];
-        }
-
-        return $name;
+        return isset($this->extractionMap[$name]) ? $this->extractionMap[$name] : $name;
     }
 }

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -36,7 +36,7 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
     /**
      * Sets hydrationMap
      *
-     * @param array $hydrationMap
+     * @param  array $hydrationMap
      * @return self
      */
     public function setHydrationMap(array $hydrationMap)
@@ -50,7 +50,7 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      * Gets hydrationMap
      *
      * @return array
-     */    
+     */
     public function getHydrationMap()
     {
         return $this->hydrationMap;
@@ -59,7 +59,7 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
     /**
      * Sets extractionMap
      *
-     * @param array $extractionMap
+     * @param  array $extractionMap
      * @return self
      */
     public function setExtractionMap(array $extractionMap)
@@ -73,7 +73,7 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      * Gets extractionMap
      *
      * @return array
-     */ 
+     */
     public function getExtractionMap()
     {
         return $this->extractionMap;
@@ -100,6 +100,6 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
             return $this->getExtractionMap()[$name];
         }
 
-        return $name;        
+        return $name;
     }
 }

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -52,16 +52,6 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
     }
 
     /**
-     * Gets hydrationMap
-     *
-     * @return array
-     */
-    public function getHydrationMap()
-    {
-        return $this->hydrationMap;
-    }
-
-    /**
      * Sets extractionMap
      *
      * @param  array $extractionMap
@@ -80,22 +70,12 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
     }
 
     /**
-     * Gets extractionMap
-     *
-     * @return array
-     */
-    public function getExtractionMap()
-    {
-        return $this->extractionMap;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function hydrate($name)
     {
-        if (isset($this->getHydrationMap()[$name])) {
-            return $this->getHydrationMap()[$name];
+        if (isset($this->hydrationMap[$name])) {
+            return $this->hydrationMap[$name];
         }
 
         return $name;
@@ -106,8 +86,8 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      */
     public function extract($name)
     {
-        if (isset($this->getExtractionMap()[$name])) {
-            return $this->getExtractionMap()[$name];
+        if (isset($this->extractionMap[$name])) {
+            return $this->extractionMap[$name];
         }
 
         return $name;

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -12,12 +12,12 @@ namespace Zend\Stdlib\Hydrator\NamingStrategy;
 class ArrayMapNamingStrategy implements NamingStrategyInterface
 {
     /**
-     * @var array
+     * @var string[]
      */
     protected $hydrationMap = array();
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $extractionMap = array();
 

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Hydrator\NamingStrategy;
+
+class ArrayMapNamingStrategy implements NamingStrategyInterface
+{
+    /**
+     * @var array
+     */
+    protected $hydrationMap = array();
+
+    /**
+     * @var array
+     */
+    protected $extractionMap = array();
+
+    /**
+     * Constructor
+     *
+     * @param array $extractionMap
+     * @param array $hydrationMap
+     */
+    public function __construct(array $extractionMap = array(), array $hydrationMap = array())
+    {
+        $this->setExtractionMap($extractionMap);
+        $this->setHydrationMap($hydrationMap);
+    }
+
+    /**
+     * Sets hydrationMap
+     *
+     * @param array $hydrationMap
+     * @return self
+     */
+    public function setHydrationMap(array $hydrationMap)
+    {
+        $this->hydrationMap = $hydrationMap;
+
+        return $this;
+    }
+
+    /**
+     * Gets hydrationMap
+     *
+     * @return array
+     */    
+    public function getHydrationMap()
+    {
+        return $this->hydrationMap;
+    }
+
+    /**
+     * Sets extractionMap
+     *
+     * @param array $extractionMap
+     * @return self
+     */
+    public function setExtractionMap(array $extractionMap)
+    {
+        $this->extractionMap = $extractionMap;
+
+        return $this;
+    }
+
+    /**
+     * Gets extractionMap
+     *
+     * @return array
+     */ 
+    public function getExtractionMap()
+    {
+        return $this->extractionMap;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hydrate($name)
+    {
+        if (isset($this->getHydrationMap()[$name])) {
+            return $this->getHydrationMap()[$name];
+        }
+
+        return $name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extract($name)
+    {
+        if (isset($this->getExtractionMap()[$name])) {
+            return $this->getExtractionMap()[$name];
+        }
+
+        return $name;        
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategy.php
@@ -29,19 +29,24 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      */
     public function __construct(array $extractionMap = array(), array $hydrationMap = array())
     {
-        $this->setExtractionMap($extractionMap);
-        $this->setHydrationMap($hydrationMap);
+        $this->setExtractionMap($extractionMap, false);
+        $this->setHydrationMap($hydrationMap, false);
     }
 
     /**
      * Sets hydrationMap
      *
      * @param  array $hydrationMap
+     * @param  bool  $bidirectional
      * @return self
      */
-    public function setHydrationMap(array $hydrationMap)
+    public function setHydrationMap(array $hydrationMap, $bidirectional = true)
     {
         $this->hydrationMap = $hydrationMap;
+
+        if ($bidirectional) {
+            $this->setExtractionMap(array_flip($hydrationMap), false);
+        }
 
         return $this;
     }
@@ -60,11 +65,16 @@ class ArrayMapNamingStrategy implements NamingStrategyInterface
      * Sets extractionMap
      *
      * @param  array $extractionMap
+     * @param  bool  $bidirectional
      * @return self
      */
-    public function setExtractionMap(array $extractionMap)
+    public function setExtractionMap(array $extractionMap, $bidirectional = true)
     {
         $this->extractionMap = $extractionMap;
+
+        if ($bidirectional) {
+            $this->setHydrationMap(array_flip($extractionMap), false);
+        }
 
         return $this;
     }

--- a/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
@@ -15,28 +15,20 @@ class ArrayMapNamingStrategyTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSameNameWithEmptyMap()
     {
-        $strategy = new ArrayMapNamingStrategy();
+        $strategy = new ArrayMapNamingStrategy([]);
         $this->assertEquals('some_stuff', $strategy->hydrate('some_stuff'));
         $this->assertEquals('some_stuff', $strategy->extract('some_stuff'));
     }
 
-    public function testSimpleMapping()
+    public function testExtract()
     {
-        $strategy = new ArrayMapNamingStrategy(array('stuff3' => 'stuff4'), array('stuff1' => 'stuff2'));
-        $this->assertEquals('stuff2', $strategy->hydrate('stuff1'));
+        $strategy = new ArrayMapNamingStrategy(array('stuff3' => 'stuff4'));
         $this->assertEquals('stuff4', $strategy->extract('stuff3'));
     }
 
-    public function testBidirectionalMapping()
+    public function testHydrate()
     {
-        $strategy = new ArrayMapNamingStrategy;
-
-        $strategy->setHydrationMap(array('foo' => 'bar'), true);
-        $this->assertEquals('bar', $strategy->hydrate('foo'));
-        $this->assertEquals('foo', $strategy->extract('bar'));
-
-        $strategy->setExtractionMap(array('foo' => 'bar'), true);
-        $this->assertEquals('bar', $strategy->extract('foo'));
+        $strategy = new ArrayMapNamingStrategy(array('foo' => 'bar'));
         $this->assertEquals('foo', $strategy->hydrate('bar'));
     }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
@@ -24,6 +24,6 @@ class ArrayMapNamingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new ArrayMapNamingStrategy(array('stuff3' => 'stuff4'), array('stuff1' => 'stuff2'));
         $this->assertEquals('stuff2', $strategy->hydrate('stuff1'));
-        $this->assertEquals('stuff4', $strategy->extract('stuff3'));        
+        $this->assertEquals('stuff4', $strategy->extract('stuff3'));
     }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
@@ -20,10 +20,23 @@ class ArrayMapNamingStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('some_stuff', $strategy->extract('some_stuff'));
     }
 
-    public function testGetNameWithMap()
+    public function testSimpleMapping()
     {
         $strategy = new ArrayMapNamingStrategy(array('stuff3' => 'stuff4'), array('stuff1' => 'stuff2'));
         $this->assertEquals('stuff2', $strategy->hydrate('stuff1'));
         $this->assertEquals('stuff4', $strategy->extract('stuff3'));
+    }
+
+    public function testBidirectionalMapping()
+    {
+        $strategy = new ArrayMapNamingStrategy;
+
+        $strategy->setHydrationMap(array('foo' => 'bar'), true);
+        $this->assertEquals('bar', $strategy->hydrate('foo'));
+        $this->assertEquals('foo', $strategy->extract('bar'));
+
+        $strategy->setExtractionMap(array('foo' => 'bar'), true);
+        $this->assertEquals('bar', $strategy->extract('foo'));
+        $this->assertEquals('foo', $strategy->hydrate('bar'));
     }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/ArrayMapNamingStrategyTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\NamingStrategy;
+
+use Zend\Stdlib\Hydrator\NamingStrategy\ArrayMapNamingStrategy;
+
+class ArrayMapNamingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSameNameWithEmptyMap()
+    {
+        $strategy = new ArrayMapNamingStrategy();
+        $this->assertEquals('some_stuff', $strategy->hydrate('some_stuff'));
+        $this->assertEquals('some_stuff', $strategy->extract('some_stuff'));
+    }
+
+    public function testGetNameWithMap()
+    {
+        $strategy = new ArrayMapNamingStrategy(array('stuff3' => 'stuff4'), array('stuff1' => 'stuff2'));
+        $this->assertEquals('stuff2', $strategy->hydrate('stuff1'));
+        $this->assertEquals('stuff4', $strategy->extract('stuff3'));        
+    }
+}


### PR DESCRIPTION
``` php
class User
{
    protected $name;

   public function setName($name)
   {
       $this->name = $name;  
   }

   public function getName() 
   {
        return $this->name;
    }
}

$hydrator = new Zend\Stdlib\Hydrator\ClassMethods;
$strategy = new Zend\Stdlib\Hydrator\NamingStrategy\ArrayMapNamingStrategy(array('name' => 'real_name'));
$hydrator->setNamingStrategy($strategy);

$user = new User();
$user->setName('Brad');

echo $hydrate->extract($user)['real_name']; // outputs Brad
```
