### PR TITLE
Created DateTime Formatter strategy for hydrator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
 
 script:
-  - vendor/bin/php-cs-fixer fix -v --dry-run .
+  - vendor/bin/php-cs-fixer fix -v --dry-run
   # Run tests for the various components in parallel
   - ls -d tests/ZendTest/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/phpunit.xml.dist --coverage-php build/coverage/coverage-{/.}.cov {};' || exit 1
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,13 @@ Develop:
 
 ## RELEASE INFORMATION
 
-*Zend Framework 2.3.1*
+*Zend Framework 2.3.2dev*
 
-This is the first maintenance release for the version 2.3 series.
+This is the second maintenance release for the version 2.3 series.
 
-15 Apr 2014
+DD MMM YYYY
 
-### UPDATES IN 2.3.1
-
-**This release contains security updates:**
-
-- **ZF2014-03:** Potential XSS vector in multiple view helpers due to
-  inappropriate HTML attribute escaping. Many view helpers were using the
-  `escapeHtml()` view helper in order to escape HTML attributes. This release
-  patches them to use the `escapeHtmlAttr()` view helper in these situations.
-  If you use form or navigation view helpers, or "HTML element" view helpers
-  (such as `gravatar()`, `htmlFlash()`, `htmlPage()`, or `htmlQuicktime()`), we
-  recommend upgrading immediately.
+### UPDATES IN 2.3.2
 
 Please see [CHANGELOG.md](CHANGELOG.md).
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ircmaxell/random-lib": "dev-master",
         "ircmaxell/security-lib": "dev-master",
         "mikey179/vfsStream": "1.2.*",
-        "fabpot/php-cs-fixer": "dev-master#2f1df1d",
+        "fabpot/php-cs-fixer": "dev-master",
         "phpunit/PHPUnit": "3.7.*",
         "satooshi/php-coveralls": "dev-master",
         "sebastianbergmann/phpcov": "1.1.0"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ircmaxell/random-lib": "dev-master",
         "ircmaxell/security-lib": "dev-master",
         "mikey179/vfsStream": "1.2.*",
-        "fabpot/php-cs-fixer": "*@dev",
+        "fabpot/php-cs-fixer": "dev-master#2f1df1d",
         "phpunit/PHPUnit": "3.7.*",
         "satooshi/php-coveralls": "dev-master",
         "sebastianbergmann/phpcov": "1.1.0"

--- a/library/Zend/Authentication/composer.json
+++ b/library/Zend/Authentication/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "authentication"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Authentication\\": ""

--- a/library/Zend/Barcode/composer.json
+++ b/library/Zend/Barcode/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "barcode"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Barcode\\": ""

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -153,8 +153,8 @@ class RedisResourceManager
             //there are two ways of determining if redis is already initialized
             //with connect function:
             //1) pinging server
-            //2) checking undocummented property socket which is available only
-            //after successfull connect
+            //2) checking undocumented property socket which is available only
+            //after successful connect
             $resource = array_merge($defaults, array(
                     'resource' => $resource,
                     'initialized' => isset($resource->socket),

--- a/library/Zend/Cache/composer.json
+++ b/library/Zend/Cache/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "cache"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Cache\\": ""

--- a/library/Zend/Captcha/composer.json
+++ b/library/Zend/Captcha/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "captcha"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Captcha\\": ""

--- a/library/Zend/Code/composer.json
+++ b/library/Zend/Code/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "code"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Code\\": ""

--- a/library/Zend/Config/composer.json
+++ b/library/Zend/Config/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "config"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Config\\": ""

--- a/library/Zend/Console/composer.json
+++ b/library/Zend/Console/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "console"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Console\\": ""

--- a/library/Zend/Crypt/Key/Derivation/SaltedS2k.php
+++ b/library/Zend/Crypt/Key/Derivation/SaltedS2k.php
@@ -53,7 +53,7 @@ class SaltedS2k
     public static function calc($hash, $password, $salt, $bytes)
     {
         if (!in_array($hash, array_keys(static::$supportedMhashAlgos))) {
-            throw new Exception\InvalidArgumentException("The hash algorihtm $hash is not supported by " . __CLASS__);
+            throw new Exception\InvalidArgumentException("The hash algorithm $hash is not supported by " . __CLASS__);
         }
         if (strlen($salt)<8) {
             throw new Exception\InvalidArgumentException('The salt size must be at least of 8 bytes');

--- a/library/Zend/Crypt/composer.json
+++ b/library/Zend/Crypt/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "crypt"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Crypt\\": ""

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -189,7 +189,13 @@ abstract class AbstractSql
             $parameterContainer->merge($stmtContainer->getParameterContainer()->getNamedArray());
             $sql = $stmtContainer->getSql();
         } else {
-            $sql = $subselect->getSqlString($platform);
+            if ($this instanceof PlatformDecoratorInterface) {
+                $subselectDecorator = clone $this;
+                $subselectDecorator->setSubject($subselect);
+                $sql = $subselectDecorator->getSqlString($platform);
+            } else {
+                $sql = $subselect->getSqlString($platform);
+            }
         }
         return $sql;
     }

--- a/library/Zend/Db/composer.json
+++ b/library/Zend/Db/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "db"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Db\\": ""

--- a/library/Zend/Debug/composer.json
+++ b/library/Zend/Debug/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "debug"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Debug\\": ""

--- a/library/Zend/Di/composer.json
+++ b/library/Zend/Di/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "di"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Di\\": ""

--- a/library/Zend/Dom/composer.json
+++ b/library/Zend/Dom/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "dom"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Dom\\": ""

--- a/library/Zend/Escaper/composer.json
+++ b/library/Zend/Escaper/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "escaper"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Escaper\\": ""

--- a/library/Zend/EventManager/composer.json
+++ b/library/Zend/EventManager/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "eventmanager"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\EventManager\\": ""

--- a/library/Zend/Feed/composer.json
+++ b/library/Zend/Feed/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "feed"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Feed\\": ""

--- a/library/Zend/File/composer.json
+++ b/library/Zend/File/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "file"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\File\\": ""

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -46,16 +46,6 @@ class DateTimeFormatter extends AbstractFilter
     }
 
     /**
-     * Gets format
-     *
-     * @return string
-     */
-    public function getFormat()
-    {
-        return $this->format;
-    }
-
-    /**
      * Filter a datetime string by normalizing it to the filters specified format
      *
      * @param  DateTime|string|integer $value

--- a/library/Zend/Filter/DateTimeFormatter.php
+++ b/library/Zend/Filter/DateTimeFormatter.php
@@ -46,6 +46,16 @@ class DateTimeFormatter extends AbstractFilter
     }
 
     /**
+     * Gets format
+     *
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
      * Filter a datetime string by normalizing it to the filters specified format
      *
      * @param  DateTime|string|integer $value

--- a/library/Zend/Filter/FilterChain.php
+++ b/library/Zend/Filter/FilterChain.php
@@ -241,7 +241,7 @@ class FilterChain extends AbstractFilter implements Countable
      *
      * Plugin manager (property 'plugins') cannot
      * be serialized. On wakeup the property remains unset
-     * and next invokation to getPluginManager() sets
+     * and next invocation to getPluginManager() sets
      * the default plugin manager instance (FilterPluginManager).
      */
     public function __sleep()

--- a/library/Zend/Filter/composer.json
+++ b/library/Zend/Filter/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "filter"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Filter\\": ""

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -543,6 +543,7 @@ class Collection extends Fieldset
     /**
      * Add a new instance of the target element
      *
+     * @param string $name
      * @return ElementInterface
      * @throws Exception\DomainException
      */

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -760,7 +760,7 @@ class Form extends Fieldset implements FormInterface
             $elements = $fieldset->getElements();
         }
 
-        if (!$fieldset instanceof Collection || $inputFilter instanceof CollectionInputFilter) {
+        if (!$fieldset instanceof Collection || !$fieldset->getTargetElement() instanceof FieldsetInterface || $inputFilter instanceof CollectionInputFilter) {
             foreach ($elements as $element) {
                 $name = $element->getName();
 

--- a/library/Zend/Form/composer.json
+++ b/library/Zend/Form/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "form"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Form\\": ""

--- a/library/Zend/Http/composer.json
+++ b/library/Zend/Http/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "http"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Http\\": ""

--- a/library/Zend/I18n/View/Helper/Plural.php
+++ b/library/Zend/I18n/View/Helper/Plural.php
@@ -17,7 +17,7 @@ use Zend\View\Helper\AbstractHelper;
  * Helper for rendering text based on a count number (like the I18n plural translation helper, but when translation
  * is not needed).
  *
- * Please note that we did not write any hard-coded rules for languages, as languages can evolve, we prefered to
+ * Please note that we did not write any hard-coded rules for languages, as languages can evolve, we preferred to
  * let the developer define the rules himself, instead of potentially break applications if we change rules in the
  * future.
  *

--- a/library/Zend/I18n/composer.json
+++ b/library/Zend/I18n/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "i18n"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\I18n\\": ""

--- a/library/Zend/InputFilter/ArrayInput.php
+++ b/library/Zend/InputFilter/ArrayInput.php
@@ -18,6 +18,7 @@ class ArrayInput extends Input
 
     /**
      * @param  array $value
+     * @throws Exception\InvalidArgumentException
      * @return Input
      */
     public function setValue($value)

--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -369,6 +369,7 @@ class BaseInputFilter implements
      * each specifying a single input.
      *
      * @param  mixed $name
+     * @throws Exception\InvalidArgumentException
      * @return InputFilterInterface
      */
     public function setValidationGroup($name)

--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -47,6 +47,7 @@ class CollectionInputFilter extends InputFilter
      * Set the input filter to use when looping the data
      *
      * @param BaseInputFilter|array|Traversable $inputFilter
+     * @throws Exception\RuntimeException
      * @return CollectionInputFilter
      */
     public function setInputFilter($inputFilter)

--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -10,6 +10,7 @@
 namespace Zend\InputFilter;
 
 use Traversable;
+use Zend\Filter\Exception;
 use Zend\Filter\FilterChain;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\ValidatorInterface;
@@ -331,6 +332,7 @@ class Factory
     /**
      * @param  FilterChain       $chain
      * @param  array|Traversable $filters
+     * @throws Exception\RuntimeException
      * @return void
      */
     protected function populateFilters(FilterChain $chain, $filters)
@@ -366,6 +368,7 @@ class Factory
     /**
      * @param  ValidatorChain    $chain
      * @param  array|Traversable $validators
+     * @throws Exception\RuntimeException
      * @return void
      */
     protected function populateValidators(ValidatorChain $chain, $validators)

--- a/library/Zend/InputFilter/composer.json
+++ b/library/Zend/InputFilter/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "inputfilter"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\InputFilter\\": ""

--- a/library/Zend/Json/composer.json
+++ b/library/Zend/Json/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "json"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Json\\": ""

--- a/library/Zend/Ldap/composer.json
+++ b/library/Zend/Ldap/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "ldap"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Ldap\\": ""

--- a/library/Zend/Loader/composer.json
+++ b/library/Zend/Loader/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "loader"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Loader\\": ""

--- a/library/Zend/Log/Filter/Priority.php
+++ b/library/Zend/Log/Filter/Priority.php
@@ -42,14 +42,14 @@ class Priority implements FilterInterface
             $operator = isset($priority['operator']) ? $priority['operator'] : null;
             $priority = isset($priority['priority']) ? $priority['priority'] : null;
         }
-        if (!is_int($priority)) {
+        if (!is_int($priority) && !ctype_digit($priority)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Priority must be an integer; received "%s"',
+                'Priority must be a number, received "%s"',
                 gettype($priority)
             ));
         }
 
-        $this->priority = $priority;
+        $this->priority = (int) $priority;
         $this->operator = $operator === null ? '<=' : $operator;
     }
 

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -594,7 +594,6 @@ class Logger implements LoggerInterface
         static::$registeredErrorHandler = false;
     }
 
-
     /**
      * Register a shutdown handler to log fatal errors
      *
@@ -627,7 +626,6 @@ class Logger implements LoggerInterface
         static::$registeredFatalErrorShutdownFunction = true;
         return true;
     }
-
 
     /**
      * Register logging system as an exception handler to log PHP exceptions

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -344,9 +344,9 @@ class Logger implements LoggerInterface
         }
         if (!$plugins instanceof ProcessorPluginManager) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'processor plugin manager must extend %s\ProcessorPluginManager; received %s',
-                    __NAMESPACE__,
-                    is_object($plugins) ? get_class($plugins) : gettype($plugins)
+                'processor plugin manager must extend %s\ProcessorPluginManager; received %s',
+                __NAMESPACE__,
+                is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }
 
@@ -381,8 +381,8 @@ class Logger implements LoggerInterface
             $processor = $this->processorPlugin($processor, $options);
         } elseif (!$processor instanceof Processor\ProcessorInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'Processor must implement Zend\Log\ProcessorInterface; received "%s"',
-                    is_object($processor) ? get_class($processor) : gettype($processor)
+                'Processor must implement Zend\Log\ProcessorInterface; received "%s"',
+                is_object($processor) ? get_class($processor) : gettype($processor)
             ));
         }
         $this->processors->insert($processor, $priority);

--- a/library/Zend/Log/Logger.php
+++ b/library/Zend/Log/Logger.php
@@ -449,7 +449,7 @@ class Logger implements LoggerInterface
             'priority'     => (int) $priority,
             'priorityName' => $this->priorities[$priority],
             'message'      => (string) $message,
-            'extra'        => $extra
+            'extra'        => $extra,
         );
 
         foreach ($this->processors->toArray() as $processor) {
@@ -617,7 +617,7 @@ class Logger implements LoggerInterface
                     $error['message'],
                     array(
                         'file' => $error['file'],
-                        'line' => $error['line']
+                        'line' => $error['line'],
                     )
                 );
             }

--- a/library/Zend/Log/ProcessorPluginManager.php
+++ b/library/Zend/Log/ProcessorPluginManager.php
@@ -14,7 +14,7 @@ use Zend\ServiceManager\AbstractPluginManager;
 class ProcessorPluginManager extends AbstractPluginManager
 {
     /**
-     * Default set of writers
+     * Default set of processors
      *
      * @var array
      */
@@ -24,7 +24,7 @@ class ProcessorPluginManager extends AbstractPluginManager
     );
 
     /**
-     * Allow many writers of the same type
+     * Allow many processors of the same type
      *
      * @var bool
      */

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -295,9 +295,9 @@ abstract class AbstractWriter implements WriterInterface
 
         if (!$formatter instanceof Formatter\FormatterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
-                    __NAMESPACE__,
-                    is_object($formatter) ? get_class($formatter) : gettype($formatter)
+                'Formatter must implement %s\Formatter\FormatterInterface; received "%s"',
+                __NAMESPACE__,
+                is_object($formatter) ? get_class($formatter) : gettype($formatter)
             ));
         }
 

--- a/library/Zend/Log/Writer/AbstractWriter.php
+++ b/library/Zend/Log/Writer/AbstractWriter.php
@@ -78,11 +78,11 @@ abstract class AbstractWriter implements WriterInterface
         if (is_array($options)) {
             if (isset($options['filters'])) {
                 $filters = $options['filters'];
-                if (is_string($filters) || $filters instanceof Filter\FilterInterface) {
+                if (is_int($filters) || is_string($filters) || $filters instanceof Filter\FilterInterface) {
                     $this->addFilter($filters);
                 } elseif (is_array($filters)) {
                     foreach ($filters as $filter) {
-                        if (is_string($filter) || $filter instanceof Filter\FilterInterface) {
+                        if (is_int($filter) || is_string($filter) || $filter instanceof Filter\FilterInterface) {
                             $this->addFilter($filter);
                         } elseif (is_array($filter)) {
                             if (!isset($filter['name'])) {

--- a/library/Zend/Log/Writer/FingersCrossed.php
+++ b/library/Zend/Log/Writer/FingersCrossed.php
@@ -113,9 +113,9 @@ class FingersCrossed extends AbstractWriter
 
         if (!$writer instanceof WriterInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'Writer must implement %s\WriterInterface; received "%s"',
-                    __NAMESPACE__,
-                    is_object($writer) ? get_class($writer) : gettype($writer)
+                'Writer must implement %s\WriterInterface; received "%s"',
+                __NAMESPACE__,
+                is_object($writer) ? get_class($writer) : gettype($writer)
             ));
         }
 
@@ -150,9 +150,9 @@ class FingersCrossed extends AbstractWriter
         }
         if (!$plugins instanceof WriterPluginManager) {
             throw new Exception\InvalidArgumentException(sprintf(
-                    'Writer plugin manager must extend %s\WriterPluginManager; received %s',
-                    __NAMESPACE__,
-                    is_object($plugins) ? get_class($plugins) : gettype($plugins)
+                'Writer plugin manager must extend %s\WriterPluginManager; received %s',
+                __NAMESPACE__,
+                is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }
 

--- a/library/Zend/Log/Writer/MongoDB.php
+++ b/library/Zend/Log/Writer/MongoDB.php
@@ -62,15 +62,11 @@ class MongoDB extends AbstractWriter
         }
 
         if (null === $collection) {
-            throw new Exception\InvalidArgumentException(
-                    'The collection parameter cannot be empty'
-            );
+            throw new Exception\InvalidArgumentException('The collection parameter cannot be empty');
         }
 
         if (null === $database) {
-            throw new Exception\InvalidArgumentException(
-                    'The database parameter cannot be empty'
-            );
+            throw new Exception\InvalidArgumentException('The database parameter cannot be empty');
         }
 
         if (!($mongo instanceof MongoClient || $mongo instanceof Mongo)) {

--- a/library/Zend/Log/composer.json
+++ b/library/Zend/Log/composer.json
@@ -7,6 +7,7 @@
         "log",
         "logging"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Log\\": ""

--- a/library/Zend/Mail/composer.json
+++ b/library/Zend/Mail/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "mail"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Mail\\": ""

--- a/library/Zend/Math/Rand.php
+++ b/library/Zend/Math/Rand.php
@@ -136,8 +136,9 @@ abstract class Rand
         // calculate number of bits required to store range on this machine
         $r = $range;
         $bits = 0;
-        while ($r >>= 1) {
+        while ($r) {
             $bits++;
+            $r >>= 1;
         }
 
         $bits   = (int) max($bits, 1);

--- a/library/Zend/Math/composer.json
+++ b/library/Zend/Math/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "math"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Math\\": ""

--- a/library/Zend/Memory/composer.json
+++ b/library/Zend/Memory/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "memory"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Memory\\": ""

--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -107,8 +107,12 @@ class Message
     public function generateMessage($EOL = Mime::LINEEND)
     {
         if (!$this->isMultiPart()) {
-            $part = current($this->parts);
-            $body = $part->getContent($EOL);
+            if (!empty($this->parts)) {
+                $part = current($this->parts);
+                $body = $part->getContent($EOL);
+            } else {
+                return '';
+            }
         } else {
             $mime = $this->getMime();
 

--- a/library/Zend/Mime/Message.php
+++ b/library/Zend/Mime/Message.php
@@ -107,12 +107,11 @@ class Message
     public function generateMessage($EOL = Mime::LINEEND)
     {
         if (!$this->isMultiPart()) {
-            if (!empty($this->parts)) {
-                $part = current($this->parts);
-                $body = $part->getContent($EOL);
-            } else {
+            if (empty($this->parts)) {
                 return '';
             }
+            $part = current($this->parts);
+            $body = $part->getContent($EOL);
         } else {
             $mime = $this->getMime();
 

--- a/library/Zend/Mime/composer.json
+++ b/library/Zend/Mime/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "mime"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Mime\\": ""

--- a/library/Zend/ModuleManager/composer.json
+++ b/library/Zend/ModuleManager/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "modulemanager"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\ModuleManager\\": ""

--- a/library/Zend/Mvc/Controller/AbstractConsoleController.php
+++ b/library/Zend/Mvc/Controller/AbstractConsoleController.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Mvc\Controller;
 
-use Zend\Console\Adapter\AdapterInterface as ConsoleAdaper;
+use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
 use Zend\Console\Request as ConsoleRequest;
 use Zend\Mvc\Exception\InvalidArgumentException;
 use Zend\Stdlib\RequestInterface;
@@ -18,15 +18,15 @@ use Zend\Stdlib\ResponseInterface;
 class AbstractConsoleController extends AbstractActionController
 {
     /**
-     * @var ConsoleAdaper
+     * @var ConsoleAdapter
      */
     protected $console;
 
     /**
-     * @param ConsoleAdaper $console
+     * @param ConsoleAdapter $console
      * @return self
      */
-    public function setConsole(ConsoleAdaper $console)
+    public function setConsole(ConsoleAdapter $console)
     {
         $this->console = $console;
 
@@ -34,7 +34,7 @@ class AbstractConsoleController extends AbstractActionController
     }
 
     /**
-     * @return ConsoleAdaper
+     * @return ConsoleAdapter
      */
     public function getConsole()
     {

--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "mvc"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Mvc\\": ""

--- a/library/Zend/Mvc/composer.json
+++ b/library/Zend/Mvc/composer.json
@@ -51,7 +51,6 @@
         "zendframework/zend-json": "Zend\\Json component",
         "zendframework/zend-log": "Zend\\Log component",
         "zendframework/zend-modulemanager": "Zend\\ModuleManager component",
-        "zendframework/zend-session": "Zend\\Session component",
         "zendframework/zend-serializer": "Zend\\Serializer component",
         "zendframework/zend-session": "Zend\\Session component for FlashMessenger, PRG, and FPRG plugins",
         "zendframework/zend-stdlib": "Zend\\Stdlib component",

--- a/library/Zend/Navigation/composer.json
+++ b/library/Zend/Navigation/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "navigation"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Navigation\\": ""

--- a/library/Zend/Paginator/composer.json
+++ b/library/Zend/Paginator/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "paginator"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Paginator\\": ""

--- a/library/Zend/Permissions/Acl/composer.json
+++ b/library/Zend/Permissions/Acl/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "acl"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Permissions\\Acl\\": ""

--- a/library/Zend/Permissions/Rbac/composer.json
+++ b/library/Zend/Permissions/Rbac/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "Rbac"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Permissions\\Rbac\\": ""

--- a/library/Zend/ProgressBar/composer.json
+++ b/library/Zend/ProgressBar/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "progressbar"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\ProgressBar\\": ""

--- a/library/Zend/Serializer/composer.json
+++ b/library/Zend/Serializer/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "serializer"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Serializer\\": ""

--- a/library/Zend/Server/composer.json
+++ b/library/Zend/Server/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "server"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Server\\": ""

--- a/library/Zend/ServiceManager/composer.json
+++ b/library/Zend/ServiceManager/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "servicemanager"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\ServiceManager\\": ""

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -332,7 +332,7 @@ class SessionManager extends AbstractManager
     {
         $validator = $this->getValidatorChain();
         $responses = $validator->triggerUntil('session.validate', $this, array($this), function ($test) {
-            return !$test;
+            return false === $test;
         });
         if ($responses->stopped()) {
             // If execution was halted, validation failed

--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "session"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Session\\": ""

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -750,6 +750,8 @@ class Server implements ZendServerServer
             $dom = new DOMDocument();
             $loadStatus = $dom->loadXML($xml);
 
+            libxml_disable_entity_loader(false);
+
             // @todo check libxml errors ? validate document ?
             if (strlen($xml) == 0 || !$loadStatus) {
                 throw new Exception\InvalidArgumentException('Invalid XML');
@@ -760,7 +762,6 @@ class Server implements ZendServerServer
                     throw new Exception\InvalidArgumentException('Invalid XML: Detected use of illegal DOCTYPE');
                 }
             }
-            libxml_disable_entity_loader(false);
         }
 
         $this->request = $xml;

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -745,12 +745,12 @@ class Server implements ZendServerServer
             }
             $xml = trim($xml);
 
-            libxml_disable_entity_loader(true);
+            $loadEntities = libxml_disable_entity_loader(true);
 
             $dom = new DOMDocument();
             $loadStatus = $dom->loadXML($xml);
 
-            libxml_disable_entity_loader(false);
+            libxml_disable_entity_loader($loadEntities);
 
             // @todo check libxml errors ? validate document ?
             if (strlen($xml) == 0 || !$loadStatus) {

--- a/library/Zend/Soap/composer.json
+++ b/library/Zend/Soap/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "soap"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Soap\\": ""

--- a/library/Zend/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategy.php
@@ -25,7 +25,7 @@ class UnderscoreNamingStrategy implements NamingStrategyInterface
      */
     public function hydrate($name)
     {
-        return $this->getUnderscoreToCamelCaseFilter()->filter($name);
+        return lcfirst($this->getUnderscoreToCamelCaseFilter()->filter($name));
     }
 
     /**

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormaterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormaterStrategy.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Hydrator\Strategy;
+
+use DateTime;
+use Zend\Filter\DateTimeFormatter;
+
+class DateTimeFormaterStrategy implements StrategyInterface
+{
+    /**
+     * @var DateTimeFormatter
+     */
+    protected $filter;
+
+    /**
+     * Constructor
+     *
+     * @param string|null $format
+     */
+    public function __construct($format = null)
+    {
+        if ($format !== null) {
+            $this->setFormat($format);
+        }
+    }
+
+    /**
+     * Sets format
+     *
+     * @param  string $format
+     * @return self
+     */
+    public function setFormat($format)
+    {
+        $this->getFilter()->setFormat($format);
+
+        return $this;
+    }
+
+    /**
+     * Converts to date time string
+     *
+     * @param DateTime|string|int
+     * @param string
+     */
+    public function extract($value)
+    {
+        return $this->getFilter()->filter($value);
+    }
+
+    /**
+     * Converts date time string to DateTime instance for injecting to object
+     *
+     * @param  string|null|int $value
+     * @return DateTime|null
+     */
+    public function hydrate($value)
+    {
+        $value = $this->getFilter()->filter($value);
+        if ($value === '' || $value === null) {
+            return null;
+        }
+
+        return new DateTime($value);
+    }
+
+    /**
+     * @return DateTimeFormatter
+     */
+    protected function getFilter()
+    {
+        if (!$this->filter) {
+            $this->filter = new DateTimeFormatter();
+        }
+
+        return $this->filter;
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -11,7 +11,6 @@ namespace Zend\Stdlib\Hydrator\Strategy;
 
 use DateTime;
 use Zend\Filter\DateTimeFormatter;
-use Zend\Filter\FilterInterface;
 
 class DateTimeFormatterStrategy implements StrategyInterface
 {
@@ -64,10 +63,10 @@ class DateTimeFormatterStrategy implements StrategyInterface
     /**
      * Sets filter for formatting date
      *
-     * @param FilterInterface $filter
+     * @param DateTimeFormatter $filter
      * @return self
      */
-    public function setFilter(FilterInterface $filter)
+    public function setFilter(DateTimeFormatter $filter)
     {
         $this->filter = $filter;
 
@@ -77,7 +76,7 @@ class DateTimeFormatterStrategy implements StrategyInterface
     /**
      * Gets filter for formatting date
      *
-     * @return FilterInterface
+     * @return DateTimeFormatter
      */
     private function getFilter($format)
     {

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -12,7 +12,7 @@ namespace Zend\Stdlib\Hydrator\Strategy;
 use DateTime;
 use Zend\Filter\DateTimeFormatter;
 
-class DateTimeFormaterStrategy implements StrategyInterface
+class DateTimeFormatterStrategy implements StrategyInterface
 {
     /**
      * @var DateTimeFormatter

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -63,7 +63,7 @@ class DateTimeFormatterStrategy implements StrategyInterface
     /**
      * Sets filter for formatting date
      *
-     * @param DateTimeFormatter $filter
+     * @param  DateTimeFormatter $filter
      * @return self
      */
     public function setFilter(DateTimeFormatter $filter)

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -21,28 +21,18 @@ class DateTimeFormatterStrategy implements StrategyInterface
     protected $filter;
 
     /**
-     * Constructor
-     *
-     * @param string|null $format
+     * @var string
      */
-    public function __construct($format = null)
-    {
-        if ($format !== null) {
-            $this->setFormat($format);
-        }
-    }
+    protected $format;
 
     /**
-     * Sets format
+     * Constructor
      *
-     * @param  string $format
-     * @return self
+     * @param string $format
      */
-    public function setFormat($format)
+    public function __construct($format)
     {
-        $this->getFilter()->setFormat($format);
-
-        return $this;
+        $this->format = $format;
     }
 
     /**
@@ -53,7 +43,7 @@ class DateTimeFormatterStrategy implements StrategyInterface
      */
     public function extract($value)
     {
-        return $this->getFilter()->filter($value);
+        return $this->getFilter($this->format)->filter($value);
     }
 
     /**
@@ -68,7 +58,7 @@ class DateTimeFormatterStrategy implements StrategyInterface
             return null;
         }
 
-        return DateTime::createFromFormat($this->getFilter()->getFormat(), $value);
+        return DateTime::createFromFormat($this->format, $value);
     }
 
     /**
@@ -89,11 +79,12 @@ class DateTimeFormatterStrategy implements StrategyInterface
      *
      * @return FilterInterface
      */
-    public function getFilter()
+    private function getFilter($format)
     {
         if (!$this->filter) {
             $this->setFilter(new DateTimeFormatter);
         }
+        $this->filter->setFormat($format);
 
         return $this->filter;
     }

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -29,7 +29,7 @@ class DateTimeFormatterStrategy implements StrategyInterface
      *
      * @param string $format
      */
-    public function __construct($format)
+    public function __construct($format = DateTime::RFC3339)
     {
         $this->format = $format;
     }

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -37,11 +37,15 @@ class DateTimeFormatterStrategy implements StrategyInterface
     /**
      * Converts to date time string
      *
-     * @param DateTime|string|int
-     * @param string
+     * @param DateTime|string|int|null
+     * @param string|null
      */
     public function extract($value)
     {
+        if ($value === null) {
+            return null;
+        }
+
         return $this->getFilter($this->format)->filter($value);
     }
 

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -11,6 +11,7 @@ namespace Zend\Stdlib\Hydrator\Strategy;
 
 use DateTime;
 use Zend\Filter\DateTimeFormatter;
+use Zend\Filter\FilterInterface;
 
 class DateTimeFormatterStrategy implements StrategyInterface
 {
@@ -71,12 +72,27 @@ class DateTimeFormatterStrategy implements StrategyInterface
     }
 
     /**
-     * @return DateTimeFormatter
+     * Sets filter for formatting date
+     *
+     * @param FilterInterface $filter
+     * @return self
      */
-    protected function getFilter()
+    public function setFilter(FilterInterface $filter)
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    /**
+     * Gets filter for formatting date
+     *
+     * @return FilterInterface
+     */
+    public function getFilter()
     {
         if (!$this->filter) {
-            $this->filter = new DateTimeFormatter();
+            $this->setFilter(new DateTimeFormatter);
         }
 
         return $this->filter;

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -63,12 +63,11 @@ class DateTimeFormatterStrategy implements StrategyInterface
      */
     public function hydrate($value)
     {
-        $value = $this->getFilter()->filter($value);
         if ($value === '' || $value === null) {
             return null;
         }
 
-        return new DateTime($value);
+        return DateTime::createFromFormat($this->getFilter()->getFormat(), $value);
     }
 
     /**

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "stdlib"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Stdlib\\": ""

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -18,12 +18,14 @@
     "require-dev": {
         "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-serializer": "self.version",
-        "zendframework/zend-servicemanager": "self.version"
+        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-filter": "self.version"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
         "zendframework/zend-serializer": "Zend\\Serializer component",
-        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage",
+        "zendframework/zend-filter": " To use DateTime Formater strategy for hydrator"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -19,12 +19,14 @@
     "require-dev": {
         "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-serializer": "self.version",
-        "zendframework/zend-servicemanager": "self.version"
+        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-filter": "self.version"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
         "zendframework/zend-serializer": "Zend\\Serializer component",
-        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage",
+        "zendframework/zend-filter": " To use DateTime Formater strategy for hydrator"
     },
     "extra": {
         "branch-alias": {

--- a/library/Zend/Tag/composer.json
+++ b/library/Zend/Tag/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "tag"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Tag\\": ""

--- a/library/Zend/Test/composer.json
+++ b/library/Zend/Test/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "test"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Test\\": ""

--- a/library/Zend/Text/composer.json
+++ b/library/Zend/Text/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "text"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Text\\": ""

--- a/library/Zend/Uri/composer.json
+++ b/library/Zend/Uri/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "uri"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Uri\\": ""

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -267,7 +267,7 @@ class ValidatorChain implements
      *
      * Plugin manager (property 'plugins') cannot
      * be serialized. On wakeup the property remains unset
-     * and next invokation to getPluginManager() sets
+     * and next invocation to getPluginManager() sets
      * the default plugin manager instance (ValidatorPluginManager).
      *
      * @return array

--- a/library/Zend/Validator/composer.json
+++ b/library/Zend/Validator/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "validator"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Validator\\": ""

--- a/library/Zend/Version/Version.php
+++ b/library/Zend/Version/Version.php
@@ -20,7 +20,7 @@ final class Version
     /**
      * Zend Framework version identification - see compareVersion()
      */
-    const VERSION = '2.3.1';
+    const VERSION = '2.3.2dev';
 
     /**
      * Github Service Identifier for version information is retrieved from

--- a/library/Zend/Version/composer.json
+++ b/library/Zend/Version/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "version"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\Version\\": ""

--- a/library/Zend/View/composer.json
+++ b/library/Zend/View/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "view"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\View\\": ""

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -197,9 +197,13 @@ class Client implements ServerClient
     {
         $this->lastRequest = $request;
 
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('default_charset', 'UTF-8');
+        }
 
         $http        = $this->getHttpClient();
         $httpRequest = $http->getRequest();

--- a/library/Zend/XmlRpc/composer.json
+++ b/library/Zend/XmlRpc/composer.json
@@ -6,6 +6,7 @@
         "zf2",
         "xmlrpc"
     ],
+    "homepage": "https://github.com/zendframework/zf2",
     "autoload": {
         "psr-0": {
             "Zend\\XmlRpc\\": ""

--- a/tests/ZendTest/Crypt/Key/Derivation/SaltedS2kTest.php
+++ b/tests/ZendTest/Crypt/Key/Derivation/SaltedS2kTest.php
@@ -43,7 +43,7 @@ class SaltedS2kTest extends \PHPUnit_Framework_TestCase
             return;
         }
         $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException',
-                                    'The hash algorihtm wrong is not supported by Zend\Crypt\Key\Derivation\SaltedS2k');
+                                    'The hash algorithm wrong is not supported by Zend\Crypt\Key\Derivation\SaltedS2k');
         $password = SaltedS2k::calc('wrong', 'test', $this->salt, 32);
     }
 

--- a/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
@@ -16,12 +16,47 @@ use Zend\Db\Adapter\Platform\Oracle as OraclePlatform;
 
 class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
-     * @testdox integration test: Testing SelectDecorator will use Select an internal state to prepare a proper from alias sql statement
+     * @testdox integration test: Testing SelectDecorator will use Select to produce properly Oracle dialect prepared sql
+     * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::prepareStatement
+     * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::processLimitOffset
+     * @dataProvider dataProvider
+     */
+    public function testPrepareStatement(Select $select, $expectedSql, $expectedParams, $notUsed, $expectedFormatParamCount)
+    {
+        $driver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $driver->expects($this->exactly($expectedFormatParamCount))->method('formatParameterName')->will($this->returnValue('?'));
+
+        // test
+        $adapter = $this->getMock(
+            'Zend\Db\Adapter\Adapter',
+            null,
+            array(
+                $driver,
+                new OraclePlatform()
+            )
+        );
+
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $statement->expects($this->once())->method('setSql')->with($expectedSql);
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $selectDecorator->prepareStatement($adapter, $statement);
+
+        $this->assertEquals($expectedParams, $parameterContainer->getNamedArray());
+    }
+
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select to produce properly Oracle dialect sql statements
      * @covers Zend\Db\Sql\Platform\Oracle\SelectDecorator::getSqlString
      * @dataProvider dataProvider
      */
-    public function testGetSqlString(Select $select, $expectedSql)
+    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
@@ -42,9 +77,17 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $select0 = new Select;
         $select0->from(array('x' => 'foo'));
         $expectedSql0 = 'SELECT "x".* FROM "foo" "x"';
+        $expectedFormatParamCount0 = 0;
+
+        $select1a = new Select('test');
+        $select1b = new Select(array('a' => $select1a));
+        $select1 = new Select(array('b' => $select1b));
+        $expectedSql1 = 'SELECT "b".* FROM (SELECT "a".* FROM (SELECT "test".* FROM "test") "a") "b"';
+        $expectedFormatParamCount1 = 0;
 
         return array(
-            array($select0, $expectedSql0),
+            array($select0, $expectedSql0, array(), $expectedSql0, $expectedFormatParamCount0),
+            array($select1, $expectedSql1, array(), $expectedSql1, $expectedFormatParamCount1),
         );
     }
 

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -178,6 +178,35 @@ class CollectionTest extends TestCase
         $this->assertArrayHasKey('colors', $messages);
     }
 
+    public function testCannotValidateFormWithCollectionWithBadFieldsetField()
+    {
+        $this->form->setData(array(
+            'colors' => array(
+                '#ffffff',
+                '#ffffff'
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'oneValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                ),
+                array(
+                    'field' => 'twoValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => null,
+                    )
+                )
+            )
+        ));
+
+        $this->assertEquals(false, $this->form->isValid());
+        $messages = $this->form->getMessages();
+        $this->assertCount(1, $messages);
+        $this->assertArrayHasKey('fieldsets', $messages);
+    }
+
     public function testCanValidateFormWithCollectionWithTemplate()
     {
         $collection = $this->form->get('colors');

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -174,6 +174,8 @@ class CollectionTest extends TestCase
         ));
 
         $this->assertEquals(false, $this->form->isValid());
+        $messages = $this->form->getMessages();
+        $this->assertArrayHasKey('colors', $messages);
     }
 
     public function testCanValidateFormWithCollectionWithTemplate()

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -150,6 +150,32 @@ class CollectionTest extends TestCase
         $this->assertEquals(true, $this->form->isValid());
     }
 
+    public function testCannotValidateFormWithCollectionWithBadColor()
+    {
+        $this->form->setData(array(
+            'colors' => array(
+                '#ffffff',
+                '123465'
+            ),
+            'fieldsets' => array(
+                array(
+                    'field' => 'oneValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                ),
+                array(
+                    'field' => 'twoValue',
+                    'nested_fieldset' => array(
+                        'anotherField' => 'anotherValue'
+                    )
+                )
+            )
+        ));
+
+        $this->assertEquals(false, $this->form->isValid());
+    }
+
     public function testCanValidateFormWithCollectionWithTemplate()
     {
         $collection = $this->form->get('colors');

--- a/tests/ZendTest/Log/Filter/PriorityTest.php
+++ b/tests/ZendTest/Log/Filter/PriorityTest.php
@@ -38,7 +38,18 @@ class PriorityTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorThrowsOnInvalidPriority()
     {
-        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'must be an integer');
+        $this->setExpectedException('Zend\Log\Exception\InvalidArgumentException', 'must be a number');
         new Priority('foo');
     }
+
+    public function testComparisonStringSupport()
+    {
+        // accept at or below priority '2'
+        $filter = new Priority('2');
+
+        $this->assertTrue($filter->filter(array('priority' => 2)));
+        $this->assertTrue($filter->filter(array('priority' => 1)));
+        $this->assertFalse($filter->filter(array('priority' => 3)));
+    }
+
 }

--- a/tests/ZendTest/Log/Processor/RequestIdTest.php
+++ b/tests/ZendTest/Log/Processor/RequestIdTest.php
@@ -26,7 +26,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             'priority'     => 1,
             'priorityName' => 'ALERT',
             'message'      => 'foo',
-            'extra'        => array()
+            'extra'        => array(),
         );
 
         $eventA = $processor->process($event);

--- a/tests/ZendTest/Log/Processor/RequestIdTest.php
+++ b/tests/ZendTest/Log/Processor/RequestIdTest.php
@@ -22,11 +22,11 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
         $processor = new RequestId();
 
         $event = array(
-                'timestamp'    => '',
-                'priority'     => 1,
-                'priorityName' => 'ALERT',
-                'message'      => 'foo',
-                'extra'        => array()
+            'timestamp'    => '',
+            'priority'     => 1,
+            'priorityName' => 'ALERT',
+            'message'      => 'foo',
+            'extra'        => array()
         );
 
         $eventA = $processor->process($event);

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -104,6 +104,39 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $this->readAttribute($filters[1], 'priority'));
     }
 
+    public function testConstructorWithPriorityFilter()
+    {
+        $options = array('filters' => 3);
+
+        $writer = new ConcreteWriter($options);
+
+        $filters = $this->readAttribute($writer, 'filters');
+        $this->assertCount(1, $filters);
+
+        $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
+        $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
+    }
+
+    public function testConstructorWithPriorityFilterArray()
+    {
+        $options = array('filters' => array(
+                             3,
+                             array(
+                                 'name' => 'mock'
+                             )
+                       )
+                   );
+
+        $writer = new ConcreteWriter($options);
+
+        $filters = $this->readAttribute($writer, 'filters');
+        $this->assertCount(2, $filters);
+
+        $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
+        $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
+        $this->assertInstanceOf('Zend\Log\Filter\Mock', $filters[1]);
+    }
+
     /**
      * @covers Zend\Log\Writer\AbstractWriter::getFormatter
      */

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -106,32 +106,19 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorWithPriorityFilter()
     {
-        $options = array('filters' => 3);
-
-        $writer = new ConcreteWriter($options);
-
+        // Accept an int as a PriorityFilter
+        $writer = new ConcreteWriter(array('filters' => 3));
         $filters = $this->readAttribute($writer, 'filters');
         $this->assertCount(1, $filters);
-
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
         $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
-    }
 
-    public function testConstructorWithPriorityFilterArray()
-    {
-        $options = array('filters' => array(
-                             3,
-                             array(
-                                 'name' => 'mock'
-                             )
-                       )
-                   );
+        // Accept an int in an array of filters as a PriorityFilter
+        $options = array('filters' => array(3, array('name' => 'mock')));
 
         $writer = new ConcreteWriter($options);
-
         $filters = $this->readAttribute($writer, 'filters');
         $this->assertCount(2, $filters);
-
         $this->assertInstanceOf('Zend\Log\Filter\Priority', $filters[0]);
         $this->assertEquals(3, $this->readAttribute($filters[0], 'priority'));
         $this->assertInstanceOf('Zend\Log\Filter\Mock', $filters[1]);

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -683,4 +683,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $restoredMessage = Message::fromString($serialized);
         $this->assertEquals($serialized, $restoredMessage->toString());
     }
+
+    /**
+     * @group ZF2-5962
+     */
+    public function testPassEmptyArrayIntoSetPartsOfMimeMessageShouldReturnEmptyBodyString()
+    {
+        $mimeMessage = new MimeMessage();
+        $mimeMessage->setParts(array());
+
+        $this->message->setBody($mimeMessage);
+        $this->assertEquals('', $this->message->getBodyText());
+    }
 }

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -43,6 +43,44 @@ class RandTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider dataProviderForTestRandIntegerRangeTest
+     */
+    public function testRandIntegerRangeTest($min, $max, $cycles)
+    {
+        $counter = array();
+        for ($i = $min; $i <= $max; $i++) {
+            $counter[$i] = 0;
+        }
+
+        for ($j = 0; $j < $cycles; $j++) {
+            $value = Rand::getInteger($min, $max);
+            $this->assertInternalType('integer', $value);
+            $this->assertGreaterThanOrEqual($min, $value);
+            $this->assertLessThanOrEqual($max, $value);
+            $counter[$value]++;
+        }
+
+        foreach ($counter as $value => $count) {
+            $this->assertGreaterThan(0, $count, sprintf('The bucket for value %d is empty.', $value));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestRandIntegerRangeTest()
+    {
+        return array(
+            array(0, 100, 10000),
+            array(-100, 100, 10000),
+            array(-100, 50, 10000),
+            array(0, 63, 10000),
+            array(0, 64, 10000),
+            array(0, 65, 10000),
+        );
+    }
+
+    /**
      * A Monte Carlo test that generates $cycles numbers from 0 to $tot
      * and test if the numbers are above or below the line y=x with a
      * frequency range of [$min, $max]

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Mime;
 
 use Zend\Mime;
+use Zend\Mail;
 
 /**
  * @group      Zend_Mime
@@ -123,5 +124,21 @@ EOD;
         $parts = $message->getParts();
         $test  = current($parts);
         $this->assertSame($part, $test);
+    }
+
+    /**
+     * @group ZF2-5962
+     */
+    public function testPassEmptyArrayIntoSetPartsShouldReturnEmptyString()
+    {
+        $mailMessage = new Mail\Message();
+        $mimeMessage = new Mime\Message();
+        $mimeMessage->setParts(array());
+
+        $mailMessage->setBody($mimeMessage);
+        $mailMessage->getBodyText();
+
+        $this->assertEquals('', $mimeMessage->generateMessage());
+        $this->assertEquals('', $mailMessage->getBodyText());
     }
 }

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Mime;
 
 use Zend\Mime;
-use Zend\Mail;
 
 /**
  * @group      Zend_Mime
@@ -131,13 +130,9 @@ EOD;
      */
     public function testPassEmptyArrayIntoSetPartsShouldReturnEmptyString()
     {
-        $mailMessage = new Mail\Message();
         $mimeMessage = new Mime\Message();
         $mimeMessage->setParts(array());
 
-        $mailMessage->setBody($mimeMessage);
-
         $this->assertEquals('', $mimeMessage->generateMessage());
-        $this->assertEquals('', $mailMessage->getBodyText());
     }
 }

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -136,7 +136,6 @@ EOD;
         $mimeMessage->setParts(array());
 
         $mailMessage->setBody($mimeMessage);
-        $mailMessage->getBodyText();
 
         $this->assertEquals('', $mimeMessage->generateMessage());
         $this->assertEquals('', $mailMessage->getBodyText());

--- a/tests/ZendTest/Mvc/Router/Http/RouteMatchTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/RouteMatchTest.php
@@ -53,7 +53,7 @@ class RouteMatchTest extends TestCase
         $this->assertEquals('bar/foo', $match->getMatchedRouteName());
     }
 
-    public function testMatchedRouteNameIsOverridenOnMerge()
+    public function testMatchedRouteNameIsOverriddenOnMerge()
     {
         $match = new RouteMatch(array());
         $match->setMatchedRouteName('foo');

--- a/tests/ZendTest/Paginator/Adapter/CallbackTest.php
+++ b/tests/ZendTest/Paginator/Adapter/CallbackTest.php
@@ -17,7 +17,7 @@ use Zend\Stdlib\CallbackHandler;
  */
 class CallbackTest extends \PHPUnit_Framework_TestCase
 {
-    public function testMustDefineTwoCallbacksOnContructor()
+    public function testMustDefineTwoCallbacksOnConstructor()
     {
         $itemsCallback = new CallbackHandler(function () {
             return array();
@@ -31,7 +31,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($countCallback, 'countCallback', $adapter);
     }
 
-    public function testShouldAcceptAnyCallableOnContructor()
+    public function testShouldAcceptAnyCallableOnConstructor()
     {
         $itemsCallback = function () {
             return range(1,  10);

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -22,6 +22,9 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
 
     public $cookieDateFormat = 'D, d-M-y H:i:s e';
 
+    /**
+     * @var SessionManager
+     */
     protected $manager;
 
     public function setUp()
@@ -535,4 +538,17 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($_SESSION['__ZF'], $metaData);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSessionValidationDoesNotHaltOnNoopListener()
+    {
+        $validator = $this->getMock('stdClass', array('__invoke'));
+
+        $validator->expects($this->once())->method('__invoke');
+
+        $this->manager->getValidatorChain()->attach('session.validate', $validator);
+
+        $this->assertTrue($this->manager->isValid());
+    }
 }

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -975,6 +975,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server->setOptions(array('location'=>'test://', 'uri'=>'http://framework.zend.com'));
         $server->setReturnResponse(true);
         $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass');
+        $loadEntities = libxml_disable_entity_loader(false);
 
         // Doing a request that is guaranteed to cause an exception in Server::_setRequest():
         $invalidRequest = '---';
@@ -985,5 +986,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         // The "disable entity loader" setting should be restored to "false" after the exception is raised:
         $this->assertFalse(libxml_disable_entity_loader());
+
+        // Cleanup; restoring original setting:
+        libxml_disable_entity_loader($loadEntities);
     }
 }

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -968,4 +968,22 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\SoapServer', $internalServer);
         $this->assertSame($internalServer, $server->getSoap());
     }
+
+    public function testDisableEntityLoaderAfterException()
+    {
+        $server = new Server();
+        $server->setOptions(array('location'=>'test://', 'uri'=>'http://framework.zend.com'));
+        $server->setReturnResponse(true);
+        $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass');
+
+        // Doing a request that is guaranteed to cause an exception in Server::_setRequest():
+        $invalidRequest = '---';
+        $response = @$server->handle($invalidRequest);
+
+        // Sanity check; making sure that an exception has been triggered:
+        $this->assertInstanceOf('\SoapFault', $response);
+
+        // The "disable entity loader" setting should be restored to "false" after the exception is raised:
+        $this->assertFalse(libxml_disable_entity_loader());
+    }
 }

--- a/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategyTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\NamingStrategy;
+
+use Zend\Stdlib\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
+
+/**
+ * Unit tests for {@see \Zend\Stdlib\Hydrator\NamingStrategy\UnderscoreNamingStrategy}
+ *
+ * @covers \Zend\Stdlib\Hydrator\NamingStrategy\UnderscoreNamingStrategy
+ * @group Zend_Stdlib
+ */
+class UnderscoreNamingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNameHydratesToCamelCase()
+    {
+        $strategy = new UnderscoreNamingStrategy();
+        $this->assertEquals('fooBarBaz', $strategy->hydrate('foo_bar_baz'));
+    }
+
+    public function testNameExtractsToUnderscore()
+    {
+        $strategy = new UnderscoreNamingStrategy();
+        $this->assertEquals('foo_bar_baz', $strategy->extract('fooBarBaz'));
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategyTest.php
@@ -15,7 +15,6 @@ use Zend\Stdlib\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
  * Unit tests for {@see \Zend\Stdlib\Hydrator\NamingStrategy\UnderscoreNamingStrategy}
  *
  * @covers \Zend\Stdlib\Hydrator\NamingStrategy\UnderscoreNamingStrategy
- * @group Zend_Stdlib
  */
 class UnderscoreNamingStrategyTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormaterStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormaterStrategyTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\Strategy;
+
+use Zend\Stdlib\Hydrator\Strategy\DateTimeFormaterStrategy;
+
+class DateTimeFormaterStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHydrate()
+    {
+        $strategy = new DateTimeFormaterStrategy;
+        $this->assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
+    }
+
+    public function testExtract()
+    {
+        $strategy = new DateTimeFormaterStrategy('d/m/Y');
+        $this->assertEquals('26/04/2014', $strategy->extract(new \DateTime('2014-04-26')));
+    }
+
+    public function testGetNullWithInvalidDateOnHydration()
+    {
+        $strategy = new DateTimeFormaterStrategy;
+        $this->assertEquals(null, $strategy->hydrate(null));
+        $this->assertEquals(null, $strategy->hydrate(''));
+    }
+}

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
@@ -27,7 +27,7 @@ class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testGetNullWithInvalidDateOnHydration()
     {
-        $strategy = new DateTimeFormatterStrategy;
+        $strategy = new DateTimeFormatterStrategy('Y-m-d');
         $this->assertEquals(null, $strategy->hydrate(null));
         $this->assertEquals(null, $strategy->hydrate(''));
     }

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
@@ -15,7 +15,7 @@ class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
 {
     public function testHydrate()
     {
-        $strategy = new DateTimeFormatterStrategy;
+        $strategy = new DateTimeFormatterStrategy('Y-m-d');
         $this->assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
     }
 

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
@@ -9,25 +9,25 @@
 
 namespace ZendTest\Stdlib\Hydrator\Strategy;
 
-use Zend\Stdlib\Hydrator\Strategy\DateTimeFormaterStrategy;
+use Zend\Stdlib\Hydrator\Strategy\DateTimeFormatterStrategy;
 
-class DateTimeFormaterStrategyTest extends \PHPUnit_Framework_TestCase
+class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
 {
     public function testHydrate()
     {
-        $strategy = new DateTimeFormaterStrategy;
+        $strategy = new DateTimeFormatterStrategy;
         $this->assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
     }
 
     public function testExtract()
     {
-        $strategy = new DateTimeFormaterStrategy('d/m/Y');
+        $strategy = new DateTimeFormatterStrategy('d/m/Y');
         $this->assertEquals('26/04/2014', $strategy->extract(new \DateTime('2014-04-26')));
     }
 
     public function testGetNullWithInvalidDateOnHydration()
     {
-        $strategy = new DateTimeFormaterStrategy;
+        $strategy = new DateTimeFormatterStrategy;
         $this->assertEquals(null, $strategy->hydrate(null));
         $this->assertEquals(null, $strategy->hydrate(''));
     }

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
@@ -31,4 +31,10 @@ class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $strategy->hydrate(null));
         $this->assertEquals(null, $strategy->hydrate(''));
     }
+
+    public function testGetNullWithNullDateOnExtraction()
+    {
+        $strategy = new DateTimeFormatterStrategy('Y-m-d');
+        $this->assertEquals(null, $strategy->extract(null));
+    }
 }

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -23,11 +23,16 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $origEncoding;
+
     public function setUp()
     {
-        $this->origEncoding = iconv_get_encoding('internal_encoding');
+        $this->origEncoding = PHP_VERSION_ID < 50600
+            ? iconv_get_encoding('internal_encoding')
+            : ini_get('default_charset');
         $this->validator = new Hostname();
     }
 
@@ -36,7 +41,11 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     public function tearDown()
     {
-        iconv_set_encoding('internal_encoding', $this->origEncoding);
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', $this->origEncoding);
+        } else {
+            ini_set('default_charset', $this->origEncoding);
+        }
     }
 
     /**
@@ -345,7 +354,12 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     public function testDifferentIconvEncoding()
     {
-        iconv_set_encoding('internal_encoding', 'ISO8859-1');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', 'ISO8859-1');
+        } else {
+            ini_set('default_charset', 'ISO8859-1');
+        }
+
         $validator = new Hostname();
 
         $valuesExpected = array(

--- a/tests/ZendTest/Validator/StringLengthTest.php
+++ b/tests/ZendTest/Validator/StringLengthTest.php
@@ -38,7 +38,12 @@ class StringLengthTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasic()
     {
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('default_charset', 'UTF-8');
+        }
+
         /**
          * The elements of each array are, in order:
          *      - minimum length
@@ -128,7 +133,12 @@ class StringLengthTest extends \PHPUnit_Framework_TestCase
      */
     public function testDifferentEncodingWithValidator()
     {
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('default_charset', 'UTF-8');
+        }
+
         $validator = new StringLength(2, 2, 'UTF-8');
         $this->assertEquals(true, $validator->isValid('ab'));
 


### PR DESCRIPTION
## Use Case:

Here's is an example:

``` php
class User
{
    protected $registrationDate;

    public function setRegistrationDate(DateTime $registrationDate)
    {
        $this-> registrationDate = $registrationDate;
    }

    public function getRegistrationDate()
    {
        return $this->registrationDate;
    }
}

$user = new User;

$hydrator = new Zend\Stdlib\Hydrator\ClassMethods;
$strategy = new Zend\Stdlib\Hydrator\Strategy\DateTimeFormaterStrategy('Y-m-d');
$hydrator->addStrategy('registration_date', $strategy);
$hydrator->hydrate(array('registration_date' => '2014-04-26'), $user);

echo $user->getRegistrationDate()->format('Y-m-d'); // will print 2014-04-26
echo $hydrator->extract($user)['registration_date']; // will print 2014-04-26
```
