### PR TITLE
Fix: Exceptions raised in Soap/Server can leave XML entity loader disabled.

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -750,6 +750,8 @@ class Server implements ZendServerServer
             $dom = new DOMDocument();
             $loadStatus = $dom->loadXML($xml);
 
+            libxml_disable_entity_loader(false);
+
             // @todo check libxml errors ? validate document ?
             if (strlen($xml) == 0 || !$loadStatus) {
                 throw new Exception\InvalidArgumentException('Invalid XML');
@@ -760,7 +762,6 @@ class Server implements ZendServerServer
                     throw new Exception\InvalidArgumentException('Invalid XML: Detected use of illegal DOCTYPE');
                 }
             }
-            libxml_disable_entity_loader(false);
         }
 
         $this->request = $xml;

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -745,12 +745,12 @@ class Server implements ZendServerServer
             }
             $xml = trim($xml);
 
-            libxml_disable_entity_loader(true);
+            $loadEntities = libxml_disable_entity_loader(true);
 
             $dom = new DOMDocument();
             $loadStatus = $dom->loadXML($xml);
 
-            libxml_disable_entity_loader(false);
+            libxml_disable_entity_loader($loadEntities);
 
             // @todo check libxml errors ? validate document ?
             if (strlen($xml) == 0 || !$loadStatus) {

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -975,6 +975,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server->setOptions(array('location'=>'test://', 'uri'=>'http://framework.zend.com'));
         $server->setReturnResponse(true);
         $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass');
+        $loadEntities = libxml_disable_entity_loader(false);
 
         // Doing a request that is guaranteed to cause an exception in Server::_setRequest():
         $invalidRequest = '---';
@@ -985,5 +986,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         // The "disable entity loader" setting should be restored to "false" after the exception is raised:
         $this->assertFalse(libxml_disable_entity_loader());
+
+        // Cleanup; restoring original setting:
+        libxml_disable_entity_loader($loadEntities);
     }
 }

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -968,4 +968,22 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\SoapServer', $internalServer);
         $this->assertSame($internalServer, $server->getSoap());
     }
+
+    public function testDisableEntityLoaderAfterException()
+    {
+        $server = new Server();
+        $server->setOptions(array('location'=>'test://', 'uri'=>'http://framework.zend.com'));
+        $server->setReturnResponse(true);
+        $server->setClass('\ZendTest\Soap\TestAsset\ServerTestClass');
+
+        // Doing a request that is guaranteed to cause an exception in Server::_setRequest():
+        $invalidRequest = '---';
+        $response = @$server->handle($invalidRequest);
+
+        // Sanity check; making sure that an exception has been triggered:
+        $this->assertInstanceOf('\SoapFault', $response);
+
+        // The "disable entity loader" setting should be restored to "false" after the exception is raised:
+        $this->assertFalse(libxml_disable_entity_loader());
+    }
 }


### PR DESCRIPTION
- The original `libxml_disable_entity_loader()` setting was not restored when an exception was raised in `\Zend\Soap\Server::_setRequest()`.
- This caused funny behaviour for subsequent requests which are processed by the same Apache process (also see https://bugs.php.net/bug.php?id=64938 for example).
- Fixed by moving the `libxml_disable_entity_loader()` "cleanup call" a bit further up.
- And instead of forcing entity loading to "false", the previous setting is saved and restored.
- Added a unittest for the intended behaviour.
