### PR TITLE
#6218 - applying hotfix for `iconv.internal_encoding` deprecation

### DIFF
--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -197,9 +197,13 @@ class Client implements ServerClient
     {
         $this->lastRequest = $request;
 
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('default_charset', 'UTF-8');
+        }
 
         $http        = $this->getHttpClient();
         $httpRequest = $http->getRequest();

--- a/tests/ZendTest/Validator/HostnameTest.php
+++ b/tests/ZendTest/Validator/HostnameTest.php
@@ -23,11 +23,16 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $origEncoding;
+
     public function setUp()
     {
-        $this->origEncoding = iconv_get_encoding('internal_encoding');
+        $this->origEncoding = PHP_VERSION_ID < 50600
+            ? iconv_get_encoding('internal_encoding')
+            : ini_get('default_charset');
         $this->validator = new Hostname();
     }
 
@@ -36,7 +41,11 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     public function tearDown()
     {
-        iconv_set_encoding('internal_encoding', $this->origEncoding);
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', $this->origEncoding);
+        } else {
+            ini_set('default_charset', $this->origEncoding);
+        }
     }
 
     /**
@@ -345,7 +354,12 @@ class HostnameTest extends \PHPUnit_Framework_TestCase
      */
     public function testDifferentIconvEncoding()
     {
-        iconv_set_encoding('internal_encoding', 'ISO8859-1');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', 'ISO8859-1');
+        } else {
+            ini_set('default_charset', 'ISO8859-1');
+        }
+
         $validator = new Hostname();
 
         $valuesExpected = array(

--- a/tests/ZendTest/Validator/StringLengthTest.php
+++ b/tests/ZendTest/Validator/StringLengthTest.php
@@ -38,7 +38,12 @@ class StringLengthTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasic()
     {
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('default_charset', 'UTF-8');
+        }
+
         /**
          * The elements of each array are, in order:
          *      - minimum length
@@ -128,7 +133,12 @@ class StringLengthTest extends \PHPUnit_Framework_TestCase
      */
     public function testDifferentEncodingWithValidator()
     {
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('default_charset', 'UTF-8');
+        }
+
         $validator = new StringLength(2, 2, 'UTF-8');
         $this->assertEquals(true, $validator->isValid('ab'));
 


### PR DESCRIPTION
Fixes #6218

See https://wiki.php.net/rfc/default_encoding

> PHP 5.6 and master, introduce new php.ini setting. Old iconv._/mbstring._ php.ini parameters will be removed for master PHP6. Use of iconv._/mbstring._ php.ini parameters raise E_DEPRECATED for 5.6 and up.
