### PR TITLE
Fix double registration of a complex type

### DIFF
--- a/library/Zend/Soap/Wsdl/ComplexTypeStrategy/DefaultComplexType.php
+++ b/library/Zend/Soap/Wsdl/ComplexTypeStrategy/DefaultComplexType.php
@@ -32,19 +32,19 @@ class DefaultComplexType extends AbstractComplexTypeStrategy
             ));
         }
 
-        if (($soapType = $this->scanRegisteredTypes($type)) !== null) {
+        $class = new ReflectionClass($type);
+        $phpType = $class->getName();
+
+        if (($soapType = $this->scanRegisteredTypes($phpType)) !== null) {
             return $soapType;
         }
 
         $dom = $this->getContext()->toDomDocument();
-        $class = new ReflectionClass($type);
-
-        $soapTypeName = $this->getContext()->translateType($type);
+        $soapTypeName = $this->getContext()->translateType($phpType);
         $soapType     = Wsdl::TYPES_NS . ':' . $soapTypeName;
 
         // Register type here to avoid recursion
-        $this->getContext()->addType($type, $soapType);
-
+        $this->getContext()->addType($phpType, $soapType);
 
         $defaultProperties = $class->getDefaultProperties();
 

--- a/tests/ZendTest/Soap/Wsdl/DefaultComplexTypeTest.php
+++ b/tests/ZendTest/Soap/Wsdl/DefaultComplexTypeTest.php
@@ -49,4 +49,14 @@ class DefaultComplexTypeTest extends WsdlTestHelper
 
         $this->testDocumentNodes();
     }
+
+    public function testDoubleClassesAreDiscoveredByStrategy() {
+        $this->strategy->addComplexType('ZendTest\Soap\TestAsset\WsdlTestClass');
+        $this->strategy->addComplexType('\ZendTest\Soap\TestAsset\WsdlTestClass');
+
+        $nodes = $this->xpath->query('//xsd:complexType[@name="WsdlTestClass"]');
+        $this->assertEquals(1, $nodes->length);
+
+        $this->testDocumentNodes();
+    }
 }

--- a/tests/ZendTest/Soap/WsdlTest.php
+++ b/tests/ZendTest/Soap/WsdlTest.php
@@ -668,7 +668,7 @@ class WsdlTest extends WsdlTestHelper
         $this->wsdl->addComplexType('\ZendTest\Soap\TestAsset\WsdlTestClass');
         $this->assertEquals(
             array(
-                '\ZendTest\Soap\TestAsset\WsdlTestClass' => 'tns:WsdlTestClass'
+                'ZendTest\Soap\TestAsset\WsdlTestClass' => 'tns:WsdlTestClass'
             ),
             $this->wsdl->getTypes()
         );
@@ -676,7 +676,7 @@ class WsdlTest extends WsdlTestHelper
         $this->wsdl->addComplexType('\ZendTest\Soap\TestAsset\WsdlTestClass');
         $this->assertEquals(
             array(
-                '\ZendTest\Soap\TestAsset\WsdlTestClass' => 'tns:WsdlTestClass'
+                'ZendTest\Soap\TestAsset\WsdlTestClass' => 'tns:WsdlTestClass'
             ),
             $this->wsdl->getTypes()
         );


### PR DESCRIPTION
Zend\Soap\Wsdl\ComplexTypeStrategy\DefaultComplexType::addComplexType()
stores already added classes under the methods argument `$type`.

Therefore a class with preceding backslash is treated like another complextype
than the same class without given backslash. As a result the xsd:ComplexType
definition is found twice (with exactly the same name) in the generated wsdl.
