### PR TITLE
Created BooleanStrategy for Hydrator

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Strategy/BooleanStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/BooleanStrategy.php
@@ -9,10 +9,10 @@
 
 namespace Zend\Stdlib\Hydrator\Strategy;
 
-
 use Zend\Stdlib\Exception\InvalidArgumentException;
 
-class BooleanStrategy implements StrategyInterface {
+class BooleanStrategy implements StrategyInterface
+{
     /**
      * @var int|string
      */
@@ -32,9 +32,9 @@ class BooleanStrategy implements StrategyInterface {
     /**
      * Converts the given value so that it can be extracted by the hydrator.
      *
-     * @param mixed $value The original value.
-     * @param object $object (optional) The original object for context.
-     * @return mixed Returns the value that should be extracted.
+     * @param  mixed  $value  The original value.
+     * @param  object $object (optional) The original object for context.
+     * @return mixed  Returns the value that should be extracted.
      */
     public function extract($value)
     {
@@ -55,8 +55,8 @@ class BooleanStrategy implements StrategyInterface {
     /**
      * Converts the given value so that it can be hydrated by the hydrator.
      *
-     * @param mixed $value The original value.
-     * @param array $data (optional) The original data for context.
+     * @param  mixed $value The original value.
+     * @param  array $data  (optional) The original data for context.
      * @return mixed Returns the value that should be hydrated.
      */
     public function hydrate($value)
@@ -98,4 +98,4 @@ class BooleanStrategy implements StrategyInterface {
     {
         return $this->falseValue;
     }
-} 
+}

--- a/library/Zend/Stdlib/Hydrator/Strategy/BooleanStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/BooleanStrategy.php
@@ -49,14 +49,7 @@ class BooleanStrategy implements StrategyInterface {
             return $this->getTrueValue();
         }
 
-        if ($value == false) {
-            return $this->getFalseValue();
-        }
-
-        throw new InvalidArgumentException(sprintf(
-            'Unexpected value %s can\'t be extracted',
-            $value
-        ));
+        return $this->getFalseValue();
     }
 
     /**
@@ -71,7 +64,7 @@ class BooleanStrategy implements StrategyInterface {
 
         if (!is_string($value) && !is_int($value)) {
             throw new InvalidArgumentException(sprintf(
-                'Unable to extract. Expected string or int. %s was given.',
+                'Unable to hydrate. Expected string or int. %s was given.',
                 is_object($value) ? get_class($value) : gettype($value)
             ));
         }

--- a/library/Zend/Stdlib/Hydrator/Strategy/BooleanStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/BooleanStrategy.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Hydrator\Strategy;
+
+
+use Zend\Stdlib\Exception\InvalidArgumentException;
+
+class BooleanStrategy implements StrategyInterface {
+    /**
+     * @var int|string
+     */
+    protected $trueValue;
+
+    /**
+     * @var int|string
+     */
+    protected $falseValue;
+
+    public function __construct($trueValue, $falseValue)
+    {
+        $this->trueValue = $trueValue;
+        $this->falseValue = $falseValue;
+    }
+
+    /**
+     * Converts the given value so that it can be extracted by the hydrator.
+     *
+     * @param mixed $value The original value.
+     * @param object $object (optional) The original object for context.
+     * @return mixed Returns the value that should be extracted.
+     */
+    public function extract($value)
+    {
+        if (is_object($value) || !is_bool($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unable to extract. Expected bool. %s was given.',
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+
+        if ($value == true) {
+            return $this->getTrueValue();
+        }
+
+        if ($value == false) {
+            return $this->getFalseValue();
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Unexpected value %s can\'t be extracted',
+            $value
+        ));
+    }
+
+    /**
+     * Converts the given value so that it can be hydrated by the hydrator.
+     *
+     * @param mixed $value The original value.
+     * @param array $data (optional) The original data for context.
+     * @return mixed Returns the value that should be hydrated.
+     */
+    public function hydrate($value)
+    {
+
+        if (!is_string($value) && !is_int($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unable to extract. Expected string or int. %s was given.',
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+
+        if ($value == $this->getTrueValue()) {
+            return true;
+        }
+
+        if ($value == $this->getFalseValue()) {
+            return false;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Unexpected value %s can\'t be hydrated',
+            $value
+        ));
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getTrueValue()
+    {
+        return $this->trueValue;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getFalseValue()
+    {
+        return $this->falseValue;
+    }
+} 

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/BooleanStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/BooleanStrategyTest.php
@@ -29,16 +29,9 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase {
 
     public function testExtractThrowsExceptionOnWrongParameter()
     {
-        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException', 'Unable to extract');
         $hydrator = new BooleanStrategy(1, 0);
         $hydrator->extract(5);
-    }
-
-    public function testExtractInvalidArgumentException()
-    {
-        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
-        $hydrator = new BooleanStrategy(1, 0);
-        $hydrator->extract(new \stdClass());
     }
 
     public function testHydrateString()
@@ -57,14 +50,14 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase {
 
     public function testHydrateUnexpectedValueThrowsException()
     {
-        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException', 'Unexpected value');
         $hydrator = new BooleanStrategy(1, 0);
         $hydrator->hydrate(2);
     }
 
     public function testHydrateInvalidArgument()
     {
-        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException', 'Unable to hydrate');
         $hydrator = new BooleanStrategy(1, 0);
         $hydrator->hydrate(new \stdClass());
     }

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/BooleanStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/BooleanStrategyTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\Strategy;
+
+
+use Zend\Stdlib\Hydrator\Strategy\BooleanStrategy;
+
+class BooleanStrategyTest extends \PHPUnit_Framework_TestCase {
+    public function testExtractString()
+    {
+        $hydrator = new BooleanStrategy('true', 'false');
+        $this->assertEquals('true', $hydrator->extract(true));
+        $this->assertEquals('false', $hydrator->extract(false));
+    }
+
+    public function testExtractInteger()
+    {
+        $hydrator = new BooleanStrategy(1, 0);
+        $this->assertEquals(1, $hydrator->extract(true));
+        $this->assertEquals(0, $hydrator->extract(false));
+    }
+
+    public function testExtractThrowsExceptionOnWrongParameter()
+    {
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $hydrator = new BooleanStrategy(1, 0);
+        $hydrator->extract(5);
+    }
+
+    public function testExtractInvalidArgumentException()
+    {
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $hydrator = new BooleanStrategy(1, 0);
+        $hydrator->extract(new \stdClass());
+    }
+
+    public function testHydrateString()
+    {
+        $hydrator = new BooleanStrategy('true', 'false');
+        $this->assertEquals(true, $hydrator->hydrate('true'));
+        $this->assertEquals(false, $hydrator->hydrate('false'));
+    }
+
+    public function testHydrateInteger()
+    {
+        $hydrator = new BooleanStrategy(1, 0);
+        $this->assertEquals(true, $hydrator->hydrate(1));
+        $this->assertEquals(false, $hydrator->hydrate(0));
+    }
+
+    public function testHydrateUnexpectedValueThrowsException()
+    {
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $hydrator = new BooleanStrategy(1, 0);
+        $hydrator->hydrate(2);
+    }
+
+    public function testHydrateInvalidArgument()
+    {
+        $this->setExpectedException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $hydrator = new BooleanStrategy(1, 0);
+        $hydrator->hydrate(new \stdClass());
+    }
+}
+ 

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/BooleanStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/BooleanStrategyTest.php
@@ -9,10 +9,10 @@
 
 namespace ZendTest\Stdlib\Hydrator\Strategy;
 
-
 use Zend\Stdlib\Hydrator\Strategy\BooleanStrategy;
 
-class BooleanStrategyTest extends \PHPUnit_Framework_TestCase {
+class BooleanStrategyTest extends \PHPUnit_Framework_TestCase
+{
     public function testExtractString()
     {
         $hydrator = new BooleanStrategy('true', 'false');
@@ -62,4 +62,3 @@ class BooleanStrategyTest extends \PHPUnit_Framework_TestCase {
         $hydrator->hydrate(new \stdClass());
     }
 }
- 


### PR DESCRIPTION
With this Strategy strings and integers will be converted to Boolean  values.

For Example:

``` php
$hydrator = new BooleanStrategy('true', 'false');
$hydrator->extract(true); // Will return 'true'
$hydrator->hydrate('false'); // will return bool(false)
```

More examples included in Unit Test.
