### PR TITLE
Fix parameter format causing duplicate mails

### DIFF
--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -248,7 +248,7 @@ class Sendmail implements TransportInterface
 
         $sender = $message->getSender();
         if ($sender instanceof AddressInterface) {
-            $parameters .= ' -f ' . $sender->getEmail();
+            $parameters .= ' -f' . $sender->getEmail();
             return $parameters;
         }
 
@@ -256,7 +256,7 @@ class Sendmail implements TransportInterface
         if (count($from)) {
             $from->rewind();
             $sender      = $from->current();
-            $parameters .= ' -f ' . $sender->getEmail();
+            $parameters .= ' -f' . $sender->getEmail();
             return $parameters;
         }
 

--- a/tests/ZendTest/Mail/Transport/SendmailTest.php
+++ b/tests/ZendTest/Mail/Transport/SendmailTest.php
@@ -85,7 +85,7 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains("From: zf-devteam@zend.com,\n Matthew <matthew@zend.com>\n", $this->additional_headers);
         $this->assertContains("X-Foo-Bar: Matthew\n", $this->additional_headers);
         $this->assertContains("Sender: Ralph Schindler <ralph.schindler@zend.com>\n", $this->additional_headers);
-        $this->assertEquals('-R hdrs -f ralph.schindler@zend.com', $this->additional_parameters);
+        $this->assertEquals('-R hdrs -fralph.schindler@zend.com', $this->additional_parameters);
     }
 
     public function testReceivesMailArtifactsOnWindowsSystems()


### PR DESCRIPTION
Recently I've experienced mails not only send to the recipient but also to the sender when using the sendmail transport. After consulting my hosting company they told me there shouldn't been a space between "-f" and the envelope sender address. Removing the space character fixed the problem. No more duplicated mails.

Furthermore I tested Swiftmailer and its sendmail transport layer. I had no problems with it.

Looking at the php docs there isn't a space character either, see http://www.php.net/manual/en/function.mail.php#example-3471. Furthermore I found http://stackoverflow.com/questions/4205228/basic-mail-function-php-additional-f-parameter-question and consulted the sendmail docs http://www.sendmail.org/~ca/email/man/sendmail.html.

However, there are other examples around with a space character: http://stackoverflow.com/questions/179014/how-to-change-envelope-from-address-using-php-mail. Are they wrong?

Since I'm not familiar with sendmail but actually trusting my hosting company I'm proposing to remove the space character.
