### PR TITLE
fixing http query parameters

### DIFF
--- a/library/Zend/Crypt/Key/Derivation/SaltedS2k.php
+++ b/library/Zend/Crypt/Key/Derivation/SaltedS2k.php
@@ -53,7 +53,7 @@ class SaltedS2k
     public static function calc($hash, $password, $salt, $bytes)
     {
         if (!in_array($hash, array_keys(static::$supportedMhashAlgos))) {
-            throw new Exception\InvalidArgumentException("The hash algorihtm $hash is not supported by " . __CLASS__);
+            throw new Exception\InvalidArgumentException("The hash algorithm $hash is not supported by " . __CLASS__);
         }
         if (strlen($salt)<8) {
             throw new Exception\InvalidArgumentException('The salt size must be at least of 8 bytes');

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -831,7 +831,7 @@ class Client implements Stdlib\DispatchableInterface
 
                 if (!empty($queryArray)) {
                     $newUri = $uri->toString();
-                    $queryString = http_build_query($query, null, $this->getArgSeparator());
+                    $queryString = http_build_query($queryArray, null, $this->getArgSeparator());
 
                     if ($this->config['rfc3986strict']) {
                         $queryString = str_replace('+', '%20', $queryString);

--- a/library/Zend/Mvc/Controller/AbstractConsoleController.php
+++ b/library/Zend/Mvc/Controller/AbstractConsoleController.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Mvc\Controller;
 
-use Zend\Console\Adapter\AdapterInterface as ConsoleAdaper;
+use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
 use Zend\Console\Request as ConsoleRequest;
 use Zend\Mvc\Exception\InvalidArgumentException;
 use Zend\Stdlib\RequestInterface;
@@ -18,15 +18,15 @@ use Zend\Stdlib\ResponseInterface;
 class AbstractConsoleController extends AbstractActionController
 {
     /**
-     * @var ConsoleAdaper
+     * @var ConsoleAdapter
      */
     protected $console;
 
     /**
-     * @param ConsoleAdaper $console
+     * @param ConsoleAdapter $console
      * @return self
      */
-    public function setConsole(ConsoleAdaper $console)
+    public function setConsole(ConsoleAdapter $console)
     {
         $this->console = $console;
 
@@ -34,7 +34,7 @@ class AbstractConsoleController extends AbstractActionController
     }
 
     /**
-     * @return ConsoleAdaper
+     * @return ConsoleAdapter
      */
     public function getConsole()
     {

--- a/tests/ZendTest/Crypt/Key/Derivation/SaltedS2kTest.php
+++ b/tests/ZendTest/Crypt/Key/Derivation/SaltedS2kTest.php
@@ -43,7 +43,7 @@ class SaltedS2kTest extends \PHPUnit_Framework_TestCase
             return;
         }
         $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException',
-                                    'The hash algorihtm wrong is not supported by Zend\Crypt\Key\Derivation\SaltedS2k');
+                                    'The hash algorithm wrong is not supported by Zend\Crypt\Key\Derivation\SaltedS2k');
         $password = SaltedS2k::calc('wrong', 'test', $this->salt, 32);
     }
 


### PR DESCRIPTION
Zend\Stdlib\Parameters is not converted to PHP array in HHVM
