### PR TITLE
ModuleManager load module childs dependents

### DIFF
--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -61,7 +61,7 @@ class ModuleManager implements ModuleManagerInterface
     /**
      * @var ModuleEvent
      */
-    protected $loadEvent = null;
+    protected $loadEvent;
 
     /**
      * True if modules have already been loaded
@@ -120,9 +120,11 @@ class ModuleManager implements ModuleManagerInterface
     public function onLoadChildsModules(ModuleEvent $e)
     {
         $parentModule = $this->loadEvent->getModuleName();
+
         if (!isset($this->childsModules[$parentModule])) {
             return;
         }
+
         foreach($this->childsModules[$parentModule] as $module) {
             $this->loadModule($module);
         }
@@ -187,7 +189,7 @@ class ModuleManager implements ModuleManagerInterface
          * loadModule() call, and use the original event otherwise.
          */
 
-        if ($this->loadFinished > 0 && $afterCurrent) {
+        if ($this->loadFinished > 0 && $this->loadEvent && $afterCurrent) {
             $parentModule = $this->loadEvent->getModuleName();
             $childModule = is_object($module)
                     ? array($moduleName=>$module)

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -59,6 +59,11 @@ class ModuleManager implements ModuleManagerInterface
     protected $childsModules = array();
 
     /**
+     * @var ModuleEvent
+     */
+    protected $loadEvent = null;
+
+    /**
      * True if modules have already been loaded
      *
      * @var bool
@@ -114,13 +119,14 @@ class ModuleManager implements ModuleManagerInterface
      */
     public function onLoadChildsModules(ModuleEvent $e)
     {
-        if (!isset($this->childsModules[$e->getModuleName()])) {
+        $parentModule = $this->loadEvent->getModuleName();
+        if (!isset($this->childsModules[$parentModule])) {
             return;
         }
-        foreach($this->childsModules[$e->getModuleName()] as $module) {
+        foreach($this->childsModules[$parentModule] as $module) {
             $this->loadModule($module);
         }
-        unset($this->childsModules[$e->getModuleName()]);
+        unset($this->childsModules[$parentModule]);
     }
 
     /**
@@ -182,7 +188,7 @@ class ModuleManager implements ModuleManagerInterface
          */
 
         if ($this->loadFinished > 0 && $afterCurrent) {
-            $parentModule = $this->getEvent()->getModuleName();
+            $parentModule = $this->loadEvent->getModuleName();
             $childModule = is_object($module)
                     ? array($moduleName=>$module)
                     : $moduleName;
@@ -200,6 +206,7 @@ class ModuleManager implements ModuleManagerInterface
         $event->setModule($module);
 
         $this->loadedModules[$moduleName] = $module;
+        $this->loadEvent = $event;
         $this->getEventManager()->trigger(ModuleEvent::EVENT_LOAD_MODULE, $this, $event);
 
         $this->loadFinished--;

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -158,7 +158,7 @@ class ModuleManager implements ModuleManagerInterface
      * @triggers loadModule
      * @return mixed Module's Module class
      */
-    public function loadModule($module, $isChild = false)
+    public function loadModule($module, $afterCurrent = false)
     {
         $moduleName = $module;
         if (is_array($module)) {
@@ -181,7 +181,7 @@ class ModuleManager implements ModuleManagerInterface
          * loadModule() call, and use the original event otherwise.
          */
 
-        if ($this->loadFinished > 0 && $isChild) {
+        if ($this->loadFinished > 0 && $afterCurrent) {
             $parentModule = $this->getEvent()->getModuleName();
             $childModule = is_object($module)
                     ? array($moduleName=>$module)

--- a/tests/ZendTest/ModuleManager/Listener/ConfigListenerTest.php
+++ b/tests/ZendTest/ModuleManager/Listener/ConfigListenerTest.php
@@ -375,12 +375,12 @@ class ConfigListenerTest extends TestCase
         $configListener = new ConfigListener;
 
         $moduleManager = $this->moduleManager;
-        $this->assertEquals(2, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(3, count($moduleManager->getEventManager()->getEvents()));
 
         $configListener->attach($moduleManager->getEventManager());
         $this->assertEquals(4, count($moduleManager->getEventManager()->getEvents()));
 
         $configListener->detach($moduleManager->getEventManager());
-        $this->assertEquals(2, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(3, count($moduleManager->getEventManager()->getEvents()));
     }
 }

--- a/tests/ZendTest/ModuleManager/Listener/DefaultListenerAggregateTest.php
+++ b/tests/ZendTest/ModuleManager/Listener/DefaultListenerAggregateTest.php
@@ -83,6 +83,7 @@ class DefaultListenerAggregateTest extends TestCase
                 'Zend\ModuleManager\Listener\OnBootstrapListener',
                 'Zend\ModuleManager\Listener\ConfigListener',
                 'Zend\ModuleManager\Listener\LocatorRegistrationListener',
+                'Zend\ModuleManager\ModuleManager',
             ),
         );
         foreach ($expectedEvents as $event => $expectedListeners) {
@@ -105,12 +106,12 @@ class DefaultListenerAggregateTest extends TestCase
         $listenerAggregate = new DefaultListenerAggregate;
         $moduleManager     = new ModuleManager(array('ListenerTestModule'));
 
-        $this->assertEquals(1, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(2, count($moduleManager->getEventManager()->getEvents()));
 
         $listenerAggregate->attach($moduleManager->getEventManager());
         $this->assertEquals(4, count($moduleManager->getEventManager()->getEvents()));
 
         $listenerAggregate->detach($moduleManager->getEventManager());
-        $this->assertEquals(1, count($moduleManager->getEventManager()->getEvents()));
+        $this->assertEquals(2, count($moduleManager->getEventManager()->getEvents()));
     }
 }

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -270,6 +270,11 @@ class ModuleManagerTest extends TestCase
         $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
         $moduleManager->loadModules();
 
+        $this->assertSame(
+            array('LoadChildsModule', 'LoadChildsModule2', 'BarModule', 'SomeModule'),
+            array_keys($moduleManager->getLoadedModules())
+        );
+
         $config = $configListener->getMergedConfig(false);
         $this->assertArrayHasKey('bar', $config);
         $this->assertSame('foo', $config['bar']);

--- a/tests/ZendTest/ModuleManager/ModuleManagerTest.php
+++ b/tests/ZendTest/ModuleManager/ModuleManagerTest.php
@@ -262,4 +262,18 @@ class ModuleManagerTest extends TestCase
         $this->setExpectedException('Zend\ModuleManager\Exception\RuntimeException');
         $moduleManager->loadModules();
     }
+
+    public function testLoadChildsModules()
+    {
+        $configListener = $this->defaultListeners->getConfigListener();
+        $moduleManager  = new ModuleManager(array('LoadChildsModule'));
+        $moduleManager->getEventManager()->attachAggregate($this->defaultListeners);
+        $moduleManager->loadModules();
+
+        $config = $configListener->getMergedConfig(false);
+        $this->assertArrayHasKey('bar', $config);
+        $this->assertSame('foo', $config['bar']);
+        $this->assertArrayHasKey('some', $config);
+        $this->assertSame('thing', $config['some']);
+    }
 }

--- a/tests/ZendTest/ModuleManager/TestAsset/LoadChildsModule/Module.php
+++ b/tests/ZendTest/ModuleManager/TestAsset/LoadChildsModule/Module.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace LoadChildsModule;
+
+
+class Module
+{
+    public function init($moduleManager)
+    {
+        $moduleManager->loadModule('BarModule', 'after');
+        $moduleManager->loadModule(array('SomeModule' => new \SomeModule\Module()), 'after');
+    }
+
+    public function getConfig()
+    {
+        return array(
+            'bar' => 'SubModule',
+        );
+    }
+}

--- a/tests/ZendTest/ModuleManager/TestAsset/LoadChildsModule2/Module.php
+++ b/tests/ZendTest/ModuleManager/TestAsset/LoadChildsModule2/Module.php
@@ -7,15 +7,14 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace LoadChildsModule;
+namespace LoadChildsModule2;
 
 
 class Module
 {
     public function init($moduleManager)
     {
-        $moduleManager->loadModule('LoadChildsModule2', 'after');
-        $moduleManager->loadModule(array('SomeModule' => new \SomeModule\Module()), 'after');
+        $moduleManager->loadModule('BarModule', 'after');
     }
 
     public function getConfig()

--- a/tests/ZendTest/ModuleManager/TestAsset/LoadChildsModule2/configs/config.php
+++ b/tests/ZendTest/ModuleManager/TestAsset/LoadChildsModule2/configs/config.php
@@ -1,0 +1,4 @@
+<?php
+return array(
+    'some' => 'thing',
+);


### PR DESCRIPTION
Allow load modules (from `Module::init()`) after current module.
Analog of https://github.com/zendframework/zf2/pull/5651, but:
   load modules `A, B` - configs order is `A, B`.
   load modules `A -> B` - configs order is `A, B`.
