### PR TITLE
Stdlib\PriorityList fix current and iterator

### DIFF
--- a/library/Zend/Stdlib/PriorityList.php
+++ b/library/Zend/Stdlib/PriorityList.php
@@ -192,6 +192,7 @@ class PriorityList implements Iterator, Countable
      */
     public function current()
     {
+        $this->sort();
         $node = current($this->items);
         return ($node !== false ? $node['data'] : false);
     }
@@ -228,6 +229,14 @@ class PriorityList implements Iterator, Countable
     public function valid()
     {
         return ($this->current() !== false);
+    }
+
+    /**
+     * @return self
+     */
+    public function getIterator()
+    {
+        return clone $this;
     }
 
     /**

--- a/library/Zend/Stdlib/PriorityList.php
+++ b/library/Zend/Stdlib/PriorityList.php
@@ -192,7 +192,7 @@ class PriorityList implements Iterator, Countable
      */
     public function current()
     {
-        $this->sort();
+        $this->sorted || $this->sort();
         $node = current($this->items);
         return ($node !== false ? $node['data'] : false);
     }
@@ -205,6 +205,7 @@ class PriorityList implements Iterator, Countable
      */
     public function key()
     {
+        $this->sorted || $this->sort();
         return key($this->items);
     }
 

--- a/tests/ZendTest/Stdlib/PriorityListTest.php
+++ b/tests/ZendTest/Stdlib/PriorityListTest.php
@@ -171,6 +171,24 @@ class PriorityListTest extends TestCase
         $this->assertEquals(array('bar', 'foo', 'baz'), $orders);
     }
 
+    public function testCurrent()
+    {
+        $this->list->insert('foo', 'foo_value', null);
+        $this->list->insert('bar', 'bar_value', 1);
+        $this->list->insert('baz', 'baz_value', -1);
+        $this->assertEquals('bar_value', $this->list->current());
+    }
+
+    public function testIterator()
+    {
+        $this->list->insert('foo', 'foo_value');
+        $iterator = $this->list->getIterator();
+        $this->assertEquals($iterator, $this->list);
+
+        $this->list->insert('bar', 'bar_value');
+        $this->assertNotEquals($iterator, $this->list);
+    }
+
     public function testToArray()
     {
         $this->list->insert('foo', 'foo_value', null);

--- a/tests/ZendTest/Stdlib/PriorityListTest.php
+++ b/tests/ZendTest/Stdlib/PriorityListTest.php
@@ -176,6 +176,8 @@ class PriorityListTest extends TestCase
         $this->list->insert('foo', 'foo_value', null);
         $this->list->insert('bar', 'bar_value', 1);
         $this->list->insert('baz', 'baz_value', -1);
+
+        $this->assertEquals('bar', $this->list->key());
         $this->assertEquals('bar_value', $this->list->current());
     }
 


### PR DESCRIPTION
add sort before get `current()`
add `getIterator()` which return cloned self instance
