### PR TITLE
Fix invalid step error caused by DST

### DIFF
--- a/library/Zend/Form/Element/Date.php
+++ b/library/Zend/Form/Element/Date.php
@@ -10,6 +10,7 @@
 namespace Zend\Form\Element;
 
 use DateInterval;
+use DateTimezone;
 use Zend\Form\Element;
 use Zend\Form\Element\DateTime as DateTimeElement;
 use Zend\Validator\DateStep as DateStepValidator;
@@ -50,6 +51,7 @@ class Date extends DateTimeElement
         return new DateStepValidator(array(
             'format'    => $format,
             'baseValue' => $baseValue,
+            'timezone'  => new DateTimezone("UTC"),
             'step'      => new DateInterval("P{$stepValue}D"),
         ));
     }

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -11,6 +11,7 @@ namespace Zend\Form\Element;
 
 use DateInterval;
 use DateTime as PhpDateTime;
+use DateTimezone;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Date as DateValidator;

--- a/library/Zend/Form/Element/DateTime.php
+++ b/library/Zend/Form/Element/DateTime.php
@@ -11,7 +11,6 @@ namespace Zend\Form\Element;
 
 use DateInterval;
 use DateTime as PhpDateTime;
-use DateTimezone;
 use Zend\Form\Element;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Date as DateValidator;

--- a/tests/ZendTest/Form/Element/DateTest.php
+++ b/tests/ZendTest/Form/Element/DateTest.php
@@ -15,6 +15,29 @@ use Zend\Form\Element\Date as DateElement;
 
 class DateTest extends TestCase
 {
+    /**
+     * Stores the original set timezone
+     *
+     * @var string
+     */
+    private $_originaltimezone;
+
+    /**
+     * Setup environment
+     */
+    public function setUp()
+    {
+        $this->_originaltimezone = date_default_timezone_get();
+    }
+
+    /**
+     * Tear down environment
+     */
+    public function tearDown()
+    {
+        date_default_timezone_set($this->_originaltimezone);
+    }
+
     public function testProvidesDefaultInputSpecification()
     {
         $element = new DateElement('foo');
@@ -109,6 +132,22 @@ class DateTest extends TestCase
                 case 'Zend\Validator\DateStep':
                 case 'Zend\Validator\Date':
                     $this->assertEquals('d-m-Y', $validator->getFormat());
+                    break;
+            }
+        }
+    }
+
+    public function testStepValidatorIgnoresDaylightSavings()
+    {
+        date_default_timezone_set('Europe/London');
+
+        $element   = new DateElement('foo');
+
+        $inputSpec = $element->getInputSpecification();
+        foreach ($inputSpec['validators'] as $validator) {
+            switch (get_class($validator)) {
+                case 'Zend\Validator\DateStep':
+                    $this->assertTrue($validator->isValid('2013-12-25'));
                     break;
             }
         }

--- a/tests/ZendTest/Form/Element/DateTest.php
+++ b/tests/ZendTest/Form/Element/DateTest.php
@@ -20,14 +20,14 @@ class DateTest extends TestCase
      *
      * @var string
      */
-    private $_originaltimezone;
+    private $originaltimezone;
 
     /**
      * Setup environment
      */
     public function setUp()
     {
-        $this->_originaltimezone = date_default_timezone_get();
+        $this->originaltimezone = date_default_timezone_get();
     }
 
     /**
@@ -35,7 +35,7 @@ class DateTest extends TestCase
      */
     public function tearDown()
     {
-        date_default_timezone_set($this->_originaltimezone);
+        date_default_timezone_set($this->originaltimezone);
     }
 
     public function testProvidesDefaultInputSpecification()


### PR DESCRIPTION
We need to force UTC on the DateStepValidator, otherwise, changes in DST causes it to fail due to the base date being an hour out.
