### PR TITLE
Added new base path option specifically for console

### DIFF
--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -80,7 +80,11 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
         $plugins->setFactory('basepath', function () use ($serviceLocator) {
             $config = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
             $basePathHelper = new ViewHelper\BasePath;
-            if (isset($config['view_manager']) && isset($config['view_manager']['base_path'])) {
+            if(Console::isConsole()
+                && isset($config['view_manager'])
+                && isset($config['view_manager']['base_path_console'])) {
+                $basePathHelper->setBasePath($config['view_manager']['base_path_console']);
+            } elseif (isset($config['view_manager']) && isset($config['view_manager']['base_path'])) {
                 $basePathHelper->setBasePath($config['view_manager']['base_path']);
             } else {
                 $request = $serviceLocator->get('Request');

--- a/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
@@ -61,4 +61,21 @@ class ViewHelperManagerFactoryTest extends TestCase
         $basePath = $manager->get('basepath');
         $this->assertInstanceof('Zend\View\Helper\BasePath', $basePath);
     }
+
+    public function testConsoleRequestWithBasePathConsole()
+    {
+        $this->services->setService('Config',
+            array(
+                'view_manager' => array(
+                    'base_path_console' => 'http://test.com'
+                )
+            )
+        );
+        $this->services->setService('Requeset', new ConsoleRequest());
+
+        $manager = $this->factory->createService($this->services);
+
+        $basePath = $manager->get('basepath');
+        $this->assertEquals('http://test.com', $basePath());
+    }
 }

--- a/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/ViewHelperManagerFactoryTest.php
@@ -71,7 +71,7 @@ class ViewHelperManagerFactoryTest extends TestCase
                 )
             )
         );
-        $this->services->setService('Requeset', new ConsoleRequest());
+        $this->services->setService('Request', new ConsoleRequest());
 
         $manager = $this->factory->createService($this->services);
 


### PR DESCRIPTION
I'm currently implementing something similar in my application, and thought maybe you guys would like the idea.

Basically, for normal http requests, I want to always fallback to using the request object, for both development and production, but for console, I want to  explicitly set the base_path.  I need the basePath view helper on a console request so I can send emails via cronjob with the correct urls to my application.  If I set the base_path with how the factory currently works, I have to now worry about setting the correct base_path no matter what the application environment is even though the request object works perfectly fine.
