### PR TITLE
Mvc\Router\Http\Segment fix nullable default parameter

### DIFF
--- a/library/Zend/Mvc/Router/Http/Segment.php
+++ b/library/Zend/Mvc/Router/Http/Segment.php
@@ -293,12 +293,14 @@ class Segment implements RouteInterface
                 case 'parameter':
                     $skippable = true;
 
-                    if (!isset($mergedParams[$part[1]])) {
+                    if (!array_key_exists($part[1], $mergedParams)) {
                         if (!$isOptional || $hasChild) {
                             throw new Exception\InvalidArgumentException(sprintf('Missing parameter "%s"', $part[1]));
                         }
 
                         return '';
+                    } elseif($mergedParams[$part[1]] === null) {
+                        $skip = true;
                     } elseif (!$isOptional || $hasChild || !isset($this->defaults[$part[1]]) || $this->defaults[$part[1]] !== $mergedParams[$part[1]]) {
                         $skip = false;
                     }

--- a/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
@@ -400,4 +400,20 @@ class SegmentTest extends TestCase
         $route->match($request);
         $this->assertSame($uri2, $route->assemble($params2));
     }
+
+    public function testWithNullableDefaultAndHasChild()
+    {
+        $segment = new Segment(
+            '/:foo[/:bar]',
+            array(),
+            array('foo' => 'foo', 'bar' => null)
+        );
+        $chain = new \Zend\Mvc\Router\Http\Chain(
+            array($segment),
+            new \Zend\Mvc\Router\RoutePluginManager()
+        );
+
+        $this->assertEquals('/foo', $segment->assemble(array()));
+        $this->assertEquals('/foo', $chain->assemble(array()));
+    }
 }


### PR DESCRIPTION
When `\Router\Http\Segment` has parent router (as sample `Http\Chain`) - it can't found the default nullable parameter
