### PR TITLE
Db\Sql\Update use sortable set

### DIFF
--- a/tests/ZendTest/Db/Sql/UpdateTest.php
+++ b/tests/ZendTest/Db/Sql/UpdateTest.php
@@ -68,7 +68,28 @@ class UpdateTest extends \PHPUnit_Framework_TestCase
     public function testSet()
     {
         $this->update->set(array('foo' => 'bar'));
-        $this->assertEquals(array('foo' => 'bar'), $this->readAttribute($this->update, 'set'));
+        $this->assertEquals(array('foo' => 'bar'), $this->update->getRawState('set'));
+    }
+
+    /**
+     * @covers Zend\Db\Sql\Update::set
+     */
+    public function testSortableSet()
+    {
+        $this->update->set(array(
+            'two'   => 'с_two',
+            'three' => 'с_three',
+        ));
+        $this->update->set(array('one' => 'с_one'), 10);
+
+        $this->assertEquals(
+            array(
+                'one'   => 'с_one',
+                'two'   => 'с_two',
+                'three' => 'с_three',
+            ),
+            $this->update->getRawState('set')
+        );
     }
 
     /**


### PR DESCRIPTION
For compatibility with http://dev.mysql.com/doc/refman/5.0/en/ansi-diff-update.html.
Because sometime set list should be reordable, as sample for moving nodes in NestedSets tables.

this is reorganized from https://github.com/zendframework/zf2/pull/5485
