### PR TITLE
Db\Sql delete parameters dependency

### DIFF
--- a/library/Zend/Db/Sql/Delete.php
+++ b/library/Zend/Db/Sql/Delete.php
@@ -145,7 +145,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process where
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
+            $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
@@ -180,7 +180,7 @@ class Delete extends AbstractSql implements SqlInterface, PreparableSqlInterface
         $sql = sprintf($this->specifications[static::SPECIFICATION_DELETE], $table);
 
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');
+            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, null, 'where');
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
 

--- a/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/SelectDecorator.php
@@ -72,7 +72,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($this->limit === null) {
             return null;
         }
-        if ($driver) {
+        if ($parameterContainer) {
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $this->limit, ParameterContainer::TYPE_INTEGER);
         } else {
@@ -87,7 +87,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         if ($this->offset === null) {
             return null;
         }
-        if ($driver) {
+        if ($parameterContainer) {
             $parameterContainer->offsetSet('offset', $this->offset, ParameterContainer::TYPE_INTEGER);
             return array($driver->formatParameterName('offset'));
         }

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -642,6 +642,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                     $column,
                     $platform,
                     $driver,
+                    $parameterContainer,
                     $this->processInfo['paramPrefix'] . ((is_string($columnIndexOrAs)) ? $columnIndexOrAs : 'column')
                 );
                 if ($parameterContainer) {
@@ -672,6 +673,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
                         $jColumn,
                         $platform,
                         $driver,
+                        $parameterContainer,
                         $this->processInfo['paramPrefix'] . ((is_string($jKey)) ? $jKey : 'column')
                     );
                     if ($parameterContainer) {
@@ -698,7 +700,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         if ($this->quantifier) {
             if ($this->quantifier instanceof ExpressionInterface) {
-                $quantifierParts = $this->processExpression($this->quantifier, $platform, $driver, 'quantifier');
+                $quantifierParts = $this->processExpression($this->quantifier, $platform, $driver, $parameterContainer, 'quantifier');
                 if ($parameterContainer) {
                     $parameterContainer->merge($quantifierParts->getParameterContainer());
                 }
@@ -757,7 +759,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
             // on expression
             // note: for Expression objects, pass them to processExpression with a prefix specific to each join (used for named parameters)
             $joinSpecArgArray[$j][] = ($join['on'] instanceof ExpressionInterface)
-                ? $this->processExpression($join['on'], $platform, $driver, $this->processInfo['paramPrefix'] . 'join' . ($j+1) . 'part')
+                ? $this->processExpression($join['on'], $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'join' . ($j+1) . 'part')
                 : $platform->quoteIdentifierInFragment($join['on'], array('=', 'AND', 'OR', '(', ')', 'BETWEEN', '<', '>')); // on
             if ($joinSpecArgArray[$j][2] instanceof StatementContainerInterface) {
                 if ($parameterContainer) {
@@ -775,7 +777,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         if ($this->where->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->where, $platform, $driver, $this->processInfo['paramPrefix'] . 'where');
+        $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'where');
         if ($parameterContainer) {
             $parameterContainer->merge($whereParts->getParameterContainer());
         }
@@ -792,7 +794,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->group as $column) {
             $columnSql = '';
             if ($column instanceof Expression) {
-                $columnParts = $this->processExpression($column, $platform, $driver, $this->processInfo['paramPrefix'] . 'group');
+                $columnParts = $this->processExpression($column, $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'group');
                 if ($parameterContainer) {
                     $parameterContainer->merge($columnParts->getParameterContainer());
                 }
@@ -810,7 +812,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         if ($this->having->count() == 0) {
             return null;
         }
-        $whereParts = $this->processExpression($this->having, $platform, $driver, $this->processInfo['paramPrefix'] . 'having');
+        $whereParts = $this->processExpression($this->having, $platform, $driver, $parameterContainer, $this->processInfo['paramPrefix'] . 'having');
         if ($parameterContainer) {
             $parameterContainer->merge($whereParts->getParameterContainer());
         }
@@ -826,7 +828,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         foreach ($this->order as $k => $v) {
             if ($v instanceof Expression) {
                 /** @var $orderParts \Zend\Db\Adapter\StatementContainer */
-                $orderParts = $this->processExpression($v, $platform, $driver);
+                $orderParts = $this->processExpression($v, $platform, $driver, $parameterContainer);
                 if ($parameterContainer) {
                     $parameterContainer->merge($orderParts->getParameterContainer());
                 }
@@ -858,7 +860,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         $limit = $this->limit;
 
-        if ($driver) {
+        if ($parameterContainer) {
             $sql = $driver->formatParameterName('limit');
             $parameterContainer->offsetSet('limit', $limit, ParameterContainer::TYPE_INTEGER);
         } else {
@@ -876,7 +878,7 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         $offset = $this->offset;
 
-        if ($driver) {
+        if ($parameterContainer) {
             $parameterContainer->offsetSet('offset', $offset, ParameterContainer::TYPE_INTEGER);
             return array($driver->formatParameterName('offset'));
         }
@@ -894,15 +896,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         if ($this->combine['modifier']) {
             $type .= ' ' . $this->combine['modifier'];
         }
-        $type = strtoupper($type);
 
-        if ($driver) {
-            $sql = $this->processSubSelect($this->combine['select'], $platform, $driver, $parameterContainer);
-            return array($type, $sql);
-        }
         return array(
-            $type,
-            $this->processSubSelect($this->combine['select'], $platform)
+            strtoupper($type),
+            $this->processSubSelect($this->combine['select'], $platform, $driver, $parameterContainer)
         );
     }
 

--- a/library/Zend/Db/Sql/Update.php
+++ b/library/Zend/Db/Sql/Update.php
@@ -190,7 +190,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         // process where
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $platform, $driver, 'where');
+            $whereParts = $this->processExpression($this->where, $platform, $driver, $parameterContainer, 'where');
             $parameterContainer->merge($whereParts->getParameterContainer());
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
@@ -238,7 +238,7 @@ class Update extends AbstractSql implements SqlInterface, PreparableSqlInterface
 
         $sql = sprintf($this->specifications[static::SPECIFICATION_UPDATE], $table, $set);
         if ($this->where->count() > 0) {
-            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, 'where');
+            $whereParts = $this->processExpression($this->where, $adapterPlatform, null, null, 'where');
             $sql .= ' ' . sprintf($this->specifications[static::SPECIFICATION_WHERE], $whereParts->getSql());
         }
         return $sql;

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -53,8 +53,9 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
             return ':' . $x;
         }));
 
+        $mockParameterContainer = $this->getMock('Zend\Db\Adapter\ParameterContainer');
         $expression = new Expression('? > ? AND y < ?', array('x', 5, 10), array(Expression::TYPE_IDENTIFIER));
-        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockDriver);
+        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockDriver, $mockParameterContainer);
 
         $parameterContainer = $sqlAndParams->getParameterContainer();
         $parameters = $parameterContainer->getNamedArray();
@@ -72,7 +73,7 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, current($parameters));
 
         // ensure next invocation increases number by 1
-        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockDriver);
+        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockDriver, $mockParameterContainer);
 
         $parameterContainer = $sqlAndParamsNext->getParameterContainer();
         $parameters = $parameterContainer->getNamedArray();
@@ -130,11 +131,11 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
      * @param \Zend\Db\Adapter\Adapter|null $adapter
      * @return \Zend\Db\Adapter\StatementContainer
      */
-    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $driver = null)
+    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $driver = null, $parameterContainer = null)
     {
         $method = new \ReflectionMethod($this->abstractSql, 'processExpression');
         $method->setAccessible(true);
-        return $method->invoke($this->abstractSql, $expression, new TrustingSql92Platform, $driver);
+        return $method->invoke($this->abstractSql, $expression, new TrustingSql92Platform, $driver, $parameterContainer);
     }
 
 }

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -24,15 +24,23 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
      */
     protected $abstractSql = null;
 
+    protected $mockDriver = null;
+
     public function setup()
     {
         $this->abstractSql = $this->getMockForAbstractClass('Zend\Db\Sql\AbstractSql');
+
+        $this->mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $this->mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue(DriverInterface::PARAMETERIZATION_NAMED));
+        $this->mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnCallback(function ($x) {
+            return ':' . $x;
+        }));
     }
 
     /**
      * @covers Zend\Db\Sql\AbstractSql::processExpression
      */
-    public function testProcessExpressionWithoutDriver()
+    public function testProcessExpressionWithoutParameterContainer()
     {
         $expression = new Expression('? > ? AND y < ?', array('x', 5, 10), array(Expression::TYPE_IDENTIFIER));
         $sqlAndParams = $this->invokeProcessExpressionMethod($expression);
@@ -45,17 +53,11 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Sql\AbstractSql::processExpression
      */
-    public function testProcessExpressionWithDriverAndParameterizationTypeNamed()
+    public function testProcessExpressionWithParameterContainerAndParameterizationTypeNamed()
     {
-        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
-        $mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue(DriverInterface::PARAMETERIZATION_NAMED));
-        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnCallback(function ($x) {
-            return ':' . $x;
-        }));
-
         $mockParameterContainer = $this->getMock('Zend\Db\Adapter\ParameterContainer');
         $expression = new Expression('? > ? AND y < ?', array('x', 5, 10), array(Expression::TYPE_IDENTIFIER));
-        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockDriver, $mockParameterContainer);
+        $sqlAndParams = $this->invokeProcessExpressionMethod($expression, $mockParameterContainer);
 
         $parameterContainer = $sqlAndParams->getParameterContainer();
         $parameters = $parameterContainer->getNamedArray();
@@ -73,7 +75,7 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, current($parameters));
 
         // ensure next invocation increases number by 1
-        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockDriver, $mockParameterContainer);
+        $sqlAndParamsNext = $this->invokeProcessExpressionMethod($expression, $mockParameterContainer);
 
         $parameterContainer = $sqlAndParamsNext->getParameterContainer();
         $parameters = $parameterContainer->getNamedArray();
@@ -131,11 +133,11 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
      * @param \Zend\Db\Adapter\Adapter|null $adapter
      * @return \Zend\Db\Adapter\StatementContainer
      */
-    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $driver = null, $parameterContainer = null)
+    protected function invokeProcessExpressionMethod(ExpressionInterface $expression, $parameterContainer = null)
     {
         $method = new \ReflectionMethod($this->abstractSql, 'processExpression');
         $method->setAccessible(true);
-        return $method->invoke($this->abstractSql, $expression, new TrustingSql92Platform, $driver, $parameterContainer);
+        return $method->invoke($this->abstractSql, $expression, new TrustingSql92Platform, $this->mockDriver, $parameterContainer);
     }
 
 }


### PR DESCRIPTION
Remove $driver from IF which switch between getSqlString() and prepareStatement() algorithm
Because `$parameterContainer` is depends of `$driver` in many methods.
As result - methods is more consistently.
