### PR TITLE
Input receives complete context for validation

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -339,7 +339,7 @@ class BaseInputFilter implements
 
             // Validate an input
             if ($input instanceof InputInterface) {
-                if (!$input->isValid($data)) {
+                if (!$input->isValid($this->data)) {
                     // Validation failure
                     $this->invalidInputs[$name] = $input;
                     $valid = false;

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -464,7 +464,7 @@ class BaseInputFilterTest extends TestCase
         $filter->add($foo, 'foo')
                ->add($bar, 'bar');
 
-        $data = array('foo' => 'foo', 'bar' => 123);
+        $data = array('foo' => 'foo', 'bar' => 123, 'baz' => 'narf');
         $filter->setData($data);
 
         $this->assertTrue($filter->isValid());


### PR DESCRIPTION
Instances of InputInterface used to receive all submitted values from BaseInputFilter as context. After the changes made in #5271, only the values extracted from other inputs are passed on.

Is this by intention or by accident? I'd like to peek into the context without defining values as an input sometimes.
