### PR TITLE
HTML5 compliant form attributes

### DIFF
--- a/library/Zend/Form/View/Helper/Form.php
+++ b/library/Zend/Form/View/Helper/Form.php
@@ -81,10 +81,16 @@ class Form extends AbstractHelper
      */
     public function openTag(FormInterface $form = null)
     {
-        $attributes = array(
-            'action' => '',
-            'method' => 'get',
-        );
+        $doctype = $this->getDoctype();
+
+        if ('HTML5' !== $doctype && 'XHTML5' !== $doctype) {
+            $attributes = array(
+                'action' => '',
+                'method' => 'get',
+            );
+        } else {
+            $attributes = array();
+        }
 
         if ($form instanceof FormInterface) {
             $formAttributes = $form->getAttributes();
@@ -94,7 +100,11 @@ class Form extends AbstractHelper
             $attributes = array_merge($attributes, $formAttributes);
         }
 
-        $tag = sprintf('<form %s>', $this->createAttributesString($attributes));
+        if ($attributes) {
+            $tag = sprintf('<form %s>', $this->createAttributesString($attributes));
+        } else {
+            $tag = '<form>';
+        }
 
         return $tag;
     }

--- a/library/Zend/Form/View/Helper/Form.php
+++ b/library/Zend/Form/View/Helper/Form.php
@@ -11,6 +11,7 @@ namespace Zend\Form\View\Helper;
 
 use Zend\Form\FieldsetInterface;
 use Zend\Form\FormInterface;
+use Zend\View\Helper\Doctype;
 
 /**
  * View helper for rendering Form objects
@@ -83,7 +84,7 @@ class Form extends AbstractHelper
     {
         $doctype = $this->getDoctype();
 
-        if ('HTML5' !== $doctype && 'XHTML5' !== $doctype) {
+        if (Doctype::HTML5 !== $doctype && Doctype::XHTML5 !== $doctype) {
             $attributes = array(
                 'action' => '',
                 'method' => 'get',

--- a/tests/ZendTest/Form/View/Helper/FormTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormTest.php
@@ -15,6 +15,7 @@ use ZendTest\Form\TestAsset\CityFieldset;
 
 use Zend\Form\Form;
 use Zend\Form\View\Helper\Form as FormHelper;
+use Zend\View\Helper\Doctype;
 
 class FormTest extends CommonTestCase
 {
@@ -112,11 +113,11 @@ class FormTest extends CommonTestCase
     {
         $helper = new FormHelper();
 
-        $helper->setDoctype('HTML4_LOOSE');
+        $helper->setDoctype(Doctype::HTML4_LOOSE);
         $html4Markup = $helper->openTag();
-        $helper->setDoctype('HTML5');
+        $helper->setDoctype(Doctype::HTML5);
         $html5Markup = $helper->openTag();
-        $helper->setDoctype('XHTML5');
+        $helper->setDoctype(Doctype::XHTML5);
         $xhtml5Markup = $helper->openTag();
 
         $this->assertContains('action=""', $html4Markup);
@@ -128,11 +129,11 @@ class FormTest extends CommonTestCase
     {
         $helper = new FormHelper();
 
-        $helper->setDoctype('HTML4_LOOSE');
+        $helper->setDoctype(Doctype::HTML4_LOOSE);
         $html4Markup = $helper->openTag();
-        $helper->setDoctype('HTML5');
+        $helper->setDoctype(Doctype::HTML5);
         $html5Markup = $helper->openTag();
-        $helper->setDoctype('XHTML5');
+        $helper->setDoctype(Doctype::XHTML5);
         $xhtml5Markup = $helper->openTag();
 
         $this->assertContains('method="get"', $html4Markup);

--- a/tests/ZendTest/Form/View/Helper/FormTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormTest.php
@@ -107,4 +107,36 @@ class FormTest extends CommonTestCase
         $this->assertContains('<form', $markup);
         $this->assertContains('</form>', $markup);
     }
+
+    public function testHtml5DoesNotAddEmptyActionAttributeToFormTag()
+    {
+        $helper = new FormHelper();
+
+        $helper->setDoctype('HTML4_LOOSE');
+        $html4Markup = $helper->openTag();
+        $helper->setDoctype('HTML5');
+        $html5Markup = $helper->openTag();
+        $helper->setDoctype('XHTML5');
+        $xhtml5Markup = $helper->openTag();
+
+        $this->assertContains('action=""', $html4Markup);
+        $this->assertNotContains('action=""', $html5Markup);
+        $this->assertNotContains('action=""', $xhtml5Markup);
+    }
+
+    public function testHtml5DoesNotSetDefaultMethodAttributeInFormTag()
+    {
+        $helper = new FormHelper();
+
+        $helper->setDoctype('HTML4_LOOSE');
+        $html4Markup = $helper->openTag();
+        $helper->setDoctype('HTML5');
+        $html5Markup = $helper->openTag();
+        $helper->setDoctype('XHTML5');
+        $xhtml5Markup = $helper->openTag();
+
+        $this->assertContains('method="get"', $html4Markup);
+        $this->assertNotContains('method="get"', $html5Markup);
+        $this->assertNotContains('method="get"', $xhtml5Markup);
+    }
 }


### PR DESCRIPTION
According to W3C specification, ‘action’ is an optional attribute and can’t be empty in HTML5. So, if the form doctype is ‘HTML5’ or ‘XHTML5’, the ‘action’ attribute isn’t set as an empty string by default. Also, if either doctypes are detected, form ‘method’ attribute is not set to ‘get’ by default, as some applications may implement submit buttons that use ‘formmethod’ attribute, making form ‘method’ redundant or useless (according to W3C, “missing value default for the method attribute is also the GET state” — and have been since HTML 2.0).

Reference:
- http://www.w3.org/TR/html5/forms.html#attr-fs-action
- http://www.w3.org/TR/html5/forms.html#attr-fs-method
