### PR TITLE
Mvc\Application add shared listeners

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -249,6 +249,13 @@ class Application implements
         $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
         $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $serviceManager->setService('ApplicationConfig', $configuration);
+
+        $sharedEvents = $serviceManager->get('SharedEventManager');
+        $sharedListeners = isset($configuration['shared_listeners']) ? $configuration['shared_listeners'] : array();
+        foreach ($sharedListeners as $listener) {
+            $sharedEvents->attachAggregate($serviceManager->get($listener));
+        }
+
         $serviceManager->get('ModuleManager')->loadModules();
 
         $listenersFromAppConfig     = isset($configuration['listeners']) ? $configuration['listeners'] : array();

--- a/tests/ZendTest/Mvc/TestAsset/StubSharedListener.php
+++ b/tests/ZendTest/Mvc/TestAsset/StubSharedListener.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\TestAsset;
+
+use Zend\EventManager\SharedListenerAggregateInterface;
+use Zend\EventManager\SharedEventManagerInterface;
+use Zend\ModuleManager\ModuleEvent;
+
+class StubSharedListener implements SharedListenerAggregateInterface
+{
+    protected $listeners = array();
+
+    public function attachShared(SharedEventManagerInterface $events)
+    {
+        $events->attach('Zend\ModuleManager\ModuleManager', ModuleEvent::EVENT_MERGE_CONFIG, array($this, 'onMergeConfig'), -1000);
+    }
+
+    public function detachShared(SharedEventManagerInterface $events)
+    {
+        foreach ($this->listeners as $index => $callback) {
+            if ($events->detach($callback)) {
+                unset($this->listeners[$index]);
+            }
+        }
+    }
+
+    public function onMergeConfig(ModuleEvent $e)
+    {
+        $e->setParam('StubSharedListener', $this);
+    }
+}


### PR DESCRIPTION
This is required for attach events to `ModuleEvent` (while `ModuleManager::loadModules()`)
