### PR TITLE
Digit filter should ignore boolean input

### DIFF
--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -25,7 +25,10 @@ class Digits extends AbstractFilter
      */
     public function filter($value)
     {
-        if (! (is_int($value) || is_float($value) || is_string($value))) {
+        if (is_int($value)) {
+            return (string) $value;
+        }
+        if (! (is_float($value) || is_string($value))) {
             return $value;
         }
         $value = (string) $value;

--- a/library/Zend/Filter/Digits.php
+++ b/library/Zend/Filter/Digits.php
@@ -18,14 +18,14 @@ class Digits extends AbstractFilter
      *
      * Returns the string $value, removing all but digit characters
      *
-     * If the value provided is non-scalar, the value will remain unfiltered
+     * If the value provided is not integer, float or string, the value will remain unfiltered
      *
      * @param  string $value
      * @return string|mixed
      */
     public function filter($value)
     {
-        if (!is_scalar($value)) {
+        if (! (is_int($value) || is_float($value) || is_string($value))) {
             return $value;
         }
         $value = (string) $value;

--- a/tests/ZendTest/Filter/DigitsTest.php
+++ b/tests/ZendTest/Filter/DigitsTest.php
@@ -90,7 +90,9 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
             array(array(
                 'abc123',
                 'abc 123'
-            ))
+            )),
+            array(true),
+            array(false),
         );
     }
 
@@ -102,6 +104,6 @@ class DigitsTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new DigitsFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }


### PR DESCRIPTION
The digits filter should only be filtering things that can represent digits. Booleans do not represent digits and should pass through unchanged.
