### PR TITLE
Created DateTime Formater strategy for hydrator

### DIFF
--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib\Hydrator\Strategy;
+
+use DateTime;
+use DateTimeZone;
+
+class DateTimeFormatterStrategy implements StrategyInterface
+{
+    /**
+     * @var string
+     */
+    protected $format;
+
+    /**
+     * @var DateTimeZone|null
+     */
+    protected $timezone;
+
+    /**
+     * Constructor
+     *
+     * @param string            $format
+     * @param DateTimeZone|null $timezone
+     */
+    public function __construct($format = DateTime::RFC3339, DateTimeZone $timezone = null)
+    {
+        $this->format   = $format;
+        $this->timezone = $timezone;
+    }
+
+    /**
+     * Sets timezone
+     *
+     * @param  DateTimeZone $timezone
+     * @return void
+     */
+    public function setTimezone(DateTimeZone $timezone)
+    {
+        $this->timezone = $timezone;
+    }
+
+    /**
+     * Converts to date time string
+     *
+     * @param DateTime|string|null
+     * @param string|null
+     */
+    public function extract($value)
+    {
+        if ($value instanceof DateTime) {
+            return $value->format($this->format);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Converts date time string to DateTime instance for injecting to object
+     *
+     * @param  string|null $value
+     * @return DateTime|null
+     */
+    public function hydrate($value)
+    {
+        if ($value === '' || $value === null) {
+            return null;
+        }
+
+        if ($this->timezone instanceof DateTimeZone) {
+            return DateTime::createFromFormat($this->format, $value, $this->timezone);
+        }
+
+        return DateTime::createFromFormat($this->format, $value);
+    }
+}

--- a/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
+++ b/library/Zend/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategy.php
@@ -51,7 +51,7 @@ class DateTimeFormatterStrategy implements StrategyInterface
      * Converts to date time string
      *
      * @param DateTime|string|null
-     * @param string|null
+     * @return string|null
      */
     public function extract($value)
     {

--- a/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
+++ b/tests/ZendTest/Stdlib/Hydrator/Strategy/DateTimeFormatterStrategyTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\Hydrator\Strategy;
+
+use Zend\Stdlib\Hydrator\Strategy\DateTimeFormatterStrategy;
+
+class DateTimeFormatterStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHydrate()
+    {
+        $strategy = new DateTimeFormatterStrategy('Y-m-d');
+        $this->assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
+        $strategy->setTimezone(new \DateTimeZone('Asia/Kathmandu'));
+        $date = $strategy->hydrate('2014-04-26');
+        $this->assertEquals('Asia/Kathmandu', $date->getTimezone()->getName());
+    }
+
+    public function testExtract()
+    {
+        $strategy = new DateTimeFormatterStrategy('d/m/Y');
+        $this->assertEquals('26/04/2014', $strategy->extract(new \DateTime('2014-04-26')));
+    }
+
+    public function testGetNullWithInvalidDateOnHydration()
+    {
+        $strategy = new DateTimeFormatterStrategy('Y-m-d');
+        $this->assertEquals(null, $strategy->hydrate(null));
+        $this->assertEquals(null, $strategy->hydrate(''));
+    }
+
+    public function testCanExtractIfNotDateTime()
+    {
+        $strategy = new DateTimeFormatterStrategy();
+        $date = $strategy->extract(new \stdClass);
+
+        $this->assertInstanceOf('stdClass', $date);
+    }
+}


### PR DESCRIPTION
I screwed up PR #6198

Removed `Zend\Filter` dependency.

``` php
class User
{
    protected $registrationDate;

    public function setRegistrationDate(DateTime $registrationDate)
    {
        $this->registrationDate = $registrationDate;
    }

    public function getRegistrationDate()
    {
        return $this->registrationDate;
    }
}

$user = new User;

$hydrator = new Zend\Stdlib\Hydrator\ClassMethods;
$strategy = new Zend\Stdlib\Hydrator\Strategy\DateTimeFormaterStrategy('Y-m-d');
$hydrator->addStrategy('registration_date', $strategy);
$hydrator->hydrate(array('registration_date' => '2014-04-26'), $user);

echo $user->getRegistrationDate()->format('Y-m-d'); // will print 2014-04-26
echo $hydrator->extract($user)['registration_date']; // will print 2014-04-26
```
