### PR TITLE
Show actual contents on assert*QueryContentContains

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractHttpControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractHttpControllerTestCase.php
@@ -688,16 +688,21 @@ abstract class AbstractHttpControllerTestCase extends AbstractControllerTestCase
                 $path
             ));
         }
+        $nodeVals = array();
         foreach ($result as $node) {
             if ($node->nodeValue == $match) {
                 $this->assertEquals($match, $node->nodeValue);
                 return;
             }
+            $nodeVals[] = $node->nodeValue;
         }
+
+        $nodeValsString = implode(',', $nodeVals);
         throw new PHPUnit_Framework_ExpectationFailedException(sprintf(
-            'Failed asserting node denoted by %s CONTAINS content "%s"',
+            'Failed asserting node denoted by %s CONTAINS content "%s", Contents: [%s]',
             $path,
-            $match
+            $match,
+            $nodeValsString
         ));
     }
 


### PR DESCRIPTION
I wrote some unit tests for my current project and found that it was quite difficult to write and test content assertions of specific nodes in the DOM.

The problem is that there are no indicators of what the contents of matches nodes really were - so I added them to the error message of the assertion.

The difference of the output is shown in the following screenshot of a unit test in Netbeans:

![2014-05-20_13-38-41](https://cloud.githubusercontent.com/assets/4665730/3026450/542ad1c0-e015-11e3-820c-30bff1cbfd83.png)
