### PR TITLE
Handle regular form elements as target elements of `Zend\Form\Element\Collection`.

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -514,7 +514,10 @@ class Collection extends Fieldset
         foreach ($this->object as $key => $value) {
             if ($this->hydrator) {
                 $values[$key] = $this->hydrator->extract($value);
-            } elseif ($value instanceof $this->targetElement->object) {
+            } elseif (
+                $this->targetElement instanceof Fieldset &&
+                $value instanceof $this->targetElement->object
+            ) {
                 // @see https://github.com/zendframework/zf2/pull/2848
                 $targetElement = clone $this->targetElement;
                 $targetElement->object = $value;
@@ -525,6 +528,8 @@ class Collection extends Fieldset
                         $fieldset->setObject($value);
                     }
                 }
+            } else {
+                $values[$key] = $value;
             }
         }
         return $values;

--- a/library/Zend/InputFilter/CollectionInput.php
+++ b/library/Zend/InputFilter/CollectionInput.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\InputFilter;
+
+/**
+ * Overrides message handling
+ */
+class CollectionInput extends ArrayInput
+{
+    /**
+     * Messages
+     * @var string[]
+     */
+    protected $messages = array();
+
+    /**
+     * @param mixed $context Extra "context" to provide the validator
+     * @return bool
+     */
+    public function isValid($context = null)
+    {
+        $this->injectNotEmptyValidator();
+        $validator = $this->getValidatorChain();
+        $values    = $this->getValue();
+        $result    = true;
+        foreach ($values as $key => $value) {
+            $result = $validator->isValid($value, $context);
+            if (!$result) {
+                // Store the messages in a custom format
+                $this->messages[$key] = $validator->getMessages();
+                if ($this->hasFallback()) {
+                    $this->setValue($this->getFallbackValue());
+                    $result = true;
+                }
+                break;
+            }
+        }
+        
+        return $result;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessages()
+    {
+        if (null !== $this->errorMessage) {
+            return (array) $this->errorMessage;
+        }
+
+        if ($this->hasFallback()) {
+            return array();
+        }
+        return $this->messages;
+    }
+}

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -1029,4 +1029,22 @@ class CollectionTest extends TestCase
 
         $this->assertCount(2, $form->get('names'));
     }
+
+    public function testCanHydrateObject()
+    {
+        $form = $this->form;
+        $data = array(
+            'colors' => array(
+                '#ffffff',
+            ),
+        );
+        $form->setData($data);
+
+        $object = new \ArrayObject();
+        
+        $form->bind($object);
+        $this->assertTrue($form->isValid());
+        $this->assertTrue(is_array($object['colors']));
+        $this->assertCount(1, $object['colors']);
+    }
 }

--- a/tests/ZendTest/InputFilter/CollectionInputTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter;
+
+use Zend\InputFilter\CollectionInput;
+use Zend\Filter;
+use Zend\Validator;
+
+class CollectionInputTest extends ArrayInputTest
+{
+    public function setUp()
+    {
+        $this->input = new CollectionInput('foo');
+    }
+
+    public function testGetMessagesReturnsValidationMessages()
+    {
+        $this->markTestSkipped('Message behaviour changed; skipping this test');
+    }
+
+    public function testNotEmptyValidatorAddedWhenIsValidIsCalled()
+    {
+        $this->markTestSkipped('Message behaviour changed; skipping this test');
+    }
+
+    public function testMessagesOverride()
+    {
+        $data = array(
+            'abc',
+        );
+
+        $this->input->getValidatorChain()->attach(new Validator\Date());
+        $this->input->setValue($data);
+        $this->input->isValid();
+        $messages = $this->input->getMessages();
+
+        $this->assertCount(1, $messages);
+        foreach ($messages as $msgArray) {
+            $this->assertTrue(is_array($msgArray));
+        }
+    }
+
+}

--- a/tests/ZendTest/InputFilter/CollectionInputTest.php~
+++ b/tests/ZendTest/InputFilter/CollectionInputTest.php~
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\InputFilter;
+
+use Zend\InputFilter\CollectionInput;
+use Zend\Filter;
+use Zend\Validator;
+
+class CollectionInputTest extends ArrayInputTest
+{
+    public function setUp()
+    {
+        $this->input = new CollectionInput('foo');
+    }
+
+}


### PR DESCRIPTION
The changes below allow for setting regular form elements (i.e. not a `Zend\Form\Fieldset`) as the target element of a form collection. Before this patch, this would create problems when binding a domain model. Now, a new input (`Zend\InputFilter\CollectionInput` -- basically a `ArrayInput` with some minor changes to message handling) is set for the collection when no input filter configuration is provided. This input will take the validators and filters of the target element and loop over an array of values. This way, domain models can be hydrated from form data. (Before this, there would be no inputs nor input filters attached to the `Collection`'s default input filter, so all values would be lost after `Form::isValid()` was called).

This pull request addresses issue #6263.
