### PR TITLE
Replacing self:: with static:: in Http\Client::setAuth

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -706,7 +706,7 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function setAuth($user, $password, $type = self::AUTH_BASIC)
     {
-        if (!defined('self::AUTH_' . strtoupper($type))) {
+        if (!defined('static::AUTH_' . strtoupper($type))) {
             throw new Exception\InvalidArgumentException("Invalid or not supported authentication type: '$type'");
         }
         if (empty($user)) {

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -18,6 +18,7 @@ use Zend\Http\Header\SetCookie;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Http\Client\Adapter\Test;
+use ZendTest\Http\TestAsset\ExtendedClient;
 
 
 class ClientTest extends \PHPUnit_Framework_TestCase
@@ -373,5 +374,16 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayNotHasKey('content-length', $headers);
         $this->assertArrayHasKey('Content-Length', $headers);
+    }
+
+    /**
+     * Test for pull request 6301
+     * Previous functionality would have thrown an exception
+     * This test serves to verify that exception is not thrown
+     */
+    public function testCanSpecifyCustomAuthMethodsInExtendingClasses()
+    {
+        $client = new ExtendedClient();
+        $client->setAuth('username', 'password', ExtendedClient::AUTH_CUSTOM);
     }
 }

--- a/tests/ZendTest/Http/TestAsset/ExtendedClient.php
+++ b/tests/ZendTest/Http/TestAsset/ExtendedClient.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZendTest\Http\TestAsset;
+
+use Zend\Http\Client;
+
+class ExtendedClient extends Client
+{
+    const AUTH_CUSTOM = 'custom';
+}


### PR DESCRIPTION
This becomes an issue if you want to create a custom authentication method in a class extending Http\Client

The self:: check only allows for the included constants (AUTH_BASIC and AUTH_DIGEST), and will throw an exception on AUTH_XXXX constants in extending classes.
