### PR TITLE
Fix Zend/Barcode composer.json to require zendframework/zend-validator.

### DIFF
--- a/library/Zend/Barcode/composer.json
+++ b/library/Zend/Barcode/composer.json
@@ -15,16 +15,15 @@
     "target-dir": "Zend/Barcode",
     "require": {
         "php": ">=5.3.23",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-validator": "self.version"
     },
     "require-dev": {
         "zendframework/zend-servicemanager": "self.version",
-        "zendframework/zend-validator": "self.version",
         "zendframework/zendpdf": "*"
     },
     "suggest": {
-        "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
-        "zendframework/zend-validator": "Zend\\Validator component",
+        "zendframework/zend-servicemanager": "Zend\\ServiceManager component, required when using the factory methods of Zend\\Barcode.",
         "zendframework/zendpdf": "ZendPdf component"
     },
     "extra": {


### PR DESCRIPTION
As per #6293, make `zendframework/zend-barcode` require `zendframework/zend-validator`, since barcodes are validated at draw time. We also mention why `zendframework/zend-servicemanager` is suggested.

I have not been able to test this yet (outside of validating the composer file), because I would first need to split Zend/Barcode into a subtree to feed it to Composer, and set-up a VM to get a recent enough version of PHP. Feel free to take it as-is or to wait until I test it.
