### PR TITLE
Fixes #6297: Fixes logic that checks if IntlDateFormatter parsed the string properly.

### DIFF
--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace Zend\I18n\Validator;
 
 use Locale;
@@ -18,15 +17,17 @@ use Zend\Validator\Exception as ValidatorException;
 
 class DateTime extends AbstractValidator
 {
-    const INVALID           = 'datetimeInvalid';
-    const INVALID_DATETIME  = 'datetimeInvalidDateTime';
+
+    const INVALID          = 'datetimeInvalid';
+    const INVALID_DATETIME = 'datetimeInvalidDateTime';
 
     /**
+     *
      * @var array
      */
     protected $messageTemplates = array(
-        self::INVALID           => "Invalid type given. String expected",
-        self::INVALID_DATETIME  => "The input does not appear to be a valid datetime",
+        self::INVALID          => "Invalid type given. String expected",
+        self::INVALID_DATETIME => "The input does not appear to be a valid datetime"
     );
 
     /**
@@ -70,7 +71,6 @@ class DateTime extends AbstractValidator
 
     /**
      * Is the formatter invalidated
-     *
      * Invalidation occurs when immutable properties are changed
      *
      * @var bool
@@ -86,10 +86,9 @@ class DateTime extends AbstractValidator
     public function __construct($options = array())
     {
         if (!extension_loaded('intl')) {
-            throw new I18nException\ExtensionNotLoadedException(sprintf(
-                '%s component requires the intl PHP extension',
-                __NAMESPACE__
-            ));
+            throw new I18nException\ExtensionNotLoadedException(
+                sprintf('%s component requires the intl PHP extension', __NAMESPACE__)
+            );
         }
 
         // Delaying initialization until we know ext/intl is available
@@ -138,7 +137,7 @@ class DateTime extends AbstractValidator
      */
     public function setDateType($dateType)
     {
-        $this->dateType          = $dateType;
+        $this->dateType            = $dateType;
         $this->invalidateFormatter = true;
 
         return $this;
@@ -185,7 +184,7 @@ class DateTime extends AbstractValidator
      */
     public function setTimeType($timeType)
     {
-        $this->timeType          = $timeType;
+        $this->timeType            = $timeType;
         $this->invalidateFormatter = true;
 
         return $this;
@@ -251,7 +250,7 @@ class DateTime extends AbstractValidator
     /**
      * Returns true if and only if $value is a floating-point value
      *
-     * @param  string                             $value
+     * @param string $value
      * @return bool
      * @throws ValidatorException\InvalidArgumentException
      */
@@ -264,25 +263,16 @@ class DateTime extends AbstractValidator
         }
 
         $this->setValue($value);
-
         $formatter = $this->getIntlDateFormatter();
 
         if (intl_is_failure($formatter->getErrorCode())) {
-            throw new ValidatorException\InvalidArgumentException("Invalid locale string given");
+            throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
         }
 
-        $position   = 0;
-        $formatter->parse($value, $position);
+        $timestamp = $formatter->parse($value);
 
-        if (intl_is_failure($formatter->getErrorCode())) {
+        if (intl_is_failure($formatter->getErrorCode()) || $timestamp === false) {
             $this->error(self::INVALID_DATETIME);
-
-            return false;
-        }
-
-        if ($position != strlen($value)) {
-            $this->error(self::INVALID_DATETIME);
-
             return false;
         }
 
@@ -297,8 +287,14 @@ class DateTime extends AbstractValidator
     protected function getIntlDateFormatter()
     {
         if ($this->formatter == null || $this->invalidateFormatter) {
-            $this->formatter = new IntlDateFormatter($this->getLocale(), $this->getDateType(), $this->getTimeType(),
-                $this->getTimezone(), $this->getCalendar(), $this->getPattern());
+            $this->formatter = new IntlDateFormatter(
+                $this->getLocale(),
+                $this->getDateType(),
+                $this->getTimeType(),
+                $this->getTimezone(),
+                $this->getCalendar(),
+                $this->getPattern()
+            );
 
             $this->formatter->setLenient(false);
 

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -250,7 +250,7 @@ class DateTime extends AbstractValidator
     /**
      * Returns true if and only if $value is a floating-point value
      *
-     * @param  string                             $value
+     * @param  string $value
      * @return bool
      * @throws ValidatorException\InvalidArgumentException
      */

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace Zend\I18n\Validator;
 
 use Locale;

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -17,7 +17,6 @@ use Zend\Validator\Exception as ValidatorException;
 
 class DateTime extends AbstractValidator
 {
-
     const INVALID          = 'datetimeInvalid';
     const INVALID_DATETIME = 'datetimeInvalidDateTime';
 
@@ -27,7 +26,7 @@ class DateTime extends AbstractValidator
      */
     protected $messageTemplates = array(
         self::INVALID          => "Invalid type given. String expected",
-        self::INVALID_DATETIME => "The input does not appear to be a valid datetime"
+        self::INVALID_DATETIME => "The input does not appear to be a valid datetime",
     );
 
     /**
@@ -250,7 +249,7 @@ class DateTime extends AbstractValidator
     /**
      * Returns true if and only if $value is a floating-point value
      *
-     * @param string $value
+     * @param  string                             $value
      * @return bool
      * @throws ValidatorException\InvalidArgumentException
      */

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -98,62 +98,33 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        return array(
-            array(
-                'May 30, 2013',
-                true,
-                array(
-                    'locale' => 'en',
-                    'dateType' => \IntlDateFormatter::MEDIUM,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-            array(
-                '30.Mai.2013',
-                true,
-                array(
-                    'locale' => 'de',
-                    'dateType' => \IntlDateFormatter::MEDIUM,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-            array(
-                '20 мая 2014 г',
-                true,
-                array(
-                    'locale' => 'ru',
-                    'dateType' => \IntlDateFormatter::MEDIUM,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-            array(
-                '2014年5月20日星期二',
-                true,
-                array(
-                    'locale' => 'zh-TW',
-                    'dateType' => \IntlDateFormatter::FULL,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-            array(
-                '2014, മേയ് 20, ചൊവ്വാഴ്ച',
-                true,
-                array(
-                    'locale' => 'ml-IN',
-                    'dateType' => \IntlDateFormatter::FULL,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-            array(
-                '30 Mei 2013',
-                true,
-                array(
-                    'locale' => 'nl',
-                    'dateType' => \IntlDateFormatter::MEDIUM,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
+        $trueArray      = array();
+        $testingDate    = new \DateTime();
+        $testingLocales = array('en', 'de', 'zh-TW', 'ja', 'ar', 'ru', 'si', 'ml-IN', 'hi');
+        $testingFormats = array(
+            \IntlDateFormatter::FULL,
+            \IntlDateFormatter::LONG,
+            \IntlDateFormatter::MEDIUM,
+            \IntlDateFormatter::SHORT,
+            \IntlDateFormatter::NONE
+        );
 
+        //Loop locales and formats for a more thorough set of "true" test data
+        foreach ($testingLocales as $locale) {
+            foreach ($testingFormats as $dateFormat) {
+                foreach ($testingFormats as $timeFormat) {
+                    if (($timeFormat !== \IntlDateFormatter::NONE) || ($dateFormat !== \IntlDateFormatter::NONE)) {
+                        $trueArray[] = array(
+                            \IntlDateFormatter::create($locale, $dateFormat, $timeFormat)->format($testingDate),
+                            true,
+                            array('locale' => $locale, 'dateType' => $dateFormat, 'timeType' => $timeFormat)
+                        );
+                    }
+                }
+            }
+        }
+
+        $falseArray = array(
             array(
                 'May 38, 2013',
                 false,
@@ -162,72 +133,10 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
                     'dateType' => \IntlDateFormatter::FULL,
                     'timeType' => \IntlDateFormatter::NONE
                 )
-            ),
-            array(
-                'Dienstag, 28. Mai 2013',
-                true,
-                array(
-                    'locale' => 'de',
-                    'dateType' => \IntlDateFormatter::FULL,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-            array(
-                'Maandag 28 Mei 2013',
-                true,
-                array(
-                    'locale' => 'nl',
-                    'dateType' => \IntlDateFormatter::FULL,
-                    'timeType' => \IntlDateFormatter::NONE
-                )
-            ),
-
-            array(
-                '0:00',
-                true,
-                array(
-                    'locale' => 'nl',
-                    'dateType' => \IntlDateFormatter::NONE,
-                    'timeType' => \IntlDateFormatter::SHORT
-                )
-            ),
-            array(
-                '01:01',
-                true,
-                array(
-                    'locale' => 'nl',
-                    'dateType' => \IntlDateFormatter::NONE,
-                    'timeType' => \IntlDateFormatter::SHORT
-                )
-            ),
-            array(
-                '01:01:01',
-                true,
-                array(
-                    'locale' => 'nl',
-                    'dateType' => \IntlDateFormatter::NONE,
-                    'timeType' => \IntlDateFormatter::MEDIUM
-                )
-            ),
-            array(
-                '01:01:01 +2',
-                true,
-                array(
-                    'locale' => 'nl',
-                    'dateType' => \IntlDateFormatter::NONE,
-                    'timeType' => \IntlDateFormatter::LONG
-                )
-            ),
-            array(
-                '03:30:42 am +2',
-                true,
-                array(
-                    'locale' => 'en',
-                    'dateType' => \IntlDateFormatter::NONE,
-                    'timeType' => \IntlDateFormatter::LONG
-                )
             )
         );
+
+        return array_merge($trueArray, $falseArray);
     }
 
     /**

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\I18n\Validator;
 
 use Zend\I18n\Validator\DateTime as DateTimeValidator;

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -117,7 +117,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '20 мая 2014 г.',
+                '20 мая 2014 г',
                 true,
                 array(
                     'locale' => 'ru',

--- a/tests/ZendTest/I18n/Validator/DateTimeTest.php
+++ b/tests/ZendTest/I18n/Validator/DateTimeTest.php
@@ -6,24 +6,33 @@
  * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-
 namespace ZendTest\I18n\Validator;
 
 use Zend\I18n\Validator\DateTime as DateTimeValidator;
 use Locale;
 
 /**
- * @group      Zend_Validator
+ * @group Zend_Validator
  */
 class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
+     *
      * @var DateTimeValidator
      */
     protected $validator;
 
+    /**
+     *
+     * @var \Locale
+     */
     protected $locale;
 
+    /**
+     *
+     * @var \DateTimeZone
+     */
     protected $timezone;
 
     public function setUp()
@@ -35,7 +44,10 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->locale = Locale::getDefault();
         $this->timezone = date_default_timezone_get();
 
-        $this->validator = new DateTimeValidator(array('locale' => 'en', 'timezone'=>'Europe/Amsterdam'));
+        $this->validator = new DateTimeValidator(array(
+            'locale' => 'en',
+            'timezone' => 'Europe/Amsterdam'
+        ));
     }
 
     public function tearDown()
@@ -59,10 +71,18 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     {
         $this->validator->setOptions($options);
 
-        $this->assertEquals($expected, $this->validator->isValid($value),
-            'Failed expecting ' . $value . ' being ' . ($expected ? 'true' : 'false') .
-                sprintf(" (locale:%s, dateType: %s, timeType: %s, pattern:%s)", $this->validator->getLocale(),
-                    $this->validator->getDateType(), $this->validator->getTimeType(), $this->validator->getPattern()));
+        $this->assertEquals(
+            $expected,
+            $this->validator->isValid($value),
+            'Failed expecting ' . $value . ' being ' . ($expected ? 'true' : 'false')
+            . sprintf(
+                " (locale:%s, dateType: %s, timeType: %s, pattern:%s)",
+                $this->validator->getLocale(),
+                $this->validator->getDateType(),
+                $this->validator->getTimeType(),
+                $this->validator->getPattern()
+            )
+        );
     }
 
     public function basicProvider()
@@ -71,24 +91,141 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
             if (version_compare(\PHPUnit_Runner_Version::id(), '3.8.0-dev') === 1) {
                 $this->markTestSkipped('ext/intl not enabled');
             } else {
-                return array(array());
+                return array(
+                    array()
+                );
             }
         }
 
         return array(
-            array('May 30, 2013',   true, array('locale'=>'en', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),
-            array('30.Mai.2013',   true, array('locale'=>'de', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),
-            array('30 Mei 2013',   true, array('locale'=>'nl', 'dateType' => \IntlDateFormatter::MEDIUM, 'timeType' => \IntlDateFormatter::NONE)),
+            array(
+                'May 30, 2013',
+                true,
+                array(
+                    'locale' => 'en',
+                    'dateType' => \IntlDateFormatter::MEDIUM,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                '30.Mai.2013',
+                true,
+                array(
+                    'locale' => 'de',
+                    'dateType' => \IntlDateFormatter::MEDIUM,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                '20 мая 2014 г.',
+                true,
+                array(
+                    'locale' => 'ru',
+                    'dateType' => \IntlDateFormatter::MEDIUM,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                '2014年5月20日星期二',
+                true,
+                array(
+                    'locale' => 'zh-TW',
+                    'dateType' => \IntlDateFormatter::FULL,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                '2014, മേയ് 20, ചൊവ്വാഴ്ച',
+                true,
+                array(
+                    'locale' => 'ml-IN',
+                    'dateType' => \IntlDateFormatter::FULL,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                '30 Mei 2013',
+                true,
+                array(
+                    'locale' => 'nl',
+                    'dateType' => \IntlDateFormatter::MEDIUM,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
 
-            array('May 38, 2013',   false, array('locale'=>'en', 'dateType' => \IntlDateFormatter::FULL, 'timeType' => \IntlDateFormatter::NONE)),
-            array('Dienstag, 28. Mai 2013',   true, array('locale'=>'de', 'dateType' => \IntlDateFormatter::FULL, 'timeType' => \IntlDateFormatter::NONE)),
-            array('Maandag 28 Mei 2013',   true, array('locale'=>'nl', 'dateType' => \IntlDateFormatter::FULL, 'timeType' => \IntlDateFormatter::NONE)),
+            array(
+                'May 38, 2013',
+                false,
+                array(
+                    'locale' => 'en',
+                    'dateType' => \IntlDateFormatter::FULL,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                'Dienstag, 28. Mai 2013',
+                true,
+                array(
+                    'locale' => 'de',
+                    'dateType' => \IntlDateFormatter::FULL,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
+            array(
+                'Maandag 28 Mei 2013',
+                true,
+                array(
+                    'locale' => 'nl',
+                    'dateType' => \IntlDateFormatter::FULL,
+                    'timeType' => \IntlDateFormatter::NONE
+                )
+            ),
 
-            array('0:00',   true, array('locale'=>'nl', 'dateType' => \IntlDateFormatter::NONE, 'timeType' => \IntlDateFormatter::SHORT)),
-            array('01:01',   true, array('locale'=>'nl', 'dateType' => \IntlDateFormatter::NONE, 'timeType' => \IntlDateFormatter::SHORT)),
-            array('01:01:01',   true, array('locale'=>'nl', 'dateType' => \IntlDateFormatter::NONE, 'timeType' => \IntlDateFormatter::MEDIUM)),
-            array('01:01:01 +2',   true, array('locale'=>'nl', 'dateType' => \IntlDateFormatter::NONE, 'timeType' => \IntlDateFormatter::LONG)),
-            array('03:30:42 am +2',   true, array('locale'=>'en', 'dateType' => \IntlDateFormatter::NONE, 'timeType' => \IntlDateFormatter::LONG)),
+            array(
+                '0:00',
+                true,
+                array(
+                    'locale' => 'nl',
+                    'dateType' => \IntlDateFormatter::NONE,
+                    'timeType' => \IntlDateFormatter::SHORT
+                )
+            ),
+            array(
+                '01:01',
+                true,
+                array(
+                    'locale' => 'nl',
+                    'dateType' => \IntlDateFormatter::NONE,
+                    'timeType' => \IntlDateFormatter::SHORT
+                )
+            ),
+            array(
+                '01:01:01',
+                true,
+                array(
+                    'locale' => 'nl',
+                    'dateType' => \IntlDateFormatter::NONE,
+                    'timeType' => \IntlDateFormatter::MEDIUM
+                )
+            ),
+            array(
+                '01:01:01 +2',
+                true,
+                array(
+                    'locale' => 'nl',
+                    'dateType' => \IntlDateFormatter::NONE,
+                    'timeType' => \IntlDateFormatter::LONG
+                )
+            ),
+            array(
+                '03:30:42 am +2',
+                true,
+                array(
+                    'locale' => 'en',
+                    'dateType' => \IntlDateFormatter::NONE,
+                    'timeType' => \IntlDateFormatter::LONG
+                )
+            )
         );
     }
 
@@ -158,5 +295,4 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid('02:00'));
         $this->assertEquals('hh:mm', $this->validator->getPattern());
     }
-
 }


### PR DESCRIPTION
Using the `$position` as an indicator does not work properly as `IntlDateFormatter::parse()` does not return the same number as `grapheme_strlen()` for all locales (try ml-IN for an example). We don't need to know _where_ it failed, just that it _did_ fail. The `parse()` function returns `false` if it fails, so we can just check for that.

Added test for Russian, Traditional Chinese, and Malayalam.

Closes #6321
