### PR TITLE
Add body to curl DELETE request if one is specified.

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -390,6 +390,9 @@ class Curl implements HttpAdapter, StreamInterface
             curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
         } elseif ($method == 'PATCH') {
             curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
+        } elseif ($method == 'DELETE' && $body) {
+            // DELETE requests can also have a body
+            curl_setopt($this->curl, CURLOPT_POSTFIELDS, $body);
         }
 
         // set additional curl options


### PR DESCRIPTION
The header will be there. Fixes issue #6315 (https://github.com/zendframework/zf2/issues/6315).

When providing a request body for a DELETE request, Zend\Http\Client will add the 'Content-Length' header but will not add and send the actual body resulting in a curl call that hangs for a very long period of time. The client should send both a body and the header since DELETE requests can have a body. From the IETF spec: "The presence of a message-body in a request is signaled by the inclusion of a Content-Length or Transfer-Encoding header field in the request's message-headers." -- http://tools.ietf.org/html/rfc2616
