### PR TITLE
Change "Unknown Error" with current internal list of messages

### DIFF
--- a/library/Zend/XmlRpc/Fault.php
+++ b/library/Zend/XmlRpc/Fault.php
@@ -92,7 +92,7 @@ class Fault
         if (empty($message) && isset($this->internal[$code])) {
             $message = $this->internal[$code];
         } elseif (empty($message)) {
-            $message = 'Unknown error';
+            $message = $this->internal[404];
         }
         $this->setMessage($message);
     }
@@ -233,7 +233,7 @@ class Fault
             if (isset($this->internal[$code])) {
                 $message = $this->internal[$code];
             } else {
-                $message = 'Unknown Error';
+                $message = $this->internal[404];
             }
         }
 

--- a/tests/ZendTest/XmlRpc/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/FaultTest.php
@@ -249,7 +249,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
     {
         $fault = new XmlRpc\Fault(1234);
         $this->assertSame(1234, $fault->getCode());
-        $this->assertSame('Unknown error', $fault->getMessage());
+        $this->assertSame('Unknown Error', $fault->getMessage());
     }
 
     public function testFaultStringWithoutStringTypeDeclaration()


### PR DESCRIPTION
pointed to develop because there is a change :  "error" and "Error" with uppercase 'E' for message result.
