### PR TITLE
Bugfix/thousand separator in number validator

### DIFF
--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -48,7 +48,7 @@ class Number extends Element implements InputProviderInterface
         // thousand separator. The prior use of the i18n Float validator
         // allowed the thousand separator, which resulted in wrong numbers
         // when casting to float.
-        $validators[] = new RegexValidator('(^\d*(\.\d+)?$)');
+        $validators[] = new RegexValidator('(^-?\d*(\.\d+)?$)');
 
         $inclusive = true;
         if (isset($this->attributes['inclusive'])) {

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -10,10 +10,10 @@
 namespace Zend\Form\Element;
 
 use Zend\Form\Element;
-use Zend\I18n\Validator\Float as NumberValidator;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\GreaterThan as GreaterThanValidator;
 use Zend\Validator\LessThan as LessThanValidator;
+use Zend\Validator\Regex as RegexValidator;
 use Zend\Validator\Step as StepValidator;
 
 class Number extends Element implements InputProviderInterface
@@ -44,9 +44,11 @@ class Number extends Element implements InputProviderInterface
         }
 
         $validators = array();
-        $validators[] = new NumberValidator(array(
-            'locale' => 'en_US', // HTML5 uses "100.01" format
-        ));
+        // HTML5 always transmits values in the format "1ß00.01", without a
+        // thousand separator. The prior use of the i18n Float validator
+        // allowed the thousand separator, which resulted in wrong numbers
+        // when casting to float.
+        $validators[] = new RegexValidator('(^\d*(\.\d+)?$)');
 
         $inclusive = true;
         if (isset($this->attributes['inclusive'])) {

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -44,7 +44,7 @@ class Number extends Element implements InputProviderInterface
         }
 
         $validators = array();
-        // HTML5 always transmits values in the format "1ß00.01", without a
+        // HTML5 always transmits values in the format "1000.01", without a
         // thousand separator. The prior use of the i18n Float validator
         // allowed the thousand separator, which resulted in wrong numbers
         // when casting to float.

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -121,7 +121,9 @@ class NumberTest extends TestCase
         foreach($inputSpec['validators'] as $validator) {
             if (get_class($validator) == 'Zend\Validator\Regex') {
                 $this->assertFalse($validator->isValid('1,000.01'));
+                $this->assertFalse($validator->isValid('-1,000.01'));
                 $this->assertTrue($validator->isValid('1000.01'));
+                $this->assertTrue($validator->isValid('-1000.01'));
                 break;
             }
         }

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -16,11 +16,6 @@ class NumberTest extends TestCase
 {
     public function testProvidesInputSpecificationWithDefaultAttributes()
     {
-        if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
-            $this->markTestSkipped('ext/intl not enabled');
-        }
-
         $element = new NumberElement();
 
         $inputSpec = $element->getInputSpecification();
@@ -28,7 +23,7 @@ class NumberTest extends TestCase
         $this->assertInternalType('array', $inputSpec['validators']);
 
         $expectedClasses = array(
-            'Zend\I18n\Validator\Float',
+            'Zend\Validator\Regex',
             'Zend\Validator\Step',
         );
         foreach ($inputSpec['validators'] as $validator) {
@@ -46,11 +41,6 @@ class NumberTest extends TestCase
 
     public function testProvidesInputSpecificationThatIncludesValidatorsBasedOnAttributes()
     {
-        if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
-            $this->markTestSkipped('ext/intl not enabled');
-        }
-
         $element = new NumberElement();
         $element->setAttributes(array(
             'inclusive' => true,
@@ -64,9 +54,9 @@ class NumberTest extends TestCase
         $this->assertInternalType('array', $inputSpec['validators']);
 
         $expectedClasses = array(
-            'Zend\I18n\Validator\Float',
             'Zend\Validator\GreaterThan',
             'Zend\Validator\LessThan',
+            'Zend\Validator\Regex',
             'Zend\Validator\Step',
         );
         foreach ($inputSpec['validators'] as $validator) {
@@ -129,7 +119,7 @@ class NumberTest extends TestCase
 
         $inputSpec = $element->getInputSpecification();
         foreach($inputSpec['validators'] as $validator) {
-            if (get_class($validator) == 'Zend\I18n\Validator\Float') {
+            if (get_class($validator) == 'Zend\Validator\Regex') {
                 $this->assertFalse($validator->isValid('1,000.01'));
                 $this->assertTrue($validator->isValid('1000.01'));
                 break;

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -122,4 +122,18 @@ class NumberTest extends TestCase
             }
         }
     }
+
+    public function testOnlyCastableDecimalsAreAccepted()
+    {
+        $element = new NumberElement();
+
+        $inputSpec = $element->getInputSpecification();
+        foreach($inputSpec['validators'] as $validator) {
+            if (get_class($validator) == 'Zend\I18n\Validator\Float') {
+                $this->assertFalse($validator->isValid('1,000.01'));
+                $this->assertTrue($validator->isValid('1000.01'));
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
 HTML5 always transmits values in the format "1ß00.01", without a thousand separator. The prior use of the i18n Float validator allowed the thousand separator, which resulted in wrong numbers when casting to float.
