### PR TITLE
Remove backslash splitName()

### DIFF
--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -481,12 +481,6 @@ class Ldap
         if ($pos) {
             $dname = substr($name, $pos + 1);
             $aname = substr($name, 0, $pos);
-        } else {
-            $pos = strpos($name, '\\');
-            if ($pos) {
-                $dname = substr($name, 0, $pos);
-                $aname = substr($name, $pos + 1);
-            }
         }
     }
 


### PR DESCRIPTION
Backslashes are used to escape special characters in AD, see here:
http://msdn.microsoft.com/en-us/library/aa366101(v=vs.85).aspx

So splitting by backslash for detecting is wrong.

Example:

``` cli
CN=Litware,OU=Docs\, Adatum,DC=Fabrikam,DC=COM
```
