### PR TITLE
Db\Sql\Sql use of different adapters

### DIFF
--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -34,7 +34,8 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     protected $defaultPlatform = null;
 
     /**
-     * @param $subject
+     * @param PreparableSqlInterface|SqlInterface $subject
+     * @return self
      */
     public function setSubject($subject)
     {
@@ -43,8 +44,10 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     }
 
     /**
-     * @param $type
+     *
+     * @param string $type
      * @param PlatformDecoratorInterface $decorator
+     * @param AdapterInterface|PlatformInterface $adapterOrPlatform
      */
     public function setTypeDecorator($type, PlatformDecoratorInterface $decorator, $adapterOrPlatform = null)
     {
@@ -52,6 +55,11 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
         $this->decorators[$platformName][$type] = $decorator;
     }
 
+    /**
+     * @param PreparableSqlInterface|SqlInterface $subject
+     * @param AdapterInterface|PlatformInterface $adapterOrPlatform
+     * @return PlatformDecoratorInterface|PreparableSqlInterface|SqlInterface
+     */
     protected function getTypeDecorator($subject, $adapterOrPlatform)
     {
         $platformName = strtolower($this->resolvePlatform($adapterOrPlatform)->getName());
@@ -104,8 +112,10 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     }
 
     /**
+     *
      * @param null|PlatformInterface|AdapterInterface $adapterOrPlatform
      * @return PlatformInterface
+     * @throws Exception\InvalidArgumentException
      */
     protected function resolvePlatform($adapterOrPlatform)
     {

--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -34,6 +34,7 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     public function setSubject($subject)
     {
         $this->subject = $subject;
+        return $this;
     }
 
     /**
@@ -43,6 +44,17 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     public function setTypeDecorator($type, PlatformDecoratorInterface $decorator)
     {
         $this->decorators[$type] = $decorator;
+    }
+
+    protected function getTypeDecorator($subject)
+    {
+        foreach ($this->decorators as $type => $decorator) {
+            if ($subject instanceof $type && is_a($decorator, $type, true)) {
+                $decorator->setSubject($subject);
+                return $decorator;
+            }
+        }
+        return $subject;
     }
 
     /**
@@ -64,21 +76,8 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
         if (!$this->subject instanceof PreparableSqlInterface) {
             throw new Exception\RuntimeException('The subject does not appear to implement Zend\Db\Sql\PreparableSqlInterface, thus calling prepareStatement() has no effect');
         }
-
-        $decoratorForType = false;
-        foreach ($this->decorators as $type => $decorator) {
-            if ($this->subject instanceof $type && $decorator instanceof PreparableSqlInterface) {
-                /** @var $decoratorForType PreparableSqlInterface|PlatformDecoratorInterface */
-                $decoratorForType = $decorator;
-                break;
-            }
-        }
-        if ($decoratorForType) {
-            $decoratorForType->setSubject($this->subject);
-            $decoratorForType->prepareStatement($adapter, $statementContainer);
-        } else {
-            $this->subject->prepareStatement($adapter, $statementContainer);
-        }
+        $this->getTypeDecorator($this->subject)->prepareStatement($adapter, $statementContainer);
+        return $statementContainer;
     }
 
     /**
@@ -89,22 +88,8 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
     public function getSqlString(PlatformInterface $adapterPlatform = null)
     {
         if (!$this->subject instanceof SqlInterface) {
-            throw new Exception\RuntimeException('The subject does not appear to implement Zend\Db\Sql\PreparableSqlInterface, thus calling prepareStatement() has no effect');
+            throw new Exception\RuntimeException('The subject does not appear to implement Zend\Db\Sql\SqlInterface, thus calling prepareStatement() has no effect');
         }
-
-        $decoratorForType = false;
-        foreach ($this->decorators as $type => $decorator) {
-            if ($this->subject instanceof $type && $decorator instanceof SqlInterface) {
-                /** @var $decoratorForType SqlInterface|PlatformDecoratorInterface */
-                $decoratorForType = $decorator;
-                break;
-            }
-        }
-        if ($decoratorForType) {
-            $decoratorForType->setSubject($this->subject);
-            return $decoratorForType->getSqlString($adapterPlatform);
-        }
-
-        return $this->subject->getSqlString($adapterPlatform);
+        return $this->getTypeDecorator($this->subject)->getSqlString($adapterPlatform);
     }
 }

--- a/library/Zend/Db/Sql/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Sql/Platform/AbstractPlatform.php
@@ -109,12 +109,19 @@ class AbstractPlatform implements PlatformDecoratorInterface, PreparableSqlInter
      */
     protected function resolvePlatform($adapterOrPlatform)
     {
-        if ($adapterOrPlatform instanceof PlatformInterface) {
-            return $adapterOrPlatform;
+        if ($adapterOrPlatform == null) {
+            return $this->defaultPlatform;
         }
         if ($adapterOrPlatform instanceof AdapterInterface) {
             return $adapterOrPlatform->getPlatform();
         }
-        return $this->defaultPlatform;
+        if ($adapterOrPlatform instanceof PlatformInterface) {
+            return $adapterOrPlatform;
+        }
+        throw new Exception\InvalidArgumentException(sprintf(
+            '$adapterOrPlatform should be null, %s, or %s',
+            'Zend\Db\Adapter\AdapterInterface',
+            'Zend\Db\Adapter\Platform\PlatformInterface'
+        ));
     }
 }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/IbmDb2.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/IbmDb2.php
@@ -10,6 +10,7 @@
 namespace Zend\Db\Sql\Platform\IbmDb2;
 
 use Zend\Db\Sql\Platform\AbstractPlatform;
+use Zend\Db\Adapter\Platform\IbmDb2 as DefaultPlatform;
 
 class IbmDb2 extends AbstractPlatform
 {
@@ -18,6 +19,7 @@ class IbmDb2 extends AbstractPlatform
      */
     public function __construct(SelectDecorator $selectDecorator = null)
     {
+        $this->defaultPlatform = new DefaultPlatform;
         $this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
     }
 }

--- a/library/Zend/Db/Sql/Platform/Mysql/Mysql.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Mysql.php
@@ -10,11 +10,13 @@
 namespace Zend\Db\Sql\Platform\Mysql;
 
 use Zend\Db\Sql\Platform\AbstractPlatform;
+use Zend\Db\Adapter\Platform\Mysql as DefaultPlatform;
 
 class Mysql extends AbstractPlatform
 {
     public function __construct()
     {
+        $this->defaultPlatform = new DefaultPlatform;
         $this->setTypeDecorator('Zend\Db\Sql\Select', new SelectDecorator());
         $this->setTypeDecorator('Zend\Db\Sql\Ddl\CreateTable', new Ddl\CreateTableDecorator());
     }

--- a/library/Zend/Db/Sql/Platform/Oracle/Oracle.php
+++ b/library/Zend/Db/Sql/Platform/Oracle/Oracle.php
@@ -10,12 +10,14 @@
 namespace Zend\Db\Sql\Platform\Oracle;
 
 use Zend\Db\Sql\Platform\AbstractPlatform;
+use Zend\Db\Adapter\Platform\Oracle as DefaultPlatform;
 
 class Oracle extends AbstractPlatform
 {
 
     public function __construct(SelectDecorator $selectDecorator = null)
     {
+        $this->defaultPlatform = new DefaultPlatform;
         $this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
     }
 

--- a/library/Zend/Db/Sql/Platform/Platform.php
+++ b/library/Zend/Db/Sql/Platform/Platform.php
@@ -13,34 +13,18 @@ use Zend\Db\Adapter\AdapterInterface;
 
 class Platform extends AbstractPlatform
 {
-    /**
-     * @var AdapterInterface
-     */
-    protected $adapter = null;
-
     public function __construct(AdapterInterface $adapter)
     {
-        $this->adapter = $adapter;
-        $platform = $adapter->getPlatform();
-        switch (strtolower($platform->getName())) {
-            case 'mysql':
-                $platform = new Mysql\Mysql();
-                $this->decorators = $platform->decorators;
-                break;
-            case 'sqlserver':
-                $platform = new SqlServer\SqlServer();
-                $this->decorators = $platform->decorators;
-                break;
-            case 'oracle':
-                $platform = new Oracle\Oracle();
-                $this->decorators = $platform->decorators;
-                break;
-            case 'ibm db2':
-            case 'ibm_db2':
-            case 'ibmdb2':
-                $platform = new IbmDb2\IbmDb2();
-                $this->decorators = $platform->decorators;
-            default:
-        }
+        $this->defaultPlatform = $adapter->getPlatform();
+        $sqlPlatform = new Mysql\Mysql();
+        $this->decorators['mysql'] = $sqlPlatform->getDecorators();
+        $sqlPlatform = new SqlServer\SqlServer();
+        $this->decorators['sqlserver'] = $sqlPlatform->getDecorators();
+        $sqlPlatform = new Oracle\Oracle();
+        $this->decorators['oracle'] = $sqlPlatform->getDecorators();
+        $sqlPlatform = new IbmDb2\IbmDb2();
+        $this->decorators['ibm db2'] = $sqlPlatform->getDecorators();
+        $this->decorators['ibm_db2'] = $this->decorators['ibm db2'];
+        $this->decorators['ibmdb2']  = $this->decorators['ibm db2'];
     }
 }

--- a/library/Zend/Db/Sql/Platform/SqlServer/SqlServer.php
+++ b/library/Zend/Db/Sql/Platform/SqlServer/SqlServer.php
@@ -10,12 +10,14 @@
 namespace Zend\Db\Sql\Platform\SqlServer;
 
 use Zend\Db\Sql\Platform\AbstractPlatform;
+use Zend\Db\Adapter\Platform\SqlServer as DefaultPlatform;
 
 class SqlServer extends AbstractPlatform
 {
 
     public function __construct(SelectDecorator $selectDecorator = null)
     {
+        $this->defaultPlatform = new DefaultPlatform;
         $this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
         $this->setTypeDecorator('Zend\Db\Sql\Ddl\CreateTable', new Ddl\CreateTableDecorator());
     }

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -117,29 +117,13 @@ class Sql
      */
     public function prepareStatementForSqlObject(PreparableSqlInterface $sqlObject, StatementInterface $statement = null)
     {
-        $statement = ($statement) ?: $this->adapter->getDriver()->createStatement();
-
-        if ($this->sqlPlatform) {
-            $this->sqlPlatform->setSubject($sqlObject);
-            $this->sqlPlatform->prepareStatement($this->adapter, $statement);
-        } else {
-            $sqlObject->prepareStatement($this->adapter, $statement);
-        }
-
-        return $statement;
+        $statement = $statement ?: $this->adapter->getDriver()->createStatement();
+        return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($this->adapter, $statement);
     }
 
     public function getSqlStringForSqlObject(SqlInterface $sqlObject, PlatformInterface $platform = null)
     {
         $platform = ($platform) ?: $this->adapter->getPlatform();
-
-        if ($this->sqlPlatform) {
-            $this->sqlPlatform->setSubject($sqlObject);
-            $sqlString = $this->sqlPlatform->getSqlString($platform);
-        } else {
-            $sqlString = $sqlObject->getSqlString($platform);
-        }
-
-        return $sqlString;
+        return $this->sqlPlatform->setSubject($sqlObject)->getSqlString($platform);
     }
 }

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -127,8 +127,19 @@ class Sql
         return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($adapter, $statement);
     }
 
-    public function getSqlStringForSqlObject(SqlInterface $sqlObject, PlatformInterface $platform = null)
+    public function getSqlStringForSqlObject(SqlInterface $sqlObject, $adapterOrPlatform = null)
     {
-        return $this->sqlPlatform->setSubject($sqlObject)->getSqlString($platform);
+        if ($adapterOrPlatform == null) {
+            $adapterOrPlatform = $this->adapter->getPlatform();
+        } elseif ($adapterOrPlatform instanceof AdapterInterface) {
+            $adapterOrPlatform = $adapterOrPlatform->getPlatform();
+        } elseif (!$adapterOrPlatform instanceof PlatformInterface) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '$adapterOrPlatform should be null, %s, or %s',
+                'Zend\Db\Adapter\AdapterInterface',
+                'Zend\Db\Adapter\Platform\PlatformInterface'
+            ));
+        }
+        return $this->sqlPlatform->setSubject($sqlObject)->getSqlString($adapterOrPlatform);
     }
 }

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -18,12 +18,17 @@ class Sql
     /** @var AdapterInterface */
     protected $adapter = null;
 
-    /** @var string|array|TableIdentifier */
+    /** @var null|string|array|TableIdentifier */
     protected $table = null;
 
     /** @var Platform\Platform */
     protected $sqlPlatform = null;
 
+    /**
+     * @param AdapterInterface $adapter
+     * @param null|string|array|TableIdentifier $table
+     * @param null|Platform\AbstractPlatform $sqlPlatform @deprecated since version 3.0
+     */
     public function __construct(AdapterInterface $adapter, $table = null, Platform\AbstractPlatform $sqlPlatform = null)
     {
         $this->adapter = $adapter;
@@ -115,15 +120,15 @@ class Sql
      * @param StatementInterface|null $statement
      * @return StatementInterface
      */
-    public function prepareStatementForSqlObject(PreparableSqlInterface $sqlObject, StatementInterface $statement = null)
+    public function prepareStatementForSqlObject(PreparableSqlInterface $sqlObject, StatementInterface $statement = null, AdapterInterface $adapter = null)
     {
-        $statement = $statement ?: $this->adapter->getDriver()->createStatement();
-        return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($this->adapter, $statement);
+        $adapter = $adapter ?: $this->adapter;
+        $statement = $statement ?: $adapter->getDriver()->createStatement();
+        return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($adapter, $statement);
     }
 
     public function getSqlStringForSqlObject(SqlInterface $sqlObject, PlatformInterface $platform = null)
     {
-        $platform = ($platform) ?: $this->adapter->getPlatform();
         return $this->sqlPlatform->setSubject($sqlObject)->getSqlString($platform);
     }
 }

--- a/library/Zend/Db/Sql/Sql.php
+++ b/library/Zend/Db/Sql/Sql.php
@@ -116,9 +116,11 @@ class Sql
     }
 
     /**
+     *
      * @param PreparableSqlInterface $sqlObject
-     * @param StatementInterface|null $statement
-     * @return StatementInterface
+     * @param StatementInterface $statement
+     * @param AdapterInterface $adapter
+     * @return mixed
      */
     public function prepareStatementForSqlObject(PreparableSqlInterface $sqlObject, StatementInterface $statement = null, AdapterInterface $adapter = null)
     {
@@ -127,6 +129,12 @@ class Sql
         return $this->sqlPlatform->setSubject($sqlObject)->prepareStatement($adapter, $statement);
     }
 
+    /**
+     * @param SqlInterface $sqlObject
+     * @param null|PlatformInterface|AdapterInterface $adapterOrPlatform
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     */
     public function getSqlStringForSqlObject(SqlInterface $sqlObject, $adapterOrPlatform = null)
     {
         if ($adapterOrPlatform == null) {

--- a/tests/ZendTest/Db/Sql/SqlTest.php
+++ b/tests/ZendTest/Db/Sql/SqlTest.php
@@ -10,6 +10,8 @@
 namespace ZendTest\Db\Sql;
 
 use Zend\Db\Sql\Sql;
+use ZendTest\Db\TestAsset;
+use Zend\Db\Adapter\Adapter;
 
 class SqlTest extends \PHPUnit_Framework_TestCase
 {
@@ -32,9 +34,10 @@ class SqlTest extends \PHPUnit_Framework_TestCase
         $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
         $mockDriver->expects($this->any())->method('createStatement')->will($this->returnValue($mockStatement));
         $mockDriver->expects($this->any())->method('getConnection')->will($this->returnValue($mockConnection));
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
 
         // setup mock adapter
-        $this->mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver));
+        $this->mockAdapter = $this->getMock('Zend\Db\Adapter\Adapter', null, array($mockDriver, new TestAsset\TrustingSql92Platform()));
 
         $this->sql = new Sql($this->mockAdapter, 'foo');
     }
@@ -123,5 +126,78 @@ class SqlTest extends \PHPUnit_Framework_TestCase
         $insert = $this->sql->insert()->columns(array('foo'))->values(array('foo'=>'bar'));
         $stmt = $this->sql->prepareStatementForSqlObject($insert);
         $this->assertInstanceOf('Zend\Db\Adapter\Driver\StatementInterface', $stmt);
+    }
+
+    public function testForDifferentAdapters()
+    {
+        $adapterSql92     = $this->getAdapterForPlatform('sql92');
+        $adapterMySql     = $this->getAdapterForPlatform('MySql');
+        $adapterOracle    = $this->getAdapterForPlatform('Oracle');
+        $adapterSqlServer = $this->getAdapterForPlatform('SqlServer');
+
+        $select = $this->sql->select()->offset(10);
+
+        // Default
+        $this->assertEquals(
+            'SELECT "foo".* FROM "foo" OFFSET \'10\'',
+            $this->sql->getSqlStringForSqlObject($select)
+        );
+        $this->mockAdapter->getDriver()->createStatement()->expects($this->any())->method('setSql')
+                ->with($this->equalTo('SELECT "foo".* FROM "foo" OFFSET ?'));
+        $this->sql->prepareStatementForSqlObject($select);
+
+        // Sql92
+        $this->assertEquals(
+            'SELECT "foo".* FROM "foo" OFFSET \'10\'',
+            $this->sql->getSqlStringForSqlObject($select, $adapterSql92->getPlatform())
+        );
+        $adapterSql92->getDriver()->createStatement()->expects($this->any())->method('setSql')
+                ->with($this->equalTo('SELECT "foo".* FROM "foo" OFFSET ?'));
+        $this->sql->prepareStatementForSqlObject($select, null, $adapterSql92);
+
+        // MySql
+        $this->assertEquals(
+            'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10',
+            $this->sql->getSqlStringForSqlObject($select, $adapterMySql->getPlatform())
+        );
+        $adapterMySql->getDriver()->createStatement()->expects($this->any())->method('setSql')
+                ->with($this->equalTo('SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET ?'));
+        $this->sql->prepareStatementForSqlObject($select, null, $adapterMySql);
+
+        // Oracle
+        $this->assertEquals(
+            'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b ) WHERE b_rownum > (10)',
+            $this->sql->getSqlStringForSqlObject($select, $adapterOracle->getPlatform())
+        );
+        $adapterOracle->getDriver()->createStatement()->expects($this->any())->method('setSql')
+                ->with($this->equalTo('SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b ) WHERE b_rownum > (:offset)'));
+        $this->sql->prepareStatementForSqlObject($select, null, $adapterOracle);
+
+        // SqlServer
+        $this->assertContains(
+            'WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 10+1 AND 0+10',
+            $this->sql->getSqlStringForSqlObject($select, $adapterSqlServer->getPlatform())
+        );
+        $adapterSqlServer->getDriver()->createStatement()->expects($this->any())->method('setSql')
+                ->with($this->stringContains('WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN ?+1 AND ?+?'));
+        $this->sql->prepareStatementForSqlObject($select, null, $adapterSqlServer);
+    }
+
+    protected function getAdapterForPlatform($platform)
+    {
+        switch($platform) {
+            case 'sql92'     : $platform  = new TestAsset\TrustingSql92Platform();     break;
+            case 'MySql'     : $platform  = new TestAsset\TrustingMysqlPlatform();     break;
+            case 'Oracle'    : $platform  = new TestAsset\TrustingOraclePlatform();    break;
+            case 'SqlServer' : $platform  = new TestAsset\TrustingSqlServerPlatform(); break;
+            default : $platform = null;
+        }
+
+        $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+        $mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnValue('?'));
+        $mockDriver->expects($this->any())->method('createStatement')->will($this->returnValue($mockStatement));
+
+        return new Adapter($mockDriver, $platform);
     }
 }

--- a/tests/ZendTest/Db/Sql/SqlTest.php
+++ b/tests/ZendTest/Db/Sql/SqlTest.php
@@ -149,6 +149,10 @@ class SqlTest extends \PHPUnit_Framework_TestCase
         // Sql92
         $this->assertEquals(
             'SELECT "foo".* FROM "foo" OFFSET \'10\'',
+            $this->sql->getSqlStringForSqlObject($select, $adapterSql92)
+        );
+        $this->assertEquals(
+            'SELECT "foo".* FROM "foo" OFFSET \'10\'',
             $this->sql->getSqlStringForSqlObject($select, $adapterSql92->getPlatform())
         );
         $adapterSql92->getDriver()->createStatement()->expects($this->any())->method('setSql')
@@ -156,6 +160,10 @@ class SqlTest extends \PHPUnit_Framework_TestCase
         $this->sql->prepareStatementForSqlObject($select, null, $adapterSql92);
 
         // MySql
+        $this->assertEquals(
+            'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10',
+            $this->sql->getSqlStringForSqlObject($select, $adapterMySql)
+        );
         $this->assertEquals(
             'SELECT `foo`.* FROM `foo` LIMIT 18446744073709551615 OFFSET 10',
             $this->sql->getSqlStringForSqlObject($select, $adapterMySql->getPlatform())
@@ -167,6 +175,10 @@ class SqlTest extends \PHPUnit_Framework_TestCase
         // Oracle
         $this->assertEquals(
             'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b ) WHERE b_rownum > (10)',
+            $this->sql->getSqlStringForSqlObject($select, $adapterOracle)
+        );
+        $this->assertEquals(
+            'SELECT * FROM (SELECT b.*, rownum b_rownum FROM ( SELECT "foo".* FROM "foo" ) b ) WHERE b_rownum > (10)',
             $this->sql->getSqlStringForSqlObject($select, $adapterOracle->getPlatform())
         );
         $adapterOracle->getDriver()->createStatement()->expects($this->any())->method('setSql')
@@ -174,6 +186,10 @@ class SqlTest extends \PHPUnit_Framework_TestCase
         $this->sql->prepareStatementForSqlObject($select, null, $adapterOracle);
 
         // SqlServer
+        $this->assertContains(
+            'WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 10+1 AND 0+10',
+            $this->sql->getSqlStringForSqlObject($select, $adapterSqlServer)
+        );
         $this->assertContains(
             'WHERE [ZEND_SQL_SERVER_LIMIT_OFFSET_EMULATION].[__ZEND_ROW_NUMBER] BETWEEN 10+1 AND 0+10',
             $this->sql->getSqlStringForSqlObject($select, $adapterSqlServer->getPlatform())

--- a/tests/ZendTest/Db/TestAsset/TrustingMysqlPlatform.php
+++ b/tests/ZendTest/Db/TestAsset/TrustingMysqlPlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\Mysql;
+
+class TrustingMysqlPlatform extends Mysql
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/TrustingOraclePlatform.php
+++ b/tests/ZendTest/Db/TestAsset/TrustingOraclePlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\Oracle;
+
+class TrustingOraclePlatform extends Oracle
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}

--- a/tests/ZendTest/Db/TestAsset/TrustingSqlServerPlatform.php
+++ b/tests/ZendTest/Db/TestAsset/TrustingSqlServerPlatform.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\TestAsset;
+
+use Zend\Db\Adapter\Platform\SqlServer;
+
+class TrustingSqlServerPlatform extends SqlServer
+{
+    public function quoteValue($value)
+    {
+        return $this->quoteTrustedValue($value);
+    }
+}


### PR DESCRIPTION
allow use differents `Adapter` for build SqlObjects via `Db\Sql`
allow use `AdapterInterface` for `Sql::getSqlStringForSqlObject()` method
