### PR TITLE
Bugfix/merging inputs with allow empty

### DIFF
--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -297,12 +297,12 @@ class Input implements InputInterface, EmptyContextInterface
      */
     public function merge(InputInterface $input)
     {
-        $this->setAllowEmpty($input->allowEmpty());
         $this->setBreakOnFailure($input->breakOnFailure());
         $this->setContinueIfEmpty($input->continueIfEmpty());
         $this->setErrorMessage($input->getErrorMessage());
         $this->setName($input->getName());
         $this->setRequired($input->isRequired());
+        $this->setAllowEmpty($input->allowEmpty());
         $this->setValue($input->getRawValue());
 
         $filterChain = $input->getFilterChain();

--- a/tests/ZendTest/InputFilter/InputTest.php
+++ b/tests/ZendTest/InputFilter/InputTest.php
@@ -311,4 +311,19 @@ class InputTest extends TestCase
         $input2->merge($input);
         $this->assertTrue($input2->continueIfEmpty());
     }
+
+    public function testMergeRetainsAllowEmptyFlag()
+    {
+        $input = new Input('foo');
+        $input->setRequired(true);
+        $input->setAllowEmpty(true);
+
+        $input2 = new Input('bar');
+        $input2->setRequired(true);
+        $input2->setAllowEmpty(false);
+        $input2->merge($input);
+
+        $this->assertTrue($input2->isRequired());
+        $this->assertTrue($input2->allowEmpty());
+    }
 }


### PR DESCRIPTION
When an input element defines an Input with the `required` flag set to `true`, and you add your own Input on top of that with the `allow_empty` flag set to `true`, it won't be properly merged into the input of the element. The reason for this is that on merge the `setRequired()` method is called after the `setAllowEmpty()` method, which automatically sets `allowEmpty` to false if the `required` flag is `true`. This PR fixes this by simply shifting the method calls in the `merge()` method around.
