### PR TITLE
Fix for performance issue in Http\Response

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -197,17 +197,15 @@ class Response extends AbstractMessage implements ResponseInterface
         $isHeader = true;
         $headers = $content = array();
 
-        while ($lines) {
-            $nextLine = array_shift($lines);
-
-            if ($isHeader && $nextLine == '') {
+        foreach ($lines as $line) {
+            if ($isHeader && $line == '') {
                 $isHeader = false;
                 continue;
             }
             if ($isHeader) {
-                $headers[] = $nextLine;
+                $headers[] = $line;
             } else {
-                $content[] = $nextLine;
+                $content[] = $line;
             }
         }
 


### PR DESCRIPTION
The previous loop proved to be the root cause of extreme performance issues when dealing with large text responses, as it caused an `array_shift` to be fired every single line.
