### PR TITLE
Duplicate interfaces on Zend/Mvc/I18n/Translator class.

### DIFF
--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -11,11 +11,9 @@ namespace Zend\Mvc\I18n;
 
 use Zend\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
 use Zend\Mvc\Exception;
-use Zend\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
 
 class Translator implements
-    I18nTranslatorInterface,
-    ValidatorTranslatorInterface
+    I18nTranslatorInterface
 {
     /**
      * @var I18nTranslatorInterface
@@ -39,6 +37,7 @@ class Translator implements
      * @deprecated
      * @param string $method
      * @param array $args
+     * @throws \Zend\Mvc\Exception\BadMethodCallException
      * @return mixed
      */
     public function __call($method, array $args)

--- a/library/Zend/Mvc/I18n/Translator.php
+++ b/library/Zend/Mvc/I18n/Translator.php
@@ -12,8 +12,7 @@ namespace Zend\Mvc\I18n;
 use Zend\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
 use Zend\Mvc\Exception;
 
-class Translator implements
-    I18nTranslatorInterface
+class Translator implements I18nTranslatorInterface
 {
     /**
      * @var I18nTranslatorInterface

--- a/tests/ZendTest/Mvc/I18n/TranslatorTest.php
+++ b/tests/ZendTest/Mvc/I18n/TranslatorTest.php
@@ -25,11 +25,6 @@ class TranslatorTest extends TestCase
         $this->assertInstanceOf('Zend\I18n\Translator\TranslatorInterface', $this->translator);
     }
 
-    public function testIsAValidatorTranslator()
-    {
-        $this->assertInstanceOf('Zend\Validator\Translator\TranslatorInterface', $this->translator);
-    }
-
     public function testCanRetrieveComposedTranslator()
     {
         $this->assertSame($this->i18nTranslator, $this->translator->getTranslator());


### PR DESCRIPTION
I receive the following error after running a fresh Skeleton Application install on PHP 5.3.5 and ZF2 2.3.1:

```
PHP Fatal error:  Can't inherit abstract function Zend\Validator\Translator\TranslatorInterface::translate() (previously declared abstract in Zend\I18n\Translator\TranslatorInterface) in .../vendor/zendframework/zendframework/library/Zend/Mvc/I18n/Translator.php on line 19
```

Upon investigation, it appears as though the Zend\Validator\Translator\TranslatorInterface interface redefines the translate() method as found in the Zend\I18n\Translator\TranslatorInterface interface.  PHP responds with the above error.
