### PR TITLE
Closes issue #4876 - added support for trait generation and trait scanning

### DIFF
--- a/library/Zend/Code/Generator/TraitGenerator.php
+++ b/library/Zend/Code/Generator/TraitGenerator.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Code\Generator;
+
+use Zend\Code\Reflection\ClassReflection;
+
+class TraitGenerator extends ClassGenerator
+{
+    const OBJECT_TYPE = "trait";
+
+    /**
+     * Build a Code Generation Php Object from a Class Reflection
+     *
+     * @param  ClassReflection $classReflection
+     * @return ClassGenerator
+     */
+    public static function fromReflection(ClassReflection $classReflection)
+    {
+        // class generator
+        $cg = new static($classReflection->getName());
+
+        $cg->setSourceContent($cg->getSourceContent());
+        $cg->setSourceDirty(false);
+
+        if ($classReflection->getDocComment() != '') {
+            $cg->setDocBlock(DocBlockGenerator::fromReflection($classReflection->getDocBlock()));
+        }
+
+        // set the namespace
+        if ($classReflection->inNamespace()) {
+            $cg->setNamespaceName($classReflection->getNamespaceName());
+        }
+
+        $properties = array();
+        foreach ($classReflection->getProperties() as $reflectionProperty) {
+            if ($reflectionProperty->getDeclaringClass()->getName() == $classReflection->getName()) {
+                $properties[] = PropertyGenerator::fromReflection($reflectionProperty);
+            }
+        }
+        $cg->addProperties($properties);
+
+        $methods = array();
+        foreach ($classReflection->getMethods() as $reflectionMethod) {
+            $className = ($cg->getNamespaceName())? $cg->getNamespaceName() . "\\" . $cg->getName() : $cg->getName();
+            if ($reflectionMethod->getDeclaringClass()->getName() == $className) {
+                $methods[] = MethodGenerator::fromReflection($reflectionMethod);
+            }
+        }
+        $cg->addMethods($methods);
+
+        return $cg;
+    }
+
+    /**
+     * Generate from array
+     *
+     * @configkey name           string        [required] Class Name
+     * @configkey filegenerator  FileGenerator File generator that holds this class
+     * @configkey namespacename  string        The namespace for this class
+     * @configkey docblock       string        The docblock information
+     * @configkey properties
+     * @configkey methods
+     *
+     * @throws Exception\InvalidArgumentException
+     * @param  array $array
+     * @return ClassGenerator
+     */
+    public static function fromArray(array $array)
+    {
+        if (!isset($array['name'])) {
+            throw new Exception\InvalidArgumentException(
+                'Class generator requires that a name is provided for this object'
+            );
+        }
+
+        $cg = new static($array['name']);
+        foreach ($array as $name => $value) {
+            // normalize key
+            switch (strtolower(str_replace(array('.', '-', '_'), '', $name))) {
+                case 'containingfile':
+                    $cg->setContainingFileGenerator($value);
+                    break;
+                case 'namespacename':
+                    $cg->setNamespaceName($value);
+                    break;
+                case 'docblock':
+                    $docBlock = ($value instanceof DocBlockGenerator) ? $value : DocBlockGenerator::fromArray($value);
+                    $cg->setDocBlock($docBlock);
+                    break;
+                case 'properties':
+                    $cg->addProperties($value);
+                    break;
+                case 'methods':
+                    $cg->addMethods($value);
+                    break;
+            }
+        }
+
+        return $cg;
+    }
+
+    /**
+     * @param  array|string $flags
+     * @return ClassGenerator
+     */
+    public function setFlags($flags)
+    {
+        return $this;
+    }
+
+    /**
+     * @param  string $flag
+     * @return ClassGenerator
+     */
+    public function addFlag($flag)
+    {
+        return $this;
+    }
+
+    /**
+     * @param  string $flag
+     * @return ClassGenerator
+     */
+    public function removeFlag($flag)
+    {
+        return $this;
+    }
+
+    /**
+     * @param  bool $isFinal
+     * @return ClassGenerator
+     */
+    public function setFinal($isFinal)
+    {
+        return $this;
+    }
+
+    /**
+     * @param  string $extendedClass
+     * @return ClassGenerator
+     */
+    public function setExtendedClass($extendedClass)
+    {
+        return $this;
+    }
+
+    /**
+     * @param  array $implementedInterfaces
+     * @return ClassGenerator
+     */
+    public function setImplementedInterfaces(array $implementedInterfaces)
+    {
+        return $this;
+    }
+
+    /**
+     * @param  bool $isAbstract
+     * @return ClassGenerator
+     */
+    public function setAbstract($isAbstract)
+    {
+        return $this;
+    }
+}

--- a/library/Zend/Code/Generator/TraitUsageGenerator.php
+++ b/library/Zend/Code/Generator/TraitUsageGenerator.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: steverhoades
- * Date: 2/24/15
- * Time: 10:02 AM
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 namespace Zend\Code\Generator;
 

--- a/library/Zend/Code/Generator/TraitUsageGenerator.php
+++ b/library/Zend/Code/Generator/TraitUsageGenerator.php
@@ -1,0 +1,303 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: steverhoades
+ * Date: 2/24/15
+ * Time: 10:02 AM
+ */
+namespace Zend\Code\Generator;
+
+class TraitUsageGenerator extends AbstractGenerator
+{
+    protected $classGenerator;
+
+    /**
+     * @var array Array of trait names
+     */
+    protected $traits = array();
+
+    /**
+     * @var array Array of trait aliases
+     */
+    protected $traitAliases = array();
+
+    /**
+     * @var array Array of trait overrides
+     */
+    protected $traitOverrides = array();
+
+    /**
+     * @var array Array of string names
+     */
+    protected $uses = array();
+
+    public function __construct(ClassGenerator $classGenerator)
+    {
+        $this->classGenerator = $classGenerator;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function addUse($use, $useAlias = null)
+    {
+        if (!empty($useAlias)) {
+            $use .= ' as ' . $useAlias;
+        }
+
+        $this->uses[$use] = $use;
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function getUses()
+    {
+        return array_values($this->uses);
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function addTrait($trait)
+    {
+        $traitName = $trait;
+        if (true === is_array($trait)) {
+            if (false === array_key_exists('traitName', $trait)) {
+                throw new Exception\InvalidArgumentException("Missing required value for traitName.");
+            }
+            $traitName = $trait['traitName'];
+
+            if (true === array_key_exists('aliases', $trait)) {
+                foreach ($trait['aliases'] as $alias) {
+                    $this->addAlias($alias);
+                }
+            }
+
+            if (true === array_key_exists('insteadof', $trait)) {
+                foreach ($trait['insteadof'] as $insteadof) {
+                    $this->addTraitOverride($insteadof);
+                }
+            }
+        }
+
+        if (false === $this->hasTrait($traitName)) {
+            $this->traits[] = $traitName;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function addTraits(array $traits)
+    {
+        foreach ($traits as $trait) {
+            $this->addTrait($trait);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function hasTrait($traitName)
+    {
+        return in_array($traitName, $this->traits);
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function getTraits()
+    {
+        return $this->traits;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function removeTrait($traitName)
+    {
+        $key = array_search($traitName, $this->traits);
+        if (false !== $key) {
+            unset($this->traits[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function addTraitAlias($method, $alias, $visibility = null)
+    {
+        $traitAndMethod = $method;
+        if (true === is_array($method)) {
+            if (false === array_key_exists('traitName', $method)) {
+                throw new Exception\InvalidArgumentException('Missing required argument "traitName" for $method');
+            }
+
+            if (false === array_key_exists('method', $method)) {
+                throw new Exception\InvalidArgumentException('Missing required argument "method" for $method');
+            }
+
+            $traitAndMethod = $method['traitName'] ."::". $method['method'];
+        }
+
+        // Validations
+        if (false === strpos($traitAndMethod, "::")) {
+            throw new Exception\InvalidArgumentException('Invalid Format: $method must be in the format of trait::method');
+        } elseif (false === is_string($alias)) {
+            throw new Exception\InvalidArgumentException('Invalid Alias: $alias must be a string or array.');
+        } elseif($this->classGenerator->hasMethod($alias)) {
+            throw new Exception\InvalidArgumentException('Invalid Alias: Method name already exists on this class.');
+        } elseif (false === is_null($visibility) && ($visibility !== \ReflectionMethod::IS_PUBLIC && $visibility !== \ReflectionMethod::IS_PRIVATE && $visibility !== \ReflectionMethod::IS_PROTECTED)) {
+            throw new Exception\InvalidArgumentException('Invalid Type: $visibility must of ReflectionMethod::IS_PUBLIC, ReflectionMethod::IS_PRIVATE or ReflectionMethod::IS_PROTECTED');
+        }
+
+        list($trait, $method) = explode("::", $traitAndMethod);
+        if (false === $this->hasTrait($trait)) {
+            throw new Exception\InvalidArgumentException('Invalid trait: Trait does not exists on this class.');
+        }
+
+        $this->traitAliases[$traitAndMethod] = array(
+            'alias' => $alias,
+            'visibility' => $visibility
+        );
+
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function getTraitAliases()
+    {
+        return $this->traitAliases;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function addTraitOverride($method, $traitsToReplace)
+    {
+        if (false === is_array($traitsToReplace)) {
+            $traitsToReplace = array($traitsToReplace);
+        }
+
+        $traitAndMethod = $method;
+        if (true === is_array($method)) {
+            if (false === array_key_exists('traitName', $method)) {
+                throw new Exception\InvalidArgumentException('Missing required argument "traitName" for $method');
+            }
+
+            if (false === array_key_exists('method', $method)) {
+                throw new Exception\InvalidArgumentException('Missing required argument "method" for $method');
+            }
+
+            $traitAndMethod = (string) $method['traitName'] ."::". (string) $method['method'];
+        }
+
+        // Validations
+        if (false === strpos($traitAndMethod, "::")) {
+            throw new Exception\InvalidArgumentException('Invalid Format: $method must be in the format of trait::method');
+        }
+
+        list($trait, $method) = explode("::", $traitAndMethod);
+        if (false === $this->hasTrait($trait)) {
+            throw new Exception\InvalidArgumentException('Invalid trait: Trait does not exists on this class.');
+        }
+
+        if (false === array_key_exists($traitAndMethod, $this->traitOverrides)) {
+            $this->traitOverrides[$traitAndMethod] = array();
+        }
+
+        foreach ($traitsToReplace as $traitToReplace) {
+            if (false === is_string($traitToReplace)) {
+                throw new Exception\InvalidArgumentException('Invalid Argument: $traitToReplace must be a string or array of strings.');
+            }
+            if (false === in_array($traitToReplace, $this->traitOverrides[$traitAndMethod])) {
+                $this->traitOverrides[$traitAndMethod][] = $traitToReplace;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function removeTraitOverride($method, $overridesToRemove = null)
+    {
+        if (false === array_key_exists($method, $this->traitOverrides)) {
+            return $this;
+        }
+
+        if (false === is_null($overridesToRemove)) {
+            $overridesToRemove = (!is_array($overridesToRemove)) ? array($overridesToRemove) : $overridesToRemove;
+            foreach ($overridesToRemove as $traitToRemove) {
+                $key = array_search($traitToRemove, $this->traitOverrides[$method]);
+                if (false !== $key) {
+                    unset($this->traitOverrides[$method][$key]);
+                }
+            }
+        } else {
+            unset($this->traitOverrides[$method]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\TraitUsageInterface
+     */
+    public function getTraitOverrides()
+    {
+        return $this->traitOverrides;
+    }
+
+    /**
+     * @inherit Zend\Code\Generator\GeneratorInterface
+     */
+    public function generate()
+    {
+        $output = '';
+        $indent = $this->getIndentation();
+        $traits = $this->getTraits();
+
+        if (!empty($traits)) {
+            $output .= $indent . "use ". join(", ", $traits);
+
+            $aliases = $this->getTraitAliases();
+            $overrides = $this->getTraitOverrides();
+            if (!empty($aliases) || !empty($overrides)) {
+                $output .= " {" . self::LINE_FEED;
+                foreach ($aliases as $method => $alias) {
+                    $visibility = (!is_null($alias['visibility'])) ? current(\Reflection::getModifierNames($alias['visibility'])) ." " : "";
+
+                    //validation check
+                    if ($this->classGenerator->hasMethod($alias['alias'])) {
+                        throw new Exception\RuntimeException("Generation Error: Aliased method {$alias['alias']} already exists on this class.");
+                    }
+                    $output .= $indent . $indent . $method ." as ". $visibility . $alias['alias'] . ";" . self::LINE_FEED;
+                }
+
+                foreach ($overrides as $method => $insteadofTraits) {
+                    foreach ($insteadofTraits as $insteadofTrait) {
+                        $output .= $indent . $indent . $method . " insteadof " . $insteadofTrait . ";" . self::LINE_FEED;
+                    }
+
+                }
+                $output .= self::LINE_FEED . $indent . "}" . self::LINE_FEED . self::LINE_FEED;
+            } else {
+                $output .= ";" . self::LINE_FEED . self::LINE_FEED;
+            }
+        }
+
+        return $output;
+    }
+}

--- a/library/Zend/Code/Generator/TraitUsageInterface.php
+++ b/library/Zend/Code/Generator/TraitUsageInterface.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Zend\Code\Generator;
+
+interface TraitUsageInterface
+{
+
+    /**
+     * Add a class to "use" classes
+     *
+     * @param  string $use
+     * @param  string|null $useAlias
+     * @return ClassGenerator
+     */
+    public function addUse($use, $useAlias = null);
+
+    /**
+     * Returns the "use" classes
+     *
+     * @return array
+     */
+    public function getUses();
+
+    /**
+     * Add trait takes an array of trait options or string as arguments.
+     *
+     * Array Format:
+     * key: traitName value: String
+     *
+     * key: aliases value: array of arrays
+     *      key: method value: @see addTraitAlias
+     *      key: alias value: @see addTraitAlias
+     *      key: visibility value: @see addTraitAlias
+     *
+     * key: insteadof value: array of arrays
+     *      key: method value: @see self::addTraitOverride
+     *      key: traitToReplace value: @see self::addTraitOverride
+     *
+     * @param mixed $trait String | Array
+     * @return ClassGenerator
+     */
+    public function addTrait($trait);
+
+    /**
+     * Add multiple traits.  Trait can be an array of trait names or array of trait
+     * configurations
+     *
+     * @param array $traitName Array of string names or configurations (@see addTrait)
+     * @return ClassGenerator
+     */
+    public function addTraits(array $traits);
+
+    /**
+     * Check to see if the class has a trait defined
+     *
+     * @param strint $traitName
+     * @return bool
+     */
+    public function hasTrait($traitName);
+
+    /**
+     * Get a list of trait names
+     *
+     * @return array
+     */
+    public function getTraits();
+
+    /**
+     * Remove a trait by its name
+     *
+     * @param $traitName
+     */
+    public function removeTrait($traitName);
+
+    /**
+     * Add a trait alias.  This will be used to generate the AS portion of the use statement.
+     *
+     * $method:
+     * This method provides 2 ways for defining the trait method.
+     * Option 1: String
+     * Option 2: Array
+     * key: traitName value: name of trait
+     * key: method value: trait method
+     *
+     * $alias:
+     * Alias is a string representing the new method name.
+     *
+     * $visibilty:
+     * ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PRIVATE| ReflectionMethod::IS_PROTECTED
+     *
+     * @param mixed $method String or Array
+     * @param string $alias
+     * @param int $visiblity
+     */
+    public function addTraitAlias($method, $alias, $visibility = null);
+
+    /**
+     * @return array
+     */
+    public function getTraitAliases();
+
+    /**
+     * Add a trait method override.  This will be used to generate the INSTEADOF portion of the use
+     * statement.
+     *
+     * $method:
+     * This method provides 2 ways for defining the trait method.
+     * Option 1: String Format: <trait name>::<method name>
+     * Option 2: Array
+     * key: traitName value: trait name
+     * key: method value: method name
+     *
+     * $traitToReplace
+     * The name of the trait that you wish to supersede.
+     *
+     * This method provides 2 ways for defining the trait method.
+     * Option 1: String of trait to replace
+     * Option 2: Array of strings of traits to replace
+
+     * @param mixed $method
+     * @param mixed $traitToReplace
+     */
+    public function addTraitOverride($method, $traitsToReplace);
+
+    /**
+     * Remove an override for a given trait::method
+     *
+     * $method:
+     * This method provides 2 ways for defining the trait method.
+     * Option 1: String Format: <trait name>::<method name>
+     * Option 2: Array
+     * key: traitName value: trait name
+     * key: method value: method name
+     *
+     * $overridesToRemove
+     * The name of the trait that you wish to remove.
+     *
+     * This method provides 2 ways for defining the trait method.
+     * Option 1: String of trait to replace
+     * Option 2: Array of strings of traits to replace
+     *
+     * @param $traitAndMethod
+     * @param null $overridesToRemove
+     * @return $this
+     */
+    public function removeTraitOverride($method, $overridesToRemove = null);
+
+    /**
+     * Return trait overrides
+     *
+     * @return array
+     */
+    public function getTraitOverrides();
+}

--- a/library/Zend/Code/Generator/TraitUsageInterface.php
+++ b/library/Zend/Code/Generator/TraitUsageInterface.php
@@ -1,5 +1,11 @@
 <?php
-
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
 namespace Zend\Code\Generator;
 
 interface TraitUsageInterface

--- a/library/Zend/Code/Reflection/ClassReflection.php
+++ b/library/Zend/Code/Reflection/ClassReflection.php
@@ -177,6 +177,21 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
         return $methods;
     }
 
+    public function getTraits()
+    {
+        $vals = array();
+        $traits = parent::getTraits();
+        if(!$traits) {
+            return;
+        }
+
+        foreach($traits as $trait) {
+            $vals[] = new ClassReflection($trait->getName());
+        }
+
+        return $vals;
+    }
+
     /**
      * Get parent reflection class of reflected class
      *

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -213,7 +213,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
      */
     protected function extractMethodContents($bodyOnly = false)
     {
-        $fileName = $this->getDeclaringClass()->getFileName();
+        $fileName = $this->getFileName();
 
         if ((class_exists($this->class) && false === $fileName) || ! file_exists($fileName)) {
             return '';

--- a/library/Zend/Code/Scanner/MethodScanner.php
+++ b/library/Zend/Code/Scanner/MethodScanner.php
@@ -15,7 +15,7 @@ use Zend\Code\NameInformation;
 
 class MethodScanner implements ScannerInterface
 {
-    /**
+   /**
      * @var bool
      */
     protected $isScanned    = false;
@@ -252,6 +252,56 @@ class MethodScanner implements ScannerInterface
     }
 
     /**
+     * Override the given name for a method, this is necessary to
+     * support traits.
+     *
+     * @param $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Visibility must be of T_PUBLIC, T_PRIVATE or T_PROTECTED
+     * Needed to support traits
+     *
+     * @param $visibility   T_PUBLIC | T_PRIVATE | T_PROTECTED
+     * @return $this
+     * @throws \Zend\Code\Exception
+     */
+    public function setVisibility($visibility)
+    {
+        switch (strtolower($visibility)) {
+            case T_PUBLIC:
+                $this->isPublic = true;
+                $this->isPrivate = false;
+                $this->isProtected = false;
+                break;
+
+            case T_PRIVATE:
+                $this->isPublic = false;
+                $this->isPrivate = true;
+                $this->isProtected = false;
+                break;
+
+            case T_PROTECTED:
+                $this->isPublic = false;
+                $this->isPrivate = false;
+                $this->isProtected = true;
+                break;
+
+            default:
+                throw new Exception("Invalid visibility argument passed to setVisibility.");
+        }
+
+        return $this;
+    }
+
+    /**
      * @return int
      */
     public function getNumberOfParameters()
@@ -452,14 +502,16 @@ class MethodScanner implements ScannerInterface
                 //goto (no break needed);
 
             case T_PROTECTED:
-                $this->isProtected = true;
-                $this->isPublic    = false;
+//                $this->isProtected = true;
+//                $this->isPublic    = false;
+                $this->setVisibility(T_PROTECTED);
                 goto SCANNER_CONTINUE_SIGNATURE;
                 //goto (no break needed);
 
             case T_PRIVATE:
-                $this->isPrivate = true;
-                $this->isPublic  = false;
+//                $this->isPrivate = true;
+//                $this->isPublic  = false;
+                $this->setVisibility(T_PRIVATE);
                 goto SCANNER_CONTINUE_SIGNATURE;
                 //goto (no break needed);
 

--- a/tests/ZendTest/Code/Generator/TraitGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/TraitGeneratorTest.php
@@ -1,0 +1,493 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Code\Generator;
+
+use Zend\Code\Generator\TraitGenerator;
+use Zend\Code\Generator\ClassGenerator;
+use Zend\Code\Generator\DocBlockGenerator;
+use Zend\Code\Generator\PropertyGenerator;
+use Zend\Code\Generator\MethodGenerator;
+use Zend\Code\Reflection\ClassReflection;
+
+/**
+ * @group Zend_Code_Generator
+ * @group Zend_Code_Generator_Php
+ */
+class TraitGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testConstruction()
+    {
+        $class = new TraitGenerator();
+        $this->isInstanceOf($class, 'Zend\Code\Generator\TraitGenerator');
+    }
+
+    public function testNameAccessors()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setName('TestClass');
+        $this->assertEquals($classGenerator->getName(), 'TestClass');
+    }
+
+    public function testClassDocBlockAccessors()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testAbstractAccessorsReturnsFalse()
+    {
+        $classGenerator = new TraitGenerator();
+        $this->assertFalse($classGenerator->isAbstract());
+        $classGenerator->setAbstract(true);
+        $this->assertFalse($classGenerator->isAbstract());
+    }
+
+    public function testExtendedClassAccessors()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setExtendedClass('ExtendedClass');
+        $this->assertEquals($classGenerator->getExtendedClass(), null);
+    }
+
+    public function testImplementedInterfacesAccessors()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setImplementedInterfaces(array('Class1', 'Class2'));
+        $this->assertEquals(count($classGenerator->getImplementedInterfaces()), 0);
+    }
+
+    public function testPropertyAccessors()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addProperties(array(
+            'propOne',
+            new PropertyGenerator('propTwo')
+        ));
+
+        $properties = $classGenerator->getProperties();
+        $this->assertEquals(count($properties), 2);
+        $this->assertInstanceOf('Zend\Code\Generator\PropertyGenerator', current($properties));
+
+        $property = $classGenerator->getProperty('propTwo');
+        $this->assertInstanceOf('Zend\Code\Generator\PropertyGenerator', $property);
+        $this->assertEquals($property->getName(), 'propTwo');
+
+        // add a new property
+        $classGenerator->addProperty('prop3');
+        $this->assertEquals(count($classGenerator->getProperties()), 3);
+    }
+
+    public function testSetPropertyAlreadyExistsThrowsException()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addProperty('prop3');
+
+        $this->setExpectedException(
+            'Zend\Code\Generator\Exception\InvalidArgumentException',
+            'A property by name prop3 already exists in this class'
+        );
+        $classGenerator->addProperty('prop3');
+    }
+
+    public function testSetPropertyNoArrayOrPropertyThrowsException()
+    {
+        $classGenerator = new TraitGenerator();
+
+        $this->setExpectedException(
+            'Zend\Code\Generator\Exception\InvalidArgumentException',
+            'Zend\Code\Generator\TraitGenerator::addProperty expects string for name'
+        );
+        $classGenerator->addProperty(true);
+    }
+
+    public function testMethodAccessors()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addMethods(array(
+            'methodOne',
+            new MethodGenerator('methodTwo')
+        ));
+
+        $methods = $classGenerator->getMethods();
+        $this->assertEquals(count($methods), 2);
+        $this->isInstanceOf(current($methods), '\Zend\Code\Generator\PhpMethod');
+
+        $method = $classGenerator->getMethod('methodOne');
+        $this->isInstanceOf($method, '\Zend\Code\Generator\PhpMethod');
+        $this->assertEquals($method->getName(), 'methodOne');
+
+        // add a new property
+        $classGenerator->addMethod('methodThree');
+        $this->assertEquals(count($classGenerator->getMethods()), 3);
+    }
+
+    public function testSetMethodNoMethodOrArrayThrowsException()
+    {
+        $classGenerator = new TraitGenerator();
+
+        $this->setExpectedException(
+            'Zend\Code\Generator\Exception\ExceptionInterface',
+            'Zend\Code\Generator\TraitGenerator::addMethod expects string for name'
+        );
+
+        $classGenerator->addMethod(true);
+    }
+
+    public function testSetMethodNameAlreadyExistsThrowsException()
+    {
+        $methodA = new MethodGenerator();
+        $methodA->setName("foo");
+        $methodB = new MethodGenerator();
+        $methodB->setName("foo");
+
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addMethodFromGenerator($methodA);
+
+        $this->setExpectedException(
+            'Zend\Code\Generator\Exception\InvalidArgumentException',
+            'A method by name foo already exists in this class.'
+        );
+
+        $classGenerator->addMethodFromGenerator($methodB);
+    }
+
+    /**
+     * @group ZF-7361
+     */
+    public function testHasMethod()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addMethod('methodOne');
+
+        $this->assertTrue($classGenerator->hasMethod('methodOne'));
+    }
+
+    public function testRemoveMethod()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addMethod('methodOne');
+        $this->assertTrue($classGenerator->hasMethod('methodOne'));
+
+        $classGenerator->removeMethod('methodOne');
+        $this->assertFalse($classGenerator->hasMethod('methodOne'));
+    }
+
+    /**
+     * @group ZF-7361
+     */
+    public function testHasProperty()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addProperty('propertyOne');
+
+        $this->assertTrue($classGenerator->hasProperty('propertyOne'));
+    }
+
+    public function testToString()
+    {
+        $classGenerator = TraitGenerator::fromArray(array(
+            'name' => 'SampleClass',
+            'properties' => array('foo',
+                array('name' => 'bar')
+            ),
+            'methods' => array(
+                array('name' => 'baz')
+            ),
+        ));
+
+        $expectedOutput = <<<EOS
+trait SampleClass
+{
+
+    public \$foo = null;
+
+    public \$bar = null;
+
+    public function baz()
+    {
+    }
+
+
+}
+
+EOS;
+
+        $output = $classGenerator->generate();
+        $this->assertEquals($expectedOutput, $output, $output);
+    }
+
+    /**
+     * @group ZF-7909
+     */
+    public function testClassFromReflectionThatImplementsInterfaces()
+    {
+        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ClassWithInterface');
+
+        $classGenerator = TraitGenerator::fromReflection($reflClass);
+        $classGenerator->setSourceDirty(true);
+
+        $code = $classGenerator->generate();
+
+        $expectedClassDef = 'trait ClassWithInterface';
+        $this->assertContains($expectedClassDef, $code);
+    }
+
+    /**
+     * @group ZF-7909
+     */
+    public function testClassFromReflectionDiscardParentImplementedInterfaces()
+    {
+        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\NewClassWithInterface');
+
+        $classGenerator = TraitGenerator::fromReflection($reflClass);
+        $classGenerator->setSourceDirty(true);
+
+        $code = $classGenerator->generate();
+
+        $expectedClassDef = 'trait NewClassWithInterface';
+        $this->assertContains($expectedClassDef, $code);
+    }
+
+    /**
+     * @group 4988
+     */
+    public function testNonNamespaceClassReturnsAllMethods()
+    {
+        require_once __DIR__ . '/../TestAsset/NonNamespaceClass.php';
+
+        $reflClass = new ClassReflection('ZendTest_Code_NsTest_BarClass');
+        $classGenerator = TraitGenerator::fromReflection($reflClass);
+        $this->assertCount(1, $classGenerator->getMethods());
+    }
+
+    /**
+     * @group ZF-9602
+     */
+    public function testSetextendedclassShouldIgnoreEmptyClassnameOnGenerate()
+    {
+        $classGeneratorClass = new TraitGenerator();
+        $classGeneratorClass
+            ->setName('MyClass')
+            ->setExtendedClass('');
+
+        $expected = <<<CODE
+trait MyClass
+{
+
+
+}
+
+CODE;
+        $this->assertEquals($expected, $classGeneratorClass->generate());
+    }
+
+    /**
+     * @group ZF-9602
+     */
+    public function testSetextendedclassShouldNotIgnoreNonEmptyClassnameOnGenerate()
+    {
+        $classGeneratorClass = new TraitGenerator();
+        $classGeneratorClass
+            ->setName('MyClass')
+            ->setExtendedClass('ParentClass');
+
+        $expected = <<<CODE
+trait MyClass
+{
+
+
+}
+
+CODE;
+        $this->assertEquals($expected, $classGeneratorClass->generate());
+    }
+
+    /**
+     * @group namespace
+     */
+    public function testCodeGenerationShouldTakeIntoAccountNamespacesFromReflection()
+    {
+        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ClassWithNamespace');
+        $classGenerator = TraitGenerator::fromReflection($reflClass);
+        $this->assertEquals('ZendTest\Code\Generator\TestAsset', $classGenerator->getNamespaceName());
+        $this->assertEquals('ClassWithNamespace', $classGenerator->getName());
+        $expected = <<<CODE
+namespace ZendTest\Code\Generator\\TestAsset;
+
+trait ClassWithNamespace
+{
+
+
+}
+
+CODE;
+        $received = $classGenerator->generate();
+        $this->assertEquals($expected, $received, $received);
+    }
+
+    /**
+     * @group namespace
+     */
+    public function testSetNameShouldDetermineIfNamespaceSegmentIsPresent()
+    {
+        $classGeneratorClass = new TraitGenerator();
+        $classGeneratorClass->setName('My\Namespaced\FunClass');
+        $this->assertEquals('My\Namespaced', $classGeneratorClass->getNamespaceName());
+    }
+
+    /**
+     * @group namespace
+     */
+    public function testPassingANamespacedClassnameShouldGenerateANamespaceDeclaration()
+    {
+        $classGeneratorClass = new TraitGenerator();
+        $classGeneratorClass->setName('My\Namespaced\FunClass');
+        $received = $classGeneratorClass->generate();
+        $this->assertContains('namespace My\Namespaced;', $received, $received);
+    }
+
+    /**
+     * @group namespace
+     */
+    public function testPassingANamespacedClassnameShouldGenerateAClassnameWithoutItsNamespace()
+    {
+        $classGeneratorClass = new TraitGenerator();
+        $classGeneratorClass->setName('My\Namespaced\FunClass');
+        $received = $classGeneratorClass->generate();
+        $this->assertContains('trait FunClass', $received, $received);
+    }
+
+    /**
+     * @group ZF2-151
+     */
+    public function testAddUses()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setName('My\Class');
+        $classGenerator->addUse('My\First\Use\Class');
+        $classGenerator->addUse('My\Second\Use\Class', 'MyAlias');
+        $generated = $classGenerator->generate();
+
+        $this->assertContains('use My\First\Use\Class;', $generated);
+        $this->assertContains('use My\Second\Use\Class as MyAlias;', $generated);
+    }
+
+    /**
+     * @group 4990
+     */
+    public function testAddOneUseTwiceOnlyAddsOne()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setName('My\Class');
+        $classGenerator->addUse('My\First\Use\Class');
+        $classGenerator->addUse('My\First\Use\Class');
+        $generated = $classGenerator->generate();
+
+        $this->assertCount(1, $classGenerator->getUses());
+
+        $this->assertContains('use My\First\Use\Class;', $generated);
+    }
+
+    /**
+     * @group 4990
+     */
+    public function testAddOneUseWithAliasTwiceOnlyAddsOne()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setName('My\Class');
+        $classGenerator->addUse('My\First\Use\Class', 'MyAlias');
+        $classGenerator->addUse('My\First\Use\Class', 'MyAlias');
+        $generated = $classGenerator->generate();
+
+        $this->assertCount(1, $classGenerator->getUses());
+
+        $this->assertContains('use My\First\Use\Class as MyAlias;', $generated);
+    }
+
+    public function testCreateFromArrayWithDocBlockFromArray()
+    {
+        $classGenerator = TraitGenerator::fromArray(array(
+            'name' => 'SampleClass',
+            'docblock' => array(
+                'shortdescription' => 'foo',
+            ),
+        ));
+
+        $docBlock = $classGenerator->getDocBlock();
+        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+    }
+
+    public function testCreateFromArrayWithDocBlockInstance()
+    {
+        $classGenerator = TraitGenerator::fromArray(array(
+            'name' => 'SampleClass',
+            'docblock' => new DocBlockGenerator('foo'),
+        ));
+
+        $docBlock = $classGenerator->getDocBlock();
+        $this->assertInstanceOf('Zend\Code\Generator\DocBlockGenerator', $docBlock);
+    }
+
+    public function testExtendedClassProperies()
+    {
+        $reflClass = new ClassReflection('ZendTest\Code\Generator\TestAsset\ExtendedClassWithProperties');
+        $classGenerator = TraitGenerator::fromReflection($reflClass);
+        $code = $classGenerator->generate();
+        $this->assertContains('publicExtendedClassProperty', $code);
+        $this->assertContains('protectedExtendedClassProperty', $code);
+        $this->assertContains('privateExtendedClassProperty', $code);
+        $this->assertNotContains('publicClassProperty', $code);
+        $this->assertNotContains('protectedClassProperty', $code);
+        $this->assertNotContains('privateClassProperty', $code);
+
+
+    }
+
+    public function testHasMethodInsensitive()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addMethod('methodOne');
+
+        $this->assertTrue($classGenerator->hasMethod('methodOne'));
+        $this->assertTrue($classGenerator->hasMethod('MethoDonE'));
+    }
+
+    public function testRemoveMethodInsensitive()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->addMethod('methodOne');
+
+        $classGenerator->removeMethod('METHODONe');
+        $this->assertFalse($classGenerator->hasMethod('methodOne'));
+    }
+
+    public function testGenerateClassAndAddMethod()
+    {
+        $classGenerator = new TraitGenerator();
+        $classGenerator->setName('MyClass');
+        $classGenerator->addMethod('methodOne');
+
+        $expected = <<<CODE
+trait MyClass
+{
+
+    public function methodOne()
+    {
+    }
+
+
+}
+
+CODE;
+
+        $output = $classGenerator->generate();
+        $this->assertEquals($expected, $output);
+    }
+}

--- a/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/MethodReflectionTest.php
@@ -352,6 +352,18 @@ CONTENTS;
         $this->setExpectedException('ReflectionException');
         $reflectionMethod = new MethodReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass11', '__prototype');
         $reflectionMethod->getBody();
+    }
 
+    /**
+     * @group 6620
+     */
+    public function testCanParseClassBodyWhenUsingTrait()
+    {
+        require_once __DIR__ .'/TestAsset/TestTraitClass1.php';
+        require_once __DIR__. '/TestAsset/TestTraitClass2.php';
+        // $method = new \Zend\Code\Reflection\ClassReflection('\FooClass');
+        // $traits = current($method->getTraits());
+        $method = new \Zend\Code\Reflection\MethodReflection('FooClass', 'getDummy');
+        $this->assertEquals(trim($method->getBody()), 'return $this->dummy;');
     }
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass1.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass1.php
@@ -1,0 +1,23 @@
+<?php
+//issue #6620
+require_once 'TestTraitClass2.php';
+class FooClass
+{
+	use TestTrait;
+
+	/**
+	* @var bool
+	*/
+	protected static $other = false;
+
+
+	/**
+	* Constructor
+	*
+	* @param bool $other
+	*/
+	public function __construct($other)
+	{
+		$this->other = $other;
+	}
+}

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass2.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass2.php
@@ -1,0 +1,27 @@
+<?php
+//issue #6620
+trait TestTrait
+{
+	/**
+	* @var bool
+	*/
+	protected $dummy = false;
+
+	/**
+	* @return bool
+	*/
+	public function getDummy()
+	{
+		return $this->dummy;
+	}
+
+	/**
+	* @param bool $autoFetchingAllowed
+	* @return Model_AbstractModel
+	*/
+	public function setDummy($dummy)
+	{
+		$this->dummy = boolval($dummy);
+		return $this;
+	}
+}

--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -12,7 +12,10 @@ namespace ZendTest\Code\Scanner;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Code\Annotation;
 use Zend\Code\Scanner\FileScanner;
+use Zend\Code\Scanner\MethodScanner;
 use Zend\Stdlib\ErrorHandler;
+use ZendTest\Code\TestAsset\TraitWithSameMethods;
+use ZendTest\Code\TestAsset\TestClassWithTraitAliases;
 
 class ClassScannerTest extends TestCase
 {
@@ -173,5 +176,123 @@ class ClassScannerTest extends TestCase
         $this->assertEquals('first',  $annotations[0]->content);
         $this->assertEquals('second', $annotations[1]->content);
         $this->assertEquals('third',  $annotations[2]->content);
+    }
+
+    /**
+     * @group trait1
+     */
+    public function testClassScannerCanScanTraits()
+    {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('Skipping; PHP 5.4 or greater is needed');
+        }
+
+        $file  = new FileScanner(__DIR__ . '/../TestAsset/BarTrait.php');
+        $class = $file->getClass('ZendTest\Code\TestAsset\BarTrait');
+
+        $this->assertTrue($class->isTrait());
+        $this->assertTrue($class->hasMethod('bar'));
+    }
+
+    /**
+     * @group trait2
+     */
+    public function testClassScannerCanScanClassThatUsesTraits()
+    {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('Skipping; PHP 5.4 or greater is needed');
+        }
+
+        $file  = new FileScanner(__DIR__ . '/../TestAsset/TestClassUsesTraitSimple.php');
+        $class = $file->getClass('ZendTest\Code\TestAsset\TestClassUsesTraitSimple');
+
+        $this->assertFalse($class->isTrait());
+        $traitNames = $class->getTraitNames();
+        $class->getTraitAliases();
+        $this->assertTrue(in_array('ZendTest\Code\TestAsset\BarTrait', $traitNames));
+        $this->assertTrue(in_array('ZendTest\Code\TestAsset\FooTrait', $traitNames));
+    }
+
+    /**
+     * @group trait3
+     */
+    public function testClassScannerCanScanClassAndGetTraitsAliases()
+    {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('Skipping; PHP 5.4 or greater is needed');
+        }
+
+        $file  = new FileScanner(__DIR__ . '/../TestAsset/TestClassWithTraitAliases.php');
+        $class = $file->getClass('ZendTest\Code\TestAsset\TestClassWithTraitAliases');
+
+        $this->assertFalse($class->isTrait());
+
+        $aliases = $class->getTraitAliases();
+
+        $this->assertEquals(count($aliases), 1);
+
+        $this->assertEquals(key($aliases), 'test');
+        $this->assertEquals(current($aliases), 'ZendTest\Code\TestAsset\TraitWithSameMethods::foo');
+    }
+
+    /**
+     * @group trait4
+     */
+    public function testClassScannerCanGetTraitMethodsInGetMethods()
+    {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('Skipping; PHP 5.4 or greater is needed');
+        }
+
+        //load files or test may fail due to autoload issues
+        require_once(__DIR__ . '/../TestAsset/TraitWithSameMethods.php');
+        require_once(__DIR__ . '/../TestAsset/BarTrait.php');
+
+        $file  = new FileScanner(__DIR__ . '/../TestAsset/TestClassWithTraitAliases.php');
+
+        $class = $file->getClass('ZendTest\Code\TestAsset\TestClassWithTraitAliases');
+
+        $this->assertFalse($class->isTrait());
+
+        $testMethods = array(
+            'fooBarBaz' => 'isPublic',
+            'foo' => 'isPublic',
+            'bar' => 'isPublic',
+            'test' => 'isPrivate',
+            'bazFooBar' => 'isPublic',
+        );
+
+        $this->assertEquals($class->getMethodNames(), array_keys($testMethods));
+
+        foreach($testMethods as $methodName => $testMethod) {
+            $this->assertTrue($class->hasMethod($methodName), "Cannot find method $methodName");
+
+            $method = $class->getMethod($methodName);
+            $this->assertTrue($method instanceof MethodScanner, $methodName . " not found.");
+
+            $this->assertTrue($method->$testMethod());
+
+            // test that we got the right ::bar method based on declaration
+            if($testMethod === "bar") {
+                $this->assertEquals(trim($method->getBody), 'echo "foo";');
+            }
+        }
+    }
+
+    /**
+     * @group trait5
+     */
+    public function testGetMethodsThrowsExceptionOnDuplicateMethods()
+    {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('Skipping; PHP 5.4 or greater is needed');
+        }
+
+        $this->setExpectedException('Zend\Code\Exception\RuntimeException');
+
+        $file  = new FileScanner(__DIR__ . '/TestAsset/TestClassWithAliasException.php');
+        $class = $file->getClass('ZendTest\Code\Scanner\TestAsset\TestClassWithAliasException');
+
+        $class->getMethods();
     }
 }

--- a/tests/ZendTest/Code/Scanner/TestAsset/TestClassWithAliasException.php
+++ b/tests/ZendTest/Code/Scanner/TestAsset/TestClassWithAliasException.php
@@ -1,0 +1,27 @@
+<?php
+namespace ZendTest\Code\Scanner\TestAsset;
+
+require_once(__DIR__ . '/TraitWithSameMethods.php');
+require_once(__DIR__ . '/BarTrait.php');
+
+use ZendTest\Code\TestAsset\FooTrait;
+use ZendTest\Code\TestAsset\BarTrait;
+use ZendTest\Code\TestAsset\TraitWithSameMethods;
+
+/**
+ * This class is used to test the ClassScanner as it should throw
+ * a RuntimeException due to the fact that bar method exists on
+ * multiple traits.
+ */
+class TestClassWithAliasException
+{
+    use BarTrait, FooTrait, TraitWithSameMethods {
+        FooTrait::foo insteadof TraitWithSameMethods;
+        TraitWithSameMethods::foo as private test;
+    }
+
+    public function bazFooBar()
+    {
+
+    }
+}

--- a/tests/ZendTest/Code/TestAsset/TestClassUsesTraitSimple.php
+++ b/tests/ZendTest/Code/TestAsset/TestClassUsesTraitSimple.php
@@ -1,0 +1,10 @@
+<?php
+namespace ZendTest\Code\TestAsset;
+
+use ZendTest\Code\TestAsset\FooTrait;
+
+class TestClassUsesTraitSimple
+{
+    use \ZendTest\Code\TestAsset\BarTrait, FooTrait;
+}
+

--- a/tests/ZendTest/Code/TestAsset/TestClassWithTraitAliases.php
+++ b/tests/ZendTest/Code/TestAsset/TestClassWithTraitAliases.php
@@ -1,0 +1,25 @@
+<?php
+namespace ZendTest\Code\TestAsset;
+
+require_once(__DIR__ . '/TraitWithSameMethods.php');
+require_once(__DIR__ . '/BarTrait.php');
+
+use ZendTest\Code\TestAsset\FooTrait;
+use ZendTest\Code\TestAsset\BarTrait;
+use ZendTest\Code\TestAsset\TraitWithSameMethods;
+
+class TestClassWithTraitAliases
+{
+    use BarTrait, FooTrait, TraitWithSameMethods {
+        FooTrait::foo insteadof TraitWithSameMethods;
+        TraitWithSameMethods::bar insteadof BarTrait;
+        TraitWithSameMethods::bar insteadof FooTrait;
+        TraitWithSameMethods::foo as private test;
+    }
+
+    public function bazFooBar()
+    {
+        
+    }
+}
+

--- a/tests/ZendTest/Code/TestAsset/TraitWithSameMethods.php
+++ b/tests/ZendTest/Code/TestAsset/TraitWithSameMethods.php
@@ -3,22 +3,21 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Code\TestAsset;
 
-trait FooTrait
+trait TraitWithSameMethods
 {
-    use BarTrait;
-
-    public function fooBarBaz()
+    public function bar()
     {
+        echo "bar";        
     }
 
     public function foo()
     {
-        
+        echo "foo";
     }
 }


### PR DESCRIPTION
This is a first attempt at adding generation and scanning support for Traits.

For basic examples see below, for other usage please see ZendTest/Code/Generation/ClassGenerationTest.php

Example 1:  Add a trait

```
$traitGenerator = new TraitGenerator();
$traitGenerator->setName('myTrait');
$traitGenerator->generate();
```

Outputs:

```
trait myTrait
{

}
```

Example 2: Add a trait to a class

```
$classGenerator = new ClassGenerator();
$classGenerator->setName('myClass');
$classGenerator->addTrait('myTrait');
```

Outputs:

```
class myClass
{
    use myTrait;

}
```

Example 2: Add multiple traits with aliases and overrides

```
$classGenerator = new ClassGenerator();
$classGenerator->setName('myClass');
$classGenerator->addTraits(array('myTrait', 'hisTrait'));
$classGenerator->addTraitAlias('myTrait::foo', 'newfoo');
$classGenerator->addTraitOverride('hisTrait::bar', 'myTrait');
```

Outputs:

```
class myClass
{
    use myTrait, hisTrait {
        myTrait::foo as newfoo;
        hisTrait::bar insteadof myTrait;
    }

}
```
