### PR TITLE
InputFilter/BaseInputFilter : Data formatting and validation

### DIFF
--- a/library/Zend/InputFilter/BaseInputFilter.php
+++ b/library/Zend/InputFilter/BaseInputFilter.php
@@ -194,7 +194,7 @@ class BaseInputFilter implements
      */
     public function isValid()
     {
-        $data = $this->getRawValues();
+        $data = $this->getValues();
         if (null === $data) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: no data present to validate!',
@@ -217,7 +217,7 @@ class BaseInputFilter implements
     {
         // backwards compatibility
         if (empty($data)) {
-            $data = $this->getRawValues();
+            $data = $this->getValues();
         }
 
         $this->validInputs   = array();

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -195,6 +195,25 @@ class BaseInputFilterTest extends TestCase
         $filter->setData($dataset);
         $this->assertSame($expected, $filter->isValid());
     }
+	
+	public function testValidatorContextIsFiltered()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
+        $filter = $this->getInputFilter();
+		
+		$filter->get('qux')->getValidatorChain()->attach(new Validator\Identical('baz'));
+		
+        $validData = array(
+            'baz' => 'aaaaa ',
+            'qux' => 'aaaaa',
+        );
+        $filter->setValidationGroup('baz', 'qux');
+        $filter->setData($validData);
+        $this->assertTrue($filter->isValid());
+    }
 
     public function testCanValidatePartialDataset()
     {

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -195,17 +195,16 @@ class BaseInputFilterTest extends TestCase
         $filter->setData($dataset);
         $this->assertSame($expected, $filter->isValid());
     }
-	
-	public function testValidatorContextIsFiltered()
+
+    public function testValidatorContextIsFiltered()
     {
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
 
         $filter = $this->getInputFilter();
-		
-		$filter->get('qux')->getValidatorChain()->attach(new Validator\Identical('baz'));
-		
+        $filter->get('qux')->getValidatorChain()->attach(new Validator\Identical('baz'));
+
         $validData = array(
             'baz' => 'aaaaa ',
             'qux' => 'aaaaa',


### PR DESCRIPTION
Hello,

I was wondering why during form validation process, the data passed to validators as $context are raw values ?
$validator->isValid($value, $context);

$value is correctly filtered.
$context is just raw data, no filter applied.

I don't understand the logic behind this.. and I have to "re-filter" the $context vars when I want to use them (code redundancy).
