### PR TITLE
unset the reference before next use of variable (library/Zend/Cache/Storage/Adapter/Redis.php)

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -256,6 +256,7 @@ class Redis extends AbstractAdapter implements
         foreach ($normalizedKeyValuePairs as $normalizedKey => & $value) {
             $namespacedKeyValuePairs[$this->namespacePrefix . $normalizedKey] = & $value;
         }
+        unset($value);
         try {
             if ($ttl > 0) {
                 //check if ttl is supported


### PR DESCRIPTION
clear the reference in $value to the array (Issue #6324)
