### PR TITLE
SessionManagerFactory can set SessionConfig Options

### DIFF
--- a/library/Zend/Session/Service/SessionManagerFactory.php
+++ b/library/Zend/Session/Service/SessionManagerFactory.php
@@ -115,7 +115,7 @@ class SessionManagerFactory implements FactoryInterface
             }
             
             // Set config options, if any
-            if (isset($managerConfig['validators'])) {
+            if (isset($managerConfig['config'])) {
                 $manager->getConfig()->setOptions($managerConfig['config']);
             }
             

--- a/library/Zend/Session/Service/SessionManagerFactory.php
+++ b/library/Zend/Session/Service/SessionManagerFactory.php
@@ -113,6 +113,12 @@ class SessionManagerFactory implements FactoryInterface
             ) {
                 $managerConfig = array_merge($managerConfig, $configService['session_manager']);
             }
+            
+            // Set config options, if any
+            if (isset($managerConfig['validators'])) {
+                $manager->getConfig()->setOptions($managerConfig['config']);
+            }
+            
             // Attach validators to session manager, if any
             if (isset($managerConfig['validators'])) {
                 $chain = $manager->getValidatorChain();


### PR DESCRIPTION
As it can set the validators, it could also set the session config, reducing the need to implement a class for this.

From doc:
http://framework.zend.com/manual/2.3/en/modules/zend.session.config.html#custom-configuration

So on our module.config.php we could made it easy:

```
    'session_manager' => array(
        'config' => array(
            'name' => 'myApp',
        ),
        'validators' => array(
            'Zend\Session\Validator\RemoteAddr',
            'Zend\Session\Validator\HttpUserAgent',
        ),
    ),
```
