### PR TITLE
Fix for #6300 - i18n flot validator

### DIFF
--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -27,23 +27,12 @@ class NumberFormat extends NumberParse
             return $value;
         }
 
-        if (!is_int($value)
-            && !is_float($value)
-        ) {
-            $result = parent::filter($value);
-        } else {
-            ErrorHandler::start();
-
-            $result = $this->getFormatter()->format(
-                $value,
-                $this->getType()
-            );
-
-            ErrorHandler::stop();
-        }
+        ErrorHandler::start();
+        $result = $this->getFormatter()->format($value, $this->getType());
+        ErrorHandler::stop();
 
         if (false !== $result) {
-            return str_replace("\xC2\xA0", ' ', $result);
+            return $result;
         }
 
         return $value;


### PR DESCRIPTION
Fix for #6300 - New validator takes into account non-Latin script numbers, exponential notation, and a few "look-alike" characters (space for NO_BREAK SPACE, comma for ARABIC DECIMAL SEPARATOR, and single quote for ARABIC THOUSANDS SEPARATOR).

Also include small NumberFormat optimization. NumberFormatter already parses the number before formatting, so trip through parent is not needed.

This is pretty much a total rewrite of the validator. Depending on `NumberFormatter::parse()` isn't useful as it's way too lenient - it will find the numbers in a string and return that. Supporting non-Latin characters and exponentials means that we can't use the old `stringval()` checking logic either. This uses the formal definition of a float as the basis for validation - with a few extra checks for edge cases (decimal before grouping, grouping too close to end of string, etc). Test class now uses `NumberFormatter` to generate valid decimal and scientific strings in addition to new test strings.
