### PR TITLE
Fix for #6300 -  I18n float validator rewrite

### DIFF
--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -27,9 +27,15 @@ class NumberFormat extends NumberParse
             return $value;
         }
 
-        ErrorHandler::start();
-        $result = $this->getFormatter()->format($value, $this->getType());
-        ErrorHandler::stop();
+        if (!is_int($value) && !is_float($value)) {
+            $result = parent::filter($value);
+        } else {
+            ErrorHandler::start();
+
+            $result = $this->getFormatter()->format($value, $this->getType());
+
+            ErrorHandler::stop();
+        }
 
         if (false !== $result) {
             return $result;

--- a/library/Zend/I18n/Filter/NumberFormat.php
+++ b/library/Zend/I18n/Filter/NumberFormat.php
@@ -27,23 +27,12 @@ class NumberFormat extends NumberParse
             return $value;
         }
 
-        if (!is_int($value)
-            && !is_float($value)
-        ) {
-            $result = parent::filter($value);
-        } else {
-            ErrorHandler::start();
-
-            $result = $this->getFormatter()->format(
-                $value,
-                $this->getType()
-            );
-
-            ErrorHandler::stop();
-        }
+        ErrorHandler::start();
+        $result = $this->getFormatter()->format($value, $this->getType());
+        ErrorHandler::stop();
 
         if (false !== $result) {
-            return str_replace("\xC2\xA0", ' ', $result);
+            return $result;
         }
 
         return $value;

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -127,7 +127,7 @@ class Float extends AbstractValidator
         }
 
         if (StringUtils::hasPcreUnicodeSupport()) {
-            $exponentialSymbols = '[Ee' . $formatter->getSymbol(NumberFormatter::EXPONENTIAL_SYMBOL) . ']{0,4}';
+            $exponentialSymbols = '[Ee' . $formatter->getSymbol(NumberFormatter::EXPONENTIAL_SYMBOL) . ']+';
             $search = '/' . $exponentialSymbols . '/u';
         } else {
             $exponentialSymbols = '[Ee]';
@@ -215,8 +215,10 @@ class Float extends AbstractValidator
         $value          = str_replace("\xE2\x80\x8E", '', $value);
         $unGroupedValue = str_replace($groupSeparator, '', $value);
 
-        //No strrpos() in the wrappers yet.
-        $lastStringGroup = $this->wrapper->substr($value, -($formatter->getAttribute(NumberFormatter::GROUPING_SIZE)));
+        //No strrpos() in wrappers yet. ICU 4.x doesn't have grouping size for everything. ICU 52 has 3 for ALL locales.
+        $groupSize = ($formatter->getAttribute(NumberFormatter::GROUPING_SIZE))
+            ? $formatter->getAttribute(NumberFormatter::GROUPING_SIZE) : 3;
+        $lastStringGroup = $this->wrapper->substr($value, -$groupSize);
 
         if ((preg_match($lnumSearch, $unGroupedValue) ||
             preg_match($dnumSearch, $unGroupedValue) ||

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -166,7 +166,7 @@ class Float extends AbstractValidator
         }
 
         //If we have Unicode support, we can use the real graphemes, otherwise, just the ASCII characters
-        $decimal     = '['. preg_quote($decSeparator) . ']';
+        $decimal     = '['. preg_quote($decSeparator, '/') . ']';
         $prefix      = '[+-]';
         $exp         = $exponentialSymbols;
         $numberRange = '0-9';
@@ -179,7 +179,7 @@ class Float extends AbstractValidator
                     $formatter->getTextAttribute(NumberFormatter::POSITIVE_PREFIX) .
                     $formatter->getTextAttribute(NumberFormatter::NEGATIVE_PREFIX) .
                     $formatter->getSymbol(NumberFormatter::PLUS_SIGN_SYMBOL) .
-                    $formatter->getSymbol(NumberFormatter::MINUS_SIGN_SYMBOL)
+                    $formatter->getSymbol(NumberFormatter::MINUS_SIGN_SYMBOL), '/'
                 ) . ']{0,3}';
             $suffix = ($formatter->getTextAttribute(NumberFormatter::NEGATIVE_SUFFIX))
                 ? '[' .
@@ -187,7 +187,7 @@ class Float extends AbstractValidator
                     $formatter->getTextAttribute(NumberFormatter::POSITIVE_SUFFIX) .
                     $formatter->getTextAttribute(NumberFormatter::NEGATIVE_SUFFIX) .
                     $formatter->getSymbol(NumberFormatter::PLUS_SIGN_SYMBOL) .
-                    $formatter->getSymbol(NumberFormatter::MINUS_SIGN_SYMBOL)
+                    $formatter->getSymbol(NumberFormatter::MINUS_SIGN_SYMBOL), '/'
                 ) . ']{0,3}'
                 : '';
             $numberRange = '\p{N}';

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -166,7 +166,7 @@ class Float extends AbstractValidator
         }
 
         //If we have Unicode support, we can use the real graphemes, otherwise, just the ASCII characters
-        $decimal     = '['. quotemeta($decSeparator) . ']';
+        $decimal     = '['. preg_quote($decSeparator) . ']';
         $prefix      = '[+-]';
         $exp         = $exponentialSymbols;
         $numberRange = '0-9';
@@ -175,7 +175,7 @@ class Float extends AbstractValidator
 
         if (StringUtils::hasPcreUnicodeSupport()) {
             $prefix = '[' .
-                quotemeta(
+                preg_quote(
                     $formatter->getTextAttribute(NumberFormatter::POSITIVE_PREFIX) .
                     $formatter->getTextAttribute(NumberFormatter::NEGATIVE_PREFIX) .
                     $formatter->getSymbol(NumberFormatter::PLUS_SIGN_SYMBOL) .
@@ -183,7 +183,7 @@ class Float extends AbstractValidator
                 ) . ']{0,3}';
             $suffix = ($formatter->getTextAttribute(NumberFormatter::NEGATIVE_SUFFIX))
                 ? '[' .
-                quotemeta(
+                preg_quote(
                     $formatter->getTextAttribute(NumberFormatter::POSITIVE_SUFFIX) .
                     $formatter->getTextAttribute(NumberFormatter::NEGATIVE_SUFFIX) .
                     $formatter->getSymbol(NumberFormatter::PLUS_SIGN_SYMBOL) .

--- a/tests/ZendTest/I18n/Filter/NumberFormatTest.php
+++ b/tests/ZendTest/I18n/Filter/NumberFormatTest.php
@@ -100,7 +100,7 @@ class NumberFormatTest extends TestCase
                 NumberFormatter::DEFAULT_STYLE,
                 NumberFormatter::TYPE_DOUBLE,
                 1234567.8912346,
-                '1 234 567,891'
+                '1 234 567,891'
             ),
         );
     }
@@ -161,6 +161,6 @@ class NumberFormatTest extends TestCase
     {
         $filter = new NumberFormatFilter('de_AT', NumberFormatter::DEFAULT_STYLE, NumberFormatter::TYPE_DOUBLE);
 
-        $this->assertEquals($input,  $filter->filter($input));
+        $this->assertEquals($input, $filter->filter($input));
     }
 }

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -55,14 +55,16 @@ class FloatTest extends \PHPUnit_Framework_TestCase
      * @dataProvider floatAndIntegerProvider
      * @return void
      */
-    public function testFloatAndIntegers($value, $expected, $locale)
+    public function testFloatAndIntegers($value, $expected, $locale, $type)
     {
         $this->validator->setLocale($locale);
 
         $this->assertEquals(
             $expected,
             $this->validator->isValid($value),
-            'Failed expecting ' . $value . ' being ' . ($expected ? 'true' : 'false') . sprintf(" (locale:%s)", $locale)
+            'Failed expecting ' . $value . ' being ' . ($expected ? 'true' : 'false') .
+            sprintf(" (locale:%s, type:%s)", $locale, $type) . ', ICU Version:' . INTL_ICU_VERSION . '-' .
+            INTL_ICU_DATA_VERSION
         );
     }
 
@@ -75,20 +77,22 @@ class FloatTest extends \PHPUnit_Framework_TestCase
         //Loop locales and examples for a more thorough set of "true" test data
         foreach ($testingLocales as $locale) {
             foreach ($testingExamples as $example) {
-                $trueArray[] = array($example, true, $locale);
+                $trueArray[] = array($example, true, $locale, 'raw');
                 //Decimal Formatted
                 $trueArray[] = array(
                     NumberFormatter::create($locale, NumberFormatter::DECIMAL)
                         ->format($example, NumberFormatter::TYPE_DOUBLE),
                     true,
-                    $locale
+                    $locale,
+                    'decimal'
                 );
                 //Scientific Notation Formatted
                 $trueArray[] = array(
                     NumberFormatter::create($locale, NumberFormatter::SCIENTIFIC)
                         ->format($example, NumberFormatter::TYPE_DOUBLE),
                     true,
-                    $locale
+                    $locale,
+                    'scientific'
                 );
             }
         }

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -69,7 +69,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     public function floatAndIntegerProvider()
     {
         $trueArray       = array();
-        $testingLocales  = array('ar', 'bn', 'de', 'dz', 'en', 'fr-CH', 'ja', 'ml-IN', 'mr', 'my', 'fa', 'ru', 'zh-TW');
+        $testingLocales  = array('ar', 'bn', 'de', 'dz', 'en', 'fr-CH', 'ja', 'ks', 'ml-IN', 'mr', 'my', 'ps', 'ru');
         $testingExamples = array(1000, -2000, +398.00, 0.04, -0.5, .6, -.70, 8E10, -9.3456E-2, 10.23E6);
 
         //Loop locales and examples for a more thorough set of "true" test data
@@ -161,7 +161,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
             'ar'    => array('10.1', '66notflot.6'),
             'ru'    => array('10.1', '66notflot.6', '2,000.00', '2 00'),
             'en'    => array('10,1', '66notflot.6', '2.000,00', '2 000', '2,00'),
-            'fr-CH' => array('10,1', '66notflot.6', '2,000.00', '2 000', "2'00"),
+            'fr-CH' => array('10,1', '66notflot.6', '2,000.00', '2 000', "2'00")
         );
 
         //Loop locales and examples for a more thorough set of "true" test data

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -72,7 +72,8 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     {
         $trueArray       = array();
         $testingLocales  = array('ar', 'bn', 'de', 'dz', 'en', 'fr-CH', 'ja', 'ks', 'ml-IN', 'mr', 'my', 'ps', 'ru');
-        $testingExamples = array(1000, -2000, +398.00, 0.04, -0.5, .6, -.70, 8E10, -9.3456E-2, 10.23E6);
+        $testingExamples = array(1000, -2000, +398.00, 0.04, -0.5, .6, -.70, 8E10, -9.3456E-2, 10.23E6,
+            123.1234567890987654321);
 
         //Loop locales and examples for a more thorough set of "true" test data
         foreach ($testingLocales as $locale) {


### PR DESCRIPTION
Fix for #6300. This is a complete rewrite of the validator to account for non-latin number systems, scientific notation, and "look-alike" characters (space for NO-BREAK SPACE, comma for ARABIC DECIMAL SEPARATOR, and single quote for ARABIC THOUSANDS SEPARATOR). Though the test class only tests against 13 locales, the logic was tested against all 709 locales in CLDR 25.

This also includes a small cleanup of the formatting on NumberFormat filter and removal of the extraneous NO-BREAK SPACE removal.

Rewrite of the test class to use programmatic values for `true` tests using both decimal and scientific notation.
