### PR TITLE
Fix #6385 Request exception

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -233,7 +233,7 @@ class Client implements Stdlib\DispatchableInterface
     {
         if (empty($this->request)) {
             $this->request = new Request();
-            $this->request->setStandardMethodsOnly(true);
+            $this->request->setAllowCustomMethods(false);
         }
         return $this->request;
     }

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -233,6 +233,7 @@ class Client implements Stdlib\DispatchableInterface
     {
         if (empty($this->request)) {
             $this->request = new Request();
+            $this->request->setStandardMethodsOnly(true);
         }
         return $this->request;
     }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -60,8 +60,10 @@ class Request extends HttpRequest
      * Construct
      * Instantiates request.
      */
-    public function __construct()
+    public function __construct($allowCustomMethods = true)
     {
+        $this->setAllowCustomMethods($allowCustomMethods);
+
         $this->setEnv(new Parameters($_ENV));
 
         if ($_GET) {

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -43,6 +43,11 @@ class Request extends AbstractMessage implements RequestInterface
     protected $method = self::METHOD_GET;
 
     /**
+     * @var bool
+     */
+    protected $standardMethodsOnly = false;
+
+    /**
      * @var string|HttpUri
      */
     protected $uri = null;
@@ -66,22 +71,26 @@ class Request extends AbstractMessage implements RequestInterface
      * A factory that produces a Request object from a well-formed Http Request string
      *
      * @param  string $string
-     * @return Request
+     * @param  bool $standardMethodsOnly
      * @throws Exception\InvalidArgumentException
+     * @return Request
      */
-    public static function fromString($string)
+    public static function fromString($string, $standardMethodsOnly = false)
     {
+        /** @var Request $request */
         $request = new static();
 
         $lines = explode("\r\n", $string);
 
         // first line must be Method/Uri/Version string
         $matches = null;
-        $methods = implode('|', array(
-            self::METHOD_OPTIONS, self::METHOD_GET, self::METHOD_HEAD, self::METHOD_POST,
-            self::METHOD_PUT, self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT,
-            self::METHOD_PATCH
-        ));
+
+        $standardMethods = array(
+            self::METHOD_OPTIONS, self::METHOD_GET, self::METHOD_HEAD, self::METHOD_POST, self::METHOD_PUT,
+            self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT, self::METHOD_PATCH
+        );
+
+        $methods   = $standardMethodsOnly ? implode('|', $standardMethods) : '[\w-]+';
         $regex     = '#^(?P<method>' . $methods . ')\s(?P<uri>[^ ]*)(?:\sHTTP\/(?P<version>\d+\.\d+)){0,1}#';
         $firstLine = array_shift($lines);
         if (!preg_match($regex, $firstLine, $matches)) {
@@ -137,7 +146,7 @@ class Request extends AbstractMessage implements RequestInterface
     public function setMethod($method)
     {
         $method = strtoupper($method);
-        if (!defined('static::METHOD_' . $method)) {
+        if (!defined('static::METHOD_' . $method) && $this->isStandardMethodsOnly()) {
             throw new Exception\InvalidArgumentException('Invalid HTTP method passed');
         }
         $this->method = $method;
@@ -502,5 +511,21 @@ class Request extends AbstractMessage implements RequestInterface
         $str .= "\r\n";
         $str .= $this->getContent();
         return $str;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isStandardMethodsOnly()
+    {
+        return $this->standardMethodsOnly;
+    }
+
+    /**
+     * @param boolean $strictMethods
+     */
+    public function setStandardMethodsOnly($strictMethods)
+    {
+        $this->standardMethodsOnly = (bool) $strictMethods;
     }
 }

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -79,6 +79,7 @@ class Request extends AbstractMessage implements RequestInterface
     {
         /** @var Request $request */
         $request = new static();
+        $request->setStandardMethodsOnly($standardMethodsOnly);
 
         $lines = explode("\r\n", $string);
 

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -45,7 +45,7 @@ class Request extends AbstractMessage implements RequestInterface
     /**
      * @var bool
      */
-    protected $standardMethodsOnly = false;
+    protected $allowCustomMethods = true;
 
     /**
      * @var string|HttpUri
@@ -71,15 +71,15 @@ class Request extends AbstractMessage implements RequestInterface
      * A factory that produces a Request object from a well-formed Http Request string
      *
      * @param  string $string
-     * @param  bool $standardMethodsOnly
+     * @param  bool $allowCustomMethods
      * @throws Exception\InvalidArgumentException
      * @return Request
      */
-    public static function fromString($string, $standardMethodsOnly = false)
+    public static function fromString($string, $allowCustomMethods = true)
     {
         /** @var Request $request */
         $request = new static();
-        $request->setStandardMethodsOnly($standardMethodsOnly);
+        $request->setAllowCustomMethods($allowCustomMethods);
 
         $lines = explode("\r\n", $string);
 
@@ -91,7 +91,7 @@ class Request extends AbstractMessage implements RequestInterface
             self::METHOD_DELETE, self::METHOD_TRACE, self::METHOD_CONNECT, self::METHOD_PATCH
         );
 
-        $methods   = $standardMethodsOnly ? implode('|', $standardMethods) : '[\w-]+';
+        $methods   = $allowCustomMethods ? '[\w-]+' : implode('|', $standardMethods);
         $regex     = '#^(?P<method>' . $methods . ')\s(?P<uri>[^ ]*)(?:\sHTTP\/(?P<version>\d+\.\d+)){0,1}#';
         $firstLine = array_shift($lines);
         if (!preg_match($regex, $firstLine, $matches)) {
@@ -147,7 +147,7 @@ class Request extends AbstractMessage implements RequestInterface
     public function setMethod($method)
     {
         $method = strtoupper($method);
-        if (!defined('static::METHOD_' . $method) && $this->isStandardMethodsOnly()) {
+        if (!defined('static::METHOD_' . $method) && ! $this->getAllowCustomMethods()) {
             throw new Exception\InvalidArgumentException('Invalid HTTP method passed');
         }
         $this->method = $method;
@@ -517,16 +517,16 @@ class Request extends AbstractMessage implements RequestInterface
     /**
      * @return boolean
      */
-    public function isStandardMethodsOnly()
+    public function getAllowCustomMethods()
     {
-        return $this->standardMethodsOnly;
+        return $this->allowCustomMethods;
     }
 
     /**
      * @param boolean $strictMethods
      */
-    public function setStandardMethodsOnly($strictMethods)
+    public function setAllowCustomMethods($strictMethods)
     {
-        $this->standardMethodsOnly = (bool) $strictMethods;
+        $this->allowCustomMethods = (bool) $strictMethods;
     }
 }

--- a/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RequestTest.php
@@ -739,4 +739,16 @@ class RequestTest extends TestCase
 
         $this->assertEquals('', $request->getBaseUrl());
     }
+
+    public function testAllowCustomMethodsFlagCanBeSetWithConstructor()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'xcustomx';
+
+        $this->setExpectedException(
+            'Zend\Http\Exception\InvalidArgumentException',
+            'Invalid HTTP method passed'
+        );
+
+        $request = new Request(false);
+    }
 }

--- a/tests/ZendTest/Http/RequestTest.php
+++ b/tests/ZendTest/Http/RequestTest.php
@@ -260,4 +260,44 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         }
         return $return;
     }
+
+    public function testCustomMethods()
+    {
+        $request = new Request();
+        $this->assertFalse($request->isStandardMethodsOnly());
+        $request->setMethod('xcustom');
+
+        $this->assertEquals('XCUSTOM', $request->getMethod());
+    }
+
+    public function testStandardMethodsOnly()
+    {
+        $request = new Request();
+        $request->setStandardMethodsOnly(true);
+
+        $this->setExpectedException(
+            'Zend\Http\Exception\InvalidArgumentException',
+            'Invalid HTTP method passed'
+        );
+
+        $request->setMethod('xcustom');
+    }
+
+    public function testCustomMethodsFromString()
+    {
+        $request = Request::fromString('X-CUS_TOM someurl');
+        $this->assertFalse($request->isStandardMethodsOnly());
+
+        $this->assertEquals('X-CUS_TOM', $request->getMethod());
+    }
+
+    public function testStandardMethodsOnlyFromString()
+    {
+        $this->setExpectedException(
+            'Zend\Http\Exception\InvalidArgumentException',
+            'A valid request line was not found in the provided string'
+        );
+
+        $request = Request::fromString('X-CUS_TOM someurl', true);
+    }
 }

--- a/tests/ZendTest/Http/RequestTest.php
+++ b/tests/ZendTest/Http/RequestTest.php
@@ -264,16 +264,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testCustomMethods()
     {
         $request = new Request();
-        $this->assertFalse($request->isStandardMethodsOnly());
+        $this->assertTrue($request->getAllowCustomMethods());
         $request->setMethod('xcustom');
 
         $this->assertEquals('XCUSTOM', $request->getMethod());
     }
 
-    public function testStandardMethodsOnly()
+    public function testDisallowCustomMethods()
     {
         $request = new Request();
-        $request->setStandardMethodsOnly(true);
+        $request->setAllowCustomMethods(false);
 
         $this->setExpectedException(
             'Zend\Http\Exception\InvalidArgumentException',
@@ -286,24 +286,24 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testCustomMethodsFromString()
     {
         $request = Request::fromString('X-CUS_TOM someurl');
-        $this->assertFalse($request->isStandardMethodsOnly());
+        $this->assertTrue($request->getAllowCustomMethods());
 
         $this->assertEquals('X-CUS_TOM', $request->getMethod());
     }
 
-    public function testStandardMethodsOnlyFromString()
+    public function testDisallowCustomMethodsFromString()
     {
         $this->setExpectedException(
             'Zend\Http\Exception\InvalidArgumentException',
             'A valid request line was not found in the provided string'
         );
 
-        $request = Request::fromString('X-CUS_TOM someurl', true);
+        $request = Request::fromString('X-CUS_TOM someurl', false);
     }
 
-    public function testStandardMethodsOnlyFlagIsSetByFromString()
+    public function testAllowCustomMethodsFlagIsSetByFromString()
     {
-        $request = Request::fromString('GET someurl', true);
-        $this->assertTrue($request->isStandardMethodsOnly());
+        $request = Request::fromString('GET someurl', false);
+        $this->assertFalse($request->getAllowCustomMethods());
     }
 }

--- a/tests/ZendTest/Http/RequestTest.php
+++ b/tests/ZendTest/Http/RequestTest.php
@@ -300,4 +300,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::fromString('X-CUS_TOM someurl', true);
     }
+
+    public function testStandardMethodsOnlyFlagIsSetByFromString()
+    {
+        $request = Request::fromString('GET someurl', true);
+        $this->assertTrue($request->isStandardMethodsOnly());
+    }
 }


### PR DESCRIPTION
this PR fixes #6385 .

The idea suggested by @weierophinney is to loosen the strictness of `Zend\Http\Request` to get rid of the uncaught exception, and then add an event listener to the mvc cycle to give users some flexibility and feedback (that will be done in a different PR against `develop`).

There is a catch that I leave for discussion, tho.

Personally, I can't see any reason why one would want to have `Application::construct()` trigger a fatal error if a bogus http method was set in the server environment, but - although unlikely - it's possible that people could rely on the exceptions thrown by `Request::setMethod()` and `Request::fromString()` when using `Zend\Http` component alone. One example is `Zend\Http\Client` itself, as shown in this PR.

It may be worth mentioning that this behaviour wasn't covered by the `Request` tests themselves, but it was in `Client` ones. Overall I'd say dropping some strictness seems legit, but I can see why it may be undesirable.

As an alternative, it's totally possible to set the flag strict by default, and open it up in `Zend\Mvc\Service\RequestFactory` instead. That could preserve the old behaviour of `Zend\Http` component and at the same time make `Application` behaviour more sane.
