### PR TITLE
Added Zend\Crypt\FileCipher for file encryption/decryption

### DIFF
--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -75,13 +75,6 @@ class BlockCipher
     protected $key;
 
     /**
-     * Buffer size for file encryption
-     *
-     * @var int
-     */
-    protected $bufferSize = 1048576; // 16 * 65536 bytes = 1 Mb
-
-    /**
      * Constructor
      *
      * @param SymmetricInterface $cipher
@@ -413,21 +406,27 @@ class BlockCipher
         if (empty($this->cipher)) {
             throw new Exception\InvalidArgumentException('No symmetric cipher specified');
         }
-
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for encryption');
+        }
         if (!$this->saltSetted) {
             // generate a random salt (IV) if the salt has not been set
             $iv = Rand::getBytes($this->cipher->getSaltSize(), true);
         } else {
             $iv = $this->getSalt();
         }
-        $keys = $this->generateKeys($iv);
-        $this->cipher->setKey($keys['enc']);
+        $keys = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
+                             $this->getKey(),
+                             $iv,
+                             $this->getKeyIteration(),
+                             $this->cipher->getKeySize() * 2);
+        $this->cipher->setKey(substr($keys, 0, $this->cipher->getKeySize()));
         $this->cipher->setSalt($iv);
 
         // encryption
         $ciphertext = $this->cipher->encrypt($data);
         // HMAC
-        $hmac = Hmac::compute($keys['hmac'],
+        $hmac = Hmac::compute(substr($keys, $this->cipher->getKeySize()),
                               $this->getHashAlgorithm(),
                               $this->cipher->getAlgorithm() . $ciphertext);
         if (!$this->binaryOutput) {
@@ -435,98 +434,6 @@ class BlockCipher
         }
 
         return $hmac . $ciphertext;
-    }
-
-    /**
-     * Encrypt then authenticate a file using HMAC
-     *
-     * @param  string                             $fileIn
-     * @param  string                             $fileOut
-     * @return bool
-     * @throws Exception\InvalidArgumentException
-     */
-    public function encryptFile($fileIn, $fileOut, $compress = true)
-    {
-        if (!file_exists($fileIn)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "I cannot open the %s file", $fileIn
-            ));
-        }
-        if (file_exists($fileOut)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "The file %s already exists", $fileOut
-            ));
-        }
-        $read = fopen($fileIn, "r");
-        if ($compress) {
-            // Compress the file to be encrypted
-            $compressFile = $fileIn . '_zip';
-            $write = fopen('compress.zlib://' . $compressFile, "w");
-            while ($data = fread($read, $this->bufferSize)) {
-                fwrite($write, $data);
-            }
-            fclose($write);
-            fclose($read);
-            $read = fopen($compressFile, "r");
-        }
-        $write = fopen($fileOut, "w");
-        if (empty($this->cipher)) {
-            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
-        }
-
-        if (!$this->saltSetted) {
-            // generate a random salt (IV) if the salt has not been set
-            $iv = Rand::getBytes($this->cipher->getSaltSize(), true);
-        } else {
-            $iv = $this->getSalt();
-        }
-        $keys  = $this->generateKeys($iv);
-        $hmac  = '';
-        $size  = 0;
-        $tot   = filesize($fileIn);
-        $this->cipher->setKey($keys['enc']);
-        $padding = $this->cipher->getPadding();
-        $this->cipher->setPadding(new Symmetric\Padding\NoPadding);
-        $this->cipher->setSalt($iv);
-
-        $hashAlgo  = $this->getHashAlgorithm();
-        $saltSize  = $this->cipher->getSaltSize();
-        $algorithm = $this->cipher->getAlgorithm();
-
-        while ($data = fread($read, $this->bufferSize)) {
-            $size += strlen($data);
-            // Padding if last block
-            if ($size == $tot) {
-                $this->cipher->setPadding($padding);
-            }
-            $result = $this->cipher->encrypt($data);
-            if ($size <= $this->bufferSize) {
-                // Write a placeholder for the HMAC and write the IV
-                fwrite($write, str_repeat(0, Hmac::getOutputSize($hashAlgo)));
-            } else {
-                $result = substr($result, $saltSize);
-            }
-            $hmac = Hmac::compute($keys['hmac'],
-                                  $hashAlgo,
-                                  $algorithm . $hmac . $result);
-            $this->cipher->setSalt(substr($result, -1 * $saltSize));
-            if (fwrite($write, $result) !== strlen($result)) {
-                return false;
-            }
-        }
-        $result = true;
-        // write the HMAC at the beginning of the file
-        fseek($write, 0);
-        if (fwrite($write, $hmac) !== strlen($hmac)) {
-            $result = false;
-        }
-        fclose($write);
-        fclose($read);
-        if ($compress) {
-            unlink($compressFile);
-        }
-
-        return $result;
     }
 
     /**
@@ -547,6 +454,9 @@ class BlockCipher
         if (empty($this->cipher)) {
             throw new Exception\InvalidArgumentException('No symmetric cipher specified');
         }
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for decryption');
+        }
         $hmacSize   = Hmac::getOutputSize($this->hash);
         $hmac       = substr($data, 0, $hmacSize);
         $ciphertext = substr($data, $hmacSize);
@@ -554,10 +464,14 @@ class BlockCipher
             $ciphertext = base64_decode($ciphertext);
         }
         $iv   = substr($ciphertext, 0, $this->cipher->getSaltSize());
-        $keys = $this->generateKeys($iv);
+        $keys = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
+                             $this->getKey(),
+                             $iv,
+                             $this->getKeyIteration(),
+                             $this->cipher->getKeySize() * 2);
         // set the decryption key
-        $this->cipher->setKey($keys['enc']);
-        $hmacNew = Hmac::compute($keys['hmac'],
+        $this->cipher->setKey(substr($keys, 0, $this->cipher->getKeySize()));
+        $hmacNew = Hmac::compute(substr($keys, $this->cipher->getKeySize()),
                                  $this->hash,
                                  $this->cipher->getAlgorithm() . $ciphertext);
         if (!Utils::compareStrings($hmacNew, $hmac)) {
@@ -565,122 +479,5 @@ class BlockCipher
         }
 
         return $this->cipher->decrypt($ciphertext);
-    }
-
-    /**
-     * Decrypt a file
-     *
-     * @param  string                             $fileIn
-     * @param  string                             $fileOut
-     * @return bool
-     * @throws Exception\InvalidArgumentException
-     */
-    public function decryptFile($fileIn, $fileOut, $compress = true)
-    {
-        if (!file_exists($fileIn)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "I cannot open the %s file", $fileIn
-            ));
-        }
-        if (file_exists($fileOut)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "The file %s already exists", $fileOut
-            ));
-        }
-        $read = fopen($fileIn, "r");
-        if ($compress) {
-            $compressFile = $fileOut . "_zip";
-            $write = fopen($compressFile, "w");
-        } else {
-            $write = fopen($fileOut, "w");
-        }
-        if (empty($this->cipher)) {
-            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
-        }
-
-        $hmacRead = fread($read, Hmac::getOutputSize($this->getHashAlgorithm()));
-        $iv       = fread($read, $this->cipher->getSaltSize());
-        $tot      = filesize($fileIn);
-        $hmac     = $iv;
-        $size     = strlen($iv) + strlen($hmacRead);
-        $keys     = $this->generateKeys($iv);
-        $padding  = $this->cipher->getPadding();
-        $this->cipher->setPadding(new Symmetric\Padding\NoPadding);
-        $this->cipher->setKey($keys['enc']);
-
-        $blockSize = $this->cipher->getBlockSize();
-        $hashAlgo  = $this->getHashAlgorithm();
-        $algorithm = $this->cipher->getAlgorithm();
-        $saltSize  = $this->cipher->getSaltSize();
-
-        while ($data = fread($read, $this->bufferSize)) {
-            $size += strlen($data);
-            // Unpadding if last block
-            if ($size + $blockSize >= $tot) {
-                $this->cipher->setPadding($padding);
-                $data .= fread($read, $blockSize);
-            }
-            $result = $this->cipher->decrypt($iv . $data);
-            $hmac   = Hmac::compute($keys['hmac'],
-                                    $hashAlgo,
-                                    $algorithm . $hmac . $data);
-            $iv     = substr($data, -1 * $saltSize);
-            if (fwrite($write, $result) !== strlen($result)) {
-                return false;
-            }
-        }
-        fclose($write);
-        fclose($read);
-
-        // check for data integrity
-        if (!Utils::compareStrings($hmac, $hmacRead)) {
-            if ($compress) {
-                unlink($compressFile);
-            } else {
-                unlink($fileOut);
-            }
-
-            return false;
-        }
-        // Uncompress the file out
-        if ($compress) {
-            $read  = fopen('compress.zlib://' . $compressFile, "r");
-            $write = fopen($fileOut, "w");
-            while ($data = fread($read, $this->bufferSize)) {
-                fwrite($write, $data);
-            }
-            fclose($write);
-            fclose($read);
-            unlink($compressFile);
-        }
-
-        return true;
-    }
-
-    /**
-     * Generate encryption key and authentication key
-     * using PBKDF2 algorithm
-     *
-     * @param  string $iv
-     * @return array
-     */
-    protected function generateKeys($iv)
-    {
-        if (!$this->getKey()) {
-            throw new Exception\InvalidArgumentException('No key specified');
-        }
-        if (empty($this->cipher)) {
-            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
-        }
-        $key = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
-                            $this->getKey(),
-                            $iv,
-                            $this->getKeyIteration(),
-                            $this->cipher->getKeySize() * 2);
-
-        return array(
-            'enc'  => substr($key, 0, $this->cipher->getKeySize()),
-            'hmac' => substr($key, $this->cipher->getKeySize())
-        );
     }
 }

--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -258,7 +258,7 @@ class BlockCipher
     /**
      * Set the encryption/decryption key
      *
-     * @param  string$key
+     * @param  string                             $key
      * @return BlockCipher
      * @throws Exception\InvalidArgumentException
      */
@@ -442,7 +442,7 @@ class BlockCipher
      *
      * @param  string                             $fileIn
      * @param  string                             $fileOut
-     * @return boolean
+     * @return bool
      * @throws Exception\InvalidArgumentException
      */
     public function encryptFile($fileIn, $fileOut, $compress = true)
@@ -572,7 +572,7 @@ class BlockCipher
      *
      * @param  string                             $fileIn
      * @param  string                             $fileOut
-     * @return boolean
+     * @return bool
      * @throws Exception\InvalidArgumentException
      */
     public function decryptFile($fileIn, $fileOut, $compress = true)

--- a/library/Zend/Crypt/FileCipher.php
+++ b/library/Zend/Crypt/FileCipher.php
@@ -1,0 +1,579 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt;
+
+use Zend\Crypt\Key\Derivation\Pbkdf2;
+use Zend\Crypt\Symmetric\SymmetricInterface;
+use Zend\Math\Rand;
+
+/**
+ * Encrypt/decrypt a file usinf a symmetric cipher then authenticate using HMAC
+ */
+class FileCipher
+{
+    /**
+     * Hash algorithm for Pbkdf2
+     *
+     * @var string
+     */
+    protected $pbkdf2Hash = 'sha256';
+
+    /**
+     * Symmetric cipher
+     *
+     * @var SymmetricInterface
+     */
+    protected $cipher;
+
+    /**
+     * Symmetric cipher plugin manager
+     *
+     * @var SymmetricPluginManager
+     */
+    protected static $symmetricPlugins = null;
+
+    /**
+     * Hash algorithm for HMAC
+     *
+     * @var string
+     */
+    protected $hash = 'sha256';
+
+    /**
+     * Number of iterations for Pbkdf2
+     *
+     * @var int
+     */
+    protected $keyIteration = 5000;
+
+    /**
+     * Key
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * Buffer size for file encryption
+     *
+     * @var int
+     */
+    protected $bufferSize = 1048576; // 16 * 65536 bytes = 1 Mb
+
+    /**
+     * Compress the file before encryption
+     * @var bool
+     */
+    protected $compress = true;
+
+    /**
+     * Constructor
+     *
+     * @param SymmetricInterface $cipher
+     */
+    public function __construct(SymmetricInterface $cipher)
+    {
+        $this->cipher = $cipher;
+    }
+
+    /**
+     * Factory.
+     *
+     * @param  string      $adapter
+     * @param  array       $options
+     * @return BlockCipher
+     */
+    public static function factory($adapter, $options = array())
+    {
+        $plugins = static::getSymmetricPluginManager();
+        $adapter = $plugins->get($adapter, (array) $options);
+
+        return new static($adapter);
+    }
+
+    /**
+     * Returns the symmetric cipher plugin manager.  If it doesn't exist it's created.
+     *
+     * @return SymmetricPluginManager
+     */
+    public static function getSymmetricPluginManager()
+    {
+        if (static::$symmetricPlugins === null) {
+            static::setSymmetricPluginManager(new SymmetricPluginManager());
+        }
+
+        return static::$symmetricPlugins;
+    }
+
+    /**
+     * Set the symmetric cipher plugin manager
+     *
+     * @param  string|SymmetricPluginManager      $plugins
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function setSymmetricPluginManager($plugins)
+    {
+        if (is_string($plugins)) {
+            if (!class_exists($plugins)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Unable to locate symmetric cipher plugins using class "%s"; class does not exist',
+                    $plugins
+                ));
+            }
+            $plugins = new $plugins();
+        }
+        if (!$plugins instanceof SymmetricPluginManager) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expected an instance or extension of %s\SymmetricPluginManager; received "%s"',
+                __NAMESPACE__,
+                (is_object($plugins) ? get_class($plugins) : gettype($plugins))
+            ));
+        }
+        static::$symmetricPlugins = $plugins;
+    }
+
+    /**
+     * Set the symmetric cipher
+     *
+     * @param  SymmetricInterface $cipher
+     * @return BlockCipher
+     */
+    public function setCipher(SymmetricInterface $cipher)
+    {
+        $this->cipher = $cipher;
+
+        return $this;
+    }
+
+    /**
+     * Get symmetric cipher
+     *
+     * @return SymmetricInterface
+     */
+    public function getCipher()
+    {
+        return $this->cipher;
+    }
+
+    /**
+     * Set the number of iterations for Pbkdf2
+     *
+     * @param  int         $num
+     * @return BlockCipher
+     */
+    public function setKeyIteration($num)
+    {
+        $this->keyIteration = (int) $num;
+
+        return $this;
+    }
+
+    /**
+     * Get the number of iterations for Pbkdf2
+     *
+     * @return int
+     */
+    public function getKeyIteration()
+    {
+        return $this->keyIteration;
+    }
+
+    /**
+     * Set the encryption/decryption key
+     *
+     * @param  string                             $key
+     * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setKey($key)
+    {
+        if (empty($key)) {
+            throw new Exception\InvalidArgumentException('The key cannot be empty');
+        }
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * Get the key
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Set algorithm of the symmetric cipher
+     *
+     * @param  string                             $algo
+     * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setCipherAlgorithm($algo)
+    {
+        if (empty($this->cipher)) {
+            throw new Exception\InvalidArgumentException('No symmetric cipher specified');
+        }
+        try {
+            $this->cipher->setAlgorithm($algo);
+        } catch (Symmetric\Exception\InvalidArgumentException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage());
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the cipher algorithm
+     *
+     * @return string|bool
+     */
+    public function getCipherAlgorithm()
+    {
+        if (!empty($this->cipher)) {
+            return $this->cipher->getAlgorithm();
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the supported algorithms of the symmetric cipher
+     *
+     * @return array
+     */
+    public function getCipherSupportedAlgorithms()
+    {
+        if (!empty($this->cipher)) {
+            return $this->cipher->getSupportedAlgorithms();
+        }
+
+        return array();
+    }
+
+    /**
+     * Set the hash algorithm for HMAC authentication
+     *
+     * @param  string                             $hash
+     * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setHashAlgorithm($hash)
+    {
+        if (!Hash::isSupported($hash)) {
+            throw new Exception\InvalidArgumentException(
+                "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
+            );
+        }
+        $this->hash = $hash;
+
+        return $this;
+    }
+
+    /**
+     * Get the hash algorithm for HMAC authentication
+     *
+     * @return string
+     */
+    public function getHashAlgorithm()
+    {
+        return $this->hash;
+    }
+
+    /**
+     * Set the hash algorithm for the Pbkdf2
+     *
+     * @param  string                             $hash
+     * @return BlockCipher
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setPbkdf2HashAlgorithm($hash)
+    {
+        if (!Hash::isSupported($hash)) {
+            throw new Exception\InvalidArgumentException(
+                "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
+            );
+        }
+        $this->pbkdf2Hash = $hash;
+
+        return $this;
+    }
+
+    /**
+     * Get the Pbkdf2 hash algorithm
+     *
+     * @return string
+     */
+    public function getPbkdf2HashAlgorithm()
+    {
+        return $this->pbkdf2Hash;
+    }
+
+    /**
+     * Set the compression of the file
+     *
+     * @param  bool       $compress
+     * @return FileCipher
+     */
+    public function setCompress($compress)
+    {
+        $this->compress = (boolean) $compress;
+
+        return $this;
+    }
+
+    /**
+     * Get the compression setting
+     *
+     * @return bool
+     */
+    public function getCompress()
+    {
+        return $this->compress;
+    }
+
+    /**
+     * Encrypt then authenticate a file using HMAC
+     *
+     * @param  string                             $fileIn
+     * @param  string                             $fileOut
+     * @param  bool                               $compress
+     * @return bool
+     * @throws Exception\InvalidArgumentException
+     */
+    public function encrypt($fileIn, $fileOut)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "I cannot open the %s file", $fileIn
+            ));
+        }
+        if (file_exists($fileOut)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "The file %s already exists", $fileOut
+            ));
+        }
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for encryption');
+        }
+
+        if ($this->compress) {
+            $compressFile = $this->compressFile($fileIn);
+            $read         = fopen($compressFile, "r");
+        } else {
+            $read = fopen($fileIn, "r");
+        }
+        $write = fopen($fileOut, "w");
+
+        $iv      = Rand::getBytes($this->cipher->getSaltSize(), true);
+        $keys    = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
+                                $this->getKey(),
+                                $iv,
+                                $this->getKeyIteration(),
+                                $this->cipher->getKeySize() * 2);
+        $hmac    = '';
+        $size    = 0;
+        $tot     = filesize($fileIn);
+        $padding = $this->cipher->getPadding();
+
+        $this->cipher->setKey(substr($keys, 0, $this->cipher->getKeySize()));
+        $this->cipher->setPadding(new Symmetric\Padding\NoPadding);
+        $this->cipher->setSalt($iv);
+
+        $hashAlgo  = $this->getHashAlgorithm();
+        $saltSize  = $this->cipher->getSaltSize();
+        $algorithm = $this->cipher->getAlgorithm();
+        $keyHmac   = substr($keys, $this->cipher->getKeySize());
+
+        while ($data = fread($read, $this->bufferSize)) {
+            $size += strlen($data);
+            // Padding if last block
+            if ($size == $tot) {
+                $this->cipher->setPadding($padding);
+            }
+            $result = $this->cipher->encrypt($data);
+            if ($size <= $this->bufferSize) {
+                // Write a placeholder for the HMAC and write the IV
+                fwrite($write, str_repeat(0, Hmac::getOutputSize($hashAlgo)));
+            } else {
+                $result = substr($result, $saltSize);
+            }
+            $hmac = Hmac::compute($keyHmac,
+                                  $hashAlgo,
+                                  $algorithm . $hmac . $result);
+            $this->cipher->setSalt(substr($result, -1 * $saltSize));
+            if (fwrite($write, $result) !== strlen($result)) {
+                return false;
+            }
+        }
+        $result = true;
+        // write the HMAC at the beginning of the file
+        fseek($write, 0);
+        if (fwrite($write, $hmac) !== strlen($hmac)) {
+            $result = false;
+        }
+        fclose($write);
+        fclose($read);
+        // Remove the file compressed
+        if ($this->compress) {
+            unlink($compressFile);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Decrypt a file
+     *
+     * @param  string                             $fileIn
+     * @param  string                             $fileOut
+     * @param  bool                               $compress
+     * @return bool
+     * @throws Exception\InvalidArgumentException
+     */
+    public function decrypt($fileIn, $fileOut)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "I cannot open the %s file", $fileIn
+            ));
+        }
+        if (file_exists($fileOut)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "The file %s already exists", $fileOut
+            ));
+        }
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for decryption');
+        }
+
+        $read = fopen($fileIn, "r");
+        if ($this->compress) {
+            $compressFile = sys_get_temp_dir() . '/' . uniqid('tmp_compress_');
+            $write = fopen($compressFile, "w");
+        } else {
+            $write = fopen($fileOut, "w");
+        }
+
+        $hmacRead = fread($read, Hmac::getOutputSize($this->getHashAlgorithm()));
+        $iv       = fread($read, $this->cipher->getSaltSize());
+        $tot      = filesize($fileIn);
+        $hmac     = $iv;
+        $size     = strlen($iv) + strlen($hmacRead);
+        $keys     = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
+                                 $this->getKey(),
+                                 $iv,
+                                 $this->getKeyIteration(),
+                                 $this->cipher->getKeySize() * 2);
+        $padding  = $this->cipher->getPadding();
+        $this->cipher->setPadding(new Symmetric\Padding\NoPadding);
+        $this->cipher->setKey(substr($keys, 0, $this->cipher->getKeySize()));
+
+        $blockSize = $this->cipher->getBlockSize();
+        $hashAlgo  = $this->getHashAlgorithm();
+        $algorithm = $this->cipher->getAlgorithm();
+        $saltSize  = $this->cipher->getSaltSize();
+        $keyHmac   = substr($keys, $this->cipher->getKeySize());
+
+        while ($data = fread($read, $this->bufferSize)) {
+            $size += strlen($data);
+            // Unpadding if last block
+            if ($size + $blockSize >= $tot) {
+                $this->cipher->setPadding($padding);
+                $data .= fread($read, $blockSize);
+            }
+            $result = $this->cipher->decrypt($iv . $data);
+            $hmac   = Hmac::compute($keyHmac,
+                                    $hashAlgo,
+                                    $algorithm . $hmac . $data);
+            $iv     = substr($data, -1 * $saltSize);
+            if (fwrite($write, $result) !== strlen($result)) {
+                return false;
+            }
+        }
+        fclose($write);
+        fclose($read);
+
+        // check for data integrity
+        if (!Utils::compareStrings($hmac, $hmacRead)) {
+            if ($this->compress) {
+                unlink($compressFile);
+            } else {
+                unlink($fileOut);
+            }
+
+            return false;
+        }
+        // Uncompress the file out
+        if ($this->compress) {
+            $this->unCompressFile($compressFile, $fileOut);
+            unlink($compressFile);
+        }
+
+        return true;
+    }
+
+    /**
+     * Compress a file
+     *
+     * @param  string                             $fileIn
+     * @param  string                             $fileOut
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     */
+    protected function compressFile($fileIn, $fileOut = null)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException("The file %s doesn't exist", $fileIn);
+        }
+        if (!$fileOut) {
+            $fileOut = sys_get_temp_dir() . '/' . uniqid('tmp_compress_');
+        }
+        $read  = fopen($fileIn, "r");
+        $write = fopen('compress.zlib://' . $fileOut, "w");
+        while ($data = fread($read, $this->bufferSize)) {
+            fwrite($write, $data);
+        }
+        fclose($write);
+        fclose($read);
+
+        return $fileOut;
+    }
+
+    /**
+     * Uncompress a file
+     *
+     * @param  string                             $fileIn
+     * @param  string                             $fileOut
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     */
+    protected function unCompressFile($fileIn, $fileOut = null)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException("The file %s doesn't exist", $fileIn);
+        }
+        if (!$fileOut) {
+            $fileOut = sys_get_temp_dir() . '/' . uniqid('tmp_compress_');
+        }
+        $read  = fopen('compress.zlib://' . $fileIn, "r");
+        $write = fopen($fileOut, "w");
+        while ($data = fread($read, $this->bufferSize)) {
+            fwrite($write, $data);
+        }
+        fclose($write);
+        fclose($read);
+
+        return $fileOut;
+    }
+}

--- a/library/Zend/Crypt/Symmetric/Padding/NoPadding.php
+++ b/library/Zend/Crypt/Symmetric/Padding/NoPadding.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt\Symmetric\Padding;
+
+/**
+ * No Padding
+ */
+class NoPadding implements PaddingInterface
+{
+    public function pad($string, $blockSize = 32)
+    {
+        return $string;
+    }
+
+    public function strip($string)
+    {
+        return $string;
+    }
+}

--- a/library/Zend/Crypt/Symmetric/Padding/NoPadding.php
+++ b/library/Zend/Crypt/Symmetric/Padding/NoPadding.php
@@ -14,11 +14,24 @@ namespace Zend\Crypt\Symmetric\Padding;
  */
 class NoPadding implements PaddingInterface
 {
+    /**
+     * Pad a string, do nothing and return the string
+     *
+     * @param  string $string
+     * @param  int    $blockSize
+     * @return string
+     */
     public function pad($string, $blockSize = 32)
     {
         return $string;
     }
 
+    /**
+     * Unpad a string, do nothing and return the string
+     *
+     * @param  string $string
+     * @return string
+     */
     public function strip($string)
     {
         return $string;

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -12,6 +12,8 @@ namespace ZendTest\Crypt;
 use Zend\Crypt\BlockCipher;
 use Zend\Crypt\Symmetric\Mcrypt;
 use Zend\Crypt\Symmetric\Exception;
+use Zend\Crypt\Hmac;
+use Zend\Math\Rand;
 
 /**
  * @group      Zend_Crypt
@@ -125,7 +127,7 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
     {
         $plaintext = 'test';
         $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
-                                    'No key specified for the encryption');
+                                    'No key specified');
         $ciphertext = $this->blockCipher->encrypt($plaintext);
     }
 
@@ -192,5 +194,173 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         $encrypted = substr($encrypted, -1);
         $decrypted = $this->blockCipher->decrypt($encrypted);
         $this->assertTrue($decrypted === false);
+    }
+
+    public function testEncryptDecryptFile()
+    {
+        // Test 5 files with a random size bewteen 1 Kb and 5 Mb
+        for ($i=1; $i <= 5; $i++) {
+            $fileIn  = $this->generateTmpFile(Rand::getInteger(1024, 1048576 * 5), Rand::getBytes(1));
+            $fileOut = $fileIn . '.enc';
+            $this->blockCipher->setKey('test');
+
+            // encrypt
+            $this->assertTrue($this->blockCipher->encryptFile($fileIn, $fileOut));
+
+            // check if the file is compressed
+            $this->assertTrue(filesize($fileOut) < fileSize($fileIn));
+
+            $decryptFile = $fileOut . '.dec';
+            // decrypt
+            $this->assertTrue($this->blockCipher->decryptFile($fileOut, $decryptFile));
+            $this->assertEquals(filesize($fileIn), filesize($decryptFile));
+            $this->assertEquals(file_get_contents($fileIn), file_get_contents($decryptFile));
+
+            unlink($fileIn);
+            unlink($fileOut);
+            unlink($decryptFile);
+        }
+    }
+
+    public function testEncrypDecryptFileNoCOmpression()
+    {
+        // Test 5 files with a random size between 1 Kb and 5 Mb
+        for ($i=1; $i <= 5; $i++) {
+            $fileIn  = $this->generateTmpFile(Rand::getInteger(1024, 1048576 * 5), Rand::getBytes(1));
+            $fileOut = $fileIn . '.enc';
+            $this->blockCipher->setKey('test');
+
+            // encrypt without compression
+            $this->assertTrue($this->blockCipher->encryptFile($fileIn, $fileOut, false));
+
+            $paddingSize = $this->blockCipher->getCipher()->getBlockSize();
+            $this->assertEquals(filesize($fileOut),
+                                filesize($fileIn) +
+                                $this->blockCipher->getCipher()->getSaltSize() +
+                                Hmac::getOutputSize($this->blockCipher->getHashAlgorithm()) +
+                                $paddingSize - filesize($fileIn) % $paddingSize);
+
+            $decryptFile = $fileOut . '.dec';
+            // decrypt
+            $this->assertTrue($this->blockCipher->decryptFile($fileOut, $decryptFile));
+            $this->assertEquals(filesize($fileIn), filesize($decryptFile));
+            $this->assertEquals(file_get_contents($fileIn), file_get_contents($decryptFile));
+
+            unlink ($fileIn);
+            unlink ($fileOut);
+            unlink ($decryptFile);
+        }
+    }
+
+    public function testDecryptFileNoValidAuthenticate()
+    {
+        $fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $fileOut = $fileIn . '.enc';
+
+        $this->blockCipher->setKey('test');
+        $this->assertTrue($this->blockCipher->encryptFile($fileIn, $fileOut, false));
+
+        $fileOut2 = $fileIn . '.dec';
+        $this->assertTrue($this->blockCipher->decryptFile($fileOut, $fileOut2, false));
+        unlink ($fileOut2);
+
+        // Tampering of the encrypted file
+        $ciphertext = file_get_contents($fileOut);
+        $ciphertext[0] = chr((ord($ciphertext[0]) + 1) % 256);
+        file_put_contents($fileOut, $ciphertext);
+
+        $this->assertFalse($this->blockCipher->decryptFile($fileOut, $fileOut2, false));
+        $this->assertFalse(file_exists($fileOut2));
+
+        unlink($fileIn);
+        unlink($fileOut);
+    }
+
+    public function testEncryptFileWithNoKey()
+    {
+        $fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $fileOut = $fileIn . '.enc';
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'No key specified');
+        $this->blockCipher->encryptFile($fileIn, $fileOut);
+
+        unlink($fileIn);
+    }
+
+    public function testDecryptFileWithNoKey()
+    {
+        $fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $fileOut = $fileIn . '.enc';
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'No key specified');
+        $this->blockCipher->decryptFile($fileIn, $fileOut);
+
+        unlink($fileIn);
+    }
+
+    public function testEncryptFileInvalidInputFile()
+    {
+        $randomFile = uniqid('Invalid_File');
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "I cannot open the $randomFile file");
+        $this->blockCipher->setKey('test');
+        $this->blockCipher->encryptFile($randomFile, '');
+    }
+
+    public function testDecryptFileInvalidInputFile()
+    {
+        $randomFile = uniqid('Invalid_File');
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "I cannot open the $randomFile file");
+        $this->blockCipher->setKey('test');
+        $this->blockCipher->decryptFile($randomFile, '');
+
+    }
+
+    public function testEncryptFileInvalidOutputFile()
+    {
+        $fileIn  = $this->generateTmpFile(1024);
+        $fileOut = $this->generateTmpFile(1024);
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "The file $fileOut already exists");
+        $this->blockCipher->setKey('test');
+        $this->blockCipher->encryptFile($fileIn, $fileOut);
+
+        unlink($fileIn);
+        unlink($fileOut);
+    }
+
+    public function testDecryptFileInvalidOutputFile()
+    {
+        $fileIn  = $this->generateTmpFile(1024);
+        $fileOut = $this->generateTmpFile(1024);
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "The file $fileOut already exists");
+        $this->blockCipher->setKey('test');
+        $this->blockCipher->decryptFile($fileIn, $fileOut);
+
+        unlink($fileIn);
+        unlink($fileOut);
+    }
+
+    /**
+     * Generate a temporary file with a selected size
+     *
+     * @param  string $size
+     * @param  string $content
+     * @return string
+     */
+    protected function generateTmpFile($size, $content = 'A')
+    {
+        $fileName = sys_get_temp_dir() . '/' . uniqid('ZF2_BlockCipher_test');
+        $num = $size / strlen($content) + 1;
+        $content  = str_repeat('A', $size / strlen($content) + 1);
+        file_put_contents($fileName, substr($content, 0, $size));
+
+        return $fileName;
     }
 }

--- a/tests/ZendTest/Crypt/FileCipherTest.php
+++ b/tests/ZendTest/Crypt/FileCipherTest.php
@@ -21,11 +21,18 @@ use Zend\Math\Rand;
 class FileCipherTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var BlockCipher
+     * @var fileCipher
      */
-    protected $blockCipher;
-    protected $plaintext;
+    protected $fileCipher;
+
+    /**
+     * @var string
+     */ 
     protected $fileIn;
+
+    /**
+     * @var string
+     */
     protected $fileOut;
 
     public function setUp()
@@ -115,44 +122,10 @@ class FileCipherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, $this->fileCipher);
         $this->assertEquals(1000, $this->fileCipher->getKeyIteration());
     }
-
-    public function testSetCompress()
-    {
-        $result = $this->fileCipher->setCompress(false);
-        $this->assertEquals($result, $this->fileCipher);
-        $this->assertEquals(false, $this->fileCipher->getCompress());
-    }
-
-    public function testEncryptDecryptFile()
-    {
-        // Test 5 files with a random size bewteen 1 Kb and 5 Mb
-        for ($i=1; $i <= 5; $i++) {
-            $fileIn  = $this->generateTmpFile(Rand::getInteger(1024, 1048576 * 5), Rand::getBytes(1));
-            $fileOut = $fileIn . '.enc';
-            $this->fileCipher->setKey('test');
-
-            // encrypt
-            $this->assertTrue($this->fileCipher->encrypt($fileIn, $fileOut));
-
-            // check if the file is compressed
-            $this->assertTrue(filesize($fileOut) < fileSize($fileIn));
-
-            $decryptFile = $fileOut . '.dec';
-            // decrypt
-            $this->assertTrue($this->fileCipher->decrypt($fileOut, $decryptFile));
-            $this->assertEquals(filesize($fileIn), filesize($decryptFile));
-            $this->assertEquals(file_get_contents($fileIn), file_get_contents($decryptFile));
-
-            unlink($fileIn);
-            unlink($fileOut);
-            unlink($decryptFile);
-        }
-    }
-
-    public function testEncrypDecryptFileNoCompress()
+ 
+    public function testEncrypDecryptFile()
     {
         $this->fileCipher->setKey('test');
-        $this->fileCipher->setCompress(false);
 
         // Test 5 files with a random size between 1 Kb and 5 Mb
         for ($i=1; $i <= 5; $i++) {

--- a/tests/ZendTest/Crypt/FileCipherTest.php
+++ b/tests/ZendTest/Crypt/FileCipherTest.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt;
+
+use Zend\Crypt\FileCipher;
+use Zend\Crypt\Symmetric\Mcrypt;
+use Zend\Crypt\Symmetric\Exception;
+use Zend\Crypt\Hmac;
+use Zend\Math\Rand;
+
+/**
+ * @group      Zend_Crypt
+ */
+class FileCipherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var BlockCipher
+     */
+    protected $blockCipher;
+    protected $plaintext;
+    protected $fileIn;
+    protected $fileOut;
+
+    public function setUp()
+    {
+        try {
+            $cipher = new Mcrypt(array(
+                'algorithm' => 'aes',
+                'mode'      => 'cbc',
+                'padding'   => 'pkcs7'
+            ));
+            $this->fileCipher = new FileCipher($cipher);
+        } catch (Exception\RuntimeException $e) {
+            $this->markTestSkipped('Mcrypt is not installed, I cannot execute the FileCipherTest');
+        }
+    }
+
+    public function tearDown()
+    {
+        if (file_exists($this->fileIn)) {
+            unlink($this->fileIn);
+        }
+        if (file_exists($this->fileOut)) {
+            unlink($this->fileOut);
+        }
+    }
+
+    public function testSetCipher()
+    {
+        $mcrypt = new Mcrypt();
+        $result = $this->fileCipher->setCipher($mcrypt);
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals($mcrypt, $this->fileCipher->getCipher());
+    }
+
+    public function testFactory()
+    {
+        $this->fileCipher = FileCipher::factory('mcrypt', array('algo' => 'blowfish'));
+        $this->assertTrue($this->fileCipher->getCipher() instanceof Mcrypt);
+        $this->assertEquals('blowfish', $this->fileCipher->getCipher()->getAlgorithm());
+    }
+
+    public function testFactoryEmptyOptions()
+    {
+        $this->fileCipher = FileCipher::factory('mcrypt');
+        $this->assertTrue($this->fileCipher->getCipher() instanceof Mcrypt);
+    }
+
+    public function testSetKey()
+    {
+        $result = $this->fileCipher->setKey('test');
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals('test', $this->fileCipher->getKey());
+    }
+
+    public function testSetAlgorithm()
+    {
+        $result = $this->fileCipher->setCipherAlgorithm('blowfish');
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals('blowfish', $this->fileCipher->getCipherAlgorithm());
+    }
+
+    public function testSetAlgorithmFail()
+    {
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'The algorithm unknown is not supported by Zend\Crypt\Symmetric\Mcrypt');
+        $result = $this->fileCipher->setCipherAlgorithm('unknown');
+
+    }
+
+    public function testSetHashAlgorithm()
+    {
+        $result = $this->fileCipher->setHashAlgorithm('sha1');
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals('sha1', $this->fileCipher->getHashAlgorithm());
+    }
+
+    public function testSetPbkdf2HashAlgorithm()
+    {
+        $result = $this->fileCipher->setPbkdf2HashAlgorithm('sha1');
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals('sha1', $this->fileCipher->getPbkdf2HashAlgorithm());
+    }
+
+    public function testSetKeyIteration()
+    {
+        $result = $this->fileCipher->setKeyIteration(1000);
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals(1000, $this->fileCipher->getKeyIteration());
+    }
+
+    public function testSetCompress()
+    {
+        $result = $this->fileCipher->setCompress(false);
+        $this->assertEquals($result, $this->fileCipher);
+        $this->assertEquals(false, $this->fileCipher->getCompress());
+    }
+
+    public function testEncryptDecryptFile()
+    {
+        // Test 5 files with a random size bewteen 1 Kb and 5 Mb
+        for ($i=1; $i <= 5; $i++) {
+            $fileIn  = $this->generateTmpFile(Rand::getInteger(1024, 1048576 * 5), Rand::getBytes(1));
+            $fileOut = $fileIn . '.enc';
+            $this->fileCipher->setKey('test');
+
+            // encrypt
+            $this->assertTrue($this->fileCipher->encrypt($fileIn, $fileOut));
+
+            // check if the file is compressed
+            $this->assertTrue(filesize($fileOut) < fileSize($fileIn));
+
+            $decryptFile = $fileOut . '.dec';
+            // decrypt
+            $this->assertTrue($this->fileCipher->decrypt($fileOut, $decryptFile));
+            $this->assertEquals(filesize($fileIn), filesize($decryptFile));
+            $this->assertEquals(file_get_contents($fileIn), file_get_contents($decryptFile));
+
+            unlink($fileIn);
+            unlink($fileOut);
+            unlink($decryptFile);
+        }
+    }
+
+    public function testEncrypDecryptFileNoCompress()
+    {
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->setCompress(false);
+
+        // Test 5 files with a random size between 1 Kb and 5 Mb
+        for ($i=1; $i <= 5; $i++) {
+            $fileIn  = $this->generateTmpFile(Rand::getInteger(1024, 1048576 * 5), Rand::getBytes(1));
+            $fileOut = $fileIn . '.enc';
+
+            // encrypt without compression
+            $this->assertTrue($this->fileCipher->encrypt($fileIn, $fileOut, false));
+
+            $paddingSize = $this->fileCipher->getCipher()->getBlockSize();
+            $this->assertEquals(filesize($fileOut),
+                                filesize($fileIn) +
+                                $this->fileCipher->getCipher()->getSaltSize() +
+                                Hmac::getOutputSize($this->fileCipher->getHashAlgorithm()) +
+                                $paddingSize - filesize($fileIn) % $paddingSize);
+
+            $decryptFile = $fileOut . '.dec';
+            // decrypt
+            $this->assertTrue($this->fileCipher->decrypt($fileOut, $decryptFile));
+            $this->assertEquals(filesize($fileIn), filesize($decryptFile));
+            $this->assertEquals(file_get_contents($fileIn), file_get_contents($decryptFile));
+
+            unlink ($fileIn);
+            unlink ($fileOut);
+            unlink ($decryptFile);
+        }
+    }
+
+    public function testDecryptFileNoValidAuthenticate()
+    {
+        $this->fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $this->fileOut = $this->fileIn . '.enc';
+
+        $this->fileCipher->setKey('test');
+        $this->assertTrue($this->fileCipher->encrypt($this->fileIn, $this->fileOut, false));
+
+        $fileOut2 = $this->fileIn . '.dec';
+        $this->assertTrue($this->fileCipher->decrypt($this->fileOut, $fileOut2, false));
+        unlink ($fileOut2);
+
+        // Tampering of the encrypted file
+        $ciphertext = file_get_contents($this->fileOut);
+        $ciphertext[0] = chr((ord($ciphertext[0]) + 1) % 256);
+        file_put_contents($this->fileOut, $ciphertext);
+
+        $this->assertFalse($this->fileCipher->decrypt($this->fileOut, $fileOut2, false));
+        $this->assertFalse(file_exists($fileOut2));
+    }
+
+    public function testEncryptFileWithNoKey()
+    {
+        $this->fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $this->fileOut = $this->fileIn . '.enc';
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'No key specified for encryption');
+        $this->fileCipher->encrypt($this->fileIn, $this->fileOut);
+    }
+
+    public function testDecryptFileWithNoKey()
+    {
+        $this->fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $this->fileOut = $this->fileIn . '.enc';
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'No key specified for decryption');
+        $this->fileCipher->decrypt($this->fileIn, $this->fileOut);
+    }
+
+    public function testEncryptFileInvalidInputFile()
+    {
+        $randomFile = uniqid('Invalid_File');
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "I cannot open the $randomFile file");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->encrypt($randomFile, '');
+    }
+
+    public function testDecryptFileInvalidInputFile()
+    {
+        $randomFile = uniqid('Invalid_File');
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "I cannot open the $randomFile file");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->decrypt($randomFile, '');
+    }
+
+    public function testEncryptFileInvalidOutputFile()
+    {
+        $this->fileIn  = $this->generateTmpFile(1024);
+        $this->fileOut = $this->generateTmpFile(1024);
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "The file {$this->fileOut} already exists");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->encrypt($this->fileIn, $this->fileOut);
+    }
+
+    public function testDecryptFileInvalidOutputFile()
+    {
+        $this->fileIn  = $this->generateTmpFile(1024);
+        $this->fileOut = $this->generateTmpFile(1024);
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "The file {$this->fileOut} already exists");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->decrypt($this->fileIn, $this->fileOut);
+    }
+
+    /**
+     * Generate a temporary file with a selected size
+     *
+     * @param  string $size
+     * @param  string $content
+     * @return string
+     */
+    protected function generateTmpFile($size, $content = 'A')
+    {
+        $fileName = sys_get_temp_dir() . '/' . uniqid('ZF2_FileCipher_test');
+        $num = $size / strlen($content) + 1;
+        $content  = str_repeat('A', $size / strlen($content) + 1);
+        file_put_contents($fileName, substr($content, 0, $size));
+
+        return $fileName;
+    }
+}


### PR DESCRIPTION
According to this [refactor](https://github.com/zendframework/zf2/pull/6410#issuecomment-47108687), I added a new class `Zend\Crypt\FileCipher` for the encryption/decryption of files.
Moreover in this [commit](https://github.com/ezimuel/zf2/commit/3f49a6b3afd95e73d140f4d9380ee11a93ad8995),  I removed the compression part to prevent potential information leakage (e.g. [CRIME](http://en.wikipedia.org/wiki/CRIME) attack).

The main methods of this class can be used to encrypt/decrypt a file:
- `encrypt($fileIn, $fileOut)`
- `decrypt($fileIn, $fileOut)`

where `$fileIn` is the input file to encrypt/decrypt and `$fileOut` is the output file. 
The  `Zend\Crypt\FileCipher` component can be used to encrypt/decrypt files of any dimension. I used a buffer memory of 1 MB to read the files, block by block.The encryption of file follows the same procedure of `Zend\Crypt\BlockCipher::encrypt`, using **encryption-then-authenticate** approach with HMAC (SHA256 by default).
