### PR TITLE
Fix nested CollectionInputFilter not valid if count not specified

### DIFF
--- a/library/Zend/InputFilter/CollectionInputFilter.php
+++ b/library/Zend/InputFilter/CollectionInputFilter.php
@@ -128,7 +128,7 @@ class CollectionInputFilter extends InputFilter
     public function getCount()
     {
         if (null === $this->count) {
-            $this->count = count($this->data);
+            return count($this->data);
         }
 
         return $this->count;

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\InputFilter\BaseInputFilter;
 use Zend\InputFilter\CollectionInputFilter;
 use Zend\InputFilter\Input;
+use Zend\InputFilter\InputFilter;
 use Zend\Validator;
 
 class CollectionInputFilterTest extends TestCase
@@ -611,5 +612,78 @@ class CollectionInputFilterTest extends TestCase
         $inputFilter->isValid();
         $values = $inputFilter->getValues();
         $this->assertEquals($data, $values);
+    }
+
+    public function dataNestingCollection()
+    {
+        return array(
+            'count not specified' => array(
+                'count' => null,
+                'isValid' => true
+            ),
+            'count = 1' =>  array(
+                'count' => 1,
+                'isValid' => true
+            ),
+            'count = 2' => array(
+                'count' => 2,
+                'isValid' => false
+            ),
+            'count = 3' => array(
+                'count' => 3,
+                'isValid' => false
+            )
+        );
+    }
+
+    /**
+     * @dataProvider dataNestingCollection
+     */
+    public function testNestingCollectionCountCached($count, $expectedIsValid)
+    {
+        $firstInputFilter = new InputFilter();
+
+        $firstCollection = new CollectionInputFilter();
+        $firstCollection->setInputFilter($firstInputFilter);
+
+        $someInput = new Input('input');
+        $secondInputFilter = new InputFilter();
+        $secondInputFilter->add($someInput, 'input');
+
+        $secondCollection = new CollectionInputFilter();
+        $secondCollection->setInputFilter($secondInputFilter);
+        if (!is_null($count)) {
+            $secondCollection->setCount($count);
+        }
+
+        $firstInputFilter->add($secondCollection, 'second_collection');
+
+        $mainInputFilter = new InputFilter();
+        $mainInputFilter->add($firstCollection, 'first_collection');
+
+        $data = array(
+            'first_collection' => array(
+                array(
+                    'second_collection' => array(
+                        array(
+                            'input' => 'some value'
+                        ),
+                        array(
+                            'input' => 'some value'
+                        )
+                    )
+                ),
+                array(
+                    'second_collection' => array(
+                        array(
+                            'input' => 'some value'
+                        ),
+                    )
+                )
+            )
+        );
+
+        $mainInputFilter->setData($data);
+        $this->assertSame($expectedIsValid, $mainInputFilter->isValid());
     }
 }


### PR DESCRIPTION
Problem using nested collections (CollectionInputFilter in another CollectionInputFilter).

inputFilter config example:

<pre>
array(
   'type' => 'Zend\InputFilter\CollectionInputFilter',
   'name' => 'first_collection',
   'required' => true,
   'input_filter' => array(
       'type' => 'Zend\InputFilter\InputFilter',
       'second_collection' => array(
           'type' => 'Zend\InputFilter\CollectionInputFilter',
           'name' => 'second_collection',
           'required' => true,
           'input_filter' => array(
               'type' => 'Zend\InputFilter\InputFilter',
               'input' => array(
                   'name' => 'input',
               ),
           )
       )
   )
)
</pre>
