### PR TITLE
Validate uploaded filename only if no upload error occured.

### DIFF
--- a/library/Zend/Validator/File/UploadFile.php
+++ b/library/Zend/Validator/File/UploadFile.php
@@ -72,15 +72,14 @@ class UploadFile extends AbstractValidator
         }
         $this->setValue($filename);
 
-        if (empty($file) || false === stream_resolve_include_path($file)) {
-            $this->error(self::FILE_NOT_FOUND);
-            return false;
-        }
-
         switch ($error) {
             case UPLOAD_ERR_OK:
-                if (!is_uploaded_file($file)) {
-                    $this->error(self::ATTACK);
+                if (empty($file) || false === stream_resolve_include_path($file)) {
+                    $this->error(self::FILE_NOT_FOUND);
+                } else {
+                    if (!is_uploaded_file($file)) {
+                        $this->error(self::ATTACK);
+                    }
                 }
                 break;
 

--- a/tests/ZendTest/Validator/File/UploadFileTest.php
+++ b/tests/ZendTest/Validator/File/UploadFileTest.php
@@ -90,6 +90,11 @@ class UploadFileTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($validator->isValid(''));
         $this->assertArrayHasKey(File\UploadFile::FILE_NOT_FOUND, $validator->getMessages());
+    }
+
+    public function testUploadErrorCodeShouldPrecedeEmptyFileCheck()
+    {
+        $validator = new File\UploadFile();
 
         $filesArray = array(
             'name'      => '',
@@ -100,6 +105,7 @@ class UploadFileTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertFalse($validator->isValid($filesArray));
-        $this->assertArrayHasKey(File\UploadFile::FILE_NOT_FOUND, $validator->getMessages());
+        $this->assertArrayHasKey(File\UploadFile::NO_FILE, $validator->getMessages());
+        $this->assertArrayNotHasKey(File\UploadFile::FILE_NOT_FOUND, $validator->getMessages());
     }
 }


### PR DESCRIPTION
Most file upload errors (in particular UPLOAD_ERR_NO_FILE) yield an empty filename. The UploadFile validator does not report the original error in that case, but FILE_NOT_FOUND instead.

This fix validates the filename only in case of UPLOAD_ERR_OK. Any other error code will be reported correctly.
