### PR TITLE
Zend Session fatal error in get array copy

### DIFF
--- a/library/Zend/Session/AbstractContainer.php
+++ b/library/Zend/Session/AbstractContainer.php
@@ -608,7 +608,7 @@ abstract class AbstractContainer extends ArrayObject
     {
         $storage   = $this->verifyNamespace();
         $container = $storage[$this->getName()];
-        
+
         if ($container instanceof ArrayObject) {
             return $container->getArrayCopy();
         }

--- a/library/Zend/Session/AbstractContainer.php
+++ b/library/Zend/Session/AbstractContainer.php
@@ -608,7 +608,11 @@ abstract class AbstractContainer extends ArrayObject
     {
         $storage   = $this->verifyNamespace();
         $container = $storage[$this->getName()];
+        
+        if ($container instanceof ArrayObject) {
+            return $container->getArrayCopy();
+        }
 
-        return $container->getArrayCopy();
+        return $container;
     }
 }

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -552,4 +552,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container->baz = 'boo';
         $this->assertEquals('boo', $storage['foo']['baz']);
     }
+
+    public function testGetArrayCopyAfterExchangeArray()
+    {
+        $this->container->exchangeArray(array('foo'=>'bar'));
+
+        $contents = $this->container->getArrayCopy();
+
+        $this->assertInternalType('array', $contents);
+        $this->assertArrayHasKey('foo', $contents, "'getArrayCopy' doesn't return exchanged array");
+    }
 }


### PR DESCRIPTION
If you call getArrayCopy on a zend session container after calling exchangeArray you get:

Fatal error: Call to a member function getArrayCopy() on a non-object in vendor/zendframework/zendframework/library/Zend/Session/AbstractContainer.php on line 614

This is one of several potential fixes. 

Another would be to have the exchangeArray method ensure that an ArrayObject is always created and assigned to storage.
