### PR TITLE
Added the file encryption/decryption to Zend\Crypt

### DIFF
--- a/library/Zend/Crypt/FileCipher.php
+++ b/library/Zend/Crypt/FileCipher.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt;
+
+use Zend\Crypt\Key\Derivation\Pbkdf2;
+use Zend\Crypt\Symmetric\Mcrypt;
+use Zend\Math\Rand;
+
+/**
+ * Encrypt/decrypt a file using a symmetric cipher in CBC mode
+ * then authenticate using HMAC
+ */
+class FileCipher
+{
+    const BUFFER_SIZE = 1048576; // 16 * 65536 bytes = 1 Mb
+ 
+    /**
+     * Hash algorithm for Pbkdf2
+     *
+     * @var string
+     */
+    protected $pbkdf2Hash = 'sha256';
+
+    /**
+     * Hash algorithm for HMAC
+     *
+     * @var string
+     */
+    protected $hash = 'sha256';
+
+    /**
+     * Number of iterations for Pbkdf2
+     *
+     * @var int
+     */
+    protected $keyIteration = 10000;
+
+    /**
+     * Key
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * Constructor
+     *
+     * @param SymmetricInterface $cipher
+     */
+    public function __construct()
+    {
+        $this->cipher = new Mcrypt;
+    }
+
+    /**
+     * Set the cipher object
+     *
+     * @param Mcrypt $cipher
+     */
+    public function setCipher(Mcrypt $cipher)
+    {
+        $this->cipher = $cipher;
+    }
+
+    /**
+     * Get the cipher object
+     *
+     * @return Mcrypt
+     */
+    public function getCipher()
+    {
+        return $this->cipher;
+    }
+
+    /**
+     * Set the number of iterations for Pbkdf2
+     *
+     * @param  int  $num
+     */
+    public function setKeyIteration($num)
+    {
+        $this->keyIteration = (int) $num;
+    }
+
+    /**
+     * Get the number of iterations for Pbkdf2
+     *
+     * @return int
+     */
+    public function getKeyIteration()
+    {
+        return $this->keyIteration;
+    }
+
+    /**
+     * Set the encryption/decryption key
+     *
+     * @param  string                             $key
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setKey($key)
+    {
+        if (empty($key)) {
+            throw new Exception\InvalidArgumentException('The key cannot be empty');
+        }
+        $this->key = $key;
+    }
+
+    /**
+     * Get the key
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * Set algorithm of the symmetric cipher
+     *
+     * @param  string                             $algo
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setCipherAlgorithm($algo)
+    {
+        try {
+            $this->cipher->setAlgorithm($algo);
+        } catch (Symmetric\Exception\InvalidArgumentException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage());
+        }
+    }
+
+    /**
+     * Get the cipher algorithm
+     *
+     * @return string|bool
+     */
+    public function getCipherAlgorithm()
+    {
+        return $this->cipher->getAlgorithm();
+    }
+
+    /**
+     * Get the supported algorithms of the symmetric cipher
+     *
+     * @return array
+     */
+    public function getCipherSupportedAlgorithms()
+    {
+        return $this->cipher->getSupportedAlgorithms();
+    }
+
+    /**
+     * Set the hash algorithm for HMAC authentication
+     *
+     * @param  string                             $hash
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setHashAlgorithm($hash)
+    {
+        if (!Hash::isSupported($hash)) {
+            throw new Exception\InvalidArgumentException(
+                "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
+            );
+        }
+        $this->hash = $hash;
+    }
+
+    /**
+     * Get the hash algorithm for HMAC authentication
+     *
+     * @return string
+     */
+    public function getHashAlgorithm()
+    {
+        return $this->hash;
+    }
+
+    /**
+     * Set the hash algorithm for the Pbkdf2
+     *
+     * @param  string                             $hash
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setPbkdf2HashAlgorithm($hash)
+    {
+        if (!Hash::isSupported($hash)) {
+            throw new Exception\InvalidArgumentException(
+                "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
+            );
+        }
+        $this->pbkdf2Hash = $hash;
+    }
+
+    /**
+     * Get the Pbkdf2 hash algorithm
+     *
+     * @return string
+     */
+    public function getPbkdf2HashAlgorithm()
+    {
+        return $this->pbkdf2Hash;
+    }
+
+    /**
+     * Encrypt then authenticate a file using HMAC
+     *
+     * @param  string                             $fileIn
+     * @param  string                             $fileOut
+     * @return bool
+     * @throws Exception\InvalidArgumentException
+     */
+    public function encrypt($fileIn, $fileOut)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "I cannot open the %s file", $fileIn
+            ));
+        }
+        if (file_exists($fileOut)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "The file %s already exists", $fileOut
+            ));
+        }
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for encryption');
+        }
+
+        $read    = fopen($fileIn, "r");
+        $write   = fopen($fileOut, "w");
+        $iv      = Rand::getBytes($this->cipher->getSaltSize(), true);
+        $keys    = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
+                                $this->getKey(),
+                                $iv,
+                                $this->getKeyIteration(),
+                                $this->cipher->getKeySize() * 2);
+        $hmac    = '';
+        $size    = 0;
+        $tot     = filesize($fileIn);
+        $padding = $this->cipher->getPadding();
+
+        $this->cipher->setKey(substr($keys, 0, $this->cipher->getKeySize()));
+        $this->cipher->setPadding(new Symmetric\Padding\NoPadding);
+        $this->cipher->setSalt($iv);
+        $this->cipher->setMode('cbc');
+
+        $hashAlgo  = $this->getHashAlgorithm();
+        $saltSize  = $this->cipher->getSaltSize();
+        $algorithm = $this->cipher->getAlgorithm();
+        $keyHmac   = substr($keys, $this->cipher->getKeySize());
+
+        while ($data = fread($read, self::BUFFER_SIZE)) {
+            $size += strlen($data);
+            // Padding if last block
+            if ($size == $tot) {
+                $this->cipher->setPadding($padding);
+            }
+            $result = $this->cipher->encrypt($data);
+            if ($size <= self::BUFFER_SIZE) {
+                // Write a placeholder for the HMAC and write the IV
+                fwrite($write, str_repeat(0, Hmac::getOutputSize($hashAlgo)));
+            } else {
+                $result = substr($result, $saltSize);
+            }
+            $hmac = Hmac::compute($keyHmac,
+                                  $hashAlgo,
+                                  $algorithm . $hmac . $result);
+            $this->cipher->setSalt(substr($result, -1 * $saltSize));
+            if (fwrite($write, $result) !== strlen($result)) {
+                return false;
+            }
+        }
+        $result = true;
+        // write the HMAC at the beginning of the file
+        fseek($write, 0);
+        if (fwrite($write, $hmac) !== strlen($hmac)) {
+            $result = false;
+        }
+        fclose($write);
+        fclose($read);
+
+        return $result;
+    }
+
+    /**
+     * Decrypt a file
+     *
+     * @param  string                             $fileIn
+     * @param  string                             $fileOut
+     * @param  bool                               $compress
+     * @return bool
+     * @throws Exception\InvalidArgumentException
+     */
+    public function decrypt($fileIn, $fileOut)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "I cannot open the %s file", $fileIn
+            ));
+        }
+        if (file_exists($fileOut)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "The file %s already exists", $fileOut
+            ));
+        }
+        if (empty($this->key)) {
+            throw new Exception\InvalidArgumentException('No key specified for decryption');
+        }
+
+        $read     = fopen($fileIn, "r");
+        $write    = fopen($fileOut, "w");
+        $hmacRead = fread($read, Hmac::getOutputSize($this->getHashAlgorithm()));
+        $iv       = fread($read, $this->cipher->getSaltSize());
+        $tot      = filesize($fileIn);
+        $hmac     = $iv;
+        $size     = strlen($iv) + strlen($hmacRead);
+        $keys     = Pbkdf2::calc($this->getPbkdf2HashAlgorithm(),
+                                 $this->getKey(),
+                                 $iv,
+                                 $this->getKeyIteration(),
+                                 $this->cipher->getKeySize() * 2);
+        $padding  = $this->cipher->getPadding();
+        $this->cipher->setPadding(new Symmetric\Padding\NoPadding);
+        $this->cipher->setKey(substr($keys, 0, $this->cipher->getKeySize()));
+        $this->cipher->setMode('cbc');
+
+        $blockSize = $this->cipher->getBlockSize();
+        $hashAlgo  = $this->getHashAlgorithm();
+        $algorithm = $this->cipher->getAlgorithm();
+        $saltSize  = $this->cipher->getSaltSize();
+        $keyHmac   = substr($keys, $this->cipher->getKeySize());
+
+        while ($data = fread($read, self::BUFFER_SIZE)) {
+            $size += strlen($data);
+            // Unpadding if last block
+            if ($size + $blockSize >= $tot) {
+                $this->cipher->setPadding($padding);
+                $data .= fread($read, $blockSize);
+            }
+            $result = $this->cipher->decrypt($iv . $data);
+            $hmac   = Hmac::compute($keyHmac,
+                                    $hashAlgo,
+                                    $algorithm . $hmac . $data);
+            $iv     = substr($data, -1 * $saltSize);
+            if (fwrite($write, $result) !== strlen($result)) {
+                return false;
+            }
+        }
+        fclose($write);
+        fclose($read);
+
+        // check for data integrity
+        if (!Utils::compareStrings($hmac, $hmacRead)) {
+            unlink($fileOut);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/library/Zend/Crypt/FileCipher.php
+++ b/library/Zend/Crypt/FileCipher.php
@@ -111,7 +111,7 @@ class FileCipher
         if (empty($key)) {
             throw new Exception\InvalidArgumentException('The key cannot be empty');
         }
-        $this->key = $key;
+        $this->key = (string) $key;
     }
 
     /**
@@ -172,7 +172,7 @@ class FileCipher
                 "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
             );
         }
-        $this->hash = $hash;
+        $this->hash = (string) $hash;
     }
 
     /**
@@ -198,7 +198,7 @@ class FileCipher
                 "The specified hash algorithm '{$hash}' is not supported by Zend\Crypt\Hash"
             );
         }
-        $this->pbkdf2Hash = $hash;
+        $this->pbkdf2Hash = (string) $hash;
     }
 
     /**
@@ -221,16 +221,7 @@ class FileCipher
      */
     public function encrypt($fileIn, $fileOut)
     {
-        if (!file_exists($fileIn)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "I cannot open the %s file", $fileIn
-            ));
-        }
-        if (file_exists($fileOut)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "The file %s already exists", $fileOut
-            ));
-        }
+        $this->checkFileInOut($fileIn, $fileOut);
         if (empty($this->key)) {
             throw new Exception\InvalidArgumentException('No key specified for encryption');
         }
@@ -302,16 +293,7 @@ class FileCipher
      */
     public function decrypt($fileIn, $fileOut)
     {
-        if (!file_exists($fileIn)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "I cannot open the %s file", $fileIn
-            ));
-        }
-        if (file_exists($fileOut)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                "The file %s already exists", $fileOut
-            ));
-        }
+        $this->checkFileInOut($fileIn, $fileOut);
         if (empty($this->key)) {
             throw new Exception\InvalidArgumentException('No key specified for decryption');
         }
@@ -365,5 +347,26 @@ class FileCipher
         }
 
         return true;
+    }
+
+    /**
+     * Check that input file exists and output file dont
+     *
+     * @param  string $fileIn
+     * @param  string $fileOut
+     * @throws Exception\InvalidArgumentException
+     */
+    protected function checkFileInOut($fileIn, $fileOut)
+    {
+        if (!file_exists($fileIn)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "I cannot open the %s file", $fileIn
+            ));
+        }
+        if (file_exists($fileOut)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "The file %s already exists", $fileOut
+            ));
+        }
     }
 }

--- a/library/Zend/Crypt/FileCipher.php
+++ b/library/Zend/Crypt/FileCipher.php
@@ -11,6 +11,7 @@ namespace Zend\Crypt;
 
 use Zend\Crypt\Key\Derivation\Pbkdf2;
 use Zend\Crypt\Symmetric\Mcrypt;
+use Zend\Crypt\Symmetric\SymmetricInterface;
 use Zend\Math\Rand;
 
 /**
@@ -62,9 +63,9 @@ class FileCipher
     /**
      * Set the cipher object
      *
-     * @param Mcrypt $cipher
+     * @param SymmetricInterface $cipher
      */
-    public function setCipher(Mcrypt $cipher)
+    public function setCipher(SymmetricInterface $cipher)
     {
         $this->cipher = $cipher;
     }

--- a/library/Zend/Crypt/FileCipher.php
+++ b/library/Zend/Crypt/FileCipher.php
@@ -51,6 +51,13 @@ class FileCipher
     protected $key;
 
     /**
+     * Cipher 
+     *
+     * @var SymmetricInterface
+     */
+    protected $cipher;
+
+    /**
      * Constructor
      *
      * @param SymmetricInterface $cipher
@@ -73,7 +80,7 @@ class FileCipher
     /**
      * Get the cipher object
      *
-     * @return Mcrypt
+     * @return SymmetricInterface
      */
     public function getCipher()
     {
@@ -117,7 +124,7 @@ class FileCipher
     /**
      * Get the key
      *
-     * @return string
+     * @return string|null
      */
     public function getKey()
     {
@@ -128,15 +135,10 @@ class FileCipher
      * Set algorithm of the symmetric cipher
      *
      * @param  string                             $algo
-     * @throws Exception\InvalidArgumentException
      */
     public function setCipherAlgorithm($algo)
     {
-        try {
-            $this->cipher->setAlgorithm($algo);
-        } catch (Symmetric\Exception\InvalidArgumentException $e) {
-            throw new Exception\InvalidArgumentException($e->getMessage());
-        }
+        $this->cipher->setAlgorithm($algo);
     }
 
     /**

--- a/library/Zend/Crypt/Symmetric/Padding/NoPadding.php
+++ b/library/Zend/Crypt/Symmetric/Padding/NoPadding.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt\Symmetric\Padding;
+
+/**
+ * No Padding
+ */
+class NoPadding implements PaddingInterface
+{
+    /**
+     * Pad a string, do nothing and return the string
+     *
+     * @param  string $string
+     * @param  int    $blockSize
+     * @return string
+     */
+    public function pad($string, $blockSize = 32)
+    {
+        return $string;
+    }
+
+    /**
+     * Unpad a string, do nothing and return the string
+     *
+     * @param  string $string
+     * @return string
+     */
+    public function strip($string)
+    {
+        return $string;
+    }
+}

--- a/tests/ZendTest/Crypt/FileCipherTest.php
+++ b/tests/ZendTest/Crypt/FileCipherTest.php
@@ -66,7 +66,7 @@ class FileCipherTest extends \PHPUnit_Framework_TestCase
             'algo' => 'blowfish'
         ));
         $this->fileCipher->setCipher($cipher);
-        $this->assertInstanceOf('Zend\Crypt\Symmetric\Mcrypt', $this->fileCipher->getCipher());
+        $this->assertInstanceOf('Zend\Crypt\Symmetric\SymmetricInterface', $this->fileCipher->getCipher());
         $this->assertEquals($cipher, $this->fileCipher->getCipher());
     }
 

--- a/tests/ZendTest/Crypt/FileCipherTest.php
+++ b/tests/ZendTest/Crypt/FileCipherTest.php
@@ -97,7 +97,7 @@ class FileCipherTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCipherAlgorithmFail()
     {
-        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+        $this->setExpectedException('Zend\Crypt\Symmetric\Exception\InvalidArgumentException',
                                     'The algorithm unknown is not supported by Zend\Crypt\Symmetric\Mcrypt');
         $this->fileCipher->setCipherAlgorithm('unknown');
 

--- a/tests/ZendTest/Crypt/FileCipherTest.php
+++ b/tests/ZendTest/Crypt/FileCipherTest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt;
+
+use Zend\Crypt\FileCipher;
+use Zend\Crypt\Symmetric\Mcrypt;
+use Zend\Crypt\Symmetric\Exception;
+use Zend\Crypt\Hmac;
+use Zend\Math\Rand;
+
+/**
+ * @group      Zend_Crypt
+ */
+class FileCipherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var fileCipher
+     */
+    protected $fileCipher;
+
+    /**
+     * @var string
+     */
+    protected $fileIn;
+
+    /**
+     * @var string
+     */
+    protected $fileOut;
+
+    public function setUp()
+    {
+        try {
+            $this->fileCipher = new FileCipher();
+        } catch (Exception\RuntimeException $e) {
+            $this->markTestSkipped('Mcrypt is not installed, I cannot execute the FileCipherTest');
+        }
+    }
+
+    public function tearDown()
+    {
+        if (file_exists($this->fileIn)) {
+            unlink($this->fileIn);
+        }
+        if (file_exists($this->fileOut)) {
+            unlink($this->fileOut);
+        }
+    }
+
+    public function testBufferConstant()
+    {
+        // The buffer size must be always the same to be able to decrypt
+        $this->assertEquals(1048576, FileCipher::BUFFER_SIZE);
+    }
+ 
+    public function testSetCipher()
+    {
+        $cipher = new Mcrypt(array(
+            'algo' => 'blowfish'
+        ));
+        $this->fileCipher->setCipher($cipher);
+        $this->assertInstanceOf('Zend\Crypt\Symmetric\Mcrypt', $this->fileCipher->getCipher());
+        $this->assertEquals($cipher, $this->fileCipher->getCipher());
+    }
+
+    public function testSetKeyIteration()
+    {
+        $this->fileCipher->setKeyIteration(5000);
+        $this->assertEquals(5000, $this->fileCipher->getKeyIteration());
+    }
+
+    public function testSetKey()
+    {
+        $this->fileCipher->setKey('test');
+        $this->assertEquals('test', $this->fileCipher->getKey());
+    }
+
+    public function testSetEmptyKey()
+    {
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'The key cannot be empty');
+        $this->fileCipher->setKey('');
+    }
+
+    public function testSetCipherAlgorithm()
+    {
+        $this->fileCipher->setCipherAlgorithm('blowfish');
+        $this->assertEquals('blowfish', $this->fileCipher->getCipherAlgorithm());
+    }
+
+    public function testSetCipherAlgorithmFail()
+    {
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'The algorithm unknown is not supported by Zend\Crypt\Symmetric\Mcrypt');
+        $this->fileCipher->setCipherAlgorithm('unknown');
+
+    }
+
+    public function testGetCipherSupportedAlgorithms()
+    {
+        $this->assertInternalType('array', $this->fileCipher->getCipherSupportedAlgorithms());
+    }
+
+    public function testSetHashAlgorithm()
+    {
+        $this->fileCipher->setHashAlgorithm('sha1');
+        $this->assertEquals('sha1', $this->fileCipher->getHashAlgorithm());
+    }
+
+    public function testSetWrongHashAlgorithm()
+    {
+         $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                     'The specified hash algorithm \'unknown\' is not supported by Zend\Crypt\Hash');
+         $this->fileCipher->setHashAlgorithm('unknown');
+    }
+
+    public function testSetPbkdf2HashAlgorithm()
+    {
+        $this->fileCipher->setPbkdf2HashAlgorithm('sha1');
+        $this->assertEquals('sha1', $this->fileCipher->getPbkdf2HashAlgorithm());
+    }
+
+    public function testSetWrongPbkdf2HashAlgorithm()
+    {
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'The specified hash algorithm \'unknown\' is not supported by Zend\Crypt\Hash');
+        $this->fileCipher->setPbkdf2HashAlgorithm('unknown');
+    }
+    
+    public function testEncrypDecryptFile()
+    {
+        $this->fileCipher->setKey('test');
+
+        // Test 5 files with a random size between 1 Kb and 5 Mb
+        for ($i=1; $i <= 5; $i++) {
+            $fileIn  = $this->generateTmpFile(Rand::getInteger(1024, 1048576 * 5), Rand::getBytes(1));
+            $fileOut = $fileIn . '.enc';
+
+            // encrypt without compression
+            $this->assertTrue($this->fileCipher->encrypt($fileIn, $fileOut, false));
+
+            $paddingSize = $this->fileCipher->getCipher()->getBlockSize();
+            $this->assertEquals(filesize($fileOut),
+                                filesize($fileIn) +
+                                $this->fileCipher->getCipher()->getSaltSize() +
+                                Hmac::getOutputSize($this->fileCipher->getHashAlgorithm()) +
+                                $paddingSize - filesize($fileIn) % $paddingSize);
+
+            $decryptFile = $fileOut . '.dec';
+            // decrypt
+            $this->assertTrue($this->fileCipher->decrypt($fileOut, $decryptFile));
+            $this->assertEquals(filesize($fileIn), filesize($decryptFile));
+            $this->assertEquals(file_get_contents($fileIn), file_get_contents($decryptFile));
+
+            unlink ($fileIn);
+            unlink ($fileOut);
+            unlink ($decryptFile);
+        }
+    }
+
+    public function testDecryptFileNoValidAuthenticate()
+    {
+        $this->fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $this->fileOut = $this->fileIn . '.enc';
+
+        $this->fileCipher->setKey('test');
+        $this->assertTrue($this->fileCipher->encrypt($this->fileIn, $this->fileOut, false));
+
+        $fileOut2 = $this->fileIn . '.dec';
+        $this->assertTrue($this->fileCipher->decrypt($this->fileOut, $fileOut2, false));
+        unlink ($fileOut2);
+
+        // Tampering of the encrypted file
+        $ciphertext = file_get_contents($this->fileOut);
+        $ciphertext[0] = chr((ord($ciphertext[0]) + 1) % 256);
+        file_put_contents($this->fileOut, $ciphertext);
+
+        $this->assertFalse($this->fileCipher->decrypt($this->fileOut, $fileOut2, false));
+        $this->assertFalse(file_exists($fileOut2));
+    }
+
+    public function testEncryptFileWithNoKey()
+    {
+        $this->fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $this->fileOut = $this->fileIn . '.enc';
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'No key specified for encryption');
+        $this->fileCipher->encrypt($this->fileIn, $this->fileOut);
+    }
+
+    public function testDecryptFileWithNoKey()
+    {
+        $this->fileIn  = $this->generateTmpFile(1048576, Rand::getBytes(1));
+        $this->fileOut = $this->fileIn . '.enc';
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    'No key specified for decryption');
+        $this->fileCipher->decrypt($this->fileIn, $this->fileOut);
+    }
+
+    public function testEncryptFileInvalidInputFile()
+    {
+        $randomFile = uniqid('Invalid_File');
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "I cannot open the $randomFile file");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->encrypt($randomFile, '');
+    }
+
+    public function testDecryptFileInvalidInputFile()
+    {
+        $randomFile = uniqid('Invalid_File');
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "I cannot open the $randomFile file");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->decrypt($randomFile, '');
+    }
+
+    public function testEncryptFileInvalidOutputFile()
+    {
+        $this->fileIn  = $this->generateTmpFile(1024);
+        $this->fileOut = $this->generateTmpFile(1024);
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "The file {$this->fileOut} already exists");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->encrypt($this->fileIn, $this->fileOut);
+    }
+
+    public function testDecryptFileInvalidOutputFile()
+    {
+        $this->fileIn  = $this->generateTmpFile(1024);
+        $this->fileOut = $this->generateTmpFile(1024);
+
+        $this->setExpectedException('Zend\Crypt\Exception\InvalidArgumentException',
+                                    "The file {$this->fileOut} already exists");
+        $this->fileCipher->setKey('test');
+        $this->fileCipher->decrypt($this->fileIn, $this->fileOut);
+    }
+
+    /**
+     * Generate a temporary file with a selected size
+     *
+     * @param  string $size
+     * @param  string $content
+     * @return string
+     */
+    protected function generateTmpFile($size, $content = 'A')
+    {
+        $fileName = sys_get_temp_dir() . '/' . uniqid('ZF2_FileCipher_test');
+        $num = $size / strlen($content) + 1;
+        $content  = str_repeat('A', $size / strlen($content) + 1);
+        file_put_contents($fileName, substr($content, 0, $size));
+
+        return $fileName;
+    }
+}

--- a/tests/ZendTest/Crypt/Symmetric/Padding/NoPaddingTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/Padding/NoPaddingTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\Symmetric\Padding;
+
+use Zend\Crypt\Symmetric\Padding\NoPadding;
+
+class NoPaddingTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NoPadding
+     */
+    protected $padding;
+    
+    public function setUp()
+    {
+        $this->padding = new NoPadding();
+    }
+
+    public function testPad()
+    {
+        $string = 'test';
+        for ($size=0; $size<10; $size++) {
+            $this->assertEquals($string, $this->padding->pad($string, $size));
+        }    
+    }
+
+    public function testStrip()
+    {
+        $string = 'test';
+        $this->assertEquals($string, $this->padding->strip($string));
+    }
+}


### PR DESCRIPTION
This PR replace the https://github.com/zendframework/zf2/pull/6410 with a new `FileCipher` implementation based on the suggestion of #6410. I removed the fluent interface and other methods not really relevant for the usage of this component. I also improved the unit tests adding the one for `Zend\Crypt\Symmetric\Padding\NoPadding`.
I also provided the documentation for this new component in this PR https://github.com/zendframework/zf2-documentation/pull/1311
