### PR TITLE
Fix for #6445, adding pagination and transaction to IBM DB2 for Zend\Db

### DIFF
--- a/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/IbmDb2/Connection.php
@@ -15,7 +15,9 @@ use Zend\Db\Adapter\Profiler;
 
 class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
 {
-    /** @var IbmDb2 */
+    /**
+     *  @var IbmDb2
+     */
     protected $driver = null;
 
     /**
@@ -34,9 +36,30 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     protected $profiler = null;
 
     /**
+     * In transaction
+     *
+     * @var bool
+     */
+    protected $inTransaction = false;
+
+    /**
+     * i5 OS
+     *
+     * @var bool
+     */
+    protected $i5;
+
+    /**
+     * Previous autocommit set
+     *
+     * @var mixed
+     */
+    protected $prevAutocommit;
+
+    /**
      * Constructor
      *
-     * @param array|resource|null $connectionParameters (ibm_db2 connection resource)
+     * @param  array|resource|null                $connectionParameters (ibm_db2 connection resource)
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($connectionParameters = null)
@@ -55,22 +78,24 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     /**
      * Set driver
      *
-     * @param IbmDb2 $driver
+     * @param  IbmDb2     $driver
      * @return Connection
      */
     public function setDriver(IbmDb2 $driver)
     {
         $this->driver = $driver;
+
         return $this;
     }
 
     /**
-     * @param Profiler\ProfilerInterface $profiler
+     * @param  Profiler\ProfilerInterface $profiler
      * @return Connection
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
         $this->profiler = $profiler;
+
         return $this;
     }
 
@@ -83,12 +108,13 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @param array $connectionParameters
+     * @param  array      $connectionParameters
      * @return Connection
      */
     public function setConnectionParameters(array $connectionParameters)
     {
         $this->connectionParameters = $connectionParameters;
+
         return $this;
     }
 
@@ -101,7 +127,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @param  resource $resource DB2 resource
+     * @param  resource   $resource DB2 resource
      * @return Connection
      */
     public function setResource($resource)
@@ -110,6 +136,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             throw new Exception\InvalidArgumentException('The resource provided must be of type "DB2 Connection"');
         }
         $this->resource = $resource;
+
         return $this;
     }
 
@@ -125,6 +152,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $info = db2_server_info($this->resource);
+
         return (isset($info->DB_NAME) ? $info->DB_NAME : '');
     }
 
@@ -159,6 +187,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                     return $p[$name];
                 }
             }
+
             return null;
         };
 
@@ -180,6 +209,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
                 __METHOD__
             ));
         }
+
         return $this;
     }
 
@@ -204,6 +234,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
             db2_close($this->resource);
             $this->resource = null;
         }
+
         return $this;
     }
 
@@ -214,7 +245,29 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function beginTransaction()
     {
-        // TODO: Implement beginTransaction() method.
+        if ($this->isI5() && !ini_get('ibm_db2.i5_allow_commit')) {
+            throw new Exception\RuntimeException(
+                'DB2 transactions are not enabled, you need to set the ibm_db2.i5_allow_commit=1 in your php.ini'
+            );
+        }
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
+        $this->prevAutocommit = db2_autocommit($this->resource);
+        db2_autocommit($this->resource, DB2_AUTOCOMMIT_OFF);
+        $this->inTransaction = true;
+
+        return $this;
+    }
+
+    /**
+     * In transaction
+     *
+     * @return bool
+     */
+    public function inTransaction()
+    {
+        return $this->inTransaction;
     }
 
     /**
@@ -224,7 +277,18 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function commit()
     {
-        // TODO: Implement commit() method.
+        if (!$this->isConnected()) {
+            $this->connect();
+        }
+        if (!db2_commit($this->resource)) {
+            throw new Exception\RuntimeException("The commit has not been successful");
+        }
+        if ($this->prevAutocommit) {
+            db2_autocommit($this->resource, $this->prevAutocommit);
+        }
+        $this->inTransaction = false;
+
+        return $this;
     }
 
     /**
@@ -234,7 +298,22 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
      */
     public function rollback()
     {
-        // TODO: Implement rollback() method.
+        if (!$this->resource) {
+            throw new Exception\RuntimeException('Must be connected before you can rollback.');
+        }
+
+        if (!$this->inTransaction) {
+            throw new Exception\RuntimeException('Must call beginTransaction() before you can rollback.');
+        }
+        if (!db2_rollback($this->resource)) {
+            throw new Exception\RuntimeException('The rollback has not been successful');
+        }
+        if ($this->prevAutocommit) {
+            db2_autocommit($this->resource, $this->prevAutocommit);
+        }
+        $this->inTransaction = false;
+
+        return $this;
     }
 
     /**
@@ -267,6 +346,7 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
         }
 
         $resultPrototype = $this->driver->createResult(($resultResource === true) ? $this->resource : $resultResource);
+
         return $resultPrototype;
     }
 
@@ -279,5 +359,19 @@ class Connection implements ConnectionInterface, Profiler\ProfilerAwareInterface
     public function getLastGeneratedValue($name = null)
     {
         return db2_last_insert_id($this->resource);
+    }
+
+    /**
+     * Determine if the OS is OS400 (AS400, IBM i)
+     *
+     * @return boolean
+     */
+    protected function isI5()
+    {
+        if (!isset($this->i5)) {
+            $this->i5 = php_uname('s') == 'OS400' ? true : false;
+        }
+
+        return $this->i5;
     }
 }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/IbmDb2.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/IbmDb2.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\IbmDb2;
+
+use Zend\Db\Sql\Platform\AbstractPlatform;
+
+class IbmDb2 extends AbstractPlatform
+{
+
+    public function __construct(SelectDecorator $selectDecorator = null)
+    {
+    	$this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
+    }
+
+}

--- a/library/Zend/Db/Sql/Platform/IbmDb2/IbmDb2.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/IbmDb2.php
@@ -16,7 +16,7 @@ class IbmDb2 extends AbstractPlatform
 
     public function __construct(SelectDecorator $selectDecorator = null)
     {
-    	$this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
+        $this->setTypeDecorator('Zend\Db\Sql\Select', ($selectDecorator) ?: new SelectDecorator());
     }
 
 }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -14,7 +14,6 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\ParameterContainer;
 use Zend\Db\Adapter\Platform\PlatformInterface;
 use Zend\Db\Adapter\StatementContainerInterface;
-use Zend\Db\Sql\ExpressionInterface;
 use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
 use Zend\Db\Sql\Select;
 
@@ -25,7 +24,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      */
     protected $select = null;
 
-	/**
+    /**
      * @param Select $select
      */
     public function setSubject($select)
@@ -33,9 +32,8 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         $this->select = $select;
     }
 
-  
     /**
-     * @param AdapterInterface $adapter
+     * @param AdapterInterface            $adapter
      * @param StatementContainerInterface $statementContainer
      */
     public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
@@ -51,9 +49,9 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         $this->specifications['LIMITOFFSET'] = null;
         parent::prepareStatement($adapter, $statementContainer);
     }
-     
+
     /**
-     * @param PlatformInterface $platform
+     * @param  PlatformInterface $platform
      * @return string
      */
     public function getSqlString(PlatformInterface $platform = null)
@@ -62,29 +60,28 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
         foreach (get_object_vars($this->select) as $name => $value) {
             $this->{$name} = $value;
         }
-        
+
         unset($this->specifications[self::LIMIT]);
         unset($this->specifications[self::OFFSET]);
         $this->specifications['LIMITOFFSET'] = null;
-        
-        
+
         return parent::getSqlString($platform);
     }
 
     /**
-     * @param PlatformInterface $platform
-     * @param DriverInterface $driver
-     * @param ParameterContainer $parameterContainer
+     * @param  PlatformInterface  $platform
+     * @param  DriverInterface    $driver
+     * @param  ParameterContainer $parameterContainer
      * @param $sqls
      * @param $parameters
      * @return null
      */
-    
+
     protected function processLimitOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, &$sqls, &$parameters)
-    {	
+    {
         if ($this->limit === null && $this->offset === null) {
-    		return null;
-    	}
+            return null;
+        }
 
         if ($parameterContainer) {
             if ((int) $this->offset > 0) {
@@ -93,31 +90,31 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             $parameterContainer->offsetSet('limit', (int) $this->limit);
         }
 
-       	if (isset($sqls[self::ORDER])) {
-    		$orderBy = $sqls[self::ORDER];
-    		unset($sqls[self::ORDER]);
-    	} else {
-    		$orderBy = null;
-    	}
-    
+           if (isset($sqls[self::ORDER])) {
+            $orderBy = $sqls[self::ORDER];
+            unset($sqls[self::ORDER]);
+        } else {
+            $orderBy = null;
+        }
+
         if (preg_match('/DISTINCT/i',$sqls[self::SELECT],$match)) {
             $sqlSyntax = 'DENSE_RANK()';
         } else {
-            $sqlSyntax = 'ROW_NUMBER()';    
+            $sqlSyntax = 'ROW_NUMBER()';
         }
-            
+
         $offset = (int) $this->offset;
         $limit  = (int) $this->limit;
-        
+
         if (empty($offset)) {
             $sqls[self::SELECT] .= " FETCH FIRST $limit ROW ONLY";
-        } else {    
+        } else {
             $sqls[self::SELECT] = sprintf(
                 "SELECT z2.* FROM " .
                 "(SELECT %s OVER(%s) AS \"ZEND_ROWNUM\", z1.* FROM (%s) z1) z2 " .
-                "WHERE z2.ZEND_ROWNUM BETWEEN %d AND %d", 
+                "WHERE z2.ZEND_ROWNUM BETWEEN %d AND %d",
                 $sqlSyntax, $orderBy, $sqls[self::SELECT], $offset, $limit + $offset
-            ); 
+            );
         }
     }
 }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -90,30 +90,20 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             $parameterContainer->offsetSet('limit', (int) $this->limit);
         }
 
-           if (isset($sqls[self::ORDER])) {
-            $orderBy = $sqls[self::ORDER];
-            unset($sqls[self::ORDER]);
-        } else {
-            $orderBy = null;
-        }
-
-        if (preg_match('/DISTINCT/i',$sqls[self::SELECT],$match)) {
-            $sqlSyntax = 'DENSE_RANK()';
-        } else {
-            $sqlSyntax = 'ROW_NUMBER()';
-        }
-
         $offset = (int) $this->offset;
         $limit  = (int) $this->limit;
 
         if (empty($offset)) {
-            $sqls[self::SELECT] .= " FETCH FIRST $limit ROW ONLY";
+            $sqls[self::SELECT] .= sprintf(
+                " FETCH FIRST %s ROW ONLY",
+                $limit
+            );
         } else {
             $sqls[self::SELECT] = sprintf(
                 "SELECT z2.* FROM " .
-                "(SELECT %s OVER(%s) AS \"ZEND_ROWNUM\", z1.* FROM (%s) z1) z2 " .
+                "(SELECT ROW_NUMBER() OVER() AS \"ZEND_ROWNUM\", z1.* FROM (%s) z1) z2 " .
                 "WHERE z2.ZEND_ROWNUM BETWEEN %d AND %d",
-                $sqlSyntax, $orderBy, $sqls[self::SELECT], $offset, $limit + $offset
+                $sqls[self::SELECT], $offset + 1, $limit + $offset
             );
         }
     }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -20,9 +20,30 @@ use Zend\Db\Sql\Select;
 class SelectDecorator extends Select implements PlatformDecoratorInterface
 {
     /**
+     * @var bool
+     */
+    protected $isSelectContainDistinct= false;
+
+    /**
      * @var Select
      */
     protected $select = null;
+
+    /**
+	 * @return the $isSelectContainDistinct
+	 */
+    public function getIsSelectContainDistinct()
+    {
+        return $this->isSelectContainDistinct;
+    }
+
+    /**
+	 * @param boolean $isSelectContainDistinct
+	 */
+    public function setIsSelectContainDistinct($isSelectContainDistinct)
+    {
+        $this->isSelectContainDistinct = $isSelectContainDistinct;
+    }
 
     /**
      * @param Select $select
@@ -30,6 +51,14 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
     public function setSubject($select)
     {
         $this->select = $select;
+    }
+
+    /**
+     * @see \Zend\Db\Sql\Select::renderTable
+     */
+    protected function renderTable($table, $alias = null)
+    {
+        return $table . ' ' . $alias;
     }
 
     /**
@@ -83,28 +112,75 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
             return null;
         }
 
+        $selectParameters = $parameters[self::SELECT];
+
+        $starSuffix = $platform->getIdentifierSeparator() . self::SQL_STAR;
+        foreach ($selectParameters[0] as $i => $columnParameters) {
+            if ($columnParameters[0] == self::SQL_STAR || (isset($columnParameters[1]) && $columnParameters[1] == self::SQL_STAR) || strpos($columnParameters[0], $starSuffix)) {
+                $selectParameters[0] = array(array(self::SQL_STAR));
+                break;
+            }
+            if (isset($columnParameters[1])) {
+                array_shift($columnParameters);
+                $selectParameters[0][$i] = $columnParameters;
+            }
+        }
+
+        // first, produce column list without compound names (using the AS portion only)
+        array_unshift($sqls, $this->createSqlFromSpecificationAndParameters(
+        array('SELECT %1$s FROM (' => current($this->specifications[self::SELECT])),
+        $selectParameters
+        ));
+
+        if (preg_match('/DISTINCT/i',$sqls[0],$match)) {
+            $this->setIsSelectContainDistinct(true);
+        }
+
         if ($parameterContainer) {
+            // create bottom part of query, with offset and limit using row_number
+            $limitParamName = $driver->formatParameterName('limit');
+            $offsetParamName = $driver->formatParameterName('offset');
+            $offsetForSumParamName = $driver->formatParameterName('offsetForSum');
+
+            array_push($sqls, sprintf(
+                ") AS ZEND_IBMDB2_SERVER_LIMIT_OFFSET_EMULATION WHERE ZEND_IBMDB2_SERVER_LIMIT_OFFSET_EMULATION.ZEND_DB_ROWNUM BETWEEN %s AND %s",
+                $offsetParamName, $limitParamName
+            ));
+
             if ((int) $this->offset > 0) {
+                $parameterContainer->offsetSet('offset', (int) $this->offset + 1);
+            } else {
                 $parameterContainer->offsetSet('offset', (int) $this->offset);
             }
-            $parameterContainer->offsetSet('limit', (int) $this->limit);
-        }
-
-        $offset = (int) $this->offset;
-        $limit  = (int) $this->limit;
-
-        if (empty($offset)) {
-            $sqls[self::SELECT] .= sprintf(
-                " FETCH FIRST %s ROW ONLY",
-                $limit
-            );
+            $parameterContainer->offsetSet('limit', (int) $this->limit + (int) $this->offset);
         } else {
-            $sqls[self::SELECT] = sprintf(
-                "SELECT z2.* FROM " .
-                "(SELECT ROW_NUMBER() OVER() AS \"ZEND_ROWNUM\", z1.* FROM (%s) z1) z2 " .
-                "WHERE z2.ZEND_ROWNUM BETWEEN %d AND %d",
-                $sqls[self::SELECT], $offset + 1, $limit + $offset
-            );
+            if ( (int) $this->offset > 0) {
+                $offset = (int) $this->offset + 1;
+            } else {
+                $offset = (int) $this->offset;
+            }
+            array_push($sqls, sprintf(
+                ") AS ZEND_IBMDB2_SERVER_LIMIT_OFFSET_EMULATION WHERE ZEND_IBMDB2_SERVER_LIMIT_OFFSET_EMULATION.ZEND_DB_ROWNUM BETWEEN %d AND %d",
+                $offset, (int) $this->limit + (int) $this->offset
+            ));
         }
+
+        if (isset($sqls[self::ORDER])) {
+            $orderBy = $sqls[self::ORDER];
+            unset($sqls[self::ORDER]);
+        } else {
+            $orderBy = '';
+        }
+
+        // add a column for row_number() using the order specification //dense_rank()
+        if ($this->getIsSelectContainDistinct()) {
+            $parameters[self::SELECT][0][] = array('DENSE_RANK() OVER (' . $orderBy . ')', 'ZEND_DB_ROWNUM');
+        } else {
+            $parameters[self::SELECT][0][] = array('ROW_NUMBER() OVER (' . $orderBy . ')', 'ZEND_DB_ROWNUM');
+        }
+        $sqls[self::SELECT] = $this->createSqlFromSpecificationAndParameters(
+            $this->specifications[self::SELECT],
+            $parameters[self::SELECT]
+        );
     }
 }

--- a/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
+++ b/library/Zend/Db/Sql/Platform/IbmDb2/SelectDecorator.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Platform\IbmDb2;
+
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\Driver\DriverInterface;
+use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Platform\PlatformInterface;
+use Zend\Db\Adapter\StatementContainerInterface;
+use Zend\Db\Sql\ExpressionInterface;
+use Zend\Db\Sql\Platform\PlatformDecoratorInterface;
+use Zend\Db\Sql\Select;
+
+class SelectDecorator extends Select implements PlatformDecoratorInterface
+{
+    /**
+     * @var Select
+     */
+    protected $select = null;
+
+	/**
+     * @param Select $select
+     */
+    public function setSubject($select)
+    {
+        $this->select = $select;
+    }
+
+  
+    /**
+     * @param AdapterInterface $adapter
+     * @param StatementContainerInterface $statementContainer
+     */
+    public function prepareStatement(AdapterInterface $adapter, StatementContainerInterface $statementContainer)
+    {
+        // localize variables
+        foreach (get_object_vars($this->select) as $name => $value) {
+            $this->{$name} = $value;
+        }
+        // set specifications
+        unset($this->specifications[self::LIMIT]);
+        unset($this->specifications[self::OFFSET]);
+
+        $this->specifications['LIMITOFFSET'] = null;
+        parent::prepareStatement($adapter, $statementContainer);
+    }
+     
+    /**
+     * @param PlatformInterface $platform
+     * @return string
+     */
+    public function getSqlString(PlatformInterface $platform = null)
+    {
+        // localize variables
+        foreach (get_object_vars($this->select) as $name => $value) {
+            $this->{$name} = $value;
+        }
+        
+        unset($this->specifications[self::LIMIT]);
+        unset($this->specifications[self::OFFSET]);
+        $this->specifications['LIMITOFFSET'] = null;
+        
+        
+        return parent::getSqlString($platform);
+    }
+
+    /**
+     * @param PlatformInterface $platform
+     * @param DriverInterface $driver
+     * @param ParameterContainer $parameterContainer
+     * @param $sqls
+     * @param $parameters
+     * @return null
+     */
+    
+    protected function processLimitOffset(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, &$sqls, &$parameters)
+    {	
+        if ($this->limit === null && $this->offset === null) {
+    		return null;
+    	}
+
+        if ($parameterContainer) {
+            if ((int) $this->offset > 0) {
+                $parameterContainer->offsetSet('offset', (int) $this->offset);
+            }
+            $parameterContainer->offsetSet('limit', (int) $this->limit);
+        }
+
+       	if (isset($sqls[self::ORDER])) {
+    		$orderBy = $sqls[self::ORDER];
+    		unset($sqls[self::ORDER]);
+    	} else {
+    		$orderBy = null;
+    	}
+    
+        if (preg_match('/DISTINCT/i',$sqls[self::SELECT],$match)) {
+            $sqlSyntax = 'DENSE_RANK()';
+        } else {
+            $sqlSyntax = 'ROW_NUMBER()';    
+        }
+            
+        $offset = (int) $this->offset;
+        $limit  = (int) $this->limit;
+        
+        if (empty($offset)) {
+            $sqls[self::SELECT] .= " FETCH FIRST $limit ROW ONLY";
+        } else {    
+            $sqls[self::SELECT] = sprintf(
+                "SELECT z2.* FROM " .
+                "(SELECT %s OVER(%s) AS \"ZEND_ROWNUM\", z1.* FROM (%s) z1) z2 " .
+                "WHERE z2.ZEND_ROWNUM BETWEEN %d AND %d", 
+                $sqlSyntax, $orderBy, $sqls[self::SELECT], $offset, $limit + $offset
+            ); 
+        }
+    }
+}

--- a/library/Zend/Db/Sql/Platform/Platform.php
+++ b/library/Zend/Db/Sql/Platform/Platform.php
@@ -36,6 +36,9 @@ class Platform extends AbstractPlatform
                 $platform = new Oracle\Oracle();
                 $this->decorators = $platform->decorators;
                 break;
+            case 'ibmdb2':
+                $platform = new IbmDb2\IbmDb2();
+                $this->decorators = $platform->decorators;
             default:
         }
     }

--- a/library/Zend/Db/Sql/Platform/Platform.php
+++ b/library/Zend/Db/Sql/Platform/Platform.php
@@ -36,6 +36,7 @@ class Platform extends AbstractPlatform
                 $platform = new Oracle\Oracle();
                 $this->decorators = $platform->decorators;
                 break;
+            case 'ibm db2':
             case 'ibmdb2':
                 $platform = new IbmDb2\IbmDb2();
                 $this->decorators = $platform->decorators;

--- a/tests/ZendTest/Db/Adapter/Driver/IbmDb2/ConnectionIntegrationTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/IbmDb2/ConnectionIntegrationTest.php
@@ -99,38 +99,75 @@ class ConnectionIntegrationTest extends AbstractIntegrationTest
 
     /**
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Connection::beginTransaction
-     * @todo   Implement testBeginTransaction().
      */
     public function testBeginTransaction()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        if (!$this->isTransactionEnabled()) {
+            $this->markTestIncomplete(
+                'I cannot test without the DB2 transactions enabled'
+            );
+        }
+        $connection = new Connection($this->variables);
+        $connection->beginTransaction();
+        $this->assertTrue($connection->inTransaction());
+        $this->assertEquals(0, db2_autocommit($connection->getResource()));
     }
 
     /**
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Connection::commit
-     * @todo   Implement testCommit().
      */
     public function testCommit()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        if (!$this->isTransactionEnabled()) {
+            $this->markTestIncomplete(
+                'I cannot test without the DB2 transactions enabled'
+            );
+        }
+        $connection = new Connection($this->variables);
+        $connection->beginTransaction();
+
+        $oldValue = db2_autocommit($connection->getResource());
+        $connection->beginTransaction();
+        $this->assertTrue($connection->inTransaction());
+        $connection->commit();
+        $this->assertFalse($connection->inTransaction());
+        $this->assertEquals($oldValue, db2_autocommit($connection->getResource()));
     }
 
     /**
      * @covers Zend\Db\Adapter\Driver\IbmDb2\Connection::rollback
-     * @todo   Implement testRollback().
      */
     public function testRollback()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        if (!$this->isTransactionEnabled()) {
+            $this->markTestIncomplete(
+                'I cannot test without the DB2 transactions enabled'
+            );
+        }
+        $connection = new Connection($this->variables);
+        $connection->beginTransaction();
+
+        $oldValue = db2_autocommit($connection->getResource());
+        $connection->beginTransaction();
+        $this->assertTrue($connection->inTransaction());
+        $connection->rollback();
+        $this->assertFalse($connection->inTransaction());
+        $this->assertEquals($oldValue, db2_autocommit($connection->getResource()));
+    }
+
+    /**
+     * Return true if the transaction is enabled for DB2
+     *
+     * @return bool
+     */
+    protected function isTransactionEnabled()
+    {
+        $os =  php_uname('s') == 'OS400' ? true : false;
+        if ($os) {
+            return ini_get('ibm_db2.i5_allow_commit') == 1;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
@@ -83,13 +83,13 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $select1->from(array('x' => 'foo'))->limit(5)->offset(10);
         $expectedPrepareSql1 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN ? AND ?';
         $expectedParams1 = array('offset' => 10, 'limit' => 5);
-        $expectedSql1 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 10 AND 15';
+        $expectedSql1 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 11 AND 15';
 
         $select2 = new Select;
         $select2->from(array('x' => 'foo'))->limit(5)->offset(10)->quantifier(Select::QUANTIFIER_DISTINCT);
-        $expectedPrepareSql2 = 'SELECT z2.* FROM (SELECT DENSE_RANK() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN ? AND ?';
+        $expectedPrepareSql2 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN ? AND ?';
         $expectedParams2 = array('offset' => 10, 'limit' => 5);
-        $expectedSql2 = 'SELECT z2.* FROM (SELECT DENSE_RANK() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 10 AND 15';
+        $expectedSql2 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 11 AND 15';
 
         return array(
             array($select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0),

--- a/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
@@ -90,7 +90,7 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
         $expectedPrepareSql2 = 'SELECT z2.* FROM (SELECT DENSE_RANK() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN ? AND ?';
         $expectedParams2 = array('offset' => 10, 'limit' => 5);
         $expectedSql2 = 'SELECT z2.* FROM (SELECT DENSE_RANK() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 10 AND 15';
- 
+
         return array(
             array($select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0),
             array($select1, $expectedPrepareSql1, $expectedParams1, $expectedSql1),

--- a/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Platform\IbmDb2;
+
+use Zend\Db\Sql\Platform\IbmDb2\SelectDecorator;
+use Zend\Db\Sql\Select;
+use Zend\Db\Adapter\ParameterContainer;
+use Zend\Db\Adapter\Platform\IbmDb2 as IbmDb2Platform;
+
+class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select to produce properly IBM Db2 dialect prepared sql
+     * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::prepareStatement
+     * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::processLimitOffset
+     * @dataProvider dataProvider
+     */
+    public function testPrepareStatement(Select $select, $notUsed, $expectedParams, $expectedSql)
+    {
+        $driver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
+
+        // test
+        $adapter = $this->getMock(
+            'Zend\Db\Adapter\Adapter',
+            null,
+            array(
+                $driver,
+                new IbmDb2Platform()
+            )
+        );
+
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $statement->expects($this->once())->method('setSql')->with($expectedSql);
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $selectDecorator->prepareStatement($adapter, $statement);
+
+        $this->assertEquals($expectedParams, $parameterContainer->getNamedArray());
+    }
+
+    /**
+     * @testdox integration test: Testing SelectDecorator will use Select to produce properly Ibm DB2 dialect sql statements
+     * @covers Zend\Db\Sql\Platform\IbmDb2\SelectDecorator::getSqlString
+     * @dataProvider dataProvider
+     */
+    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
+    {
+        $parameterContainer = new ParameterContainer;
+        $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
+        $statement->expects($this->any())->method('getParameterContainer')->will($this->returnValue($parameterContainer));
+
+        $selectDecorator = new SelectDecorator;
+        $selectDecorator->setSubject($select);
+        $this->assertEquals($expectedSql, $selectDecorator->getSqlString(new IbmDb2Platform));
+    }
+
+    /**
+     * Data provider for testGetSqlString
+     *
+     * @return array
+     */
+    public function dataProvider()
+    {
+        $select0 = new Select;
+        $select0->from(array('x' => 'foo'))->limit(5);
+        $expectedPrepareSql0 = 'SELECT "x".* FROM "foo" AS "x" FETCH FIRST ? ROW ONLY';
+        $expectedParams0 = array('limit' => 5);
+        $expectedSql0 = 'SELECT "x".* FROM "foo" AS "x" FETCH FIRST 5 ROW ONLY';
+
+        $select1 = new Select;
+        $select1->from(array('x' => 'foo'))->limit(5)->offset(10);
+        $expectedPrepareSql1 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN ? AND ?';
+        $expectedParams1 = array('offset' => 10, 'limit' => 5);
+        $expectedSql1 = 'SELECT z2.* FROM (SELECT ROW_NUMBER() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 10 AND 15';
+
+        $select2 = new Select;
+        $select2->from(array('x' => 'foo'))->limit(5)->offset(10)->quantifier(Select::QUANTIFIER_DISTINCT);
+        $expectedPrepareSql2 = 'SELECT z2.* FROM (SELECT DENSE_RANK() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN ? AND ?';
+        $expectedParams2 = array('offset' => 10, 'limit' => 5);
+        $expectedSql2 = 'SELECT z2.* FROM (SELECT DENSE_RANK() OVER() AS "ZEND_ROWNUM", z1.* FROM (SELECT DISTINCT "x".* FROM "foo" AS "x") z1) z2 WHERE z2.ZEND_ROWNUM BETWEEN 10 AND 15';
+ 
+        return array(
+            array($select0, $expectedPrepareSql0, $expectedParams0, $expectedSql0),
+            array($select1, $expectedPrepareSql1, $expectedParams1, $expectedSql1),
+            array($select2, $expectedPrepareSql2, $expectedParams2, $expectedSql2)
+        );
+    }
+
+}


### PR DESCRIPTION
This PR adds the following missing features to IBM DB2 adapter of `Zend\Db`:
- [X] pagination using the LIMIT and OFFSET sql statement (in `Zend\Db\Sql\Platform\IbmDb2\SelectDecorator.php`);
- [x] transaction using COMMIT, ROLLBACK (in `Zend\Db\Adapter\Driver\IbmDb2\Connection.php`)

I'm testing the PR using unit tests and functional tests, with the usage of this tool: https://github.com/ezimuel/zf2dbtest.
