### PR TITLE
Add new *Aware[Interface|Traits]

### DIFF
--- a/library/Zend/Crypt/Password/PasswordAwareInterface.php
+++ b/library/Zend/Crypt/Password/PasswordAwareInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt\Password;
+
+interface PasswordAwareInterface
+{
+    /**
+     * Set the password format.
+     *
+     * @param PasswordInterface $password The new password format.
+     *
+     * @return PasswordAwareInterface
+     */
+    public function setPassword(PasswordInterface $password);
+
+    /**
+     * Retrieve the password format.
+     *
+     * @return PasswordInterface
+     */
+    public function getPassword();
+}

--- a/library/Zend/Crypt/Password/PasswordAwareTrait.php
+++ b/library/Zend/Crypt/Password/PasswordAwareTrait.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt\Password;
+
+trait PasswordAwareTrait
+{
+    /**
+     * Password format instance.
+     *
+     * @var PasswordInterface
+     */
+    protected $password = null;
+
+    /**
+     * Set the password format.
+     *
+     * @param PasswordInterface $password The new password format
+     *
+     * @return self
+     */
+    public function setPassword(PasswordInterface $password)
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the password format.
+     *
+     * @return null|PasswordInterface
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+}

--- a/library/Zend/Mail/Transport/TransportAwareInterface.php
+++ b/library/Zend/Mail/Transport/TransportAwareInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail\Transport;
+
+/**
+ * Interface for TransportInterface injection
+ */
+interface TransportAwareInterface
+{
+    /**
+     * Set the mail transport.
+     *
+     * @param \Zend\Mail\Transport\TransportInterface $transport
+     *
+     * @return TransportAwareInterface
+     */
+    public function setTransport(TransportInterface $transport);
+
+    /**
+     * Get the mail trainsport.
+     *
+     * @return \Zend\Mail\Transport\TransportInterface
+     */
+    public function getTransport();
+}

--- a/library/Zend/Mail/Transport/TransportAwareTrait.php
+++ b/library/Zend/Mail/Transport/TransportAwareTrait.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail\Transport;
+
+/**
+ * A trait for objects that provide a TransportInterface
+ */
+trait TransportAwareTrait
+{
+    protected $mailTransport;
+
+    /**
+     * Set the mail transport.
+     *
+     * @param \Zend\Mail\Transport\TransportInterface $transport
+     *
+     * @return self
+     */
+    public function setTransport(TransportInterface $transport)
+    {
+        $this->mailTransport = $transport;
+        return $this;
+    }
+
+    /**
+     * Get the mail trainsport.
+     *
+     * @return \Zend\Mail\Transport\TransportInterface
+     */
+    public function getTransport()
+    {
+        return $this->mailTransport;
+    }
+}

--- a/tests/ZendTest/Crypt/Password/PasswordAwareTraitTest.php
+++ b/tests/ZendTest/Crypt/Password/PasswordAwareTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\Password;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @requires PHP 5.4
+ */
+class PasswordAwareTraitTest extends TestCase
+{
+    /**
+     * Verify basic behavior of setPassword().
+     *
+     * @return void
+     */
+    public function testSetPassword()
+    {
+        $object = $this->getObjectForTrait('\Zend\Crypt\Password\PasswordAwareTrait');
+        $this->assertAttributeEquals(null, 'password', $object);
+        $password = new TestAsset\SimplePassword();
+        $object->setPassword($password);
+        $this->assertAttributeEquals($password, 'password', $object);
+    }
+
+    /**
+     * Verify basic behavior of getPassword().
+     *
+     * @return void
+     */
+    public function testGetPassword()
+    {
+        $object = $this->getObjectForTrait('\Zend\Crypt\Password\PasswordAwareTrait');
+        $this->assertNull($object->getPassword());
+        $password = new TestAsset\SimplePassword();
+        $object->setPassword($password);
+        $this->assertEquals($password, $object->getPassword());
+    }
+}

--- a/tests/ZendTest/Crypt/Password/TestAsset/SimplePassword.php
+++ b/tests/ZendTest/Crypt/Password/TestAsset/SimplePassword.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\Password\TestAsset;
+
+use Zend\Crypt\Password\PasswordInterface;
+
+final class SimplePassword implements PasswordInterface
+{
+    /**
+     * Verify a password hash against a given plain text password
+     *
+     * @param string $password The password to hash
+     * @param string $hash     The supplied hash to validate
+     *
+     * @return bool Does the password validate against the hash
+     */
+    public function verify($password, $hash)
+    {
+        return md5($password) === $hash;
+    }
+
+    /**
+     * Create a password hash for a given plain text password
+     *
+     * @param string $password The password to hash
+     *
+     * @return string The formatted password hash
+     */
+    public function create($password)
+    {
+        return md5($password);
+    }
+}

--- a/tests/ZendTest/Mail/Transport/TransportAwareTraitTest.php
+++ b/tests/ZendTest/Mail/Transport/TransportAwareTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mail\Transport;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @requires PHP 5.4
+ */
+class TransportAwareTraitTest extends TestCase
+{
+    /**
+     * Verify basic behavior of setTransport().
+     *
+     * @return void
+     */
+    public function testSetTransport()
+    {
+        $object = $this->getObjectForTrait('\Zend\Mail\Transport\TransportAwareTrait');
+        $this->assertAttributeEquals(null, 'mailTransport', $object);
+        $mailTransport = new \Zend\Mail\Transport\Null();
+        $object->setTransport($mailTransport);
+        $this->assertAttributeEquals($mailTransport, 'mailTransport', $object);
+    }
+
+    /**
+     * Verify basic behavior of getTransport().
+     *
+     * @return void
+     */
+    public function testGetTransport()
+    {
+        $object = $this->getObjectForTrait('\Zend\Mail\Transport\TransportAwareTrait');
+        $this->assertNull($object->getTransport());
+        $mailTransport = new \Zend\Mail\Transport\Null();
+        $object->setTransport($mailTransport);
+        $this->assertEquals($mailTransport, $object->getTransport());
+    }
+}


### PR DESCRIPTION
Adds simple **Aware** Interface and traits to be used with `\Zend\Crypt\Password\PasswordInterface`
and `\Zend\Mail\Transport\TransportInterface`

Though these interfaces/traits are not used elsewhere in the framework, I believe this project is the best place for them to reside. 
