### PR TITLE
Fix + tests for #5969

### DIFF
--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -216,7 +216,7 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected function executeSelect(Select $select)
     {
         $selectState = $select->getRawState();
-        if ($selectState['table'] != $this->table) {
+        if ($selectState['table'] != $this->table && (is_array($selectState['table']) && end($selectState['table']) != $this->table)) {
             throw new Exception\RuntimeException('The table name of the provided select object must match that of the table');
         }
 

--- a/tests/ZendTest/Db/TableGateway/AbstractTableGatewayTest.php
+++ b/tests/ZendTest/Db/TableGateway/AbstractTableGatewayTest.php
@@ -164,6 +164,50 @@ class AbstractTableGatewayTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::select
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::selectWith
+     * @covers Zend\Db\TableGateway\AbstractTableGateway::executeSelect
+     *
+     * This is a test for the case when a valid $select is built using an aliased table name, then used
+     * with AbstractTableGateway::selectWith (or AbstractTableGateway::select).
+     *
+     * $myTable = new MyTable(...);
+     * $sql = new \Zend\Db\Sql\Sql(...);
+     * $select = $sql->select()->from(array('t' => 'mytable'));
+     *
+     * // Following fails, with Fatal error: Uncaught exception 'RuntimeException' with message
+     * 'The table name of the provided select object must match that of the table' unless fix is provided.
+     * $myTable->selectWith($select);
+     *
+     */
+    public function testSelectWithArrayTable()
+    {
+        // Case 1
+
+        $select1 = $this->getMock('Zend\Db\Sql\Select', array('getRawState'));
+        $select1->expects($this->once())
+            ->method('getRawState')
+            ->will($this->returnValue(array(
+                'table' => 'foo',               // Standard table name format, valid according to Select::from()
+                'columns' => null,
+            )));
+        $return = $this->table->selectWith($select1);
+        $this->assertNotNull($return);
+
+        // Case 2
+
+        $select1 = $this->getMock('Zend\Db\Sql\Select', array('getRawState'));
+        $select1->expects($this->once())
+            ->method('getRawState')
+            ->will($this->returnValue(array(
+                'table' => array('f' => 'foo'), // Alias table name format, valid according to Select::from()
+                'columns' => null,
+            )));
+        $return = $this->table->selectWith($select1);
+        $this->assertNotNull($return);
+    }
+
+    /**
      * @covers Zend\Db\TableGateway\AbstractTableGateway::insert
      * @covers Zend\Db\TableGateway\AbstractTableGateway::insertWith
      * @covers Zend\Db\TableGateway\AbstractTableGateway::executeInsert


### PR DESCRIPTION
Added test for issue #5969 per request of @weierophinney and @feliperamaral

Might need to be cleaned up and moved, but it does demonstrate the problem. Running the test without the fix shows the error:

```
thorie@tim-mbp:~/work/zf2/tests$ phpunit --filter testSelectWithArrayTable ZendTest/Db/TableGateway/AbstractTableGatewayTest.php 
PHPUnit 3.7.19 by Sebastian Bergmann.

Configuration read from /Users/thorie/work/zf2/tests/phpunit.xml

E

Time: 32 ms, Memory: 10.50Mb

There was 1 error:

1) ZendTest\Db\TableGateway\AbstractTableGatewayTest::testSelectWithArrayTable
Zend\Db\TableGateway\Exception\RuntimeException: The table name of the provided select object must match that of the table

/Users/thorie/work/zf2/library/Zend/Db/TableGateway/AbstractTableGateway.php:220
/Users/thorie/work/zf2/library/Zend/Db/TableGateway/AbstractTableGateway.php:208
/Users/thorie/work/zf2/tests/ZendTest/Db/TableGateway/AbstractTableGatewayTest.php:206
/usr/lib/php/pear/PHPUnit/TextUI/Command.php:176
/usr/lib/php/pear/PHPUnit/TextUI/Command.php:129

FAILURES!
Tests: 1, Assertions: 1, Errors: 1.
```
