### PR TITLE
Fix for odd php-cs-fixer finds

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -175,6 +175,21 @@ class Di implements DependencyInjectionInterface
     }
 
     /**
+     * Utility method used to retrieve the class of a particular instance. This is here to allow extending classes to
+     * override how class names are resolved
+     *
+     * @internal this method is used by the ServiceLocator\DependencyInjectorProxy class to interact with instances
+     *           and is a hack to be used internally until a major refactor does not split the `resolveMethodParameters`. Do not
+     *           rely on its functionality.
+     * @param  Object $instance
+     * @return string
+     */
+    protected function getClass($instance)
+    {
+        return get_class($instance);
+    }
+
+    /**
      * @param $name
      * @param array $params
      * @param string $method
@@ -868,21 +883,6 @@ class Di implements DependencyInjectionInterface
         }
 
         return $resolvedParams; // return ordered list of parameters
-    }
-
-    /**
-     * Utility method used to retrieve the class of a particular instance. This is here to allow extending classes to
-     * override how class names are resolved
-     *
-     * @internal this method is used by the ServiceLocator\DependencyInjectorProxy class to interact with instances
-     *           and is a hack to be used internally until a major refactor does not split the `resolveMethodParameters`. Do not
-     *           rely on its functionality.
-     * @param  Object $instance
-     * @return string
-     */
-    protected function getClass($instance)
-    {
-        return get_class($instance);
     }
 
     /**

--- a/tests/ZendTest/Tag/Cloud/Decorator/HtmlTagTest.php
+++ b/tests/ZendTest/Tag/Cloud/Decorator/HtmlTagTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Tag\Cloud\Decorator;
 
-use	Zend\Tag;
+use Zend\Tag;
 use Zend\Tag\Cloud\Decorator;
 use Zend\Tag\Cloud\Decorator\Exception\InvalidArgumentException;
 


### PR DESCRIPTION
I do not know why `php-cs-fixer` reported these errors, I'm assuming some character(s) within the files themselves caused some weird tokenizing. 

On a fresh clone of `zend/master` You will get the following errors

```
zf2$ ./vendor/bin/php-cs-fixer fix -v --dry-run
Loaded config from "/home/chadicus/projects/zf2/.php_cs"
   1) Zend/Cache/Storage/Adapter/MemcachedResourceManager.php (visibility)
   2) Zend/Cache/Storage/Adapter/RedisResourceManager.php (visibility)
   3) Zend/Json/Decoder.php (visibility)
   4) Zend/Di/Di.php (visibility)
   5) ZendTest/Tag/Cloud/Decorator/HtmlTagTest.php (indentation)
```

My solution for all of the `visibility` errors was to move the methods within the class files.  `php-cs-fixer` solution was to type-hint the methods with `public` resulting in

``` php
protected function getClass(public $instance)
{
```
