### PR TITLE
Repeal `autocomplete` form attribute being boolean

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -26,7 +26,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
      * @var array
      */
     protected $booleanAttributes = array(
-        'autocomplete' => array('on' => 'on',        'off' => 'off'),
         'autofocus'    => array('on' => 'autofocus', 'off' => ''),
         'checked'      => array('on' => 'checked',   'off' => ''),
         'disabled'     => array('on' => 'disabled',  'off' => ''),


### PR DESCRIPTION
`autocomplete` attribute may have string values:
http://www.whatwg.org/specs/web-apps/current-work/multipage/association-of-controls-and-forms.html#attr-fe-autocomplete
