### PR TITLE
AbstractAddressList handles names with comma incorrectly

### DIFF
--- a/tests/ZendTest/Mail/Header/AddressListHeaderTest.php
+++ b/tests/ZendTest/Mail/Header/AddressListHeaderTest.php
@@ -80,11 +80,15 @@ class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
         $list->add($address);
         $list->add('zf-contributors@lists.zend.com');
         $list->add('fw-announce@lists.zend.com', 'ZF Announce List');
+        $list->add('zf-comma@lists.zend.com', 'ZF, with comma');
     }
 
     public function getExpectedFieldValue()
     {
-        return "ZF DevTeam <zf-devteam@zend.com>,\r\n zf-contributors@lists.zend.com,\r\n ZF Announce List <fw-announce@lists.zend.com>";
+        return "ZF DevTeam <zf-devteam@zend.com>,\r\n"
+            . " zf-contributors@lists.zend.com,\r\n"
+            . " ZF Announce List <fw-announce@lists.zend.com>,\r\n"
+            . " \"ZF, with comma\" <zf-comma@lists.zend.com>";
     }
 
     /**
@@ -118,7 +122,7 @@ class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
         $header   = call_user_func($callback, $headerLine);
         $this->assertInstanceOf($class, $header);
         $list = $header->getAddressList();
-        $this->assertEquals(3, count($list));
+        $this->assertEquals(4, count($list));
         $this->assertTrue($list->has('zf-devteam@zend.com'));
         $this->assertTrue($list->has('zf-contributors@lists.zend.com'));
         $this->assertTrue($list->has('fw-announce@lists.zend.com'));
@@ -152,7 +156,7 @@ class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
         $header   = call_user_func($callback, $headerLine);
         $this->assertInstanceOf($class, $header);
         $list = $header->getAddressList();
-        $this->assertEquals(3, count($list));
+        $this->assertEquals(4, count($list));
         $this->assertTrue($list->has('zf-devteam@zend.com'));
         $this->assertTrue($list->has('zf-contributors@lists.zend.com'));
         $this->assertTrue($list->has('fw-announce@lists.zend.com'));


### PR DESCRIPTION
Zend\Mail\Header\AbstractAddressList::fromString() gets confused if the name of a named email address is quoted and contains a comma, as it explodes the string using a comma, not taking into account the quotation. For example:
From: "Name, Given Name" my@email.com
is split into two addresses.

I'm adding a pull request to this issue whith a test case and hotfix.
