### PR TITLE
Support colon in console routes

### DIFF
--- a/library/Zend/Console/RouteMatcher/DefaultRouteMatcher.php
+++ b/library/Zend/Console/RouteMatcher/DefaultRouteMatcher.php
@@ -105,12 +105,16 @@ class DefaultRouteMatcher implements RouteMatcherInterface
         $parts  = array();
         $unnamedGroupCounter = 1;
 
+        // Masks
+        $allCaseMask   = '[a-zA-Z0-9\_\-\:]';
+        $upperCaseMask = '[A-Z0-9\_\-\:]';
+
         while ($pos < $length) {
             /**
              * Optional value param, i.e.
              *    [SOMETHING]
              */
-            if (preg_match('/\G\[(?P<name>[A-Z][A-Z0-9\_\-]*?)\](?: +|$)/s', $def, $m, 0, $pos)) {
+            if (preg_match('/\G\[(?P<name>[A-Z]'.$upperCaseMask.'*?)\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => strtolower($m['name']),
                     'literal'    => false,
@@ -123,7 +127,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Mandatory value param, i.e.
              *   SOMETHING
              */
-            elseif (preg_match('/\G(?P<name>[A-Z][A-Z0-9\_\-]*?)(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G(?P<name>[A-Z]'.$upperCaseMask.'*?)(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => strtolower($m['name']),
                     'literal'    => false,
@@ -136,7 +140,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Optional literal param, i.e.
              *    [something]
              */
-            elseif (preg_match('/\G\[ *?(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?) *?\](?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G\[ *?(?P<name>[a-zA-Z]'.$allCaseMask.'*?) *?\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => true,
@@ -149,7 +153,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Optional value param, syntax 2, i.e.
              *    [<something>]
              */
-            elseif (preg_match('/\G\[ *\<(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?)\> *\](?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G\[ *\<(?P<name>[a-zA-Z]'.$allCaseMask.'*?)\> *\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => false,
@@ -162,7 +166,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Mandatory value param, i.e.
              *    <something>
              */
-            elseif (preg_match('/\G\< *(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?) *\>(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G\< *(?P<name>[a-zA-Z]'.$allCaseMask.'*?) *\>(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => false,
@@ -175,7 +179,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Mandatory literal param, i.e.
              *   something
              */
-            elseif (preg_match('/\G(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?)(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G(?P<name>[a-zA-Z]'.$allCaseMask.'*?)(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => true,
@@ -189,7 +193,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              *    --param=
              *    --param=whatever
              */
-            elseif (preg_match('/\G--(?P<name>[a-zA-Z0-9][a-zA-Z0-9\_\-]+)(?P<hasValue>=\S*?)?(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G--(?P<name>[a-zA-Z0-9]'.$allCaseMask.'+)(?P<hasValue>=\S*?)?(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'short'      => false,
@@ -204,7 +208,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              *    [--param]
              */
             elseif (preg_match(
-                '/\G\[ *?--(?P<name>[a-zA-Z0-9][a-zA-Z0-9\_\-]+) *?\](?: +|$)/s', $def, $m, 0, $pos
+                '/\G\[ *?--(?P<name>[a-zA-Z0-9]'.$allCaseMask.'+) *?\](?: +|$)/s', $def, $m, 0, $pos
             )) {
                 $item = array(
                     'name'       => $m['name'],
@@ -221,7 +225,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              *    [--param=whatever]
              */
             elseif (preg_match(
-                '/\G\[ *?--(?P<name>[a-zA-Z0-9][a-zA-Z0-9\_\-]+)(?P<hasValue>=\S*?)? *?\](?: +|$)/s', $def, $m, 0, $pos
+                '/\G\[ *?--(?P<name>[a-zA-Z0-9]'.$allCaseMask.'+)(?P<hasValue>=\S*?)? *?\](?: +|$)/s', $def, $m, 0, $pos
             )) {
                 $item = array(
                     'name'       => $m['name'],
@@ -276,7 +280,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            (?P<name>[a-zA-Z][a-zA-Z0-9_\-]*?)
+                            (?P<name>[a-zA-Z]'.$allCaseMask.'*?)
                             \ *?
                             (?:\||(?=\]))
                             \ *?
@@ -316,7 +320,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            (?P<name>[a-zA-Z][a-zA-Z0-9_\-]+)
+                            (?P<name>[a-zA-Z]'.$allCaseMask.'+)
                             \ *?
                             (?:\||(?=\)))
                             \ *?
@@ -354,7 +358,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            \-+(?P<name>[a-zA-Z0-9][a-zA-Z0-9_\-]*?)
+                            \-+(?P<name>[a-zA-Z0-9]'.$allCaseMask.'*?)
                             \ *?
                             (?:\||(?=\)))
                             \ *?
@@ -397,7 +401,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            \-+(?P<name>[a-zA-Z0-9][a-zA-Z0-9_\-]*?)
+                            \-+(?P<name>[a-zA-Z0-9]'.$allCaseMask.'*?)
                             \ *?
                             (?:\||(?=\]))
                             \ *?

--- a/library/Zend/Console/RouteMatcher/DefaultRouteMatcher.php
+++ b/library/Zend/Console/RouteMatcher/DefaultRouteMatcher.php
@@ -105,16 +105,12 @@ class DefaultRouteMatcher implements RouteMatcherInterface
         $parts  = array();
         $unnamedGroupCounter = 1;
 
-        // Masks
-        $allCaseMask   = '[a-zA-Z0-9\_\-\:]';
-        $upperCaseMask = '[A-Z0-9\_\-\:]';
-
         while ($pos < $length) {
             /**
              * Optional value param, i.e.
              *    [SOMETHING]
              */
-            if (preg_match('/\G\[(?P<name>[A-Z]'.$upperCaseMask.'*?)\](?: +|$)/s', $def, $m, 0, $pos)) {
+            if (preg_match('/\G\[(?P<name>[A-Z][A-Z0-9\_\-]*?)\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => strtolower($m['name']),
                     'literal'    => false,
@@ -127,7 +123,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Mandatory value param, i.e.
              *   SOMETHING
              */
-            elseif (preg_match('/\G(?P<name>[A-Z]'.$upperCaseMask.'*?)(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G(?P<name>[A-Z][A-Z0-9\_\-]*?)(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => strtolower($m['name']),
                     'literal'    => false,
@@ -140,7 +136,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Optional literal param, i.e.
              *    [something]
              */
-            elseif (preg_match('/\G\[ *?(?P<name>[a-zA-Z]'.$allCaseMask.'*?) *?\](?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G\[ *?(?P<name>[a-zA-Z][a-zA-Z0-9\_\-\:]*?) *?\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => true,
@@ -153,7 +149,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Optional value param, syntax 2, i.e.
              *    [<something>]
              */
-            elseif (preg_match('/\G\[ *\<(?P<name>[a-zA-Z]'.$allCaseMask.'*?)\> *\](?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G\[ *\<(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?)\> *\](?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => false,
@@ -166,7 +162,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Mandatory value param, i.e.
              *    <something>
              */
-            elseif (preg_match('/\G\< *(?P<name>[a-zA-Z]'.$allCaseMask.'*?) *\>(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G\< *(?P<name>[a-zA-Z][a-zA-Z0-9\_\-]*?) *\>(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => false,
@@ -179,7 +175,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              * Mandatory literal param, i.e.
              *   something
              */
-            elseif (preg_match('/\G(?P<name>[a-zA-Z]'.$allCaseMask.'*?)(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G(?P<name>[a-zA-Z][a-zA-Z0-9\_\-\:]*?)(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'literal'    => true,
@@ -193,7 +189,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              *    --param=
              *    --param=whatever
              */
-            elseif (preg_match('/\G--(?P<name>[a-zA-Z0-9]'.$allCaseMask.'+)(?P<hasValue>=\S*?)?(?: +|$)/s', $def, $m, 0, $pos)) {
+            elseif (preg_match('/\G--(?P<name>[a-zA-Z0-9][a-zA-Z0-9\_\-]+)(?P<hasValue>=\S*?)?(?: +|$)/s', $def, $m, 0, $pos)) {
                 $item = array(
                     'name'       => $m['name'],
                     'short'      => false,
@@ -208,7 +204,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              *    [--param]
              */
             elseif (preg_match(
-                '/\G\[ *?--(?P<name>[a-zA-Z0-9]'.$allCaseMask.'+) *?\](?: +|$)/s', $def, $m, 0, $pos
+                '/\G\[ *?--(?P<name>[a-zA-Z0-9][a-zA-Z0-9\_\-]+) *?\](?: +|$)/s', $def, $m, 0, $pos
             )) {
                 $item = array(
                     'name'       => $m['name'],
@@ -225,7 +221,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
              *    [--param=whatever]
              */
             elseif (preg_match(
-                '/\G\[ *?--(?P<name>[a-zA-Z0-9]'.$allCaseMask.'+)(?P<hasValue>=\S*?)? *?\](?: +|$)/s', $def, $m, 0, $pos
+                '/\G\[ *?--(?P<name>[a-zA-Z0-9][a-zA-Z0-9\_\-]+)(?P<hasValue>=\S*?)? *?\](?: +|$)/s', $def, $m, 0, $pos
             )) {
                 $item = array(
                     'name'       => $m['name'],
@@ -280,7 +276,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            (?P<name>[a-zA-Z]'.$allCaseMask.'*?)
+                            (?P<name>[a-zA-Z][a-zA-Z0-9_\-]*?)
                             \ *?
                             (?:\||(?=\]))
                             \ *?
@@ -320,7 +316,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            (?P<name>[a-zA-Z]'.$allCaseMask.'+)
+                            (?P<name>[a-zA-Z][a-zA-Z0-9_\-]+)
                             \ *?
                             (?:\||(?=\)))
                             \ *?
@@ -358,7 +354,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            \-+(?P<name>[a-zA-Z0-9]'.$allCaseMask.'*?)
+                            \-+(?P<name>[a-zA-Z0-9][a-zA-Z0-9_\-]*?)
                             \ *?
                             (?:\||(?=\)))
                             \ *?
@@ -401,7 +397,7 @@ class DefaultRouteMatcher implements RouteMatcherInterface
                     (?P<options>
                         (?:
                             \ *?
-                            \-+(?P<name>[a-zA-Z0-9]'.$allCaseMask.'*?)
+                            \-+(?P<name>[a-zA-Z0-9][a-zA-Z0-9_\-]*?)
                             \ *?
                             (?:\||(?=\]))
                             \ *?

--- a/tests/ZendTest/Console/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/tests/ZendTest/Console/RouteMatcher/DefaultRouteMatcherTest.php
@@ -321,9 +321,24 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
                 array('fooo'),
                 null
             ),
+            'mandatory-literal-colon-match' => array(
+                'foo:bar',
+                array('foo:bar'),
+                array('foo:bar' => null)
+            ),
+            'mandatory-literal-colon-match-2' => array(
+                'foo:bar baz',
+                array('foo:bar', 'baz'),
+                array('foo:bar' => null, 'baz' => null)
+            ),
             'mandatory-literal-order' => array(
                 'foo bar',
                 array('bar','foo'),
+                null
+            ),
+            'mandatory-literal-order-colon' => array(
+                'foo bar baz:inga',
+                array('bar','foo', 'baz:inga'),
                 null
             ),
             'mandatory-literal-partial-mismatch' => array(
@@ -373,9 +388,19 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
                 array('foo','bar'),
                 array('foo' => null, 'bar' => true, 'baz' => null)
             ),
+            'optional-literal-colon-match' => array(
+                'foo [bar] [baz:inga]',
+                array('foo','bar'),
+                array('foo' => null, 'bar' => true, 'baz:inga' => null)
+            ),
             'optional-literal-mismatch' => array(
                 'foo [bar] [baz]',
                 array('baz','bar'),
+                null
+            ),
+            'optional-literal-colon-mismatch' => array(
+                'foo [bar] [baz:inga]',
+                array('baz:inga','bar'),
                 null
             ),
             'optional-literal-shuffled-mismatch' => array(


### PR DESCRIPTION
I think Symfony supports this already. I wanted to create a route such like this:

`php public/index.php engine:generate controller` but couldn't because colons were not supported. I added support for flags as well, but it can be limited to parameters only.

Will write tests if it's approved.
