### PR TITLE
Fix: Undefined field in Zend\Http\Header\Origin

### DIFF
--- a/library/Zend/Http/Header/Origin.php
+++ b/library/Zend/Http/Header/Origin.php
@@ -17,6 +17,10 @@ use Zend\Uri\UriFactory;
  */
 class Origin implements HeaderInterface
 {
+    /**
+     * @var string
+     */
+    private $value;
 
     public static function fromString($headerLine)
     {


### PR DESCRIPTION
Field `$value` is used, but never declared.
