### PR TITLE
Header\ContentType: remove empty values from parsed header

### DIFF
--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -37,6 +37,9 @@ class ContentType implements HeaderInterface
         $values = preg_split('#\s*;\s*#', $value);
         $type   = array_shift($values);
 
+        //Remove empty values
+        $values = array_filter($values);
+
         $header = new static();
         $header->setType($type);
 

--- a/tests/ZendTest/Mail/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Mail/Header/ContentTypeTest.php
@@ -48,6 +48,15 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Content-Type: foo/bar", $contentTypeHeader->toString());
     }
 
+    public function testTrailingSemiColonFromString()
+    {
+        $contentTypeHeader = ContentType::fromString(
+            'Content-Type: multipart/alternative; boundary="Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD";'
+        );
+        $params = $contentTypeHeader->getParameters();
+        $this->assertEquals($params,array('boundary' => 'Apple-Mail=_1B852F10-F9C6-463D-AADD-CD503A5428DD'));
+    }
+
     public function testProvidingParametersIntroducesHeaderFolding()
     {
         $header = new ContentType();


### PR DESCRIPTION
Fix bug where a header string ending in ';' will add an empty element in array, triggering an 'Undefined offset' error later.
