### PR TITLE
CollectionInputFilter throws warning if invalid collection provided

### DIFF
--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -612,4 +612,18 @@ class CollectionInputFilterTest extends TestCase
         $values = $inputFilter->getValues();
         $this->assertEquals($data, $values);
     }
+    
+    public function testInvalidCollectionIsNotValid()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
+        $data = 1;
+
+        $this->filter->setInputFilter($this->getBaseInputFilter());
+        $this->filter->setData($data);
+
+        $this->assertFalse($this->filter->isValid());
+    }
 }

--- a/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/CollectionInputFilterTest.php
@@ -612,13 +612,9 @@ class CollectionInputFilterTest extends TestCase
         $values = $inputFilter->getValues();
         $this->assertEquals($data, $values);
     }
-    
+
     public function testInvalidCollectionIsNotValid()
     {
-        if (!extension_loaded('intl')) {
-            $this->markTestSkipped('ext/intl not enabled');
-        }
-
         $data = 1;
 
         $this->filter->setInputFilter($this->getBaseInputFilter());


### PR DESCRIPTION
invalid value for foreach that means not traversable or iteratable array

throws php Warning: `Invalid argument supplied for foreach()`
