### PR TITLE
Redis Server URI correct parsing

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -293,7 +293,7 @@ class RedisResourceManager
             $this->normalizePersistentId($resource['persistent_id']);
             $this->normalizeLibOptions($resource['lib_options']);
             $password = $this->normalizeServer($resource['server']);
-            if (empty($resource['password']) && $password !== null){
+            if (empty($resource['password']) && $password !== null) {
                 $resource['password'] = $password;
             }
         } else {
@@ -556,8 +556,7 @@ class RedisResourceManager
         if ($resource['resource'] instanceof RedisResource) {
             if (empty($resource['password']) && $password) {
                 $this->setResource($id, array('server' => $server, 'password' => $password));
-            }
-            else {
+            } else {
                 $this->setResource($id, array('server' => $server));
             }
         } else {

--- a/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php
@@ -162,10 +162,12 @@ class RedisResourceManager
      * array('host' => <host>[, 'port' => <port>[, 'timeout' => <timeout>]])
      *
      * @param string|array $server
+     * @return string|null password parsed from server URI string if any
      * @throws Exception\InvalidArgumentException
      */
     protected function normalizeServer(&$server)
     {
+        $password = null;
         $host    = null;
         $port    = null;
         $timeout = 0;
@@ -192,9 +194,10 @@ class RedisResourceManager
         } else {
             // parse server from URI host{:?port}
             $server = trim($server);
-            if (!strpos($server, '/') === 0) {
+            if (strpos($server, '/') !== 0) {
                 //non unix domain socket connection
                 $server = parse_url($server);
+                $password = isset($server['pass']) ? $server['pass'] : null;
             } else {
                 $server = array('host' => $server);
             }
@@ -216,6 +219,7 @@ class RedisResourceManager
             'port'    => $port,
             'timeout' => $timeout,
         );
+        return $password;
     }
 
     /**
@@ -288,7 +292,10 @@ class RedisResourceManager
             // normalize and validate params
             $this->normalizePersistentId($resource['persistent_id']);
             $this->normalizeLibOptions($resource['lib_options']);
-            $this->normalizeServer($resource['server']);
+            $password = $this->normalizeServer($resource['server']);
+            if (empty($resource['password']) && $password !== null){
+                $resource['password'] = $password;
+            }
         } else {
             //there are two ways of determining if redis is already initialized
             //with connect function:
@@ -543,13 +550,21 @@ class RedisResourceManager
             ));
         }
 
-        $this->normalizeServer($server);
+        $password = $this->normalizeServer($server);
 
         $resource = & $this->resources[$id];
         if ($resource['resource'] instanceof RedisResource) {
-            $this->setResource($id, array('server' => $server));
+            if (empty($resource['password']) && $password) {
+                $this->setResource($id, array('server' => $server, 'password' => $password));
+            }
+            else {
+                $this->setResource($id, array('server' => $server));
+            }
         } else {
             $resource['server'] = $server;
+            if (empty($resource['password']) && $password) {
+                $resource['password'] = $password;
+            }
         }
         return $this;
     }

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisResourceManagerTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisResourceManagerTest.php
@@ -32,6 +32,37 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
         $this->resourceManager = new RedisResourceManager();
     }
 
+    public function testSetServer()
+    {
+        $dummyResId = '1234567890';
+        $server = 'redis://dummyuser:dummypass@testhost:1234';
+        $this->resourceManager->setServer($dummyResId, $server);
+        $server = $this->resourceManager->getServer($dummyResId);
+        $this->assertEquals('testhost', $server['host']);
+        $this->assertEquals(1234, $server['port']);
+        $this->assertEquals('dummypass', $this->resourceManager->getPassword($dummyResId));
+
+        $dummyResId2 = '12345678901';
+        $resource   = array(
+            'persistent_id' => 1234,
+            'server' => $server,
+            'password' => 'abcd1234'
+        );
+        $this->resourceManager->setResource($dummyResId2, $resource);
+        $this->assertEquals('testhost', $server['host']);
+        $this->assertEquals(1234, $server['port']);
+        // Password should not be overridden
+        $this->assertEquals('abcd1234', $this->resourceManager->getPassword($dummyResId2));
+
+        $server2 = 'redis://dummyuser:dummypass@testhost2:1234';
+        $this->resourceManager->setServer($dummyResId2, $server2);
+        $server = $this->resourceManager->getServer($dummyResId2);
+        $this->assertEquals('testhost2', $server['host']);
+        $this->assertEquals(1234, $server['port']);
+        // Password should not be overridden
+        $this->assertEquals('abcd1234', $this->resourceManager->getPassword($dummyResId2));
+    }
+
     /**
      * Test with 'persistent_id'
      */


### PR DESCRIPTION
Including password support.

Some PaaS give you full-blown URIs to configure Redis (and other servers) - up until now the URIs were not parsed due to a bad condition in normalizeServer and there was no support for URIs containing a password anyway. This should fix both.
