### PR TITLE
Provided failing tests for CurrencyFormat helper

### DIFF
--- a/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
+++ b/tests/ZendTest/I18n/View/Helper/CurrencyFormatTest.php
@@ -63,6 +63,13 @@ class CurrencyFormatTest extends \PHPUnit_Framework_TestCase
             //array('en_US', 'EUR',     false,             1234567.891234567890000,  null, '€1,234,568'),
             //array('en_US', 'EUR',     false,             1234567.891234567890000,  null, '€1,234,568'),
             array('en_US', 'USD',       false, 1234567.891234567890000, null,                       '$1,234,568'),
+            array('de_DE', 'USD',       true,  0.123,                   null,                       '0,12 $'),
+            array('de_DE', 'USD',       false, 0.123,                   null,                       '0 $'),
+            array('de_DE', 'LYD',       true,  0.1231231,               null,                       '0,123 LYD'),
+            array('de_DE', 'LYD',       true,  0.123,                   '#,##0.00 ¤',               '0,12 LYD'),
+            array('de_DE', 'LYD',       false, 0.1231231,               null,                       '0 LYD'),
+            array('de_DE', 'EUR',       true,  1234.56,                 null,                       '1.234,56 €'),
+            array('de_DE', 'EUR',       true,  0.123,                   null,                       '0,12 €'),
         );
     }
 


### PR DESCRIPTION
referencing https://github.com/zendframework/zf2/pull/2318
We're on icu version 51.2 and still have the problem of wrong formatting for some locale and currency code combination

Please run this test and verify the results
