### PR TITLE
swap order of initalization

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -39,12 +39,12 @@ class Factory
      */
     public function __construct(InputFilterPluginManager $inputFilterManager = null)
     {
+        $this->defaultFilterChain    = new FilterChain();
+        $this->defaultValidatorChain = new ValidatorChain();
+        
         if ($inputFilterManager) {
             $this->setInputFilterManager($inputFilterManager);
         }
-
-        $this->defaultFilterChain    = new FilterChain();
-        $this->defaultValidatorChain = new ValidatorChain();
     }
 
     /**

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -570,6 +570,13 @@ class FactoryTest extends TestCase
         $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
     }
 
+    public function testSetInputFilterManagerOnConstruct()
+    {
+        $inputFilterManager = new InputFilterPluginManager();
+        $factory = new Factory($inputFilterManager);
+        $this->assertSame($inputFilterManager, $factory->getInputFilterManager());
+    }
+
     /**
      * @group 5691
      *


### PR DESCRIPTION
Since setInputFilterManager will use the defaultFilterChain and defaultValidatorChain the original order of execution gave a "call to a member function setPluginManager() on a non-object" error. 
