### PR TITLE
fixed conflicted phpdoc return values (see #6511)

### DIFF
--- a/library/Zend/EventManager/SharedEventManagerInterface.php
+++ b/library/Zend/EventManager/SharedEventManagerInterface.php
@@ -33,7 +33,7 @@ interface SharedEventManagerInterface
      * @param  string $event
      * @param  callable $callback PHP Callback
      * @param  int $priority Priority at which listener should execute
-     * @return void
+     * @return CallbackHandler|array Either CallbackHandler or array of CallbackHandlers
      */
     public function attach($id, $event, $callback, $priority = 1);
 


### PR DESCRIPTION
As explained in #6511, the phpdoc `@return` value in the interface was not conformed to the actual behaviour
