### PR TITLE
Ignore some files/paths when running CS checks

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,6 @@
 <?php
 $finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->notPath('Zend/View/Stream.php')
     ->notPath('ZendTest/Code/Generator/TestAsset')
     ->notPath('ZendTest/Code/Reflection/FunctionReflectionTest.php')
     ->notPath('ZendTest/Code/Reflection/MethodReflectionTest.php')
@@ -8,6 +9,8 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->notPath('ZendTest/Validator/_files')
     ->notPath('ZendTest/Loader/_files')
     ->notPath('ZendTest/Loader/TestAsset')
+    ->notPath('demos')
+    ->notPath('resources')
     ->filter(function (SplFileInfo $file) {
         if (strstr($file->getPath(), 'compatibility')) {
             return false;


### PR DESCRIPTION
- Recent changes to php-cs-fixer (see
  https://github.com/fabpot/PHP-CS-Fixer/issues/422) have led to errors being
  raised that should not. This change to the php-cs-fixer configuration places
  several new paths into the "do not test" list. They will be re-instated when
  the issues are fixed.
