### PR TITLE
AbstractAdapter::getItem() should return null, if the item cannot be retrieved

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -370,7 +370,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
-            $result = false;
+            $result = null;
+            $success = false;
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }

--- a/tests/ZendTest/Cache/Storage/Adapter/AbstractAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/AbstractAdapterTest.php
@@ -356,6 +356,32 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, $rs);
     }
 
+    public function testGetItemReturnsNullIfFailed()
+    {
+        $this->_storage = $this->getMockForAbstractAdapter(['internalGetItem']);
+
+        $key    = 'key1';
+
+        // Do not throw exceptions outside the adapter
+        $pluginOptions = new Cache\Storage\Plugin\PluginOptions(
+            array('throw_exceptions' => false)
+        );
+        $plugin = new Cache\Storage\Plugin\ExceptionHandler();
+        $plugin->setOptions($pluginOptions);
+        $this->_storage->addPlugin($plugin);
+
+        // Simulate internalGetItem() throwing an exception
+        $this->_storage
+            ->expects($this->once())
+            ->method('internalGetItem')
+            ->with($this->equalTo($key))
+            ->will($this->throwException(new \Exception('internalGet failed')));
+
+        $result = $this->_storage->getItem($key, $success);
+        $this->assertNull($result, 'GetItem should return null the item cannot be retrieved');
+        $this->assertFalse($success, '$success should be false if the item cannot be retrieved');
+    }
+
 /*
     public function testGetMetadatas()
     {

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -114,33 +114,6 @@ class RedisTest extends CommonAdapterTest
         $this->assertCount(count($value), $this->_storage->getItem('key'), 'Problem with Redis serialization');
     }
 
-
-    public function testRedisGetItemIfRedisNotAvailable()
-    {
-        // Simulate unavailable Redis server
-        $portWithoutRedis = 50000;
-        $this->_options->getResourceManager()->setServer(__CLASS__, array(
-            TESTS_ZEND_CACHE_REDIS_HOST, $portWithoutRedis
-        ));
-        $this->_storage->setOptions($this->_options);
-
-        // Do not throw the exception
-        $pluginOptions = new Cache\Storage\Plugin\PluginOptions(
-            array('throw_exceptions' => false)
-        );
-        $plugin = new Cache\Storage\Plugin\ExceptionHandler();
-        $plugin->setOptions($pluginOptions);
-        $this->_storage->addPlugin($plugin);
-
-        $key = 'not_existing_key';
-        $value = $this->_storage->getItem($key, $success);
-        $this->assertSame(null, $value, 'GetItem should return null if the key is not set');
-        $this->assertFalse($success, '$success should be false, if the item cannot be retrieved');
-
-        // Prevent an exception, when tearDown() tries to flush Redis
-        $this->_storage = null;
-    }
-
     public function testRedisSetInt()
     {
         $key = 'key';

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -119,14 +119,14 @@ class RedisTest extends CommonAdapterTest
     {
         // Simulate unavailable Redis server
         $portWithoutRedis = 50000;
-        $this->_options->getResourceManager()->setServer(__CLASS__, [
+        $this->_options->getResourceManager()->setServer(__CLASS__, array(
             TESTS_ZEND_CACHE_REDIS_HOST, $portWithoutRedis
-        ]);
+        ));
         $this->_storage->setOptions($this->_options);
 
         // Do not throw the exception
         $pluginOptions = new Cache\Storage\Plugin\PluginOptions(
-            ['throw_exceptions' => false]
+            array('throw_exceptions' => false)
         );
         $plugin = new Cache\Storage\Plugin\ExceptionHandler();
         $plugin->setOptions($pluginOptions);

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -114,6 +114,33 @@ class RedisTest extends CommonAdapterTest
         $this->assertCount(count($value), $this->_storage->getItem('key'), 'Problem with Redis serialization');
     }
 
+
+    public function testRedisGetItemIfRedisNotAvailable()
+    {
+        // Simulate unavailable Redis server
+        $portWithoutRedis = 50000;
+        $this->_options->getResourceManager()->setServer(__CLASS__, [
+            TESTS_ZEND_CACHE_REDIS_HOST, $portWithoutRedis
+        ]);
+        $this->_storage->setOptions($this->_options);
+
+        // Do not throw the exception
+        $pluginOptions = new Cache\Storage\Plugin\PluginOptions(
+            ['throw_exceptions' => false]
+        );
+        $plugin = new Cache\Storage\Plugin\ExceptionHandler();
+        $plugin->setOptions($pluginOptions);
+        $this->_storage->addPlugin($plugin);
+
+        $key = 'not_existing_key';
+        $value = $this->_storage->getItem($key, $success);
+        $this->assertSame(null, $value, 'GetItem should return null if the key is not set');
+        $this->assertFalse($success, '$success should be false, if the item cannot be retrieved');
+
+        // Prevent an exception, when tearDown() tries to flush Redis
+        $this->_storage = null;
+    }
+
     public function testRedisSetInt()
     {
         $key = 'key';


### PR DESCRIPTION
The AbstractAdapter::getItem() is specified to return _null_, if the item cannot be retrieved. Also the _$success_ variable passed by reference should be set to _false_ in this case.

In our setup we've encountered errors, because it was not the case. We are using Redis as cache, and have configured the ExceptionHandler Plugin to not throw exceptions ('throw_exceptions' => false), because if the cache fails, it is not breaking the application. But in this case, if the Redis server is unavailable, the getItem() function, return _false_ instead of _null_, also the _$success_ variable is set to _null_ instead of _false_. This is not the expected behavior, and our app was broken, because we checked explicitly, if the return value is strictly not null ($value !== null) 

The problem is not only in Redis, but in the AbstractAdapter generally. If there is an exception in getItem(), and this exception is ignored (which is rather ok, for the cache), the $success var is not set and the result equals to null.

As a proof, i have made a unit test for the Redis class. It would be better, to make a general AbstractAdapter unit test, i could make if you give me some ideas how it can be done :)
