### PR TITLE
[Http] Rationalize timeout behavior between adapters

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -201,8 +201,17 @@ class Curl implements HttpAdapter, StreamInterface
         }
 
         if (isset($this->config['timeout'])) {
-            // Set timeout
-            curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->config['timeout']);
+            if (defined('CURLOPT_CONNECTTIMEOUT_MS')) {
+                curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT_MS, $this->config['timeout'] * 1000);
+            } else {
+                curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->config['timeout']);
+            }
+
+            if (defined('CURLOPT_TIMEOUT_MS')) {
+                curl_setopt($this->curl, CURLOPT_TIMEOUT_MS, $this->config['timeout'] * 1000);
+            } else {
+                curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->config['timeout']);
+            }
         }
 
         if (isset($this->config['maxredirects'])) {


### PR DESCRIPTION
Hey!

This PR rationalizes the timeout behavior across adapters. (curl only set timeout for connect whereas the socket sets it for connect/read timeout). Additionally, `CURLOPT_CONNECTTIMEOUT_MS` and `CURLOPT_TIMEOUT_MS` has been introduced in curl 7.16.2, so if it is defined it is better to rely on them because they are more precise.
