### PR TITLE
Zend Db Query Builder Optimisation

### DIFF
--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -107,8 +107,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             }
         } elseif (is_string($name)) {
             // is a string:
-            $currentNames = array_keys($this->data);
-            $position = array_search($name, $currentNames, true);
+            $position = isset($this->data[$name]);
         } elseif ($name === null) {
             $name = (string) count($this->data);
         } else {

--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -107,7 +107,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             }
         } elseif (is_string($name)) {
             // is a string:
-            $position = isset($this->data[$name]);
+            $position = array_key_exists($name, $this->data);
         } elseif ($name === null) {
             $name = (string) count($this->data);
         } else {


### PR DESCRIPTION
Found that the query builder was spending a long time building queries with large arrays in the where clause. After a little bit of profiling noticed that line 111 was been called a lot. `array_search` is an expensive lookup, especially as the return value wasn't been used beyond checking it wasn't false, so replaced with a less expensive `isset`.
