### PR TITLE
ServiceManager peering does not respect shared flag 

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -437,15 +437,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $cName = $this->canonicalizeName($name);
 
-        if (!isset($this->shared[$cName])) {
-            return $this->shareByDefault();
-        }
-
-        if (
-            !isset($this->invokableClasses[$cName])
-            && !isset($this->factories[$cName])
-            && !$this->canCreateFromAbstractFactory($cName, $name)
-        ) {
+        if ( ! $this->has($name) ) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: A service by the name "%s" was not found',
                 get_class($this) . '::' . __FUNCTION__,
@@ -453,6 +445,10 @@ class ServiceManager implements ServiceLocatorInterface
             ));
         }
 
+        if (!isset($this->shared[$cName])) {
+            return $this->shareByDefault();
+        }
+        
         return $this->shared[$cName];
     }
 

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -437,7 +437,7 @@ class ServiceManager implements ServiceLocatorInterface
     {
         $cName = $this->canonicalizeName($name);
 
-        if ( ! $this->has($name) ) {
+        if (!$this->has($name)) {
             throw new Exception\ServiceNotFoundException(sprintf(
                 '%s: A service by the name "%s" was not found',
                 get_class($this) . '::' . __FUNCTION__,

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1165,4 +1165,19 @@ class ServiceManagerTest extends TestCase
             array(tmpfile())
         );
     }
+
+    /**
+     * @group ZF2-4377
+     */
+    public function testServiceManagerRespectsSharedFlagWhenRetrievingFromPeeredServiceManager()
+    {
+        $this->serviceManager->setInvokableClass('foo', 'ZendTest\ServiceManager\TestAsset\Foo');
+        $this->serviceManager->setShared('foo', false);
+
+        $childManager = new ServiceManager(new Config());
+        $childManager->addPeeringServiceManager($this->serviceManager);
+        $childManager->setRetrieveFromPeeringManagerFirst(false);
+
+        $this->assertNotSame($childManager->get('foo'), $childManager->get('foo'));
+    }
 }

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1180,4 +1180,13 @@ class ServiceManagerTest extends TestCase
 
         $this->assertNotSame($childManager->get('foo'), $childManager->get('foo'));
     }
+
+    /**
+     * @group ZF2-4377
+     */
+    public function testIsSharedThrowsExceptionWhenPassedNameWhichDoesNotExistAnywhere()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
+        $this->serviceManager->isShared('foobarbazbat');
+    }
 }


### PR DESCRIPTION
When pulling a service from a peered ServiceManager it's shared flag is not respected:  If the service is marked as non-shared in the peered service, the SM which is retrieving it will still cache it internally and return that same instance upon multiple calls to `get('servicename')`

This will (obviously) change the behaviour of any code suffering from this bug:  they will now receive a new instance on each get call instead of the same instance each time.  This would likely constitute a BC break, but IMO services are usually marked non-shared for a specific reason and so there is a high probability that any code experiencing this bug is already broken. 
