### PR TITLE
Remove double dots from cache path without keys

### DIFF
--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -107,8 +107,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             }
         } elseif (is_string($name)) {
             // is a string:
-            $currentNames = array_keys($this->data);
-            $position = array_search($name, $currentNames, true);
+            $position = isset($this->data[$name]);
         } elseif ($name === null) {
             $name = (string) count($this->data);
         } else {

--- a/library/Zend/Db/Adapter/ParameterContainer.php
+++ b/library/Zend/Db/Adapter/ParameterContainer.php
@@ -107,7 +107,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             }
         } elseif (is_string($name)) {
             // is a string:
-            $position = isset($this->data[$name]);
+            $position = array_key_exists($name, $this->data);
         } elseif ($name === null) {
             $name = (string) count($this->data);
         } else {

--- a/library/Zend/ModuleManager/Listener/ListenerOptions.php
+++ b/library/Zend/ModuleManager/Listener/ListenerOptions.php
@@ -250,7 +250,11 @@ class ListenerOptions extends AbstractOptions
      */
     public function getConfigCacheFile()
     {
-        return $this->getCacheDir() . '/module-config-cache.' . $this->getConfigCacheKey().'.php';
+        if ($this->getConfigCacheKey()) {
+            return $this->getCacheDir() . '/module-config-cache.' . $this->getConfigCacheKey().'.php';
+        }
+
+        return $this->getCacheDir() . '/module-config-cache.php';
     }
 
     /**
@@ -330,7 +334,11 @@ class ListenerOptions extends AbstractOptions
      */
     public function getModuleMapCacheFile()
     {
-        return $this->getCacheDir() . '/module-classmap-cache.'.$this->getModuleMapCacheKey().'.php';
+        if ($this->getModuleMapCacheKey()) {
+            return $this->getCacheDir() . '/module-classmap-cache.' . $this->getModuleMapCacheKey() . '.php';
+        }
+
+        return $this->getCacheDir() . '/module-classmap-cache.php';
     }
 
     /**

--- a/tests/ZendTest/ModuleManager/Listener/ListenerOptionsTest.php
+++ b/tests/ZendTest/ModuleManager/Listener/ListenerOptionsTest.php
@@ -35,6 +35,36 @@ class ListenerOptionsTest extends TestCase
         $this->assertSame(array('static', 'custom_paths'), $options->getConfigStaticPaths());
     }
 
+    public function testConfigCacheFileWithEmptyCacheKey()
+    {
+        $options = new ListenerOptions(array(
+           'cache_dir'               => __DIR__,
+           'config_cache_enabled'    => true,
+           'module_paths'            => array('module','paths'),
+           'config_glob_paths'       => array('glob','paths'),
+           'config_static_paths'     => array('static','custom_paths'),
+       ));
+
+        $this->assertEquals(__DIR__ . '/module-config-cache.php', $options->getConfigCacheFile());
+        $options->setConfigCacheKey('foo');
+        $this->assertEquals(__DIR__ . '/module-config-cache.foo.php', $options->getConfigCacheFile());
+    }
+
+    public function testModuleMapCacheFileWithEmptyCacheKey()
+    {
+        $options = new ListenerOptions(array(
+           'cache_dir'                => __DIR__,
+           'module_map_cache_enabled' => true,
+           'module_paths'             => array('module','paths'),
+           'config_glob_paths'        => array('glob','paths'),
+           'config_static_paths'      => array('static','custom_paths'),
+       ));
+
+        $this->assertEquals(__DIR__ . '/module-classmap-cache.php', $options->getModuleMapCacheFile());
+        $options->setModuleMapCacheKey('foo');
+        $this->assertEquals(__DIR__ . '/module-classmap-cache.foo.php', $options->getModuleMapCacheFile());
+    }
+
     public function testCanAccessKeysAsProperties()
     {
         $options = new ListenerOptions(array(


### PR DESCRIPTION
This PR is a continuation of #5165 from @juriansluiman that was closed by the lack of tests.

I only have added tests cases to this feature.
