### PR TITLE
Method for adding extra identifiers to Abstract Controller Event Manager

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -144,7 +144,7 @@ abstract class AbstractController implements
      */
     public function getResponse()
     {
-        if (! $this->response) {
+        if (!$this->response) {
             $this->response = new HttpResponse();
         }
 

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -81,12 +81,6 @@ abstract class AbstractController implements
      * @var string
      */
     protected $eventIdentifier;
-    
-    /**
-     * 
-     * @var array
-     */
-    protected $extraIdentifiers = array();
 
     /**
      * Execute the request
@@ -164,20 +158,20 @@ abstract class AbstractController implements
      * @return AbstractController
      */
     public function setEventManager(EventManagerInterface $events)
-    {
-         $eventManagerIdentifiers = array(
-            'Zend\Stdlib\DispatchableInterface',
-            __CLASS__,
-            get_class($this),
-            $this->eventIdentifier,
-            substr(get_class($this), 0, strpos(get_class($this), '\\'))
+    { 
+        $eventManagerIdentifiers = array (
+                'Zend\Stdlib\DispatchableInterface',
+                __CLASS__,
+                get_class ( $this ),
+                substr ( get_class ( $this ), 0, strpos ( get_class ( $this ), '\\' ) ) 
         );
         
-        if ($this->extraIdentifiers && is_array($this->extraIdentifiers)) {            
-            $eventManagerIdentifiers = array_unique(array_merge($eventManagerIdentifiers, $this->extraIdentifiers));           
-        } 
-                
+        $eventIdentifier = (array) $this->eventIdentifier;
+        
+        $eventManagerIdentifiers = array_unique(array_merge($eventManagerIdentifiers, $eventIdentifier));
+        
         $events->setIdentifiers($eventManagerIdentifiers);
+        
         $this->events = $events;
         $this->attachDefaultListeners();
 
@@ -316,26 +310,7 @@ abstract class AbstractController implements
 
         return $plugin;
     }
-    
-    /**
-     * Add extra identifiers to AbstractController
-     * 
-     * @param string|array $extraIdentifiers
-     * @return \Zend\Mvc\Controller\AbstractController
-     */
-    public function setExtraIdentifiers($extraIdentifiers)
-    {
-        if (is_array($extraIdentifiers)) {
-            foreach ($extraIdentifiers as $extraIdentifier) {
-                $this->extraIdentifiers[] = $extraIdentifier;
-            }
-        } else {
-            $this->extraIdentifiers[] = $extraIdentifiers;
-        }
-        
-        return $this;
-    }
-    
+
     /**
      * Register the default events for this controller
      *

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -133,7 +133,7 @@ abstract class AbstractController implements
         if (!$this->request) {
             $this->request = new HttpRequest();
         }
-
+        
         return $this->request;
     }
 
@@ -144,7 +144,7 @@ abstract class AbstractController implements
      */
     public function getResponse()
     {
-        if (!$this->response) {
+        if (! $this->response) {
             $this->response = new HttpResponse();
         }
 
@@ -159,18 +159,15 @@ abstract class AbstractController implements
      */
     public function setEventManager(EventManagerInterface $events)
     { 
-        $eventManagerIdentifiers = array (
-                'Zend\Stdlib\DispatchableInterface',
-                __CLASS__,
-                get_class ( $this ),
-                substr ( get_class ( $this ), 0, strpos ( get_class ( $this ), '\\' ) ) 
-        );
-        
-        $eventIdentifier = (array) $this->eventIdentifier;
-        
-        $eventManagerIdentifiers = array_unique(array_merge($eventManagerIdentifiers, $eventIdentifier));
-        
-        $events->setIdentifiers($eventManagerIdentifiers);
+        $events->setIdentifiers(array(
+            'Zend\Stdlib\DispatchableInterface',
+            __CLASS__,
+            get_class($this),
+            substr(get_class($this), 0, strpos(get_class($this), '\\'))
+        ));
+                
+        $eventIdentifiers = is_array($this->eventIdentifier) ? $this->eventIdentifier : array($this->eventIdentifier);
+        $events->addIdentifiers($eventIdentifiers);
         
         $this->events = $events;
         $this->attachDefaultListeners();

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -81,6 +81,12 @@ abstract class AbstractController implements
      * @var string
      */
     protected $eventIdentifier;
+    
+    /**
+     * 
+     * @var array
+     */
+    protected $extraIdentifiers = array();
 
     /**
      * Execute the request
@@ -159,13 +165,19 @@ abstract class AbstractController implements
      */
     public function setEventManager(EventManagerInterface $events)
     {
-        $events->setIdentifiers(array(
+         $eventManagerIdentifiers = array(
             'Zend\Stdlib\DispatchableInterface',
             __CLASS__,
             get_class($this),
             $this->eventIdentifier,
             substr(get_class($this), 0, strpos(get_class($this), '\\'))
-        ));
+        );
+        
+        if ($this->extraIdentifiers && is_array($this->extraIdentifiers)) {            
+            $eventManagerIdentifiers = array_unique(array_merge($eventManagerIdentifiers, $this->extraIdentifiers));           
+        } 
+                
+        $events->setIdentifiers($eventManagerIdentifiers);
         $this->events = $events;
         $this->attachDefaultListeners();
 
@@ -304,7 +316,26 @@ abstract class AbstractController implements
 
         return $plugin;
     }
-
+    
+    /**
+     * Add extra identifiers to AbstractController
+     * 
+     * @param string|array $extraIdentifiers
+     * @return \Zend\Mvc\Controller\AbstractController
+     */
+    public function setExtraIdentifiers($extraIdentifiers)
+    {
+        if (is_array($extraIdentifiers)) {
+            foreach ($extraIdentifiers as $extraIdentifier) {
+                $this->extraIdentifiers[] = $extraIdentifier;
+            }
+        } else {
+            $this->extraIdentifiers[] = $extraIdentifiers;
+        }
+        
+        return $this;
+    }
+    
     /**
      * Register the default events for this controller
      *


### PR DESCRIPTION
I extended the functionallity of Zend\Mvc\Controller\AbstractController because i face the following problem:

There was a need of a Zf2 module with the following structure:

Module Name: Modules

Modules
- src

-- FolderA 
-- FolderB 
- view

-- foldera 
-- folderb 

I wanted to disable the layout only for that module. So i need an identifier for that module only.

However namespace configuration was the following

```
   return array(
        'Zend\Loader\StandardAutoloader' => array(
                'namespaces' => array(
                   'FolderA' => __DIR__ . '/src/FolderA',
                   'FolderB' => __DIR__ . '/src/FolderB',
                ),
        ),
    );
```

Tha means that identifiers in AbstractController event manager are:

 'Zend\Stdlib\DispatchableInterface'
 'Zend\Mvc\Controller\AbstractController'
 'FolderA\Controller\IndexController'
 'AbstractModulesController'
 'FolderA' (or FolderB)

So i ve added some lines of code in case someone need to extend AstractActionController and implement his own 

"AbstractActionController" class setting also his own identifiers to the event manager.
