### PR TITLE
 AbstractAdapter::getItem() should return null, if the item cannot be retrieved

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
+++ b/library/Zend/Cache/Storage/Adapter/AbstractAdapter.php
@@ -370,7 +370,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             }
             return $this->triggerPost(__FUNCTION__, $args, $result);
         } catch (\Exception $e) {
-            $result = false;
+            $result = null;
+            $success = false;
             return $this->triggerException(__FUNCTION__, $args, $result, $e);
         }
     }

--- a/tests/ZendTest/Cache/Storage/Adapter/AbstractAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/AbstractAdapterTest.php
@@ -358,7 +358,7 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetItemReturnsNullIfFailed()
     {
-        $this->_storage = $this->getMockForAbstractAdapter(['internalGetItem']);
+        $this->_storage = $this->getMockForAbstractAdapter(array('internalGetItem'));
 
         $key    = 'key1';
 

--- a/tests/ZendTest/Cache/Storage/Adapter/AbstractAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/AbstractAdapterTest.php
@@ -356,6 +356,32 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, $rs);
     }
 
+    public function testGetItemReturnsNullIfFailed()
+    {
+        $this->_storage = $this->getMockForAbstractAdapter(['internalGetItem']);
+
+        $key    = 'key1';
+
+        // Do not throw exceptions outside the adapter
+        $pluginOptions = new Cache\Storage\Plugin\PluginOptions(
+            array('throw_exceptions' => false)
+        );
+        $plugin = new Cache\Storage\Plugin\ExceptionHandler();
+        $plugin->setOptions($pluginOptions);
+        $this->_storage->addPlugin($plugin);
+
+        // Simulate internalGetItem() throwing an exception
+        $this->_storage
+            ->expects($this->once())
+            ->method('internalGetItem')
+            ->with($this->equalTo($key))
+            ->will($this->throwException(new \Exception('internalGet failed')));
+
+        $result = $this->_storage->getItem($key, $success);
+        $this->assertNull($result, 'GetItem should return null the item cannot be retrieved');
+        $this->assertFalse($success, '$success should be false if the item cannot be retrieved');
+    }
+
 /*
     public function testGetMetadatas()
     {


### PR DESCRIPTION
_(Reopened the PR against develop branch, original PR: https://github.com/zendframework/zf2/pull/6525)_

The AbstractAdapter::getItem() is specified to return _null_, if the item cannot be retrieved. Also the _$success_ variable passed by reference should be set to _false_ in this case.

In our setup we've encountered errors, because it was not the case. We are using Redis as cache, and have configured the ExceptionHandler Plugin to not throw exceptions ('throw_exceptions' => false), because if the cache fails, it is not breaking the application. But in this case, if the Redis server is unavailable, the getItem() function, return _false_ instead of _null_, also the _$success_ variable is set to _null_ instead of _false_. This is not the expected behavior, and our app was broken, because we checked explicitly, if the return value is strictly not null ($value !== null) 

The problem is not only in Redis, but in the AbstractAdapter generally. If there is an exception in getItem(), and this exception is ignored (which is rather ok, for the cache), the $success var is not set and the result equals to null.
