### PR TITLE
Add failing test for encoded routes with a query

### DIFF
--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -371,9 +371,21 @@ class TreeRouteStack extends SimpleRouteStack
                 $uri->setScheme($this->requestUri->getScheme());
             }
 
-            return $uri->setPath($path)->normalize()->toString();
+            $uri->setPath($path);
+
+            if (!isset($options['normalize_path']) || $options['normalize_path']) {
+                $uri->normalize();
+            }
+
+            return $uri->toString();
         } elseif (!$uri->isAbsolute() && $uri->isValidRelative()) {
-            return $uri->setPath($path)->normalize()->toString();
+            $uri->setPath($path);
+
+            if (!isset($options['normalize_path']) || $options['normalize_path']) {
+                $uri->normalize();
+            }
+
+            return $uri->toString();
         }
 
         return $path;

--- a/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
@@ -258,7 +258,7 @@ class TreeRouteStackTest extends TestCase
             )
         );
 
-        $this->assertEquals('/this%2Fthat?foo=bar', $stack->assemble(array(), array('name' => 'index', 'query' => array('foo' => 'bar'))));
+        $this->assertEquals('/this%2Fthat?foo=bar', $stack->assemble(array(), array('name' => 'index', 'query' => array('foo' => 'bar'), 'normalize_path' => false)));
     }
 
     public function testAssembleWithScheme()

--- a/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/TreeRouteStackTest.php
@@ -229,6 +229,38 @@ class TreeRouteStackTest extends TestCase
         $this->assertEquals('/?foo=bar', $stack->assemble(array(), array('name' => 'index', 'query' => array('foo' => 'bar'))));
     }
 
+    public function testAssembleWithEncodedPath()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addRoute(
+            'index',
+            array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/this%2Fthat',
+                ),
+            )
+        );
+
+        $this->assertEquals('/this%2Fthat', $stack->assemble(array(), array('name' => 'index')));
+    }
+
+    public function testAssembleWithEncodedPathAndQueryParams()
+    {
+        $stack = new TreeRouteStack();
+        $stack->addRoute(
+            'index',
+            array(
+                'type' => 'Literal',
+                'options' => array(
+                    'route' => '/this%2Fthat',
+                ),
+            )
+        );
+
+        $this->assertEquals('/this%2Fthat?foo=bar', $stack->assemble(array(), array('name' => 'index', 'query' => array('foo' => 'bar'))));
+    }
+
     public function testAssembleWithScheme()
     {
         $uri   = new HttpUri();


### PR DESCRIPTION
A route like /this%2FAthat with a query string is being assembled
wrongly to /this/that?foo=bar
