### PR TITLE
Add ability to set SMTP envelope addresses

### DIFF
--- a/library/Zend/Mail/Transport/Envelope.php
+++ b/library/Zend/Mail/Transport/Envelope.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *
@@ -9,63 +10,18 @@
 
 namespace Zend\Mail\Transport;
 
-use Zend\Mail\Exception;
 use Zend\Stdlib\AbstractOptions;
 
 class Envelope extends AbstractOptions
 {
     /**
-     * @var string
+     * @var string|null
      */
-    protected $from = null;
+    protected $from;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $to = null;
+    protected $to;
 
-  
-    /**
-     * Get MAIL FROM
-     *
-     * @return string
-     */
-    public function getFrom()
-    {
-        return $this->from;
-    }
-
-    /**
-     * Set MAIL FROM
-     *
-     * @param  string $from
-     * @return Envelope
-     */
-    public function setFrom($from)
-    {
-        $this->from = (string) $from;
-        return $this;
-    }
-
-    /**
-     * Get RCPT TO
-     *
-     * @return string
-     */
-    public function getTo()
-    {
-        return $this->to;
-    }
-
-    /**
-     * Set RCPT TO
-     *
-     * @param  string $to
-     * @return Envelope
-     */
-    public function setTo($to)
-    {
-        $this->to = (string) $to;
-        return $this;
-    }
 }

--- a/library/Zend/Mail/Transport/Envelope.php
+++ b/library/Zend/Mail/Transport/Envelope.php
@@ -1,10 +1,9 @@
 <?php
-
 /**
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -24,4 +23,47 @@ class Envelope extends AbstractOptions
      */
     protected $to;
 
+    /**
+     * Get MAIL FROM
+     *
+     * @return string
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * Set MAIL FROM
+     *
+     * @param  string $from
+     * @return Envelope
+     */
+    public function setFrom($from)
+    {
+        $this->from = (string) $from;
+        return $this;
+    }
+
+    /**
+     * Get RCPT TO
+     *
+     * @return string
+     */
+    public function getTo()
+    {
+        return $this->to;
+    }
+
+    /**
+     * Set RCPT TO
+     *
+     * @param  string $to
+     * @return Envelope
+     */
+    public function setTo($to)
+    {
+        $this->to = $to;
+        return $this;
+    }
 }

--- a/library/Zend/Mail/Transport/Envelope.php
+++ b/library/Zend/Mail/Transport/Envelope.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail\Transport;
+
+use Zend\Mail\Exception;
+use Zend\Stdlib\AbstractOptions;
+
+class Envelope extends AbstractOptions
+{
+    /**
+     * @var string
+     */
+    protected $from = null;
+
+    /**
+     * @var string
+     */
+    protected $to = null;
+
+  
+    /**
+     * Get MAIL FROM
+     *
+     * @return string
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * Set MAIL FROM
+     *
+     * @param  string $from
+     * @return Envelope
+     */
+    public function setFrom($from)
+    {
+        $this->from = (string) $from;
+        return $this;
+    }
+
+    /**
+     * Get RCPT TO
+     *
+     * @return string
+     */
+    public function getTo()
+    {
+        return $this->to;
+    }
+
+    /**
+     * Set RCPT TO
+     *
+     * @param  string $to
+     * @return Envelope
+     */
+    public function setTo($to)
+    {
+        $this->to = (string) $to;
+        return $this;
+    }
+}

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -271,8 +271,8 @@ class Smtp implements TransportInterface
      */
     protected function prepareFromAddress(Message $message)
     {
-        if ($this->envelope) {
-            return $this->getEnvelope()->from;
+        if ($this->getEnvelope() && $this->getEnvelope()->getFrom()) {
+            return $this->getEnvelope()->getFrom();
         }
 
         $sender = $message->getSender();
@@ -301,8 +301,8 @@ class Smtp implements TransportInterface
      */
     protected function prepareRecipients(Message $message)
     {      
-        if (isset($this->envelope->to)) {
-           return (array) $this->envelope->to;
+        if ($this->getEnvelope() && $this->getEnvelope()->getTo()) {
+            return (array) $this->getEnvelope()->getTo();
         }
 
         $recipients = array();

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -28,7 +28,7 @@ class Smtp implements TransportInterface
     protected $options;
     
     /**
-     * @var Envelope
+     * @var Envelope|null
      */
     protected $envelope;
 
@@ -85,7 +85,7 @@ class Smtp implements TransportInterface
     /**
      * Set options
      *
-     * @param  SmtpOptions $options
+     * @param  Envelope $envelope
      * @return Smtp
      */
     public function setEnvelope(Envelope $envelope)
@@ -97,7 +97,7 @@ class Smtp implements TransportInterface
     /**
      * Get envelope
      *
-     * @return SmtpOptions
+     * @return Envelope|null
      */
     public function getEnvelope()
     {
@@ -271,10 +271,10 @@ class Smtp implements TransportInterface
      */
     protected function prepareFromAddress(Message $message)
     {
-        if (isset($this->envelope->from)) {
-            return $this->envelope->from;
+        if ($this->envelope) {
+            return $this->getEnvelope()->from;
         }
-        
+
         $sender = $message->getSender();
         if ($sender instanceof Address\AddressInterface) {
             return $sender->getEmail();
@@ -302,19 +302,20 @@ class Smtp implements TransportInterface
     protected function prepareRecipients(Message $message)
     {      
         if (isset($this->envelope->to)) {
-            $recipients = (array) $this->envelope->to;
-        } else {
-            $recipients = array();
-            foreach ($message->getTo() as $address) {
-                $recipients[] = $address->getEmail();
-            }
-            foreach ($message->getCc() as $address) {
-                $recipients[] = $address->getEmail();
-            }
-            foreach ($message->getBcc() as $address) {
-                $recipients[] = $address->getEmail();
-            }
+           return (array) $this->envelope->to;
         }
+
+        $recipients = array();
+        foreach ($message->getTo() as $address) {
+            $recipients[] = $address->getEmail();
+        }
+        foreach ($message->getCc() as $address) {
+            $recipients[] = $address->getEmail();
+        }
+        foreach ($message->getBcc() as $address) {
+            $recipients[] = $address->getEmail();
+        }
+
         $recipients = array_unique($recipients);
         return $recipients;
     }

--- a/library/Zend/Mail/Transport/Smtp.php
+++ b/library/Zend/Mail/Transport/Smtp.php
@@ -26,6 +26,11 @@ class Smtp implements TransportInterface
      * @var SmtpOptions
      */
     protected $options;
+    
+    /**
+     * @var Envelope
+     */
+    protected $envelope;
 
     /**
      * @var Protocol\Smtp
@@ -75,6 +80,28 @@ class Smtp implements TransportInterface
     public function getOptions()
     {
         return $this->options;
+    }
+    
+    /**
+     * Set options
+     *
+     * @param  SmtpOptions $options
+     * @return Smtp
+     */
+    public function setEnvelope(Envelope $envelope)
+    {
+        $this->envelope = $envelope;
+        return $this;
+    }
+    
+    /**
+     * Get envelope
+     *
+     * @return SmtpOptions
+     */
+    public function getEnvelope()
+    {
+        return $this->envelope;
     }
 
     /**
@@ -244,6 +271,10 @@ class Smtp implements TransportInterface
      */
     protected function prepareFromAddress(Message $message)
     {
+        if (isset($this->envelope->from)) {
+            return $this->envelope->from;
+        }
+        
         $sender = $message->getSender();
         if ($sender instanceof Address\AddressInterface) {
             return $sender->getEmail();
@@ -269,16 +300,20 @@ class Smtp implements TransportInterface
      * @return array
      */
     protected function prepareRecipients(Message $message)
-    {
-        $recipients = array();
-        foreach ($message->getTo() as $address) {
-            $recipients[] = $address->getEmail();
-        }
-        foreach ($message->getCc() as $address) {
-            $recipients[] = $address->getEmail();
-        }
-        foreach ($message->getBcc() as $address) {
-            $recipients[] = $address->getEmail();
+    {      
+        if (isset($this->envelope->to)) {
+            $recipients = (array) $this->envelope->to;
+        } else {
+            $recipients = array();
+            foreach ($message->getTo() as $address) {
+                $recipients[] = $address->getEmail();
+            }
+            foreach ($message->getCc() as $address) {
+                $recipients[] = $address->getEmail();
+            }
+            foreach ($message->getBcc() as $address) {
+                $recipients[] = $address->getEmail();
+            }
         }
         $recipients = array_unique($recipients);
         return $recipients;

--- a/tests/ZendTest/Mail/Protocol/SmtpTest.php
+++ b/tests/ZendTest/Mail/Protocol/SmtpTest.php
@@ -44,6 +44,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         ;
         $expectedMessage = "EHLO localhost\r\n"
                            . "MAIL FROM:<ralph.schindler@zend.com>\r\n"
+                           . "RCPT TO:<zf-devteam@zend.com>\r\n"
                            . "DATA\r\n"
                            . "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"
                            . "Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n"
@@ -70,6 +71,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         ;
         $expectedMessage = "EHLO localhost\r\n"
             . "MAIL FROM:<ralph.schindler@zend.com>\r\n"
+            . "RCPT TO:<zf-devteam@zend.com>\r\n"
             . "DATA\r\n"
             . "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"
             . "Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n"

--- a/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
+++ b/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
@@ -54,11 +54,11 @@ class SmtpProtocolSpy extends Smtp
     public function mail($from)
     {
         parent::mail($from);
-        $this->mail = $from;
     }
 
     public function rcpt($to)
     {
+        parent::rcpt($to);
         $this->rcpt = true;
         $this->rcptTest[] = $to;
     }

--- a/tests/ZendTest/Mail/Transport/SmtpTest.php
+++ b/tests/ZendTest/Mail/Transport/SmtpTest.php
@@ -106,16 +106,15 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $message = $this->getMessage();
         $this->transport->send($message);
 
-        $this->assertEquals('ralph.schindler@zend.com', $this->connection->getMail());
         $expectedRecipients = array('zf-devteam@zend.com', 'matthew@zend.com', 'zf-crteam@lists.zend.com');
         $this->assertEquals($expectedRecipients, $this->connection->getRecipients());
 
-        $data = $this->connection->getLog();
+        $data = $this->connection->getLog();echo $data;
+        $this->assertContains('MAIL FROM:<ralph.schindler@zend.com>', $data);
         $this->assertContains('To: ZF DevTeam <zf-devteam@zend.com>', $data);
         $this->assertContains('Subject: Testing Zend\Mail\Transport\Sendmail', $data);
         $this->assertContains("Cc: matthew@zend.com\r\n", $data);
         $this->assertNotContains("Bcc: \"CR-Team, ZF Project\" <zf-crteam@lists.zend.com>\r\n", $data);
-        $this->assertNotContains("zf-crteam@lists.zend.com", $data);
         $this->assertContains("From: zf-devteam@zend.com,\r\n Matthew <matthew@zend.com>\r\n", $data);
         $this->assertContains("X-Foo-Bar: Matthew\r\n", $data);
         $this->assertContains("Sender: Ralph Schindler <ralph.schindler@zend.com>\r\n", $data);

--- a/tests/ZendTest/Mail/Transport/SmtpTest.php
+++ b/tests/ZendTest/Mail/Transport/SmtpTest.php
@@ -109,7 +109,7 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $expectedRecipients = array('zf-devteam@zend.com', 'matthew@zend.com', 'zf-crteam@lists.zend.com');
         $this->assertEquals($expectedRecipients, $this->connection->getRecipients());
 
-        $data = $this->connection->getLog();echo $data;
+        $data = $this->connection->getLog();
         $this->assertContains('MAIL FROM:<ralph.schindler@zend.com>', $data);
         $this->assertContains('To: ZF DevTeam <zf-devteam@zend.com>', $data);
         $this->assertContains('Subject: Testing Zend\Mail\Transport\Sendmail', $data);


### PR DESCRIPTION
I am working on a program that is called from a mail server, and re-injects the message back into the mail queue to be sent to multiple recipients (using a Postfix content filter).  The problem is that this library forms the RCPT TO: information from the message headers, which in this case, will not work (the goal is for the message to arrive untouched).  There should be an option to pass SMTP-level message options to the transport to handle situations like this.

I currently have something like the following:

```
$email = file_get_contents("php://stdin");
$headers = $body = '';
Zend\Mime\Decode::splitMessage($email, $headers, $body);

// Setup SMTP transport
$transport = new Zend\Mail\Transport\Smtp();
$options = new Zend\Mail\Transport\SmtpOptions(
        array(
    'name' => php_uname('n'),
    'host' => '127.0.0.1',
    'port' => 10025,
        )
);
$transport->setOptions($options);

$message = new Zend\Mail\Message();
$message->setHeaders($headers);
$message->setBody($body);
$transport->send($message);
```

This pull request will allow you to do:

```
    $message = new Zend\Mail\Message();
    $message->setHeaders($headers);
    $message->setBody($body);
    $envelope = new Zend\Mail\Transport\Envelope(array(
        'from' => 'mail-from@address.com',
        'to' => 'rcpt-to@address.com',
            )
    );
    $transport->setEnvelope($envelope);
    $transport->send($message);
```
