### PR TITLE
Allow HTTP client configuration to be supplied when using ClientStatic

### DIFF
--- a/library/Zend/Http/ClientStatic.php
+++ b/library/Zend/Http/ClientStatic.php
@@ -15,18 +15,21 @@ namespace Zend\Http;
  */
 class ClientStatic
 {
-
+    /**
+     * @var Client
+     */
     protected static $client;
 
     /**
      * Get the static HTTP client
      *
+     * @param array|Traversable $options
      * @return Client
      */
-    protected static function getStaticClient()
+    protected static function getStaticClient($options = null)
     {
-        if (!isset(static::$client)) {
-            static::$client = new Client();
+        if (!isset(static::$client) || $options !== null) {
+            static::$client = new Client(null, $options);
         }
         return static::$client;
     }
@@ -38,9 +41,10 @@ class ClientStatic
      * @param  array $query
      * @param  array $headers
      * @param  mixed $body
+     * @param  array|Traversable $clientOptions
      * @return Response|bool
      */
-    public static function get($url, $query = array(), $headers = array(), $body = null)
+    public static function get($url, $query = array(), $headers = array(), $body = null, $clientOptions = null)
     {
         if (empty($url)) {
             return false;
@@ -62,7 +66,7 @@ class ClientStatic
             $request->setContent($body);
         }
 
-        return static::getStaticClient()->send($request);
+        return static::getStaticClient($clientOptions)->send($request);
     }
 
     /**
@@ -72,10 +76,11 @@ class ClientStatic
      * @param  array $params
      * @param  array $headers
      * @param  mixed $body
+     * @param  array|Traversable $clientOptions
      * @throws Exception\InvalidArgumentException
      * @return Response|bool
      */
-    public static function post($url, $params, $headers = array(), $body = null)
+    public static function post($url, $params, $headers = array(), $body = null, $clientOptions = null)
     {
         if (empty($url)) {
             return false;
@@ -92,7 +97,7 @@ class ClientStatic
         }
 
         if (!isset($headers['Content-Type'])) {
-            $headers['Content-Type']= Client::ENC_URLENCODED;
+            $headers['Content-Type'] = Client::ENC_URLENCODED;
         }
 
         if (!empty($headers) && is_array($headers)) {
@@ -103,6 +108,6 @@ class ClientStatic
             $request->setContent($body);
         }
 
-        return static::getStaticClient()->send($request);
+        return static::getStaticClient($clientOptions)->send($request);
     }
 }

--- a/tests/ZendTest/Http/Client/StaticClientTest.php
+++ b/tests/ZendTest/Http/Client/StaticClientTest.php
@@ -51,7 +51,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testHttpSimpleGet()
     {
-        $response= HTTPClient::get($this->baseuri . 'testSimpleRequests.php');
+        $response = HTTPClient::get($this->baseuri . 'testSimpleRequests.php');
         $this->assertTrue($response->isSuccess());
     }
 
@@ -60,7 +60,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testHttpGetWithParamsInUri()
     {
-        $response= HTTPClient::get($this->baseuri . 'testGetData.php?foo');
+        $response = HTTPClient::get($this->baseuri . 'testGetData.php?foo');
         $this->assertTrue($response->isSuccess());
         $this->assertContains('foo', $response->getBody());
     }
@@ -70,7 +70,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testHttpMultiGetWithParam()
     {
-        $response= HTTPClient::get($this->baseuri . 'testGetData.php',array('foo' => 'bar'));
+        $response = HTTPClient::get($this->baseuri . 'testGetData.php',array('foo' => 'bar'));
         $this->assertTrue($response->isSuccess());
         $this->assertContains('foo', $response->getBody());
         $this->assertContains('bar', $response->getBody());
@@ -83,7 +83,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
     {
         $getBody = 'baz';
 
-        $response= HTTPClient::get($this->baseuri . 'testRawGetData.php',
+        $response = HTTPClient::get($this->baseuri . 'testRawGetData.php',
                                    array('foo' => 'bar'),
                                    array(),
                                    $getBody);
@@ -99,7 +99,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testHttpSimplePost()
     {
-        $response= HTTPClient::post($this->baseuri . 'testPostData.php',array('foo' => 'bar'));
+        $response = HTTPClient::post($this->baseuri . 'testPostData.php',array('foo' => 'bar'));
         $this->assertTrue($response->isSuccess());
         $this->assertContains('foo', $response->getBody());
         $this->assertContains('bar', $response->getBody());
@@ -110,7 +110,7 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testHttpPostContentType()
     {
-        $response= HTTPClient::post($this->baseuri . 'testPostData.php',
+        $response = HTTPClient::post($this->baseuri . 'testPostData.php',
                                     array('foo' => 'bar'),
                                     array('Content-Type' => Client::ENC_URLENCODED));
         $this->assertTrue($response->isSuccess());
@@ -125,12 +125,62 @@ class StaticClientTest extends \PHPUnit_Framework_TestCase
     {
         $postBody = 'foo';
 
-        $response= HTTPClient::post($this->baseuri . 'testRawPostData.php',
+        $response = HTTPClient::post($this->baseuri . 'testRawPostData.php',
                                     array('foo' => 'bar'),
                                     array('Content-Type' => Client::ENC_URLENCODED),
                                     $postBody);
 
         $this->assertTrue($response->isSuccess());
         $this->assertContains($postBody, $response->getBody());
+    }
+
+    /**
+     * Test GET with adapter configuration
+     *
+     * @link https://github.com/zendframework/zf2/issues/6482
+     */
+    public function testHttpGetUsesAdapterConfig()
+    {
+        $testUri = $this->baseuri . 'testSimpleRequests.php';
+
+        $config = array(
+            'useragent' => 'simplegettest'
+        );
+
+        HTTPClient::get($testUri, array(), array(), null, $config);
+
+        $reflectedClass = new \ReflectionClass('Zend\Http\ClientStatic');
+        $property = $reflectedClass->getProperty('client');
+        $property->setAccessible(true);
+        $client = $property->getValue();
+
+        $rawRequest = $client->getLastRawRequest();
+
+        $this->assertContains('User-Agent: simplegettest', $rawRequest);
+    }
+
+    /**
+     * Test POST with adapter configuration
+     *
+     * @link https://github.com/zendframework/zf2/issues/6482
+     */
+    public function testHttpPostUsesAdapterConfig()
+    {
+        $testUri = $this->baseuri . 'testPostData.php';
+
+        $config = array(
+            'useragent' => 'simpleposttest'
+        );
+
+        HTTPClient::post($testUri, array('foo' => 'bar'), array(), null, $config);
+
+        $reflectedClass = new \ReflectionClass('Zend\Http\ClientStatic');
+        $property = $reflectedClass->getProperty('client');
+        $property->setAccessible(true);
+        $client = $property->getValue();
+
+        $rawRequest = $client->getLastRawRequest();
+
+        $this->assertContains('User-Agent: simpleposttest', $rawRequest);
     }
 }


### PR DESCRIPTION
Allow HTTP client configuration to be supplied when making `get()` or `post()` calls with the static HTTP client. As well as adding flexibility, without this it is difficult/impossible to use the static client with SSL URLs. 

This is an additional optional param, so no BC break. Fixes #6482.
