### PR TITLE
fixed #6324: Redis::setItems: the last item is overwritten

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Redis.php
+++ b/library/Zend/Cache/Storage/Adapter/Redis.php
@@ -173,7 +173,7 @@ class Redis extends AbstractAdapter implements
         $redis = $this->getRedisResource();
 
         $namespacedKeys = array();
-        foreach ($normalizedKeys as & $normalizedKey) {
+        foreach ($normalizedKeys as $normalizedKey) {
             $namespacedKeys[] = $this->namespacePrefix . $normalizedKey;
         }
 
@@ -253,8 +253,8 @@ class Redis extends AbstractAdapter implements
         $ttl   = $this->getOptions()->getTtl();
 
         $namespacedKeyValuePairs = array();
-        foreach ($normalizedKeyValuePairs as $normalizedKey => & $value) {
-            $namespacedKeyValuePairs[$this->namespacePrefix . $normalizedKey] = & $value;
+        foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
+            $namespacedKeyValuePairs[$this->namespacePrefix . $normalizedKey] = $value;
         }
         try {
             if ($ttl > 0) {

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -579,36 +579,55 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped("Adapter doesn't support item expiration");
         }
 
+        // item definition
+        $itemsHigh = array(
+            'keyHigh1' => 'valueHigh1',
+            'keyHigh2' => 'valueHigh2',
+            'keyHigh3' => 'valueHigh3'
+        );
+        $itemsLow = array(
+            'keyLow1' => 'valueLow1',
+            'keyLow2' => 'valueLow2',
+            'keyLow3' => 'valueLow3'
+        );
+        $items = $itemsHigh + $itemsLow;
+
+        // set items with high TTL
+        $this->_options->setTtl(123456);
+        $this->assertSame(array(), $this->_storage->setItems($itemsHigh));
+
+        // set items with low TTL
         $ttl = $capabilities->getTtlPrecision();
         $this->_options->setTtl($ttl);
-
-        $items = array(
-            'key1' => 'value1',
-            'key2' => 'value2',
-            'key3' => 'value3'
-        );
-
         $this->waitForFullSecond();
-
-        $this->assertSame(array(), $this->_storage->setItems($items));
+        $this->assertSame(array(), $this->_storage->setItems($itemsLow));
 
         // wait until expired
         $wait = $ttl + $capabilities->getTtlPrecision();
         usleep($wait * 2000000);
 
         $rs = $this->_storage->getItems(array_keys($items));
-        if (!$capabilities->getUseRequestTime()) {
-            $this->assertEquals(array(), $rs);
-        } else {
-            ksort($rs);
-            $this->assertEquals($items, $rs);
-        }
+        ksort($rs); // make comparable
 
-        $this->_options->setTtl(0);
         if ($capabilities->getExpiredRead()) {
+            // if item expiration will be done on read there is no difference
+            // between the previos set items in TTL.
+            // -> all items will be expired
+            $this->assertEquals(array(), $rs);
+
+            // after disabling TTL all items will be available
+            $this->_options->setTtl(0);
             $rs = $this->_storage->getItems(array_keys($items));
-            ksort($rs);
+            ksort($rs); // make comparable
             $this->assertEquals($items, $rs);
+
+        } elseif ($capabilities->getUseRequestTime()) {
+            // if the request time will be used as current time all items will
+            // be available as expiration doesn't work within the same process
+            $this->assertEquals($items, $rs);
+
+        } else {
+            $this->assertEquals($itemsHigh, $rs);
         }
     }
 


### PR DESCRIPTION
This PR fixes #6324 where the last item value will be overwritten by the previous one in `Redis::setItems()`.
I have updated the common test to catch this issue up on all adapters.

The PR #6347 can be closed.
