### PR TITLE
hotfix custom barcode adapter wasn't being set to options.

### DIFF
--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -96,7 +96,10 @@ class Barcode extends AbstractValidator
         
         if (!$adapter instanceof Barcode\AdapterInterface) {
             throw new Exception\InvalidArgumentException(
-                sprintf("Adapter %s does not implement Zend\\Validator\\Barcode\\AdapterInterface", get_class($adapter))
+                sprintf(
+                    "Adapter %s does not implement Zend\\Validator\\Barcode\\AdapterInterface",
+                    (is_object($adapter) ? get_class($adapter) : gettype($adapter))
+                )
             );
         }
 

--- a/library/Zend/Validator/Barcode.php
+++ b/library/Zend/Validator/Barcode.php
@@ -91,15 +91,17 @@ class Barcode extends AbstractValidator
                 throw new Exception\InvalidArgumentException('Barcode adapter matching "' . $adapter . '" not found');
             }
 
-            $this->options['adapter'] = new $adapter($options);
+            $adapter = new $adapter($options);
         }
-
-        if (!$this->options['adapter'] instanceof Barcode\AdapterInterface) {
+        
+        if (!$adapter instanceof Barcode\AdapterInterface) {
             throw new Exception\InvalidArgumentException(
-                "Adapter $adapter does not implement Zend\\Validate\\Barcode\\AdapterInterface"
+                sprintf("Adapter %s does not implement Zend\\Validator\\Barcode\\AdapterInterface", get_class($adapter))
             );
         }
 
+        $this->options['adapter'] = $adapter;
+        
         return $this;
     }
 

--- a/tests/ZendTest/Validator/BarcodeTest.php
+++ b/tests/ZendTest/Validator/BarcodeTest.php
@@ -32,6 +32,15 @@ class BarcodeTest extends \PHPUnit_Framework_TestCase
         $barcode->setAdapter('ean13');
         $this->assertTrue($barcode->isValid('0075678164125'));
     }
+    
+    public function testSetCustomAdapter()
+    {
+        $barcode = new Barcode([
+            'adapter' => $this->getMock('Zend\Validator\Barcode\AdapterInterface')
+        ]);
+        
+        $this->assertInstanceOf('Zend\Validator\Barcode\AdapterInterface', $barcode->getAdapter());
+    }
 
     /**
      * @ZF-4352


### PR DESCRIPTION
since it was only setting the adapter to $this->options in line 11, and there was an if to check if the adapter was a string in line 3, the adapter were never going to be set to options if the param provided was an object.
