### PR TITLE
activate commented Exception in Validator/Between::__construct

### DIFF
--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -74,6 +74,11 @@ class Between extends AbstractValidator
             }
 
             $options = $temp;
+        } else {
+            if (count($options) == 2 && !array_key_exists('min', $options)) {
+                $options['min'] = $options[0];
+                $options['max'] = $options[1];
+            }
         }
 
         if (!array_key_exists('min', $options) || !array_key_exists('max', $options)) {

--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -74,14 +74,10 @@ class Between extends AbstractValidator
             }
 
             $options = $temp;
-        } else {
-            if (count($options) == 2 && !array_key_exists('min', $options)) {
-                $options['min'] = $options[0];
-                $options['max'] = $options[1];
-            }
         }
 
-        if (!array_key_exists('min', $options) || !array_key_exists('max', $options)) {
+        if (count($options) !== 2
+            && (!array_key_exists('min', $options) || !array_key_exists('max', $options))) {
             throw new Exception\InvalidArgumentException("Missing option. 'min' and 'max' has to be given");
         }
 

--- a/library/Zend/Validator/Between.php
+++ b/library/Zend/Validator/Between.php
@@ -77,7 +77,7 @@ class Between extends AbstractValidator
         }
 
         if (!array_key_exists('min', $options) || !array_key_exists('max', $options)) {
-//            throw new Exception\InvalidArgumentException("Missing option. 'min' and 'max' has to be given");
+            throw new Exception\InvalidArgumentException("Missing option. 'min' and 'max' has to be given");
         }
 
         parent::__construct($options);

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -112,7 +112,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowPullingValidatorsByFile()
     {
-        $this->adapter->addValidator('Between', false, false, 'foo');
+        $this->adapter->addValidator('Between', false, array('min' => 1, 'max' => 5), 'foo');
         $validators = $this->adapter->getValidators('foo');
         $this->assertEquals(1, count($validators));
         $validator = array_shift($validators);

--- a/tests/ZendTest/Validator/BetweenTest.php
+++ b/tests/ZendTest/Validator/BetweenTest.php
@@ -104,4 +104,28 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validator->getOption('messageVariables'),
                                      'messageVariables', $validator);
     }
+
+    /**
+     * @covers Zend\Validator\Between::__construct()
+     * @dataProvider constructBetweenValidatorDataProvider
+     *
+     * @param array $args
+     */
+    public function testMissingMinOrMax(array $args)
+    {
+        $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException', "Missing option. 'min' and 'max' has to be given");
+        $barcode = new Between($args);
+    }
+
+    public function constructBetweenValidatorDataProvider()
+    {
+        return array(
+            array(
+                array('min' => 1),
+            ),
+            array(
+                array('max' => 5),
+            ),
+        );
+    }
 }

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -47,7 +47,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
     public function populateValidatorChain()
     {
         $this->validator->attach(new NotEmpty());
-        $this->validator->attach(new Between());
+        $this->validator->attach(new Between(1, 5));
     }
 
     public function testValidatorChainIsEmptyByDefault()


### PR DESCRIPTION
- [x]  if parameter is an array, it should have 'min' and 'max'.
- [x]  if the array parameter count !==2 and doesn't have 'min' or 'max' anymore, throws an Exception, because if array parameter count == 2, then 1st is a 'min', and 2nd is a 'max' like at 

``` php
// at ZendTest\Validator\ValidatorChainTest::testIsValidWithParameters()
$this->assertTrue(StaticValidator::execute(5, 'Between', array(1, 10)));
```
