### PR TITLE
Remove Identical validator type hint

### DIFF
--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Validator;
 
+use ArrayObject;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 
@@ -18,7 +19,7 @@ class Identical extends AbstractValidator
      * Error codes
      * @const string
      */
-    const NOT_SAME      = 'notSame';
+    const NOT_SAME = 'notSame';
     const MISSING_TOKEN = 'missingToken';
 
     /**
@@ -26,7 +27,7 @@ class Identical extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_SAME      => "The two given tokens do not match",
+        self::NOT_SAME => "The two given tokens do not match",
         self::MISSING_TOKEN => 'No token was provided to match against',
     );
 
@@ -43,7 +44,7 @@ class Identical extends AbstractValidator
      */
     protected $tokenString;
     protected $token;
-    protected $strict  = true;
+    protected $strict = true;
     protected $literal = false;
 
     /**
@@ -92,8 +93,8 @@ class Identical extends AbstractValidator
      */
     public function setToken($token)
     {
-        $this->tokenString = (is_array($token) ? var_export($token, true) : (string) $token);
-        $this->token       = $token;
+        $this->tokenString = (is_array($token) ? var_export($token, true) : (string)$token);
+        $this->token = $token;
         return $this;
     }
 
@@ -115,7 +116,7 @@ class Identical extends AbstractValidator
      */
     public function setStrict($strict)
     {
-        $this->strict = (bool) $strict;
+        $this->strict = (bool)$strict;
         return $this;
     }
 
@@ -137,7 +138,7 @@ class Identical extends AbstractValidator
      */
     public function setLiteral($literal)
     {
-        $this->literal = (bool) $literal;
+        $this->literal = (bool)$literal;
         return $this;
     }
 
@@ -146,17 +147,25 @@ class Identical extends AbstractValidator
      * matches that token.
      *
      * @param  mixed $value
-     * @param  array $context
+     * @param  array|ArrayObject $context
+     * @throws Exception\InvalidArgumentException If context is not array or ArrayObject
      * @return bool
-     * @throws Exception\RuntimeException if the token doesn't exist in the context array
      */
-    public function isValid($value, array $context = null)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
 
         $token = $this->getToken();
 
         if (!$this->getLiteral() && $context !== null) {
+            if (!is_array($context) && !($context instanceof ArrayObject)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Context passed to %s must be array, ArrayObject or null; received "%s"',
+                    __METHOD__,
+                    (is_object($context) ? get_class($context) : gettype($context))
+                ));
+            }
+
             if (is_array($token)) {
                 while (is_array($token)) {
                     $key = key($token);
@@ -164,7 +173,7 @@ class Identical extends AbstractValidator
                         break;
                     }
                     $context = $context[$key];
-                    $token   = $token[$key];
+                    $token = $token[$key];
                 }
             }
 

--- a/library/Zend/Validator/Identical.php
+++ b/library/Zend/Validator/Identical.php
@@ -19,7 +19,7 @@ class Identical extends AbstractValidator
      * Error codes
      * @const string
      */
-    const NOT_SAME = 'notSame';
+    const NOT_SAME      = 'notSame';
     const MISSING_TOKEN = 'missingToken';
 
     /**
@@ -27,7 +27,7 @@ class Identical extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = array(
-        self::NOT_SAME => "The two given tokens do not match",
+        self::NOT_SAME      => "The two given tokens do not match",
         self::MISSING_TOKEN => 'No token was provided to match against',
     );
 
@@ -44,7 +44,7 @@ class Identical extends AbstractValidator
      */
     protected $tokenString;
     protected $token;
-    protected $strict = true;
+    protected $strict  = true;
     protected $literal = false;
 
     /**
@@ -93,8 +93,8 @@ class Identical extends AbstractValidator
      */
     public function setToken($token)
     {
-        $this->tokenString = (is_array($token) ? var_export($token, true) : (string)$token);
-        $this->token = $token;
+        $this->tokenString = (is_array($token) ? var_export($token, true) : (string) $token);
+        $this->token       = $token;
         return $this;
     }
 
@@ -116,7 +116,7 @@ class Identical extends AbstractValidator
      */
     public function setStrict($strict)
     {
-        $this->strict = (bool)$strict;
+        $this->strict = (bool) $strict;
         return $this;
     }
 
@@ -138,7 +138,7 @@ class Identical extends AbstractValidator
      */
     public function setLiteral($literal)
     {
-        $this->literal = (bool)$literal;
+        $this->literal = (bool) $literal;
         return $this;
     }
 
@@ -173,7 +173,7 @@ class Identical extends AbstractValidator
                         break;
                     }
                     $context = $context[$key];
-                    $token = $token[$key];
+                    $token   = $token[$key];
                 }
             }
 

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\Validator;
 
+use Zend\Stdlib\Parameters;
+use Zend\Validator\Exception\InvalidArgumentException;
 use Zend\Validator\Identical;
 
 /**
@@ -115,67 +117,139 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageVariables'),
-                                     'messageVariables', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageVariables'),
+            'messageVariables',
+            $validator
+        );
     }
 
     public function testValidatingStringTokenInContext()
     {
         $this->validator->setToken('email');
 
-        $this->assertTrue($this->validator->isValid(
-            'john@doe.com',
-            array('email' => 'john@doe.com')
-        ));
+        $this->assertTrue(
+            $this->validator->isValid(
+                'john@doe.com',
+                array('email' => 'john@doe.com')
+            )
+        );
 
-        $this->assertFalse($this->validator->isValid(
-            'john@doe.com',
-            array('email' => 'harry@hoe.com')
-        ));
+        $this->assertFalse(
+            $this->validator->isValid(
+                'john@doe.com',
+                array('email' => 'harry@hoe.com')
+            )
+        );
 
-        $this->assertFalse($this->validator->isValid(
-            'harry@hoe.com',
-            array('email' => 'john@doe.com')
-        ));
+        $this->assertFalse(
+            $this->validator->isValid(
+                'harry@hoe.com',
+                array('email' => 'john@doe.com')
+            )
+        );
+
+        $this->assertTrue(
+            $this->validator->isValid(
+                'john@doe.com',
+                new Parameters(array('email' => 'john@doe.com'))
+            )
+        );
+
+        $this->assertFalse(
+            $this->validator->isValid(
+                'john@doe.com',
+                new Parameters(array('email' => 'harry@hoe.com'))
+            )
+        );
+
+        $this->assertFalse(
+            $this->validator->isValid(
+                'harry@hoe.com',
+                new Parameters(array('email' => 'john@doe.com'))
+            )
+        );
     }
 
     public function testValidatingArrayTokenInContext()
     {
         $this->validator->setToken(array('user' => 'email'));
 
-        $this->assertTrue($this->validator->isValid(
-            'john@doe.com',
-            array(
-                'user' => array(
-                    'email' => 'john@doe.com'
+        $this->assertTrue(
+            $this->validator->isValid(
+                'john@doe.com',
+                array(
+                    'user' => array(
+                        'email' => 'john@doe.com'
+                    )
                 )
             )
-        ));
+        );
 
-        $this->assertFalse($this->validator->isValid(
-            'john@doe.com',
-            array(
-                'user' => array(
-                    'email' => 'harry@hoe.com'
+        $this->assertFalse(
+            $this->validator->isValid(
+                'john@doe.com',
+                array(
+                    'user' => array(
+                        'email' => 'harry@hoe.com'
+                    )
                 )
             )
-        ));
+        );
 
-        $this->assertFalse($this->validator->isValid(
-            'harry@hoe.com',
-            array(
-                'user' => array(
-                    'email' => 'john@doe.com'
+        $this->assertFalse(
+            $this->validator->isValid(
+                'harry@hoe.com',
+                array(
+                    'user' => array(
+                        'email' => 'john@doe.com'
+                    )
                 )
             )
-        ));
+        );
+
+        $this->assertTrue(
+            $this->validator->isValid(
+                'john@doe.com',
+                new Parameters(array(
+                    'user' => array(
+                        'email' => 'john@doe.com'
+                    )
+                ))
+            )
+        );
+
+        $this->assertFalse(
+            $this->validator->isValid(
+                'john@doe.com',
+                new Parameters(array(
+                    'user' => array(
+                        'email' => 'harry@hoe.com'
+                    )
+                ))
+            )
+        );
+
+        $this->assertFalse(
+            $this->validator->isValid(
+                'harry@hoe.com',
+                new Parameters(array(
+                    'user' => array(
+                        'email' => 'john@doe.com'
+                    )
+                ))
+            )
+        );
     }
 
     public function testCanSetLiteralParameterThroughConstructor()
@@ -202,9 +276,21 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
         $this->validator->setToken(array('foo' => 'bar'));
         $this->validator->setLiteral(true);
 
-        $this->assertTrue($this->validator->isValid(
-            array('foo' => 'bar'),
-            array('foo' => 'baz') // Provide a context to make sure the literal parameter will work
-        ));
+        $this->assertTrue(
+            $this->validator->isValid(
+                array('foo' => 'bar'),
+                array('foo' => 'baz') // Provide a context to make sure the literal parameter will work
+            )
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testIsValidThrowsExceptionOnInvalidContext()
+    {
+        $this->validator->isValid('john@doe.com', false);
+        $this->validator->isValid('john@doe.com', new \stdClass());
+        $this->validator->isValid('john@doe.com', 'dummy');
     }
 }

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -117,139 +117,109 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
+                                     'messageTemplates', $validator);
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertAttributeEquals($validator->getOption('messageVariables'),
+                                     'messageVariables', $validator);
     }
 
     public function testValidatingStringTokenInContext()
     {
         $this->validator->setToken('email');
 
-        $this->assertTrue(
-            $this->validator->isValid(
-                'john@doe.com',
-                array('email' => 'john@doe.com')
-            )
-        );
+        $this->assertTrue($this->validator->isValid(
+            'john@doe.com',
+            array('email' => 'john@doe.com')
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'john@doe.com',
-                array('email' => 'harry@hoe.com')
-            )
-        );
+        $this->assertFalse($this->validator->isValid(
+            'john@doe.com',
+            array('email' => 'harry@hoe.com')
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'harry@hoe.com',
-                array('email' => 'john@doe.com')
-            )
-        );
+        $this->assertFalse($this->validator->isValid(
+            'harry@hoe.com',
+            array('email' => 'john@doe.com')
+        ));
 
-        $this->assertTrue(
-            $this->validator->isValid(
-                'john@doe.com',
-                new Parameters(array('email' => 'john@doe.com'))
-            )
-        );
+        $this->assertTrue($this->validator->isValid(
+            'john@doe.com',
+            new Parameters(array('email' => 'john@doe.com'))
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'john@doe.com',
-                new Parameters(array('email' => 'harry@hoe.com'))
-            )
-        );
+        $this->assertFalse($this->validator->isValid(
+            'john@doe.com',
+            new Parameters(array('email' => 'harry@hoe.com'))
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'harry@hoe.com',
-                new Parameters(array('email' => 'john@doe.com'))
-            )
-        );
+        $this->assertFalse($this->validator->isValid(
+            'harry@hoe.com',
+            new Parameters(array('email' => 'john@doe.com'))
+        ));
     }
 
     public function testValidatingArrayTokenInContext()
     {
         $this->validator->setToken(array('user' => 'email'));
 
-        $this->assertTrue(
-            $this->validator->isValid(
-                'john@doe.com',
-                array(
-                    'user' => array(
-                        'email' => 'john@doe.com'
-                    )
+        $this->assertTrue($this->validator->isValid(
+            'john@doe.com',
+            array(
+                'user' => array(
+                    'email' => 'john@doe.com'
                 )
             )
-        );
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'john@doe.com',
-                array(
-                    'user' => array(
-                        'email' => 'harry@hoe.com'
-                    )
+        $this->assertFalse($this->validator->isValid(
+            'john@doe.com',
+            array(
+                'user' => array(
+                    'email' => 'harry@hoe.com'
                 )
             )
-        );
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'harry@hoe.com',
-                array(
-                    'user' => array(
-                        'email' => 'john@doe.com'
-                    )
+        $this->assertFalse($this->validator->isValid(
+            'harry@hoe.com',
+            array(
+                'user' => array(
+                    'email' => 'john@doe.com'
                 )
             )
-        );
+        ));
 
-        $this->assertTrue(
-            $this->validator->isValid(
-                'john@doe.com',
-                new Parameters(array(
-                    'user' => array(
-                        'email' => 'john@doe.com'
-                    )
-                ))
-            )
-        );
+        $this->assertTrue($this->validator->isValid(
+            'john@doe.com',
+            new Parameters(array(
+                'user' => array(
+                    'email' => 'john@doe.com'
+                )
+            ))
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'john@doe.com',
-                new Parameters(array(
-                    'user' => array(
-                        'email' => 'harry@hoe.com'
-                    )
-                ))
-            )
-        );
+        $this->assertFalse($this->validator->isValid(
+            'john@doe.com',
+            new Parameters(array(
+                'user' => array(
+                    'email' => 'harry@hoe.com'
+                )
+            ))
+        ));
 
-        $this->assertFalse(
-            $this->validator->isValid(
-                'harry@hoe.com',
-                new Parameters(array(
-                    'user' => array(
-                        'email' => 'john@doe.com'
-                    )
-                ))
-            )
-        );
+        $this->assertFalse($this->validator->isValid(
+            'harry@hoe.com',
+            new Parameters(array(
+                'user' => array(
+                    'email' => 'john@doe.com'
+                )
+            ))
+        ));
     }
 
     public function testCanSetLiteralParameterThroughConstructor()
@@ -276,12 +246,10 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
         $this->validator->setToken(array('foo' => 'bar'));
         $this->validator->setLiteral(true);
 
-        $this->assertTrue(
-            $this->validator->isValid(
-                array('foo' => 'bar'),
-                array('foo' => 'baz') // Provide a context to make sure the literal parameter will work
-            )
-        );
+        $this->assertTrue($this->validator->isValid(
+            array('foo' => 'bar'),
+            array('foo' => 'baz') // Provide a context to make sure the literal parameter will work
+        ));
     }
 
     /**


### PR DESCRIPTION
7bcd59a8 introduced an array type hint for the `$context` parameter in `Zend\Validator\Identical::isValid()`. This causes PHP errors if the InputFilter containing the Identical validator is executed on form values (they are passed not as arrays, but `Zend\Stdlib\Parameters`).

Remove the type hint and add a check if `$context` is `array` or `ArrayObject`.
