### PR TITLE
add try/catch around statements that execute intl_is_failure()

### DIFF
--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -12,6 +12,7 @@ namespace Zend\I18n\Validator;
 use Locale;
 use IntlDateFormatter;
 use Traversable;
+use IntlException;
 use Zend\I18n\Exception as I18nException;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception as ValidatorException;
@@ -270,11 +271,7 @@ class DateTime extends AbstractValidator
             if (intl_is_failure($formatter->getErrorCode())) {
                 throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
             }
-        } catch(\Exception $e) {
-            if(!$e instanceof IntlException){
-                throw $e;
-            }
-
+        } catch(IntlException $e) {
             throw new ValidatorException\InvalidArgumentException($e->getMessage());
         }
 
@@ -286,11 +283,7 @@ class DateTime extends AbstractValidator
                 $this->error(self::INVALID_DATETIME);
                 return false;
             }
-        } catch(\Exception $e) {
-            if(!$e instanceof IntlException){
-                throw $e;
-            }
-
+        } catch(IntlException $e) {
             $this->error(self::INVALID_DATETIME);
             return false;
         }

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -263,15 +263,26 @@ class DateTime extends AbstractValidator
         }
 
         $this->setValue($value);
-        $formatter = $this->getIntlDateFormatter();
 
-        if (intl_is_failure($formatter->getErrorCode())) {
-            throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
+        try {
+            $formatter = $this->getIntlDateFormatter();
+
+            if (intl_is_failure($formatter->getErrorCode())) {
+                throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
+            }
+        } catch(\Exception $e) {
+            throw new ValidatorException\InvalidArgumentException($e->getMessage());
         }
 
-        $timestamp = $formatter->parse($value);
 
-        if (intl_is_failure($formatter->getErrorCode()) || $timestamp === false) {
+        try {
+            $timestamp = $formatter->parse($value);
+
+            if (intl_is_failure($formatter->getErrorCode()) || $timestamp === false) {
+                $this->error(self::INVALID_DATETIME);
+                return false;
+            }
+        } catch(\Exception $e) {
             $this->error(self::INVALID_DATETIME);
             return false;
         }

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -271,7 +271,7 @@ class DateTime extends AbstractValidator
                 throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
             }
         } catch(\Exception $e) {
-            if(get_class($e) != 'IntlException'){
+            if($e instanceof IntlException){
                 throw $e;
             }
 
@@ -287,7 +287,7 @@ class DateTime extends AbstractValidator
                 return false;
             }
         } catch(\Exception $e) {
-            if(get_class($e) != 'IntlException'){
+            if($e instanceof IntlException){
                 throw $e;
             }
 

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -271,6 +271,10 @@ class DateTime extends AbstractValidator
                 throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
             }
         } catch(\Exception $e) {
+            if(get_class($e) != 'IntlException'){
+                throw $e;
+            }
+
             throw new ValidatorException\InvalidArgumentException($e->getMessage());
         }
 
@@ -283,6 +287,10 @@ class DateTime extends AbstractValidator
                 return false;
             }
         } catch(\Exception $e) {
+            if(get_class($e) != 'IntlException'){
+                throw $e;
+            }
+
             $this->error(self::INVALID_DATETIME);
             return false;
         }

--- a/library/Zend/I18n/Validator/DateTime.php
+++ b/library/Zend/I18n/Validator/DateTime.php
@@ -271,7 +271,7 @@ class DateTime extends AbstractValidator
                 throw new ValidatorException\InvalidArgumentException($formatter->getErrorMessage());
             }
         } catch(\Exception $e) {
-            if($e instanceof IntlException){
+            if(!$e instanceof IntlException){
                 throw $e;
             }
 
@@ -287,7 +287,7 @@ class DateTime extends AbstractValidator
                 return false;
             }
         } catch(\Exception $e) {
-            if($e instanceof IntlException){
+            if(!$e instanceof IntlException){
                 throw $e;
             }
 

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -127,6 +127,10 @@ class Float extends AbstractValidator
                 throw new Exception\InvalidArgumentException($formatter->getErrorMessage());
             }
         } catch(\Exception $e) {
+            if(get_class($e) != 'IntlException'){
+                throw $e;
+            }
+
             throw new Exception\InvalidArgumentException($e->getMessage());
         }
 

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -127,7 +127,7 @@ class Float extends AbstractValidator
                 throw new Exception\InvalidArgumentException($formatter->getErrorMessage());
             }
         } catch(\Exception $e) {
-            if($e instanceof IntlException){
+            if(!$e instanceof IntlException){
                 throw $e;
             }
 

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -127,7 +127,7 @@ class Float extends AbstractValidator
                 throw new Exception\InvalidArgumentException($formatter->getErrorMessage());
             }
         } catch(\Exception $e) {
-            if(get_class($e) != 'IntlException'){
+            if($e instanceof IntlException){
                 throw $e;
             }
 

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -122,8 +122,12 @@ class Float extends AbstractValidator
         // Need to check if this is scientific formatted string. If not, switch to decimal.
         $formatter = new NumberFormatter($this->getLocale(), NumberFormatter::SCIENTIFIC);
 
-        if (intl_is_failure($formatter->getErrorCode())) {
-            throw new Exception\InvalidArgumentException($formatter->getErrorMessage());
+        try {
+            if (intl_is_failure($formatter->getErrorCode())) {
+                throw new Exception\InvalidArgumentException($formatter->getErrorMessage());
+            }
+        } catch(\Exception $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage());
         }
 
         if (StringUtils::hasPcreUnicodeSupport()) {

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -12,6 +12,7 @@ namespace Zend\I18n\Validator;
 use Locale;
 use NumberFormatter;
 use Traversable;
+use IntlException;
 use Zend\I18n\Exception as I18nException;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\StringUtils;
@@ -126,11 +127,7 @@ class Float extends AbstractValidator
             if (intl_is_failure($formatter->getErrorCode())) {
                 throw new Exception\InvalidArgumentException($formatter->getErrorMessage());
             }
-        } catch(\Exception $e) {
-            if(!$e instanceof IntlException){
-                throw $e;
-            }
-
+        } catch(IntlException $e) {
             throw new Exception\InvalidArgumentException($e->getMessage());
         }
 

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -114,7 +114,7 @@ class Int extends AbstractValidator
                 throw new Exception\InvalidArgumentException("Invalid locale string given");
             }
         } catch(\Exception $e) {
-            if($e instanceof IntlException){
+            if(!$e instanceof IntlException){
                 throw $e;
             }
 
@@ -128,7 +128,7 @@ class Int extends AbstractValidator
                 return false;
             }
         } catch(\Exception $e) {
-            if($e instanceof IntlException){
+            if(!$e instanceof IntlException){
                 throw $e;
             }
 

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -114,6 +114,10 @@ class Int extends AbstractValidator
                 throw new Exception\InvalidArgumentException("Invalid locale string given");
             }
         } catch(\Exception $e) {
+            if(get_class($e) != 'IntlException'){
+                throw $e;
+            }
+
             throw new Exception\InvalidArgumentException("Invalid locale string given");
         }
 
@@ -124,6 +128,10 @@ class Int extends AbstractValidator
                 return false;
             }
         } catch(\Exception $e) {
+            if(get_class($e) != 'IntlException'){
+                throw $e;
+            }
+
             $this->error(self::NOT_INT);
             return false;
         }

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -114,7 +114,7 @@ class Int extends AbstractValidator
                 throw new Exception\InvalidArgumentException("Invalid locale string given");
             }
         } catch(\Exception $e) {
-            if(get_class($e) != 'IntlException'){
+            if($e instanceof IntlException){
                 throw $e;
             }
 
@@ -128,7 +128,7 @@ class Int extends AbstractValidator
                 return false;
             }
         } catch(\Exception $e) {
-            if(get_class($e) != 'IntlException'){
+            if($e instanceof IntlException){
                 throw $e;
             }
 

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -12,6 +12,7 @@ namespace Zend\I18n\Validator;
 use Locale;
 use NumberFormatter;
 use Traversable;
+use IntlException;
 use Zend\I18n\Exception as I18nException;
 use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
@@ -113,11 +114,7 @@ class Int extends AbstractValidator
             if (intl_is_failure($format->getErrorCode())) {
                 throw new Exception\InvalidArgumentException("Invalid locale string given");
             }
-        } catch(\Exception $e) {
-            if(!$e instanceof IntlException){
-                throw $e;
-            }
-
+        } catch(IntlException $e) {
             throw new Exception\InvalidArgumentException("Invalid locale string given");
         }
 
@@ -127,11 +124,7 @@ class Int extends AbstractValidator
                 $this->error(self::NOT_INT);
                 return false;
             }
-        } catch(\Exception $e) {
-            if(!$e instanceof IntlException){
-                throw $e;
-            }
-
+        } catch(IntlException $e) {
             $this->error(self::NOT_INT);
             return false;
         }

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -17,6 +17,7 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
 
+
 class Int extends AbstractValidator
 {
     const INVALID = 'intInvalid';
@@ -107,13 +108,22 @@ class Int extends AbstractValidator
         $this->setValue($value);
 
         $locale = $this->getLocale();
-        $format = new NumberFormatter($locale, NumberFormatter::DECIMAL);
-        if (intl_is_failure($format->getErrorCode())) {
+        try {
+            $format = new NumberFormatter($locale, NumberFormatter::DECIMAL);
+            if (intl_is_failure($format->getErrorCode())) {
+                throw new Exception\InvalidArgumentException("Invalid locale string given");
+            }
+        } catch(\Exception $e) {
             throw new Exception\InvalidArgumentException("Invalid locale string given");
         }
 
-        $parsedInt = $format->parse($value, NumberFormatter::TYPE_INT64);
-        if (intl_is_failure($format->getErrorCode())) {
+        try {
+            $parsedInt = $format->parse($value, NumberFormatter::TYPE_INT64);
+            if (intl_is_failure($format->getErrorCode())) {
+                $this->error(self::NOT_INT);
+                return false;
+            }
+        } catch(\Exception $e) {
             $this->error(self::NOT_INT);
             return false;
         }


### PR DESCRIPTION
Since PHP 5.5.0, the configuration option 'intl.use_exceptions' is available.
When set to true, IntlException's are thrown instead of just setting a error
code, so no calls to intl_is_failure() are necessary.
Without the try/catch, the Int, Float and DateTime I18n validators hard-fail
in case 'intl.use_exceptions' is set to true.

NOTE: catching Exception (super class of IntlException), as IntlException is
not available prior to PHP 5.5.0.

refs #6312
