### PR TITLE
add label option to add css class to wrap element

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -205,7 +205,11 @@ class FormRow extends AbstractHelper
                 if ($label !== '' && (!$element->hasAttribute('id'))
                     || ($element instanceof LabelAwareInterface && $element->getLabelOption('always_wrap'))
                 ) {
-                    $label = '<span>' . $label . '</span>';
+                    if ($element->getLabelOption('wrap_class')) {
+                        $label = '<span class="' . $element->getLabelOption('wrap_class') . '">' . $label . '</span>';
+                    } else {
+                        $label = '<span>' . $label . '</span>';    
+                    }
                 }
 
                 // Button element is a special case, because label is always rendered inside it

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -429,4 +429,25 @@ class FormRowTest extends TestCase
         $markup = $this->helper->render($element);
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
     }
+
+    public function testLabelOptionWrapClassDefaultsToFalse()
+    {
+        $element = new Element('foo');
+        $this->assertEmpty($element->getLabelOption('wrap_class'));
+    }
+
+    public function testCanSetOptionToAddClassToWrapElementInLabel()
+    {
+        $element = new Element('foo', array(
+            'label_options' => array(
+                'always_wrap' => true,
+                'wrap_class' => 'fooclass',
+            )
+        ));
+        $element->setAttribute('id', 'bar');
+        $element->setLabel('baz');
+
+        $markup = $this->helper->render($element);
+        $this->assertRegexp('#^<label><span class="fooclass">baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
+    }
 }


### PR DESCRIPTION
I've added an option to add a css class to the `<span>` element that wraps form labels. Useful when working with bootstrap forms.
