### PR TITLE
fix Atom tests with fractional seconds in dates

### DIFF
--- a/tests/ZendTest/Feed/Reader/Entry/AtomTest.php
+++ b/tests/ZendTest/Feed/Reader/Entry/AtomTest.php
@@ -111,7 +111,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath . '/datecreated/plain/fractional.xml')
         );
         $entry = $feed->current();
-        $edate = DateTime::createFromFormat(DateTime::ISO8601, '2009-03-07T08:03:50Z');
+        $edate = new DateTime('2009-03-07T08:03:50.80Z');
         $this->assertEquals($edate, $entry->getDateCreated());
     }
 
@@ -144,7 +144,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath . '/datemodified/plain/fractional.xml')
         );
         $entry = $feed->current();
-        $edate = DateTime::createFromFormat(DateTime::ISO8601, '2009-03-07T08:03:50Z');
+        $edate = new DateTime('2009-03-07T08:03:50.80Z');
         $this->assertEquals($edate, $entry->getDateModified());
     }
 


### PR DESCRIPTION
Tests for fractional seconds in created/modified datetimes fail.
The `DateTime` object is correctly created in [Extension\Atom\Entry#L173](https://github.com/zendframework/zf2/blob/master/library/Zend/Feed/Reader/Extension/Atom/Entry.php#L173),
but the tests created the comparison DateTime with the wrong format (ISO8601)
and the wrong datetime string (did not include the fractional seconds).
Using the same method for creating the DateTime in the tests as is used in Extension\Atom\Entry#L173 makes the tests pass.

see #6468 
