### PR TITLE
fix Ldap converter serialize test

### DIFF
--- a/tests/ZendTest/Ldap/Converter/ConverterTest.php
+++ b/tests/ZendTest/Ldap/Converter/ConverterTest.php
@@ -106,14 +106,28 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
 
     public function toLdapSerializeProvider()
     {
-        return array(
-            array('N;', null),
-            array('i:1;', 1),
-            array('O:8:"DateTime":3:{s:4:"date";s:19:"1970-01-01 00:00:00";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}',
-                  new DateTime('@0')),
-            array('a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}', array('test', 1,
-                                                                             'foo'=> 'bar')),
-        );
+        if ((version_compare(PHP_VERSION, '5.4.30', '>=') && version_compare(PHP_VERSION, '5.5', '<'))
+            || (version_compare(PHP_VERSION, '5.5.14', '>=') && version_compare(PHP_VERSION, '5.6', '<'))
+            || (version_compare(PHP_VERSION, '5.6.0beta4', '>='))
+        ) {
+            return array(
+                array('N;', null),
+                array('i:1;', 1),
+                array('O:8:"DateTime":3:{s:4:"date";s:26:"1970-01-01 00:00:00.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}',
+                      new DateTime('@0')),
+                array('a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}', array('test', 1,
+                                                                                 'foo'=> 'bar')),
+            );
+        } else {
+            return array(
+                array('N;', null),
+                array('i:1;', 1),
+                array('O:8:"DateTime":3:{s:4:"date";s:19:"1970-01-01 00:00:00";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}',
+                      new DateTime('@0')),
+                array('a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}', array('test', 1,
+                                                                                 'foo'=> 'bar')),
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Starting from PHP versions 5.4.30, 5.5.14 and 5.6.0beta4, the serialized
representation of a DateTime includes fractional seconds.
The data provider must check the PHP version and provide a correct
serialized representation of the DateTime object.

refs #6468
