### PR TITLE
Deprecate [Global]EventManager::triggerUntil()

### DIFF
--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -167,12 +167,10 @@ class EventManager implements EventManagerInterface
     /**
      * Trigger all listeners for a given event
      *
-     * Can emulate triggerUntil() if the last argument provided is a callback.
-     *
-     * @param  string $event
-     * @param  string|object $target Object calling emit, or symbol describing target (such as static method name)
-     * @param  array|ArrayAccess $argv Array of arguments; typically, should be associative
-     * @param  null|callable $callback
+     * @param  string            $event
+     * @param  string|object     $target   Object calling emit, or symbol describing target (such as static method name)
+     * @param  array|ArrayAccess $argv     Array of arguments; typically, should be associative
+     * @param  null|callable     $callback Trigger listeners until return value of this callback evaluate to true
      * @return ResponseCollection All listener return values
      * @throws Exception\InvalidCallbackException
      */
@@ -225,8 +223,7 @@ class EventManager implements EventManagerInterface
     public function triggerUntil($event, $target, $argv = null, $callback = null)
     {
         trigger_error(
-            'This method is deprecated and will be removed in the future. ' .
-            'Please use trigger() instead.',
+            'This method is deprecated and will be removed in the future. Please use trigger() instead.',
             E_USER_DEPRECATED
         );
         return $this->trigger($event, $target, $argv, $callback);

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -220,30 +220,7 @@ class EventManager implements EventManagerInterface
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null)
     {
-        if ($event instanceof EventInterface) {
-            $e        = $event;
-            $event    = $e->getName();
-            $callback = $target;
-        } elseif ($target instanceof EventInterface) {
-            $e = $target;
-            $e->setName($event);
-            $callback = $argv;
-        } elseif ($argv instanceof EventInterface) {
-            $e = $argv;
-            $e->setName($event);
-            $e->setTarget($target);
-        } else {
-            $e = new $this->eventClass();
-            $e->setName($event);
-            $e->setTarget($target);
-            $e->setParams($argv);
-        }
-
-        if (!is_callable($callback)) {
-            throw new Exception\InvalidCallbackException('Invalid callback provided');
-        }
-
-        return $this->triggerListeners($event, $e, $callback);
+        return $this->trigger($event, $target, $argv, $callback);
     }
 
     /**

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -393,7 +393,7 @@ class EventManager implements EventManagerInterface
      *
      * Use this method if you want to be able to modify arguments from within a
      * listener. It returns an ArrayObject of the arguments, which may then be
-     * passed to trigger() or triggerUntil().
+     * passed to trigger().
      *
      * @param  array $args
      * @return ArrayObject
@@ -406,8 +406,7 @@ class EventManager implements EventManagerInterface
     /**
      * Trigger listeners
      *
-     * Actual functionality for triggering listeners, to which both trigger() and triggerUntil()
-     * delegate.
+     * Actual functionality for triggering listeners, to which trigger() delegate.
      *
      * @param  string           $event Event name
      * @param  EventInterface $e

--- a/library/Zend/EventManager/EventManager.php
+++ b/library/Zend/EventManager/EventManager.php
@@ -216,10 +216,16 @@ class EventManager implements EventManagerInterface
      * @param  array|ArrayAccess $argv Array of arguments; typically, should be associative
      * @param  callable $callback
      * @return ResponseCollection
+     * @deprecated Please use trigger()
      * @throws Exception\InvalidCallbackException if invalid callable provided
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null)
     {
+        trigger_error(
+            'This method is deprecated and will be removed in the future. ' .
+            'Please use trigger() instead.',
+            E_USER_DEPRECATED
+        );
         return $this->trigger($event, $target, $argv, $callback);
     }
 

--- a/library/Zend/EventManager/EventManagerInterface.php
+++ b/library/Zend/EventManager/EventManagerInterface.php
@@ -25,8 +25,7 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
      * - Passing event name and Event object only
      * - Passing event name, target, and Event object
      * - Passing event name, target, and array|ArrayAccess of arguments
-     *
-     * Can emulate triggerUntil() if the last argument provided is a callback.
+     * - Passing event name, target, array|ArrayAccess of arguments, and callback
      *
      * @param  string $event
      * @param  object|string $target
@@ -50,6 +49,7 @@ interface EventManagerInterface extends SharedEventManagerAwareInterface
      * @param  array|object $argv
      * @param  callable $callback
      * @return ResponseCollection
+     * @deprecated Please use trigger()
      */
     public function triggerUntil($event, $target, $argv = null, $callback = null);
 

--- a/library/Zend/EventManager/GlobalEventManager.php
+++ b/library/Zend/EventManager/GlobalEventManager.php
@@ -52,14 +52,15 @@ class GlobalEventManager
     /**
      * Trigger an event
      *
-     * @param  string $event
+     * @param  string        $event
      * @param  object|string $context
-     * @param  array|object $argv
+     * @param  array|object  $argv
+     * @param  null|callable $callback
      * @return ResponseCollection
      */
-    public static function trigger($event, $context, $argv = array())
+    public static function trigger($event, $context, $argv = array(), $callback = null)
     {
-        return static::getEventCollection()->trigger($event, $context, $argv);
+        return static::getEventCollection()->trigger($event, $context, $argv, $callback);
     }
 
     /**
@@ -71,10 +72,15 @@ class GlobalEventManager
      * @param  array|object $argv
      * @param  callable $callback
      * @return ResponseCollection
+     * @deprecated Please use trigger()
      */
     public static function triggerUntil($event, $context, $argv, $callback)
     {
-        return static::getEventCollection()->triggerUntil($event, $context, $argv, $callback);
+        trigger_error(
+            'This method is deprecated and will be removed in the future. Please use trigger() instead.',
+            E_USER_DEPRECATED
+        );
+        return static::trigger($event, $context, $argv, $callback);
     }
 
     /**

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -331,7 +331,7 @@ class SessionManager extends AbstractManager
     public function isValid()
     {
         $validator = $this->getValidatorChain();
-        $responses = $validator->triggerUntil('session.validate', $this, array($this), function ($test) {
+        $responses = $validator->trigger('session.validate', $this, array($this), function ($test) {
             return false === $test;
         });
         if ($responses->stopped()) {

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -162,7 +162,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             $search = $e->getParam('search', '?');
             return strstr($string, $search);
         });
-        $responses = $this->events->triggerUntil(
+        $responses = $this->events->trigger(
             'foo.bar',
             $this,
             array('string' => 'foo', 'search' => 'f'),
@@ -205,7 +205,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach('foo.bar', function () { return 'nada'; }, 3);
         $this->events->attach('foo.bar', function () { return 'found'; }, 2);
         $this->events->attach('foo.bar', function () { return 'zero'; }, 1);
-        $responses = $this->events->triggerUntil('foo.bar', $this, array(), function ($result) {
+        $responses = $this->events->trigger('foo.bar', $this, array(), function ($result) {
             return ($result === 'found');
         });
         $this->assertTrue($responses instanceof ResponseCollection);
@@ -221,7 +221,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach('foo.bar', function () { return 'nada'; });
         $this->events->attach('foo.bar', function () { return 'zero'; });
         $this->events->attach('foo.bar', function () { return 'found'; });
-        $responses = $this->events->triggerUntil('foo.bar', $this, array(), function ($result) {
+        $responses = $this->events->trigger('foo.bar', $this, array(), function ($result) {
             return ($result === 'found');
         });
         $this->assertTrue($responses instanceof ResponseCollection);
@@ -235,7 +235,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach('foo.bar', function () { return 'nada'; }, 3);
         $this->events->attach('foo.bar', function () { return 'found'; }, 2);
         $this->events->attach('foo.bar', function () { return 'zero'; }, 1);
-        $responses = $this->events->triggerUntil('foo.bar', $this, array(), function ($result) {
+        $responses = $this->events->trigger('foo.bar', $this, array(), function ($result) {
             return ($result === 'never found');
         });
         $this->assertTrue($responses instanceof ResponseCollection);
@@ -465,7 +465,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach(__FUNCTION__, function ($e) {
             return $e;
         });
-        $responses = $this->events->triggerUntil($event, function ($r) {
+        $responses = $this->events->trigger($event, function ($r) {
             return ($r instanceof EventInterface);
         });
         $this->assertTrue($responses->stopped());
@@ -480,7 +480,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach(__FUNCTION__, function ($e) {
             return $e;
         });
-        $responses = $this->events->triggerUntil(__FUNCTION__, $event, function ($r) {
+        $responses = $this->events->trigger(__FUNCTION__, $event, function ($r) {
             return ($r instanceof EventInterface);
         });
         $this->assertTrue($responses->stopped());
@@ -495,7 +495,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach(__FUNCTION__, function ($e) {
             return $e;
         });
-        $responses = $this->events->triggerUntil(__FUNCTION__, $this, $event, function ($r) {
+        $responses = $this->events->trigger(__FUNCTION__, $this, $event, function ($r) {
             return ($r instanceof EventInterface);
         });
         $this->assertTrue($responses->stopped());
@@ -665,9 +665,22 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         };
         $event = new Event();
         $event->stopPropagation(true);
-        $this->events->triggerUntil('foo', $event, $criteria);
+        $this->events->trigger('foo', $event, $criteria);
 
         $this->assertFalse($marker->propagationIsStopped);
         $this->assertFalse($event->propagationIsStopped());
+    }
+
+    public function testTriggerUntilDeprecated()
+    {
+        $deprecated = null;
+        set_error_handler(function () use (&$deprecated) {
+            $deprecated = true;
+        }, E_USER_DEPRECATED);
+
+        $this->events->triggerUntil('foo.bar', $this, array('foo' => 'bar'), function () {});
+        restore_error_handler();
+
+        $this->assertTrue($deprecated, 'EventManager::triggerUntil not marked as E_USER_DEPRECATED');
     }
 }

--- a/tests/ZendTest/EventManager/GlobalEventManagerTest.php
+++ b/tests/ZendTest/EventManager/GlobalEventManagerTest.php
@@ -40,7 +40,7 @@ class GlobalEventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testProxiesAllStaticOperationsToEventCollectionInstance()
     {
-        $test    = new \stdClass();
+        $test     = new \stdClass();
         $listener = GlobalEventManager::attach('foo.bar', function ($e) use ($test) {
             $test->event  = $e->getName();
             $test->target = $e->getTarget();
@@ -54,9 +54,10 @@ class GlobalEventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo.bar', $test->event);
         $this->assertEquals(array('foo' => 'bar'), $test->params);
 
-        $results = GlobalEventManager::triggerUntil('foo.bar', $this, array('baz' => 'bat'), function ($r) {
+        $results = GlobalEventManager::trigger('foo.bar', $this, array('baz' => 'bat'), function ($r) {
             return is_array($r);
         });
+
         $this->assertTrue($results->stopped());
         $this->assertEquals(array('baz' => 'bat'), $test->params);
         $this->assertEquals(array('baz' => 'bat'), $results->last());
@@ -82,5 +83,18 @@ class GlobalEventManagerTest extends \PHPUnit_Framework_TestCase
         GlobalEventManager::clearListeners('foo.bar');
         $events = GlobalEventManager::getEvents();
         $this->assertEquals(array(), $events);
+    }
+
+    public function testTriggerUntilDeprecated()
+    {
+        $deprecated = null;
+        set_error_handler(function () use (&$deprecated) {
+            $deprecated = true;
+        }, E_USER_DEPRECATED);
+
+        GlobalEventManager::triggerUntil('foo.bar', $this, array('foo' => 'bar'), function () {});
+        restore_error_handler();
+
+        $this->assertTrue($deprecated, 'GlobalEventManager::triggerUntil not marked as E_USER_DEPRECATED');
     }
 }


### PR DESCRIPTION
see #4122

Also deprecated `GlobalEventManager::triggerUntil()` in the same way as `EventManager::triggerUntil()`
and `EventManagerInterface::triggerUntil()`.

@weierophinney All tests updated!
