### PR TITLE
Add controller's implemented interfaces to its shared event manager default identifiers

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -159,13 +159,20 @@ abstract class AbstractController implements
      */
     public function setEventManager(EventManagerInterface $events)
     {
-        $events->setIdentifiers(array(
+        $identifiers = array(
             'Zend\Stdlib\DispatchableInterface',
             __CLASS__,
             get_class($this),
             $this->eventIdentifier,
             substr(get_class($this), 0, strpos(get_class($this), '\\'))
-        ));
+        );
+
+        $instanceof = class_implements($this);
+        if (is_array($instanceof)) {
+            $identifiers = array_merge($identifiers, array_values($instanceof));
+        }
+
+        $events->setIdentifiers($identifiers);
         $this->events = $events;
         $this->attachDefaultListeners();
 

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -167,8 +167,7 @@ abstract class AbstractController implements
             substr(get_class($this), 0, strpos(get_class($this), '\\'))
         );
 
-        $instanceof = class_implements($this);
-        if (is_array($instanceof)) {
+        if ($instanceof = class_implements($this)) {
             $identifiers = array_merge($identifiers, array_values($instanceof));
         }
 

--- a/tests/ZendTest/Mvc/Controller/ActionControllerTest.php
+++ b/tests/ZendTest/Mvc/Controller/ActionControllerTest.php
@@ -140,6 +140,19 @@ class ActionControllerTest extends TestCase
         $this->assertSame($response, $result);
     }
 
+    public function testEventManagerListensOnInterfaceName()
+    {
+        $response = new Response();
+        $response->setContent('short circuited!');
+        $events = new SharedEventManager();
+        $events->attach('ZendTest\\Mvc\\Controller\\TestAsset\\SampleInterface', MvcEvent::EVENT_DISPATCH, function ($e) use ($response) {
+            return $response;
+        }, 10);
+        $this->controller->getEventManager()->setSharedManager($events);
+        $result = $this->controller->dispatch($this->request, $this->response);
+        $this->assertSame($response, $result);
+    }
+
     public function testDispatchInjectsEventIntoController()
     {
         $this->controller->dispatch($this->request, $this->response);

--- a/tests/ZendTest/Mvc/Controller/TestAsset/SampleController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/SampleController.php
@@ -11,7 +11,7 @@ namespace ZendTest\Mvc\Controller\TestAsset;
 
 use Zend\Mvc\Controller\AbstractActionController;
 
-class SampleController extends AbstractActionController
+class SampleController extends AbstractActionController implements SampleInterface
 {
     public function testAction()
     {

--- a/tests/ZendTest/Mvc/Controller/TestAsset/SampleInterface.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/SampleInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Controller\TestAsset;
+
+interface SampleInterface
+{}

--- a/tests/ZendTest/Mvc/Controller/TestAsset/SampleInterface.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/SampleInterface.php
@@ -10,4 +10,5 @@
 namespace ZendTest\Mvc\Controller\TestAsset;
 
 interface SampleInterface
-{}
+{
+}


### PR DESCRIPTION
Apparently, from the shared manager, it is not possible to attach a callback to a controller (dispatch event) from an interface id it implements. 

I simply added the list of the implemented classes to the identifiers. This adds the possibility to do this:

``` php
// Module.php - this was never triggered
$eventManager->getSharedManager()->attach(LambdaControllerInterface::class, 'dispatch', [
    $this, 'myCallback'
]);

// MyController.php
class MyController extends AbstractActionController implements LambdaControllerInterface
{
}
```

I am not an expert on the event managers, waiting for some feedback before adding some tests.
