### PR TITLE
Do not gitignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 .*.sw*
 .*.un~
 build/
-composer.lock
 nbproject
 tmp/


### PR DESCRIPTION
https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
"Commit your application's composer.lock (along with composer.json) into version control.

This is important because the install command checks if a lock file is present, and if it is, it downloads the versions specified there (regardless of what composer.json says)."
