### PR TITLE
Feature/log writer mail - 

### DIFF
--- a/library/Zend/Log/Writer/Mail.php
+++ b/library/Zend/Log/Writer/Mail.php
@@ -86,6 +86,9 @@ class Mail extends AbstractWriter
             }
             $transport = isset($mail['transport']) ? $mail['transport'] : null;
             $mail      = isset($mail['mail']) ? $mail['mail'] : null;
+            if (is_array($mail)) {
+                $mail = new MailMessage($mail);
+            }
         }
 
         // Ensure we have a valid mail message

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -53,7 +53,7 @@ class Message
      * @return self
      * @throws Exception\InvalidArgumentException
      */
-    public function setOptions($options)
+    private function setOptions($options)
     {
         if (!is_array($options) && !$options instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -36,6 +36,44 @@ class Message
     protected $encoding = 'ASCII';
 
     /**
+     * Constructor.
+     *
+     * @param null|array|Traversable $options (Optional) Options to set
+     * @param array|Traversable $options
+     */
+    public function __construct($options = null)
+    {
+        if (null !== $options) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * @param  array|Traversable $options         Options to set
+     * @return self
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setOptions($options)
+    {
+        if (!is_array($options) && !$options instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '"%s" expects an array or Traversable; received "%s"',
+                __METHOD__,
+                (is_object($options) ? get_class($options) : gettype($options))
+            ));
+        }
+
+        foreach ($options as $key => $value) {
+            $setter = 'set' . str_replace(' ', '', ucwords(str_replace('-', ' ', str_replace('_', ' ', $key))));
+            if (method_exists($this, $setter)) {
+                $this->{$setter}($value);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Is the message valid?
      *
      * If we don't any From addresses, we're invalid, according to RFC2822.

--- a/tests/ZendTest/Log/Writer/MailTest.php
+++ b/tests/ZendTest/Log/Writer/MailTest.php
@@ -111,4 +111,21 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $filters);
         $this->assertEquals($filter, $filters[0]);
     }
+
+    public function testConstructWithMailOptions()
+    {
+        $message = array(
+            'from'      => 'matthew@example.com',
+            'to'        => 'zf-devteam@example.com',
+            'cc'        => 'zf-contributors@example.com',
+            'bcc'       => 'zf-devteam@example.com',
+            'subject'   => 'subject',
+        );
+
+        $writer = new MailWriter(array(
+            'mail' => $message,
+        ));
+
+        $this->assertAttributeInstanceOf('Zend\Mail\Message', 'mail', $writer);
+    }
 }

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -734,7 +734,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Zend\Mail\AddressList', $value);
             $this->assertEquals(1, count($value));
             $this->assertTrue($value->has($options[$key]));
-
         }
     }
 
@@ -775,7 +774,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Zend\Mail\AddressList', $value);
             $this->assertEquals(1, count($value));
             $this->assertTrue($value->has($options[$key]));
-
         }
     }
 }

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -717,7 +717,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('UTF-8',   $message->getEncoding());
         $this->assertEquals('subject', $message->getSubject());
         $this->assertEquals('body',    $message->getBody());
-        
         $this->assertInstanceOf('Zend\Mail\Address', $message->getSender());
         $this->assertEquals($options['sender'], $message->getSender()->getEmail());
 

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -696,7 +696,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->message->getBodyText());
     }
 
-    public function testSetOptionsInConstructor()
+    public function testConstructorWithOptions()
     {
         $options = array(
             'encoding'  => 'UTF-8',

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -695,4 +695,87 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setBody($mimeMessage);
         $this->assertEquals('', $this->message->getBodyText());
     }
+
+    public function testSetOptions()
+    {
+        $options = array(
+            'encoding'  => 'UTF-8',
+            'from'      => 'matthew@example.com',
+            'to'        => 'zf-devteam@example.com',
+            'cc'        => 'zf-contributors@example.com',
+            'bcc'       => 'zf-devteam@example.com',
+            'reply-to'  => 'matthew@example.com',
+            'sender'    => 'matthew@example.com',
+            'subject'   => 'subject',
+            'body'      => 'body',
+            'ignore'    => 'ignore options',
+        );
+
+        $message = new Message($options);
+        $message->setOptions($options);
+
+        $this->assertEquals('UTF-8',   $message->getEncoding());
+        $this->assertEquals('subject', $message->getSubject());
+        $this->assertEquals('body',    $message->getBody());
+        
+        $this->assertInstanceOf('Zend\Mail\Address', $message->getSender());
+        $this->assertEquals($options['sender'], $message->getSender()->getEmail());
+
+        $getMethods = array(
+            'from'      => 'getFrom',
+            'to'        => 'getTo',
+            'cc'        => 'getCc',
+            'bcc'       => 'getBcc',
+            'reply-to'  => 'getReplyTo',
+        );
+
+        foreach ($getMethods as $key => $method) {
+            $value = $message->{$method}();
+            $this->assertInstanceOf('Zend\Mail\AddressList', $value);
+            $this->assertEquals(1, count($value));
+            $this->assertTrue($value->has($options[$key]));
+
+        }
+    }
+
+    public function testSetOptionsInConstructor()
+    {
+        $options = array(
+            'encoding'  => 'UTF-8',
+            'from'      => 'matthew@example.com',
+            'to'        => 'zf-devteam@example.com',
+            'cc'        => 'zf-contributors@example.com',
+            'bcc'       => 'zf-devteam@example.com',
+            'reply-to'  => 'matthew@example.com',
+            'sender'    => 'matthew@example.com',
+            'subject'   => 'subject',
+            'body'      => 'body',
+            'ignore'    => 'ignore options',
+        );
+
+        $message = new Message(new \ArrayObject($options));
+
+        $this->assertEquals('UTF-8',   $message->getEncoding());
+        $this->assertEquals('subject', $message->getSubject());
+        $this->assertEquals('body',    $message->getBody());
+        
+        $this->assertInstanceOf('Zend\Mail\Address', $message->getSender());
+        $this->assertEquals($options['sender'], $message->getSender()->getEmail());
+
+        $getMethods = array(
+            'from'      => 'getFrom',
+            'to'        => 'getTo',
+            'cc'        => 'getCc',
+            'bcc'       => 'getBcc',
+            'reply-to'  => 'getReplyTo',
+        );
+
+        foreach ($getMethods as $key => $method) {
+            $value = $message->{$method}();
+            $this->assertInstanceOf('Zend\Mail\AddressList', $value);
+            $this->assertEquals(1, count($value));
+            $this->assertTrue($value->has($options[$key]));
+
+        }
+    }
 }

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -696,46 +696,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->message->getBodyText());
     }
 
-    public function testSetOptions()
-    {
-        $options = array(
-            'encoding'  => 'UTF-8',
-            'from'      => 'matthew@example.com',
-            'to'        => 'zf-devteam@example.com',
-            'cc'        => 'zf-contributors@example.com',
-            'bcc'       => 'zf-devteam@example.com',
-            'reply-to'  => 'matthew@example.com',
-            'sender'    => 'matthew@example.com',
-            'subject'   => 'subject',
-            'body'      => 'body',
-            'ignore'    => 'ignore options',
-        );
-
-        $message = new Message($options);
-        $message->setOptions($options);
-
-        $this->assertEquals('UTF-8',   $message->getEncoding());
-        $this->assertEquals('subject', $message->getSubject());
-        $this->assertEquals('body',    $message->getBody());
-        $this->assertInstanceOf('Zend\Mail\Address', $message->getSender());
-        $this->assertEquals($options['sender'], $message->getSender()->getEmail());
-
-        $getMethods = array(
-            'from'      => 'getFrom',
-            'to'        => 'getTo',
-            'cc'        => 'getCc',
-            'bcc'       => 'getBcc',
-            'reply-to'  => 'getReplyTo',
-        );
-
-        foreach ($getMethods as $key => $method) {
-            $value = $message->{$method}();
-            $this->assertInstanceOf('Zend\Mail\AddressList', $value);
-            $this->assertEquals(1, count($value));
-            $this->assertTrue($value->has($options[$key]));
-        }
-    }
-
     public function testSetOptionsInConstructor()
     {
         $options = array(

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -756,7 +756,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('UTF-8',   $message->getEncoding());
         $this->assertEquals('subject', $message->getSubject());
         $this->assertEquals('body',    $message->getBody());
-        
         $this->assertInstanceOf('Zend\Mail\Address', $message->getSender());
         $this->assertEquals($options['sender'], $message->getSender()->getEmail());
 


### PR DESCRIPTION
Hi,

This patch allow the creation of an Zend\Mail\Message in Zend\Log\Writer\Mail through options passed to the writer. if $mail['mail'] is an array, we create a Zend\Mail\Message.

Here is a example of configuration, allowed by this patch

```
    'log' => array(
        'Log\App' => array(
            'writers' => array(
                'mail_log' => array(
                    'name'      => 'mail',
                    'options'   => array(
                        'mail' => array(
                            'from'      => 'system@example.com',
                            'to'        => 'admin@example.com',
                            'Encoding'  => 'UTF-8',
                        ),
                        'subject_prepend_text' => '[alert]',
                    ),
                ),
            ),
        ),
    ),
```

As this is my first pull-request in zf2, don't hesitate to give me feedback so that I can be better.

Cheers,
Patrick
