### PR TITLE
Feature/support unix domain socket

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -320,8 +320,8 @@ class Client implements Stdlib\DispatchableInterface
                 $this->setAuth($this->getUri()->getUser(), $this->getUri()->getPassword());
             }
 
-            // We have no ports, set the defaults
-            if (! $this->getUri()->getPort()) {
+            // We have no ports, set the defaults but not if the medium is a unix socket
+            if (! $this->getUri()->getPort() && $this->getUri()->getScheme() !== 'unix') {
                 $this->getUri()->setPort(($this->getUri()->getScheme() == 'https' ? 443 : 80));
             }
         }
@@ -847,8 +847,8 @@ class Client implements Stdlib\DispatchableInterface
                     $uri = new Http($newUri);
                 }
             }
-            // If we have no ports, set the defaults
-            if (!$uri->getPort()) {
+            // If we have no ports, set the defaults but not if the medium is a unix socket
+            if (!$uri->getPort() && $uri->getScheme() !== 'unix') {
                 $uri->setPort($uri->getScheme() == 'https' ? 443 : 80);
             }
 
@@ -1356,7 +1356,7 @@ class Client implements Stdlib\DispatchableInterface
     protected function doRequest(Http $uri, $method, $secure = false, $headers = array(), $body = '')
     {
         // Open the connection, send the request and read the response
-        $this->adapter->connect($uri->getHost(), $uri->getPort(), $secure);
+        $this->adapter->connect($uri->getHost(), $uri->getPort(), $secure, $uri->getScheme() === 'unix');
 
         if ($this->config['outputstream']) {
             if ($this->adapter instanceof Client\Adapter\StreamInterface) {

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -245,13 +245,11 @@ class Socket implements HttpAdapter, StreamInterface
 
             if ($local) {
                 $host = 'unix://' . $host;
-            } else {
-                $host .= ':' . $port;
             }
 
             ErrorHandler::start();
             $this->socket = stream_socket_client(
-                $host,
+                $host . (($local) ? '' : ':' . $port),
                 $errno,
                 $errstr,
                 (int) $this->config['timeout'],

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -14,6 +14,7 @@ use Zend\Stdlib\ParametersInterface;
 use Zend\Stdlib\RequestInterface;
 use Zend\Uri\Exception as UriException;
 use Zend\Uri\Http as HttpUri;
+use Zend\Uri\UnixHttp as UnixHttpUri;
 
 /**
  * HTTP Request
@@ -185,7 +186,11 @@ class Request extends AbstractMessage implements RequestInterface
     {
         if (is_string($uri)) {
             try {
-                $uri = new HttpUri($uri);
+                if (preg_match('/^unix:/', $uri)) {
+                    $uri = new UnixHttpUri($uri);
+                } else {
+                    $uri = new HttpUri($uri);
+                }
             } catch (UriException\InvalidUriPartException $e) {
                 throw new Exception\InvalidArgumentException(
                     sprintf('Invalid URI passed as string (%s)', (string) $uri),


### PR DESCRIPTION
Unix sockets are also used for http, however, the current socket adapter just supports tcp/ip sockets. Related to PR #6624.
