### PR TITLE
Added zendframework/zend-servicemanager into suggest at Zend\Permissions\Acl's composer.json

### DIFF
--- a/library/Zend/Permissions/Acl/composer.json
+++ b/library/Zend/Permissions/Acl/composer.json
@@ -16,6 +16,9 @@
     "require": {
         "php": ">=5.3.23"
     },
+    "suggest": {
+        "zendframework/zend-servicemanager": "To support Zend\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.3-dev",


### PR DESCRIPTION
to support Zend\Permissions\Acl\Assertion\AssertionManager plugin manager usage
