### PR TITLE
Allow `crossorigin` attribute in headScript

### DIFF
--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -83,7 +83,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      *
      * @var array
      */
-    protected $optionalAttributes = array('charset', 'defer', 'language', 'src');
+    protected $optionalAttributes = array('charset', 'crossorigin', 'defer', 'language', 'src');
 
     /**
      * Required attributes for script tag


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin
