### PR TITLE
Allow multidimensional params in AbstractControllerTestCase

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -232,13 +232,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
             $query = array_merge($query, $params);
         } elseif ($method == HttpRequest::METHOD_PUT) {
             if (count($params) != 0) {
-                array_walk(
-                    $params,
-                    function (&$item, $key) {
-                        $item = $key . '=' . $item;
-                    }
-                );
-                $content = implode('&', $params);
+                $content = http_build_query($params);
                 $request->setContent($content);
             }
         } elseif ($params) {

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractControllerTestCaseTest.php
@@ -305,6 +305,12 @@ class AbstractControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->dispatch('/tests', 'PUT', array('a' => 1));
         $this->assertEquals('a=1', $this->getRequest()->getContent());
     }
+    
+    public function testCanHandleMultidimensionalParams()
+    {
+        $this->dispatch('/tests', 'PUT', array('a' => array('b' => 1)));
+        $this->assertEquals('a[b]=1', urldecode($this->getRequest()->getContent()));
+    }
 
     public function testAssertTemplateName()
     {


### PR DESCRIPTION
Fixes bug #6636

Added test method testCanHandleMultidimensionalParams to \ZendTest\Test\PHPUnit\Controller\AbstractControllerTestCaseTest that isolates the issue
Fixed the bug by using http_build_query instead of the self-written code to generate the Request-Content
