### PR TITLE
removed unneeded use statement

### DIFF
--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -14,7 +14,6 @@ use ArrayIterator;
 use Traversable;
 use Zend\Stdlib\ArrayUtils;
 use Zend\View\Exception;
-use Zend\View\Model;
 use Zend\View\Variables as ViewVariables;
 
 class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableChildrenInterface


### PR DESCRIPTION
Removed unused `use` statement . Can be that one forgot to remove it or forgot to extend some class, not sure about the reason why it was there 
