### PR TITLE
The /e modifier of preg_replace() deprecated as of PHP 5.5.0

### DIFF
--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -182,7 +182,6 @@ foreach ($l as $file) {
     $map->{$mapName} = $filename;
 }
 
-
 if ($appending) {
     $content = var_export((array) $map, true) . ';';
 
@@ -230,7 +229,9 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
-$content = preg_replace('(\n\s+([^=]+)=>)e', "'\n    \\1' . str_repeat(' ', " . $maxWidth . " - strlen('\\1')) . '=>'", $content);
+$content = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches) use ($maxWidth) {
+    return PHP_EOL . '    ' . $matches[1] . str_repeat(' ', $maxWidth - strlen($matches[1])) . '=>';
+}, $content);
 
 // Make the file end by EOL
 $content = rtrim($content, "\n") . "\n";


### PR DESCRIPTION
As of PHP 5.5.0, the `/e` modifier [marked as deprecated](http://php.net/manual/en/function.preg-replace.php) and `bin/templatemap_generator.php` uses that. I just replaced one `preg_replace()` method with  `preg_replace_callback()` using a clousure while keeping current functionality.
