### PR TITLE
InArray validator accepts boolean true

### DIFF
--- a/tests/ZendTest/Validator/InArrayTest.php
+++ b/tests/ZendTest/Validator/InArrayTest.php
@@ -364,4 +364,16 @@ class InArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($this->validator->getOption('messageTemplates'),
                                      'messageTemplates', $this->validator);
     }
+
+    public function testShouldNotAcceptBooleanTrue()
+    {
+        $validator = new InArray(
+            array(
+                'haystack' => array('a', 'b')
+            )
+        );
+        $this->assertTrue($validator->isValid('a'));
+        $this->assertTrue($validator->isValid('b'));
+        $this->assertFalse($validator->isValid(true));
+    }
 }


### PR DESCRIPTION
If `true` is not in a haystack it should not accept it.
