### PR TITLE
6649

### DIFF
--- a/library/Zend/Form/View/Helper/FormMultiCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormMultiCheckbox.php
@@ -94,7 +94,6 @@ class FormMultiCheckbox extends FormInput
      *
      * @param  ElementInterface $element
      * @throws Exception\InvalidArgumentException
-     * @throws Exception\DomainException
      * @return string
      */
     public function render(ElementInterface $element)
@@ -109,12 +108,6 @@ class FormMultiCheckbox extends FormInput
         $name = static::getName($element);
 
         $options = $element->getValueOptions();
-        if (empty($options)) {
-            throw new Exception\DomainException(sprintf(
-                '%s requires that the element has "value_options"; none found',
-                __METHOD__
-            ));
-        }
 
         $attributes         = $element->getAttributes();
         $attributes['name'] = $name;

--- a/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
@@ -276,14 +276,6 @@ class FormMultiCheckboxTest extends CommonTestCase
         $this->helper->render($element);
     }
 
-    public function testRenderElementWithNoValueOptionsRaisesException()
-    {
-        $element = new MultiCheckboxElement('foo');
-
-        $this->setExpectedException('Zend\Form\Exception\DomainException');
-        $this->helper->render($element);
-    }
-
     public function testCanMarkSingleOptionAsSelected()
     {
         $element = new MultiCheckboxElement('foo');


### PR DESCRIPTION
I've removed the exception being throw when the valueOptions array is empty. I feel that there is a valid use case for the array to be empty - for example, in database backed forms.
