### PR TITLE
Ldap rename bug: emulate flag was always true

### DIFF
--- a/library/Zend/Ldap/Ldap.php
+++ b/library/Zend/Ldap/Ldap.php
@@ -1382,7 +1382,7 @@ class Ldap
         if (!function_exists('ldap_rename')) {
             $emulate = true;
         } elseif ($recursively) {
-            $emulate = true;
+            $emulate = false;
         }
 
         if ($emulate === false) {


### PR DESCRIPTION
Ldap rename bug: emulate flag was always true
