### PR TITLE
Month/Date select return null when empty

### DIFF
--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -114,16 +114,17 @@ class DateSelect extends MonthSelect
         $this->dayElement->setValue($value['day']);
     }
 
-    /**
-     * @return String
-     */
     public function getValue()
     {
-        return sprintf('%s-%s-%s',
-            $this->getYearElement()->getValue(),
-            $this->getMonthElement()->getValue(),
-            $this->getDayElement()->getValue()
-        );
+        $yearValue = $this->getYearElement()->getValue();
+        $monthValue = $this->getMonthElement()->getValue();
+        $dayValue = $this->getDayElement()->getValue();
+
+        if ($this->nullWhenEmpty() && empty($yearValue) && empty($monthValue) && empty($dayValue)) {
+            return null;
+        }
+
+        return sprintf('%s-%s-%s', $yearValue, $monthValue, $dayValue);
     }
 
     /**

--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -114,6 +114,9 @@ class DateSelect extends MonthSelect
         $this->dayElement->setValue($value['day']);
     }
 
+    /**
+     * @return null|string
+     */
     public function getValue()
     {
         $yearValue = $this->getYearElement()->getValue();

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -64,6 +64,13 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     protected $renderDelimiters = true;
 
     /**
+     * If set to true the element will return null when the selects are both empty
+     *
+     * @var bool
+     */
+    protected $nullWhenEmpty = false;
+
+    /**
      * @var ValidatorInterface
      */
     protected $validator;
@@ -122,6 +129,10 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
 
         if (isset($options['render_delimiters'])) {
             $this->setShouldRenderDelimiters($options['render_delimiters']);
+        }
+
+        if (isset($options['null_when_empty'])) {
+            $this->setNullWhenEmpty($options['null_when_empty']);
         }
 
         return $this;
@@ -260,6 +271,24 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     }
 
     /**
+     * @param boolean $nullWhenEmpty
+     * @return MonthSelect
+     */
+    public function setNullWhenEmpty($nullWhenEmpty)
+    {
+        $this->nullWhenEmpty = $nullWhenEmpty;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function nullWhenEmpty()
+    {
+        return $this->nullWhenEmpty;
+    }
+
+    /**
      * @param mixed $value
      * @return void|\Zend\Form\Element
      */
@@ -281,10 +310,14 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
      */
     public function getValue()
     {
-        return sprintf('%s-%s',
-            $this->getYearElement()->getValue(),
-            $this->getMonthElement()->getValue()
-        );
+        $yearValue = $this->getYearElement()->getValue();
+        $monthValue = $this->getMonthElement()->getValue();
+
+        if ($this->nullWhenEmpty() && empty($yearValue) && empty($monthValue)) {
+            return null;
+        }
+
+        return sprintf('%s-%s', $yearValue, $monthValue);
     }
 
     /**

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -306,7 +306,7 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     }
 
     /**
-     * @return String
+     * @return null|string
      */
     public function getValue()
     {

--- a/tests/ZendTest/Form/Element/DateSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateSelectTest.php
@@ -68,6 +68,13 @@ class DateSelectTest extends TestCase
         $this->assertEquals('2012-09-24', $element->getValue());
     }
 
+    public function testGetValueReturnsNullWhenEmptyAndFlagIsSet()
+    {
+        $element  = new DateSelectElement();
+        $element->setNullWhenEmpty(true);
+        $this->assertNull($element->getValue());
+    }
+
     /**
      * @expectedException \Zend\Form\Exception\InvalidArgumentException
      */

--- a/tests/ZendTest/Form/Element/MonthSelectTest.php
+++ b/tests/ZendTest/Form/Element/MonthSelectTest.php
@@ -86,4 +86,11 @@ class MonthSelectTest extends TestCase
         $element->setValue(new DateTime('2012-09'));
         $this->assertEquals('2012-09', $element->getValue());
     }
+
+    public function testGetValueReturnsNullWhenEmptyAndFlagIsSet()
+    {
+        $element  = new MonthSelectElement();
+        $element->setNullWhenEmpty(true);
+        $this->assertNull($element->getValue());
+    }
 }


### PR DESCRIPTION
Changed Month and Date select elements to return null when the composed select boxes are all empty, for backward compatibility, this behaviour must be turned on via a flag.
