### PR TITLE
Use file_exists to check for an uploaded file.

### DIFF
--- a/library/Zend/Validator/File/UploadFile.php
+++ b/library/Zend/Validator/File/UploadFile.php
@@ -74,7 +74,7 @@ class UploadFile extends AbstractValidator
 
         switch ($error) {
             case UPLOAD_ERR_OK:
-                if (empty($file) || false === file_exists($file)) {
+                if (empty($file) || false === is_file($file)) {
                     $this->error(self::FILE_NOT_FOUND);
                 } elseif (! is_uploaded_file($file)) {
                     $this->error(self::ATTACK);

--- a/library/Zend/Validator/File/UploadFile.php
+++ b/library/Zend/Validator/File/UploadFile.php
@@ -74,7 +74,7 @@ class UploadFile extends AbstractValidator
 
         switch ($error) {
             case UPLOAD_ERR_OK:
-                if (empty($file) || false === stream_resolve_include_path($file)) {
+                if (empty($file) || false === file_exists($file)) {
                     $this->error(self::FILE_NOT_FOUND);
                 } elseif (! is_uploaded_file($file)) {
                     $this->error(self::ATTACK);


### PR DESCRIPTION
It turns out that stream_resolve_include_path doesn't work for a default
Windows install where upload_tmp_dir is set to C:\Windows\Temp. I'm
unclear if this is intended PHP behaviour or not, but the upload file
validator should not be checking for a file of the same name on the
include path regardless.
