### PR TITLE
bugfix : options can't be passed to SeparatorToSeparator via PluginManager

### DIFF
--- a/library/Zend/Filter/Word/DashToUnderscore.php
+++ b/library/Zend/Filter/Word/DashToUnderscore.php
@@ -16,6 +16,7 @@ class DashToUnderscore extends SeparatorToSeparator
      */
     public function __construct()
     {
-        parent::__construct('-', '_');
+        $this->setSearchSeparator('-');
+        $this->setReplacementSeparator('_');
     }
 }

--- a/library/Zend/Filter/Word/SeparatorToDash.php
+++ b/library/Zend/Filter/Word/SeparatorToDash.php
@@ -18,6 +18,7 @@ class SeparatorToDash extends SeparatorToSeparator
      */
     public function __construct($searchSeparator = ' ')
     {
-        parent::__construct($searchSeparator, '-');
+        $this->setSearchSeparator($searchSeparator);
+        $this->setReplacementSeparator('-');
     }
 }

--- a/library/Zend/Filter/Word/SeparatorToSeparator.php
+++ b/library/Zend/Filter/Word/SeparatorToSeparator.php
@@ -22,7 +22,8 @@ class SeparatorToSeparator extends AbstractFilter
      *
      * @param  array|Traversable $options
      */
-    public function __construct($options = null) {
+    public function __construct($options = null)
+    {
         if (null !== $options) {
             $this->setOptions($options);
         }

--- a/library/Zend/Filter/Word/SeparatorToSeparator.php
+++ b/library/Zend/Filter/Word/SeparatorToSeparator.php
@@ -14,19 +14,18 @@ use Zend\Filter\Exception;
 
 class SeparatorToSeparator extends AbstractFilter
 {
-    protected $searchSeparator = null;
-    protected $replacementSeparator = null;
+    protected $searchSeparator = ' ';
+    protected $replacementSeparator = '-';
 
     /**
      * Constructor
      *
-     * @param  string $searchSeparator      Separator to search for
-     * @param  string $replacementSeparator Separator to replace with
+     * @param  array|Traversable $options
      */
-    public function __construct($searchSeparator = ' ', $replacementSeparator = '-')
-    {
-        $this->setSearchSeparator($searchSeparator);
-        $this->setReplacementSeparator($replacementSeparator);
+    public function __construct($options = null) {
+        if (null !== $options) {
+            $this->setOptions($options);
+        }
     }
 
     /**

--- a/library/Zend/Filter/Word/UnderscoreToDash.php
+++ b/library/Zend/Filter/Word/UnderscoreToDash.php
@@ -17,6 +17,7 @@ class UnderscoreToDash extends SeparatorToSeparator
      */
     public function __construct()
     {
-        parent::__construct('_', '-');
+        $this->setSearchSeparator('_');
+        $this->setReplacementSeparator('-');
     }
 }

--- a/library/Zend/Filter/Word/UnderscoreToSeparator.php
+++ b/library/Zend/Filter/Word/UnderscoreToSeparator.php
@@ -18,6 +18,7 @@ class UnderscoreToSeparator extends SeparatorToSeparator
      */
     public function __construct($replacementSeparator = ' ')
     {
-        parent::__construct('_', $replacementSeparator);
+        $this->setSearchSeparator('_');
+        $this->setReplacementSeparator($replacementSeparator);
     }
 }

--- a/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
+++ b/tests/ZendTest/Filter/Word/SeparatorToSeparatorTest.php
@@ -48,7 +48,7 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
     public function testFilterSeparatesWordsWithSearchSpecified()
     {
         $string   = 'dash=separated=words';
-        $filter   = new SeparatorToSeparatorFilter('=');
+        $filter   = new SeparatorToSeparatorFilter(array('search_separator' => '='));
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
@@ -58,7 +58,10 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
     public function testFilterSeparatesWordsWithSearchAndReplacementSpecified()
     {
         $string   = 'dash=separated=words';
-        $filter   = new SeparatorToSeparatorFilter('=', '?');
+        $filter   = new SeparatorToSeparatorFilter(array(
+            'search_separator'      => '=',
+            'replacement_separator' => '?',
+        ));
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
@@ -79,7 +82,10 @@ class SeparatorToSeparatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testReturnUnfiltered($input)
     {
-        $filter = new SeparatorToSeparatorFilter('=', '?');
+        $filter = new SeparatorToSeparatorFilter(array(
+            'search_separator'      => '=',
+            'replacement_separator' => '?',
+        ));
 
         $this->assertEquals($input, $filter($input));
     }


### PR DESCRIPTION
Hi,

When you try to create a SeparatorToSeparator via PluginManager, array options are not passed correctly to the Filter

This exemple

```
$filter = new Filter\FilterChain(array(
    'filters' => array(
        array(
            'name' => 'wordseparatortoseparator',
            'options' => array(
                'search_separator' => '/',
                'remplacement_separator' => '-'
            ),
        ),
     )
));

$filter('/path/to/file');
```

throws this error :

```
PHP Warning:  preg_quote() expects parameter 1 to be string, array given in ./vendor/zendframework/zendframework/library/Zend/Filter/Word/SeparatorToSeparator.php on line 94
```

My PR propose to change the Zend\Filter\Word\SeparatorToSeparator constructor argument to an array option, as all descending classes.

Cheers,
Patrick
