### PR TITLE
Added "zendframework/zend-filter" into suggest at Zend\Stdlib

### DIFF
--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -24,7 +24,8 @@
     "suggest": {
         "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
         "zendframework/zend-serializer": "Zend\\Serializer component",
-        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage",
+        "zendframework/zend-filter": "To support hydrator ClassMethods"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
In order to use the hydrator library in Zend/Stdlib
you have to add also "zendframework/zend-filter" and
"zendframework/zend-servicemanager" otherwise a couple
of exceptions are thrown.
