### PR TITLE
Support subscribing to folders in IMAP

### DIFF
--- a/library/Zend/Mail/Protocol/Imap.php
+++ b/library/Zend/Mail/Protocol/Imap.php
@@ -753,6 +753,17 @@ class Imap
     }
 
     /**
+     * subscribe to a folder
+     * 
+     * @param string $folder folder name
+     * @return bool success
+     */
+    public function subscribe($folder)
+    {
+        return $this->requestAndResponse('SUBSCRIBE', array($this->escapeString($folder)), true);
+    }
+    
+    /**
      * permanently remove messages
      *
      * @return bool success


### PR DESCRIPTION
This brings in support for the IMAP `SUBSCRIBE` command.

There were no direct tests on Mail\Protocol, so I wasn't sure how you wanted to handle that.

Thanks!
-Ameir
