### PR TITLE
Translator accept null

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -430,7 +430,7 @@ class Translator implements TranslatorInterface
         $locale,
         $textDomain = 'default'
     ) {
-        if ($message === '') {
+        if ($message === '' || $message === null) {
             return '';
         }
 


### PR DESCRIPTION
Currently when a module tries to translate something with null, following error comes up (ErrorException is custom)
2014-09-16T11:57:12+02:00 WARN (4): exception 'ErrorException' with message 'Illegal offset type' in vendor\zendframework\zendframework\library\Zend\I18n\Translator\Translator.php:441
