### PR TITLE
Quickfix for php-cs-fixer issues

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,16 +9,11 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->notPath('ZendTest/Validator/_files')
     ->notPath('ZendTest/Loader/_files')
     ->notPath('ZendTest/Loader/TestAsset')
-    ->notPath('demos')
-    ->notPath('resources')
     ->filter(function (SplFileInfo $file) {
         if (strstr($file->getPath(), 'compatibility')) {
             return false;
         }
-    })
-    ->in(__DIR__ . '/library')
-    ->in(__DIR__ . '/tests')
-    ->in(__DIR__ . '/bin');
+    });
 $config = Symfony\CS\Config\Config::create();
 $config->fixers(
     array(

--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,8 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->notPath('ZendTest/Validator/_files')
     ->notPath('ZendTest/Loader/_files')
     ->notPath('ZendTest/Loader/TestAsset')
+    ->notPath('demos')
+    ->notPath('resources')
     // Following are necessary when you use `parallel` or specify a path
     // from the project root.
     ->notPath('Stream.php')

--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,15 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->notPath('ZendTest/Validator/_files')
     ->notPath('ZendTest/Loader/_files')
     ->notPath('ZendTest/Loader/TestAsset')
+    // Following are necessary when you use `parallel` or specify a path
+    // from the project root.
+    ->notPath('Stream.php')
+    ->notPath('Generator/TestAsset')
+    ->notPath('Reflection/FunctionReflectionTest.php')
+    ->notPath('Reflection/MethodReflectionTest.php')
+    ->notPath('Reflection/TestAsset')
+    ->notPath('TestAsset')
+    ->notPath('_files')
     ->filter(function (SplFileInfo $file) {
         if (strstr($file->getPath(), 'compatibility')) {
             return false;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_script:
   - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
 
 script:
-  - vendor/bin/php-cs-fixer fix -v --dry-run
+  # Run coding standard checks in parallel
+  - ls -d library/Zend/* tests/ZendTest/* bin | parallel --gnu --keep-order 'echo "Running {} CS checks"; ./vendor/bin/php-cs-fixer fix {} -v --dry-run --config-file=.php_cs;' || exit 1
   # Run tests for the various components in parallel
   - ls -d tests/ZendTest/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/phpunit.xml.dist --coverage-php build/coverage/coverage-{/.}.cov {};' || exit 1
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ircmaxell/random-lib": "dev-master",
         "ircmaxell/security-lib": "dev-master",
         "mikey179/vfsStream": "1.2.*",
-        "fabpot/php-cs-fixer": "dev-master",
+        "fabpot/php-cs-fixer": "dev-master#fcbb09b5204",
         "phpunit/PHPUnit": "3.7.*",
         "satooshi/php-coveralls": "dev-master",
         "sebastianbergmann/phpcov": "1.1.0"


### PR DESCRIPTION
A recent spate of breakages on the php-cs-fixer project are leading to false positive reports of CS failures, and, most recently, build errors (due to php-cs-fixer taking longer than 10 minutes to run).

This pull request does the following:
- Pins php-cs-fixer to a "known good" version (based on last build without CS failures).
- Modifies the travis build to run CS validations in parallel.
- Updates the php-cs-fixer configuration to allow it to accept directories as arguments and still use the configuration file (unforunately, the configuration must vary based on whether it is invoked without arguments or with; additionally, path matching will be relative to the argument, not where the fixer is invoked).

The plan is to move to PHP CodeSniffer in the long term, but this patch will get us working for the near term.
