### PR TITLE
PHPCS fixes for Zend\View

### DIFF
--- a/library/Zend/View/Exception/BadMethodCallException.php
+++ b/library/Zend/View/Exception/BadMethodCallException.php
@@ -12,8 +12,6 @@ namespace Zend\View\Exception;
 /**
  * Bad method call exception
  */
-class BadMethodCallException
-    extends \BadMethodCallException
-    implements ExceptionInterface
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
 }

--- a/library/Zend/View/Exception/DomainException.php
+++ b/library/Zend/View/Exception/DomainException.php
@@ -12,8 +12,6 @@ namespace Zend\View\Exception;
 /**
  * Domain exception
  */
-class DomainException
-    extends \DomainException
-    implements ExceptionInterface
+class DomainException extends \DomainException implements ExceptionInterface
 {
 }

--- a/library/Zend/View/Exception/InvalidArgumentException.php
+++ b/library/Zend/View/Exception/InvalidArgumentException.php
@@ -12,8 +12,6 @@ namespace Zend\View\Exception;
 /**
  * Invalid argument exception
  */
-class InvalidArgumentException
-    extends \InvalidArgumentException
-    implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/library/Zend/View/Exception/InvalidHelperException.php
+++ b/library/Zend/View/Exception/InvalidHelperException.php
@@ -12,8 +12,6 @@ namespace Zend\View\Exception;
 /**
  * Invalid helper exception
  */
-class InvalidHelperException
-    extends \Exception
-    implements ExceptionInterface
+class InvalidHelperException extends \Exception implements ExceptionInterface
 {
 }

--- a/library/Zend/View/Exception/RuntimeException.php
+++ b/library/Zend/View/Exception/RuntimeException.php
@@ -12,8 +12,6 @@ namespace Zend\View\Exception;
 /**
  * Runtime exception
  */
-class RuntimeException
-    extends \RuntimeException
-    implements ExceptionInterface
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/library/Zend/View/Exception/UnexpectedValueException.php
+++ b/library/Zend/View/Exception/UnexpectedValueException.php
@@ -12,7 +12,6 @@ namespace Zend\View\Exception;
 /**
  * Unexpected value exception
  */
-class UnexpectedValueException extends \UnexpectedValueException implements
-    ExceptionInterface
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
 }

--- a/library/Zend/View/Helper/Cycle.php
+++ b/library/Zend/View/Helper/Cycle.php
@@ -88,7 +88,7 @@ class Cycle extends AbstractHelper implements Iterator
      * @param  string $name
      * @return Cycle
      */
-    public function assign(Array $data , $name = self::DEFAULT_NAME)
+    public function assign(array $data, $name = self::DEFAULT_NAME)
     {
         $this->setName($name);
         $this->data[$name] = $data;
@@ -126,7 +126,6 @@ class Cycle extends AbstractHelper implements Iterator
     {
         return $this->name;
     }
-
 
     /**
      * Return all elements

--- a/library/Zend/View/Helper/EscapeCss.php
+++ b/library/Zend/View/Helper/EscapeCss.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-
 /**
  * Helper for escaping values
  */

--- a/library/Zend/View/Helper/EscapeHtml.php
+++ b/library/Zend/View/Helper/EscapeHtml.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-
 /**
  * Helper for escaping values
  */

--- a/library/Zend/View/Helper/EscapeHtmlAttr.php
+++ b/library/Zend/View/Helper/EscapeHtmlAttr.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-
 /**
  * Helper for escaping values
  */

--- a/library/Zend/View/Helper/EscapeJs.php
+++ b/library/Zend/View/Helper/EscapeJs.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-
 /**
  * Helper for escaping values
  */

--- a/library/Zend/View/Helper/EscapeUrl.php
+++ b/library/Zend/View/Helper/EscapeUrl.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-
 /**
  * Helper for escaping values
  */

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -144,10 +144,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             }
 
             if (1 > $argc) {
-                throw new Exception\BadMethodCallException(sprintf(
-                    '%s requires at least one argument',
-                    $method
-                 ));
+                throw new Exception\BadMethodCallException(
+                    sprintf('%s requires at least one argument', $method)
+                );
             }
 
             if (is_array($args[0])) {
@@ -266,7 +265,6 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         return $this->getContainer()->set($value);
     }
 
-
     /**
      * Create HTML link element from data item
      *
@@ -300,10 +298,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             return '';
         }
 
-        if (isset($attributes['conditionalStylesheet'])
-            && !empty($attributes['conditionalStylesheet'])
-            && is_string($attributes['conditionalStylesheet'])
-        ) {
+        if (isset($attributes['conditionalStylesheet']) && !empty($attributes['conditionalStylesheet']) && is_string($attributes['conditionalStylesheet'])) {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $attributes['conditionalStylesheet']) === '!IE') {
                 $link = '<!-->' . $link . '<!--';

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -115,11 +115,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
      */
     public function __call($method, $args)
     {
-        if (preg_match(
-            '/^(?P<action>set|(pre|ap)pend|offsetSet)(?P<type>Name|HttpEquiv|Property|Itemprop)$/',
-            $method,
-            $matches)
-        ) {
+        if (preg_match('/^(?P<action>set|(pre|ap)pend|offsetSet)(?P<type>Name|HttpEquiv|Property|Itemprop)$/', $method, $matches)) {
             $action = $matches['action'];
             $type   = $this->normalizeType($matches['type']);
             $argc   = count($args);
@@ -265,10 +261,7 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
             $modifiersString
         );
 
-        if (isset($item->modifiers['conditional'])
-            && !empty($item->modifiers['conditional'])
-            && is_string($item->modifiers['conditional'])
-        ) {
+        if (isset($item->modifiers['conditional']) && !empty($item->modifiers['conditional']) && is_string($item->modifiers['conditional'])) {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $item->modifiers['conditional']) === '!IE') {
                 $meta = '<!-->' . $meta . '<!--';

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -328,10 +328,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
     protected function isDuplicate($file)
     {
         foreach ($this->getContainer() as $item) {
-            if (($item->source === null)
-                && array_key_exists('src', $item->attributes)
-                && ($file == $item->attributes['src'])
-            ) {
+            if (($item->source === null) && array_key_exists('src', $item->attributes) && ($file == $item->attributes['src'])) {
                 return true;
             }
         }
@@ -347,10 +344,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     protected function isValid($value)
     {
-        if ((!$value instanceof stdClass)
-            || !isset($value->type)
-            || (!isset($value->source) && !isset($value->attributes))
-        ) {
+        if ((!$value instanceof stdClass) || !isset($value->type) || (!isset($value->source) && !isset($value->attributes))) {
             return false;
         }
 
@@ -372,8 +366,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         if (!empty($item->attributes)) {
             foreach ($item->attributes as $key => $value) {
                 if ((!$this->arbitraryAttributesAllowed() && !in_array($key, $this->optionalAttributes))
-                    || in_array($key, array('conditional', 'noescape'))
-                ) {
+                    || in_array($key, array('conditional', 'noescape'))) {
                     continue;
                 }
                 if ('defer' == $key) {
@@ -404,10 +397,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
         }
         $html .= '</script>';
 
-        if (isset($item->attributes['conditional'])
-            && !empty($item->attributes['conditional'])
-            && is_string($item->attributes['conditional'])
-        ) {
+        if (isset($item->attributes['conditional']) && !empty($item->attributes['conditional']) && is_string($item->attributes['conditional'])) {
             // inner wrap with comment end and start if !IE
             if (str_replace(' ', '', $item->attributes['conditional']) === '!IE') {
                 $html = '<!-->' . $html . '<!--';

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -264,10 +264,7 @@ class HeadStyle extends Placeholder\Container\AbstractStandalone
      */
     protected function isValid($value)
     {
-        if ((!$value instanceof stdClass)
-            || !isset($value->content)
-            || !isset($value->attributes)
-        ) {
+        if ((!$value instanceof stdClass) || !isset($value->content) || !isset($value->attributes)) {
             return false;
         }
 

--- a/library/Zend/View/Helper/HeadTitle.php
+++ b/library/Zend/View/Helper/HeadTitle.php
@@ -111,9 +111,7 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
 
         if (null !== ($translator = $this->getTranslator())) {
             foreach ($this as $item) {
-                $items[] = $translator->translate(
-                    $item, $this->getTranslatorTextDomain()
-                );
+                $items[] = $translator->translate($item, $this->getTranslatorTextDomain());
             }
         } else {
             foreach ($this as $item) {

--- a/library/Zend/View/Helper/Navigation.php
+++ b/library/Zend/View/Helper/Navigation.php
@@ -201,7 +201,8 @@ class Navigation extends AbstractNavigationHelper
 
         if ($this->getInjectTranslator() && !$helper->hasTranslator()) {
             $helper->setTranslator(
-                $this->getTranslator(), $this->getTranslatorTextDomain()
+                $this->getTranslator(),
+                $this->getTranslatorTextDomain()
             );
         }
     }

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -203,8 +203,8 @@ class Breadcrumbs extends AbstractHelper
             if (count($partial) != 2) {
                 throw new Exception\InvalidArgumentException(
                     'Unable to render menu: A view partial supplied as '
-                        .  'an array must contain two values: partial view '
-                        .  'script and module where script can be found'
+                    .  'an array must contain two values: partial view '
+                    .  'script and module where script can be found'
                 );
             }
 

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -237,8 +237,7 @@ class Sitemap extends AbstractHelper
                 if (!$this->getUseSitemapValidators() ||
                     $priorityValidator->isValid($priority)) {
                     $urlNode->appendChild(
-                        $dom->createElementNS(self::SITEMAP_NS, 'priority',
-                            $priority)
+                        $dom->createElementNS(self::SITEMAP_NS, 'priority', $priority)
                     );
                 }
             }

--- a/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/AbstractStandalone.php
@@ -250,10 +250,12 @@ abstract class AbstractStandalone extends AbstractHelper implements
     {
         if (!class_exists($name)) {
             throw new Exception\DomainException(
-                sprintf('%s expects a valid container class name; received "%s", which did not resolve',
+                sprintf(
+                    '%s expects a valid container class name; received "%s", which did not resolve',
                     __METHOD__,
                     $name
-                ));
+                )
+            );
         }
 
         if (!in_array('Zend\View\Helper\Placeholder\Container\AbstractContainer', class_parents($name))) {

--- a/library/Zend/View/Helper/Placeholder/Registry.php
+++ b/library/Zend/View/Helper/Placeholder/Registry.php
@@ -156,10 +156,12 @@ class Registry
     {
         if (!class_exists($name)) {
             throw new Exception\DomainException(
-                sprintf('%s expects a valid registry class name; received "%s", which did not resolve',
-                        __METHOD__,
-                        $name
-                ));
+                sprintf(
+                    '%s expects a valid registry class name; received "%s", which did not resolve',
+                    __METHOD__,
+                    $name
+                )
+            );
         }
 
         if (!in_array('Zend\View\Helper\Placeholder\Container\AbstractContainer', class_parents($name))) {

--- a/library/Zend/View/Model/ConsoleModel.php
+++ b/library/Zend/View/Model/ConsoleModel.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Model;
 
-
 class ConsoleModel extends ViewModel
 {
     const RESULT = 'result';

--- a/library/Zend/View/Model/ModelInterface.php
+++ b/library/Zend/View/Model/ModelInterface.php
@@ -150,7 +150,6 @@ interface ModelInterface extends Countable, IteratorAggregate
      */
     public function terminate();
 
-
     /**
      * Set flag indicating whether or not append to child  with the same capture
      *

--- a/library/Zend/View/Model/ViewModel.php
+++ b/library/Zend/View/Model/ViewModel.php
@@ -58,7 +58,6 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
      */
     protected $variables = array();
 
-
     /**
      * Is this append to child  with the same capture?
      *

--- a/library/Zend/View/Stream.php
+++ b/library/Zend/View/Stream.php
@@ -73,8 +73,8 @@ class Stream
          * Convert <?= ?> to long-form <?php echo ?> and <?php ?> to <?php ?>
          *
          */
-        $this->data = preg_replace('/\<\?\=/',          "<?php echo ",  $this->data);
-        $this->data = preg_replace('/<\?(?!xml|php)/s', '<?php ',       $this->data);
+        $this->data = preg_replace('/\<\?\=/', "<?php echo ", $this->data);
+        $this->data = preg_replace('/<\?(?!xml|php)/s', '<?php ', $this->data);
 
         /**
          * file_get_contents() won't update PHP's stat cache, so we grab a stat
@@ -109,7 +109,6 @@ class Stream
         return $ret;
     }
 
-
     /**
      * Tells the current position in the stream.
      *
@@ -119,7 +118,6 @@ class Stream
     {
         return $this->pos;
     }
-
 
     /**
      * Tells if we are at the end of the stream.
@@ -131,7 +129,6 @@ class Stream
         return $this->pos >= strlen($this->data);
     }
 
-
     /**
      * Stream statistics.
      *
@@ -141,7 +138,6 @@ class Stream
     {
         return $this->stat;
     }
-
 
     /**
      * Seek to a specific point in the stream.


### PR DESCRIPTION
Mostly whitespace changes. 
One instance of keyword `Array` to `array`
