### PR TITLE
Fixed the unit tests on Windows. The /tmp folder doesn't exist so we sho...

### DIFF
--- a/tests/ZendTest/Code/Generator/FileGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/FileGeneratorTest.php
@@ -309,7 +309,7 @@ EOS;
     {
         $g = new \Zend\Code\Generator\FileGenerator();
         $g = $g->fromReflectedFileName(__DIR__ . '/TestAsset/ClassWithUses.php');
-        $g->setFilename('/tmp/result_class.php');
+        $g->setFilename(sys_get_temp_dir() . '/result_class.php');
         $g->getClass()->addMethod('added');
         $g->write();
 
@@ -343,7 +343,7 @@ class ClassWithUses
 
 
 CODE;
-        $actual = file_get_contents('/tmp/result_class.php');
+        $actual = file_get_contents(sys_get_temp_dir() . '/result_class.php');
         $this->assertEquals($expected, $actual);
     }
 
@@ -354,7 +354,7 @@ CODE;
     {
         $g = new \Zend\Code\Generator\FileGenerator();
         $g = $g->fromReflectedFileName(__DIR__ . '/TestAsset/ClassWithUses.php');
-        $g->setFilename('/tmp/result_class.php');
+        $g->setFilename(sys_get_temp_dir() . '/result_class.php');
         $g->getClass()->addMethod('added');
         $g->setBody("\$foo->bar();");
         $g->write();
@@ -390,7 +390,7 @@ class ClassWithUses
 
 $foo->bar();
 CODE;
-        $actual = file_get_contents('/tmp/result_class.php');
+        $actual = file_get_contents(sys_get_temp_dir() . '/result_class.php');
         $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
These unit tests didn't pass on Windows because the /tmp folder doesn't exist there. We now use the tmp folder as defined by PHP resulting in all unit tests to pass.
