### PR TITLE
TemplateWrapper getter

### DIFF
--- a/library/Zend/Form/View/Helper/FormCollection.php
+++ b/library/Zend/Form/View/Helper/FormCollection.php
@@ -184,7 +184,7 @@ class FormCollection extends AbstractHelper
         }
 
         return sprintf(
-            $this->templateWrapper,
+            $this->getTemplateWrapper(),
             $escapeHtmlAttribHelper($templateMarkup)
         );
     }


### PR DESCRIPTION
Added the call of getTemplateWrapper() instead of directly passing the protected var.
