### PR TITLE
Update FirePhpInterface for Log Writer

### DIFF
--- a/library/Zend/Log/Writer/FirePhp/FirePhpBridge.php
+++ b/library/Zend/Log/Writer/FirePhp/FirePhpBridge.php
@@ -56,9 +56,9 @@ class FirePhpBridge implements FirePhpInterface
      * @param  string $line
      * @return void
      */
-    public function error($line)
+    public function error($line, $label = null, $options = array())
     {
-        return $this->firephp->error($line);
+        return $this->firephp->error($line, $label, $options);
     }
 
     /**
@@ -67,9 +67,9 @@ class FirePhpBridge implements FirePhpInterface
      * @param  string $line
      * @return void
      */
-    public function warn($line)
+    public function warn($line, $label = null, $options = array())
     {
-        return $this->firephp->warn($line);
+        return $this->firephp->warn($line, $label, $options);
     }
 
     /**
@@ -78,9 +78,9 @@ class FirePhpBridge implements FirePhpInterface
      * @param  string $line
      * @return void
      */
-    public function info($line)
+    public function info($line, $label = null, $options = array())
     {
-        return $this->firephp->info($line);
+        return $this->firephp->info($line, $label, $options);
     }
 
     /**
@@ -89,9 +89,9 @@ class FirePhpBridge implements FirePhpInterface
      * @param  string $line
      * @return void
      */
-    public function trace($line)
+    public function trace($line, $label = null, $options = array())
     {
-        return $this->firephp->trace($line);
+        return $this->firephp->trace($line, $label, $options);
     }
 
     /**
@@ -100,8 +100,8 @@ class FirePhpBridge implements FirePhpInterface
      * @param  string $line
      * @return void
      */
-    public function log($line)
+    public function log($line, $label = null, $options = array())
     {
-        return $this->firephp->trace($line);
+        return $this->firephp->trace($line, $label, $options);
     }
 }

--- a/library/Zend/Log/Writer/FirePhp/FirePhpInterface.php
+++ b/library/Zend/Log/Writer/FirePhp/FirePhpInterface.php
@@ -23,7 +23,7 @@ interface FirePhpInterface
      *
      * @param string $line
      * @param string $label
-     * @param array $options 
+     * @param array $options
      */
     public function error($line, $label = null, $options = array());
 
@@ -32,7 +32,7 @@ interface FirePhpInterface
      *
      * @param string $line
      * @param string $label
-     * @param array $options 
+     * @param array $options
      */
     public function warn($line, $label = null, $options = array());
 
@@ -41,7 +41,7 @@ interface FirePhpInterface
      *
      * @param string $line
      * @param string $label
-     * @param array $options 
+     * @param array $options
      */
     public function info($line, $label = null, $options = array());
 
@@ -50,7 +50,7 @@ interface FirePhpInterface
      *
      * @param string $line
      * @param string $label
-     * @param array $options 
+     * @param array $options
      */
     public function trace($line, $label = null, $options = array());
 
@@ -59,7 +59,7 @@ interface FirePhpInterface
      *
      * @param string $line
      * @param string $label
-     * @param array $options 
+     * @param array $options
      */
     public function log($line, $label = null, $options = array());
 }

--- a/library/Zend/Log/Writer/FirePhp/FirePhpInterface.php
+++ b/library/Zend/Log/Writer/FirePhp/FirePhpInterface.php
@@ -22,34 +22,44 @@ interface FirePhpInterface
      * Log an error message
      *
      * @param string $line
+     * @param string $label
+     * @param array $options 
      */
-    public function error($line);
+    public function error($line, $label = null, $options = array());
 
     /**
      * Log a warning
      *
      * @param string $line
+     * @param string $label
+     * @param array $options 
      */
-    public function warn($line);
+    public function warn($line, $label = null, $options = array());
 
     /**
      * Log informational message
      *
      * @param string $line
+     * @param string $label
+     * @param array $options 
      */
-    public function info($line);
+    public function info($line, $label = null, $options = array());
 
     /**
      * Log a trace
      *
      * @param string $line
+     * @param string $label
+     * @param array $options 
      */
-    public function trace($line);
+    public function trace($line, $label = null, $options = array());
 
     /**
      * Log a message
      *
      * @param string $line
+     * @param string $label
+     * @param array $options 
      */
-    public function log($line);
+    public function log($line, $label = null, $options = array());
 }

--- a/tests/ZendTest/Log/TestAsset/MockFirePhp.php
+++ b/tests/ZendTest/Log/TestAsset/MockFirePhp.php
@@ -27,28 +27,28 @@ class MockFirePhp implements FirePhpInterface
         return $this->enabled;
     }
 
-    public function error($line)
+    public function error($line, $label = null, $options = array())
     {
-        $this->calls['error'][] = $line;
+        $this->calls['error'][] = array('line' => $line, 'label' => $label, 'options' => $options);
     }
 
-    public function warn($line)
+    public function warn($line, $label = null, $options = array())
     {
-        $this->calls['warn'][] = $line;
+        $this->calls['warn'][] = array('line' => $line, 'label' => $label, 'options' => $options);
     }
 
-    public function info($line)
+    public function info($line, $label = null, $options = array())
     {
-        $this->calls['info'][] = $line;
+        $this->calls['info'][] = array('line' => $line, 'label' => $label, 'options' => $options);
     }
 
-    public function trace($line)
+    public function trace($line, $label = null, $options = array())
     {
-        $this->calls['trace'][] = $line;
+        $this->calls['trace'][] = array('line' => $line, 'label' => $label, 'options' => $options);
     }
 
-    public function log($line)
+    public function log($line, $label = null, $options = array())
     {
-        $this->calls['log'][] = $line;
+        $this->calls['log'][] = array('line' => $line, 'label' => $label, 'options' => $options);
     }
 }

--- a/tests/ZendTest/Log/Writer/FirePhpTest.php
+++ b/tests/ZendTest/Log/Writer/FirePhpTest.php
@@ -60,7 +60,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         ));
         $this->assertEquals('my msg', $this->firephp->calls['trace'][0]['line']);
     }
-    
+
     /**
      * Test write with extra parameters
      */
@@ -75,7 +75,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('info message', $this->firephp->calls['info'][0]['label']);
         $this->assertEquals(array('more info'), $this->firephp->calls['info'][0]['line']);
     }
-    
+
     /**
      * Test write with FirePhp disabled
      */

--- a/tests/ZendTest/Log/Writer/FirePhpTest.php
+++ b/tests/ZendTest/Log/Writer/FirePhpTest.php
@@ -58,8 +58,24 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
             'message' => 'my msg',
             'priority' => Logger::DEBUG
         ));
-        $this->assertEquals('my msg', $this->firephp->calls['trace'][0]);
+        $this->assertEquals('my msg', $this->firephp->calls['trace'][0]['line']);
     }
+    
+    /**
+     * Test write with extra parameters
+     */
+    public function testWriteExtra()
+    {
+        $writer = new FirePhp($this->firephp);
+        $writer->write(array(
+            'message' => 'info message',
+            'priority' => Logger::INFO,
+            'extra' => array('more info'),
+        ));
+        $this->assertEquals('info message', $this->firephp->calls['info'][0]['label']);
+        $this->assertEquals(array('more info'), $this->firephp->calls['info'][0]['line']);
+    }
+    
     /**
      * Test write with FirePhp disabled
      */


### PR DESCRIPTION
Update /Zend/Log/Writer/FirePhp/FirePhpInterface methods to match signatures in FirePhp. This is needed because the /Zend/Log/Formatter/FirePhp changes the log message to a label when the log contains extra data. The message/label is then lost because FirePhpBridge does not pass it along to FirePhp.
