### PR TITLE
Add error message to Float validator

### DIFF
--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -162,6 +162,7 @@ class Float extends AbstractValidator
 
         //We have seperators, and they are flipped. i.e. 2.000,000 for en-US
         if ($groupSeparatorPosition && $decSeparatorPosition && $groupSeparatorPosition > $decSeparatorPosition) {
+            $this->error(self::NOT_FLOAT);
             return false;
         }
 
@@ -237,6 +238,7 @@ class Float extends AbstractValidator
             return true;
         }
 
+        $this->error(self::NOT_FLOAT);
         return false;
     }
 }


### PR DESCRIPTION
Fixed Float validator not setting error message for failed validation.

PR needs tests but i have no time atm
