### PR TITLE
Patches/add interfaces as identifiers

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -168,7 +168,7 @@ abstract class AbstractController implements
         );
 
         $interfaces = class_implements($this);
-        $interfaces = is_array($interfaces) ? $interfaces : [];
+        $interfaces = is_array($interfaces) ? $interfaces : array();
 
         $events->setIdentifiers(array_merge($identifiers, $interfaces));
         $this->events = $events;

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -159,13 +159,18 @@ abstract class AbstractController implements
      */
     public function setEventManager(EventManagerInterface $events)
     {
-        $events->setIdentifiers(array(
+        $identifiers = array(
             'Zend\Stdlib\DispatchableInterface',
             __CLASS__,
             get_class($this),
             $this->eventIdentifier,
             substr(get_class($this), 0, strpos(get_class($this), '\\'))
-        ));
+        );
+
+        $interfaces = class_implements($this);
+        $interfaces = is_array($interfaces) ? $interfaces : [];
+
+        $events->setIdentifiers(array_merge($identifiers, $interfaces));
         $this->events = $events;
         $this->attachDefaultListeners();
 


### PR DESCRIPTION
Adding interfaces implemented by a controller as identifiers. This helps to attach events to controllers sharing an interface. Right now we can only do so with abstract classes.
