### PR TITLE
Failing test for I18n\Validator\Float

### DIFF
--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -198,6 +198,14 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * This throws a warning: grapheme_substr(): grapheme_substr: start not contained in string in Zend\Stdlib\StringWrapper\Intl.php:73
+     */
+    public function testStringValidation()
+    {
+        $this->assertFalse($this->validator->isValid('a string');
+    }
+    
+    /**
      * @ZF-4352
      */
     public function testNonStringValidation()

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -202,7 +202,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringValidation()
     {
-        $this->assertFalse($this->validator->isValid('a string');
+        $this->assertFalse($this->validator->isValid('a string'));
     }
     
     /**

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,4 +1,9 @@
-<phpunit bootstrap="./Bootstrap.php" colors="true">
+<phpunit 
+    bootstrap="./Bootstrap.php" colors="true" 
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+>
     <testsuites>
         <testsuite name="Zend Framework Test Suite">
             <directory>./ZendTest</directory>


### PR DESCRIPTION
Following form element example:

``` php
    public function getInputFilterSpecification()
    {
        return [
            'value' => [
                'filters' => [
                    [
                        'name' => 'Zend\I18n\Filter\NumberFormat'
                    ]
                ],

                'validators' => [
                    [
                        'name' => 'Zend\I18n\Validator\Float'
                    ],
                    [
                        'name' => 'Zend\Validator\NotEmpty',
                        'options' => [
                            'type' => NotEmpty::STRING
                        ]
                    ]
                ]
            ]
     ];
}
```

If the user provides a string, the filter is skipped so the string goes directly to the validator
