### PR TITLE
Form view helper for Zend\Captcha\Dumb should be translator-aware

### DIFF
--- a/library/Zend/Captcha/Dumb.php
+++ b/library/Zend/Captcha/Dumb.php
@@ -19,30 +19,6 @@ namespace Zend\Captcha;
 class Dumb extends AbstractWord
 {
     /**
-     * CAPTCHA label
-     * @type string
-     */
-    protected $label = 'Please type this word backwards';
-
-    /**
-     * Set the label for the CAPTCHA
-     * @param string $label
-     */
-    public function setLabel($label)
-    {
-        $this->label = $label;
-    }
-
-    /**
-     * Retrieve the label for the CAPTCHA
-     * @return string
-     */
-    public function getLabel()
-    {
-        return $this->label;
-    }
-
-    /**
      * Retrieve optional view helper name to use when rendering this captcha
      *
      * @return string

--- a/library/Zend/Form/View/Helper/Captcha/Dumb.php
+++ b/library/Zend/Form/View/Helper/Captcha/Dumb.php
@@ -15,6 +15,18 @@ use Zend\Form\Exception;
 
 class Dumb extends AbstractWord
 {
+    protected static $defaultTemplate = 'Please type this word backwards <b>%s</b>';
+    
+    public static function setDefaultTemplate($template)
+    {
+        static::$defaultTemplate = $template;
+    }
+    
+    public static function getDefaultTemplate()
+    {
+        return static::$defaultTemplate;
+    }
+
     /**
      * Render the captcha
      *
@@ -34,12 +46,13 @@ class Dumb extends AbstractWord
         }
 
         $captcha->generate();
+        
+        $template = $element->getLabel() ?: static::getDefaultTemplate();
+        if (null !== ($translator = $this->getTranslator())) {
+            $template = $translator->translate($template, $this->getTranslatorTextDomain());
+        }
 
-        $label = sprintf(
-            '%s <b>%s</b>',
-            $captcha->getLabel(),
-            strrev($captcha->getWord())
-        );
+        $label = $this->renderRiddle($template, $captcha->getWord());
 
         $position     = $this->getCaptchaPosition();
         $separator    = $this->getSeparator();
@@ -51,5 +64,10 @@ class Dumb extends AbstractWord
         }
 
         return sprintf($pattern, $label, $separator, $captchaInput);
+    }
+    
+    public function renderRiddle($template, $word)
+    {
+        return sprintf($template, strrev($word));
     }
 }

--- a/tests/ZendTest/Captcha/DumbTest.php
+++ b/tests/ZendTest/Captcha/DumbTest.php
@@ -70,21 +70,4 @@ class DumbTest extends CommonWordTest
         $word = $this->captcha->getWord();
         $this->assertEquals(10, strlen($word));
     }
-
-    /**
-     * @group ZF-11522
-     */
-    public function testDefaultLabelIsUsedWhenNoAlternateLabelSet()
-    {
-        $this->assertEquals('Please type this word backwards', $this->captcha->getLabel());
-    }
-
-    /**
-     * @group ZF-11522
-     */
-    public function testChangeLabelViaSetterMethod()
-    {
-        $this->captcha->setLabel('Testing');
-        $this->assertEquals('Testing', $this->captcha->getLabel());
-    }
 }

--- a/tests/ZendTest/Form/View/Helper/FormCaptchaTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCaptchaTest.php
@@ -83,7 +83,7 @@ class FormCaptchaTest extends CommonTestCase
         $element->setCaptcha($captcha);
         $element->setAttribute('id', 'foo');
         $markup = $this->helper->render($element);
-        $this->assertContains($captcha->getLabel(), $markup);
+        $this->assertContains(strrev($captcha->getWord()), $markup);
         $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '")[^>]*(type="text")[^>]*>#', $markup);
         $this->assertRegExp('#<[^>]*(id="' . $element->getAttribute('id') . '-hidden")[^>]*(type="hidden")[^>]*>#', $markup);
     }

--- a/tests/ZendTest/Form/View/Helper/FormElementTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormElementTest.php
@@ -141,7 +141,7 @@ class FormElementTest extends TestCase
         $element->setCaptcha($captcha);
         $markup = $this->helper->render($element);
 
-        $this->assertContains($captcha->getLabel(), $markup);
+        $this->assertContains(strrev($captcha->getWord()), $markup);
     }
 
     public function testRendersCsrfAsExpected()

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -87,7 +87,7 @@ class FormRowTest extends TestCase
         $element = new Element\Hidden('foo');
         $element->setLabel('My label');
         $markup = $this->helper->render($element);
-        $this->assertEquals('<input type="hidden" name="foo" value=""/>', $markup);
+        $this->assertRegexp('/<input type="hidden" name="foo" value=""[^\/>]*\/?>/', $markup);
     }
 
     public function testCanHandleMultiCheckboxesCorrectly()


### PR DESCRIPTION
Currently, label of the Zend\Captcha\Dumb can not be customized/translated. This proposal fixes this issue, so that when rendering captcha element, translation is performed on element's label or on the default one, if element does not provide it.
