### PR TITLE
HtmlTag helper

### DIFF
--- a/library/Zend/View/Helper/HtmlTag.php
+++ b/library/Zend/View/Helper/HtmlTag.php
@@ -28,12 +28,12 @@ class HtmlTag extends AbstractHtmlElement
      * Retrieve object instance; optionally add attributes.
      *
      * @param array $attribs
-     * @return \Zend\View\Helper\HtmlTag
+     * @return self
      */
     public function __invoke(array $attribs = array())
     {
         if (!empty($attribs)) {
-            $this->addAttributes($attribs);
+            $this->setAttributes($attribs);
         }
 
         return $this;
@@ -44,7 +44,7 @@ class HtmlTag extends AbstractHtmlElement
      *
      * @param string $attrName
      * @param string $attrValue
-     * @return \Zend\View\Helper\HtmlTag
+     * @return self
      */
     public function setAttribute($attrName, $attrValue)
     {
@@ -53,12 +53,12 @@ class HtmlTag extends AbstractHtmlElement
     }
 
     /**
-     * Add set of attributes.
+     * Add new or overwrite the existing attributes.
      *
      * @param array $attribs
-     * @return \Zend\View\Helper\HtmlTag
+     * @return self
      */
-    public function addAttributes(array $attribs)
+    public function setAttributes(array $attribs)
     {
         foreach ($attribs as $name => $value) {
             $this->setAttribute($name, $value);

--- a/library/Zend/View/Helper/HtmlTag.php
+++ b/library/Zend/View/Helper/HtmlTag.php
@@ -10,23 +10,23 @@
 namespace Zend\View\Helper;
 
 /**
- * Renders <html> tag (both opening and closing) of a web page, to which some custom 
+ * Renders <html> tag (both opening and closing) of a web page, to which some custom
  * attributes can be added dynamically.
- * 
+ *
  * @author Nikola Posa <posa.nikola@gmail.com>
  */
 class HtmlTag extends AbstractHtmlElement
 {
     /**
      * Attributes for the <html> tag.
-     * 
-     * @var array 
+     *
+     * @var array
      */
     protected $attributes = array();
-    
+
     /**
      * Retrieve object instance; optionally add attributes.
-     * 
+     *
      * @param array $attribs
      * @return \Zend\View\Helper\HtmlTag
      */
@@ -35,13 +35,13 @@ class HtmlTag extends AbstractHtmlElement
         if (!empty($attribs)) {
             $this->addAttributes($attribs);
         }
-        
+
         return $this;
     }
-    
+
     /**
      * Set new attribute.
-     * 
+     *
      * @param string $attrName
      * @param string $attrValue
      * @return \Zend\View\Helper\HtmlTag
@@ -51,10 +51,10 @@ class HtmlTag extends AbstractHtmlElement
         $this->attributes[$attrName] = $attrValue;
         return $this;
     }
-    
+
     /**
      * Add set of attributes.
-     * 
+     *
      * @param array $attribs
      * @return \Zend\View\Helper\HtmlTag
      */
@@ -65,7 +65,7 @@ class HtmlTag extends AbstractHtmlElement
         }
         return $this;
     }
-    
+
     /**
      * @return array
      */
@@ -76,17 +76,17 @@ class HtmlTag extends AbstractHtmlElement
 
     /**
      * Render opening tag.
-     * 
+     *
      * @return string
      */
     public function openTag()
     {
         return sprintf('<html%s>', $this->htmlAttribs($this->attributes));
     }
-    
+
     /**
      * Render closing tag.
-     * 
+     *
      * @return string
      */
     public function closeTag()

--- a/library/Zend/View/Helper/HtmlTag.php
+++ b/library/Zend/View/Helper/HtmlTag.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Helper;
+
+/**
+ * Renders <html> tag (both opening and closing) of a web page, to which some custom 
+ * attributes can be added dynamically.
+ * 
+ * @author Nikola Posa <posa.nikola@gmail.com>
+ */
+class HtmlTag extends AbstractHtmlElement
+{
+    /**
+     * Attributes for the <html> tag.
+     * 
+     * @var array 
+     */
+    protected $attributes = array();
+    
+    /**
+     * Retrieve object instance; optionally add attributes.
+     * 
+     * @param array $attribs
+     * @return \Zend\View\Helper\HtmlTag
+     */
+    public function __invoke(array $attribs = array())
+    {
+        if (!empty($attribs)) {
+            $this->addAttributes($attribs);
+        }
+        
+        return $this;
+    }
+    
+    /**
+     * Set new attribute.
+     * 
+     * @param string $attrName
+     * @param string $attrValue
+     * @return \Zend\View\Helper\HtmlTag
+     */
+    public function setAttribute($attrName, $attrValue)
+    {
+        $this->attributes[$attrName] = $attrValue;
+        return $this;
+    }
+    
+    /**
+     * Add set of attributes.
+     * 
+     * @param array $attribs
+     * @return \Zend\View\Helper\HtmlTag
+     */
+    public function addAttributes(array $attribs)
+    {
+        foreach ($attribs as $name => $value) {
+            $this->setAttribute($name, $value);
+        }
+        return $this;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Render opening tag.
+     * 
+     * @return string
+     */
+    public function openTag()
+    {
+        return sprintf('<html%s>', $this->htmlAttribs($this->attributes));
+    }
+    
+    /**
+     * Render closing tag.
+     * 
+     * @return string
+     */
+    public function closeTag()
+    {
+        return '</html>';
+    }
+}

--- a/library/Zend/View/Helper/HtmlTag.php
+++ b/library/Zend/View/Helper/HtmlTag.php
@@ -25,16 +25,17 @@ class HtmlTag extends AbstractHtmlElement
     protected $attributes = array();
 
     /**
-     * Whether to add appropriate attributes in accordance with currently set DOCTYPE.
+     * Whether to pre-set appropriate attributes in accordance
+     * with the currently set DOCTYPE.
      *
      * @var bool
      */
-    protected $addDoctypeAttributes = false;
+    protected $useNamespaces = false;
 
     /**
      * @var bool
      */
-    private $doctypeAttribsAdded = false;
+    private $handledNamespaces = false;
 
     /**
      * Retrieve object instance; optionally add attributes.
@@ -87,21 +88,21 @@ class HtmlTag extends AbstractHtmlElement
     }
 
     /**
-     * @param bool $addDoctypeAttributes
+     * @param bool $useNamespaces
      * @return self
      */
-    public function setAddDoctypeAttributes($addDoctypeAttributes)
+    public function setUseNamespaces($useNamespaces)
     {
-        $this->addDoctypeAttributes = (bool) $addDoctypeAttributes;
+        $this->useNamespaces = (bool) $useNamespaces;
         return $this;
     }
 
     /**
      * @return bool
      */
-    public function getAddDoctypeAttributes()
+    public function getUseNamespaces()
     {
-        return $this->addDoctypeAttributes;
+        return $this->useNamespaces;
     }
 
     /**
@@ -111,14 +112,14 @@ class HtmlTag extends AbstractHtmlElement
      */
     public function openTag()
     {
-        $this->handleDoctypeAttributes();
-        
+        $this->handleNamespaceAttributes();
+
         return sprintf('<html%s>', $this->htmlAttribs($this->attributes));
     }
 
-    protected function handleDoctypeAttributes()
+    protected function handleNamespaceAttributes()
     {
-        if ($this->addDoctypeAttributes && !$this->doctypeAttribsAdded) {
+        if ($this->useNamespaces && !$this->handledNamespaces) {
             if (method_exists($this->view, 'plugin')) {
                 $doctypeAttributes = array();
 
@@ -131,7 +132,7 @@ class HtmlTag extends AbstractHtmlElement
                 }
             }
 
-            $this->doctypeAttribsAdded = true;
+            $this->handledNamespaces = true;
         }
     }
 

--- a/library/Zend/View/Helper/HtmlTag.php
+++ b/library/Zend/View/Helper/HtmlTag.php
@@ -25,6 +25,18 @@ class HtmlTag extends AbstractHtmlElement
     protected $attributes = array();
 
     /**
+     * Whether to add appropriate attributes in accordance with currently set DOCTYPE.
+     *
+     * @var bool
+     */
+    protected $addDoctypeAttributes = false;
+
+    /**
+     * @var bool
+     */
+    private $doctypeAttribsAdded = false;
+
+    /**
      * Retrieve object instance; optionally add attributes.
      *
      * @param array $attribs
@@ -75,13 +87,52 @@ class HtmlTag extends AbstractHtmlElement
     }
 
     /**
+     * @param bool $addDoctypeAttributes
+     * @return self
+     */
+    public function setAddDoctypeAttributes($addDoctypeAttributes)
+    {
+        $this->addDoctypeAttributes = (bool) $addDoctypeAttributes;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAddDoctypeAttributes()
+    {
+        return $this->addDoctypeAttributes;
+    }
+
+    /**
      * Render opening tag.
      *
      * @return string
      */
     public function openTag()
     {
+        $this->handleDoctypeAttributes();
+        
         return sprintf('<html%s>', $this->htmlAttribs($this->attributes));
+    }
+
+    protected function handleDoctypeAttributes()
+    {
+        if ($this->addDoctypeAttributes && !$this->doctypeAttribsAdded) {
+            if (method_exists($this->view, 'plugin')) {
+                $doctypeAttributes = array();
+
+                if ($this->view->plugin('doctype')->isXhtml()) {
+                    $doctypeAttributes = array('xmlns' => 'http://www.w3.org/1999/xhtml');
+                }
+
+                if (!empty($doctypeAttributes)) {
+                    $this->attributes = array_merge($doctypeAttributes, $this->attributes);
+                }
+            }
+
+            $this->doctypeAttribsAdded = true;
+        }
     }
 
     /**

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -52,6 +52,7 @@ class HelperPluginManager extends AbstractPluginManager
         'escapecss'           => 'Zend\View\Helper\EscapeCss',
         'escapeurl'           => 'Zend\View\Helper\EscapeUrl',
         'gravatar'            => 'Zend\View\Helper\Gravatar',
+        'htmltag'             => 'Zend\View\Helper\HtmlTag',
         'headlink'            => 'Zend\View\Helper\HeadLink',
         'headmeta'            => 'Zend\View\Helper\HeadMeta',
         'headscript'          => 'Zend\View\Helper\HeadScript',

--- a/tests/ZendTest/View/Helper/HtmlTagTest.php
+++ b/tests/ZendTest/View/Helper/HtmlTagTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Helper;
+
+use Zend\View\Renderer\PhpRenderer as View;
+use Zend\View\Helper\HtmlTag;
+
+/**
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class HtmlTagTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HtmlTag
+     */
+    public $helper;
+
+    protected function setUp()
+    {
+        $this->view   = new View();
+        $this->helper = new HtmlTag();
+        $this->helper->setView($this->view);
+    }
+
+    public function tearDown()
+    {
+        unset($this->helper);
+    }
+    
+    protected function assertAttribute($name, $value = null)
+    {
+        $attributes = $this->helper->getAttributes();
+        $this->assertArrayHasKey($name, $attributes);
+        if ($value) {
+            $this->assertEquals($value, $attributes[$name]);
+        }
+    }
+
+    public function testSettingSingleAttribute()
+    {
+        $this->helper->setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+        $this->assertAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+    }
+    
+    public function testAddingMultipleAttributes()
+    {
+        $attribs = array(
+            'xmlns' => 'http://www.w3.org/1999/xhtml',
+            'prefix' => 'og: http://ogp.me/ns#',
+        );
+        $this->helper->addAttributes($attribs);
+        
+        foreach ($attribs as $name => $value) {
+            $this->assertAttribute($name, $value);
+        }
+    }
+    
+    public function testRenderingOpenTagWithNoAttributes()
+    {
+        $this->assertEquals('<html>', $this->helper->openTag());
+    }
+    
+    public function testRenderingOpenTagWithAttributes()
+    {
+        $attribs = array(
+            'xmlns' => 'http://www.w3.org/1999/xhtml',
+            'xmlns:og' => 'http://ogp.me/ns#',
+        );
+        
+        $this->helper->addAttributes($attribs);
+        
+        $tag = $this->helper->openTag();
+        
+        $this->assertStringStartsWith('<html', $tag);
+        
+        $escape = $this->view->plugin('escapehtmlattr');
+        foreach ($attribs as $name => $value) {
+            $this->assertContains(sprintf('%s="%s"', $name, $escape($value)), $tag);
+        }
+    }
+    
+    public function testRenderingCloseTag()
+    {
+        $this->assertEquals('</html>', $this->helper->closeTag());
+    }
+}

--- a/tests/ZendTest/View/Helper/HtmlTagTest.php
+++ b/tests/ZendTest/View/Helper/HtmlTagTest.php
@@ -34,7 +34,7 @@ class HtmlTagTest extends \PHPUnit_Framework_TestCase
     {
         unset($this->helper);
     }
-    
+
     protected function assertAttribute($name, $value = null)
     {
         $attributes = $this->helper->getAttributes();
@@ -49,44 +49,60 @@ class HtmlTagTest extends \PHPUnit_Framework_TestCase
         $this->helper->setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
         $this->assertAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     }
-    
+
     public function testAddingMultipleAttributes()
     {
         $attribs = array(
             'xmlns' => 'http://www.w3.org/1999/xhtml',
             'prefix' => 'og: http://ogp.me/ns#',
         );
-        $this->helper->addAttributes($attribs);
-        
+        $this->helper->setAttributes($attribs);
+
         foreach ($attribs as $name => $value) {
             $this->assertAttribute($name, $value);
         }
     }
-    
+
+    public function testSettingMultipleAttributesOverwritesExisting()
+    {
+        $this->helper->setAttribute('prefix', 'foobar');
+
+        $attribs = array(
+            'xmlns' => 'http://www.w3.org/1999/xhtml',
+            'prefix' => 'og: http://ogp.me/ns#',
+        );
+        $this->helper->setAttributes($attribs);
+
+        $this->assertCount(2, $this->helper->getAttributes());
+        foreach ($attribs as $name => $value) {
+            $this->assertAttribute($name, $value);
+        }
+    }
+
     public function testRenderingOpenTagWithNoAttributes()
     {
         $this->assertEquals('<html>', $this->helper->openTag());
     }
-    
+
     public function testRenderingOpenTagWithAttributes()
     {
         $attribs = array(
             'xmlns' => 'http://www.w3.org/1999/xhtml',
             'xmlns:og' => 'http://ogp.me/ns#',
         );
-        
-        $this->helper->addAttributes($attribs);
-        
+
+        $this->helper->setAttributes($attribs);
+
         $tag = $this->helper->openTag();
-        
+
         $this->assertStringStartsWith('<html', $tag);
-        
+
         $escape = $this->view->plugin('escapehtmlattr');
         foreach ($attribs as $name => $value) {
             $this->assertContains(sprintf('%s="%s"', $name, $escape($value)), $tag);
         }
     }
-    
+
     public function testRenderingCloseTag()
     {
         $this->assertEquals('</html>', $this->helper->closeTag());

--- a/tests/ZendTest/View/Helper/HtmlTagTest.php
+++ b/tests/ZendTest/View/Helper/HtmlTagTest.php
@@ -108,13 +108,13 @@ class HtmlTagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('</html>', $this->helper->closeTag());
     }
 
-    public function testDoctypeAttributesSetter()
+    public function testUseNamespacesSetter()
     {
-        $this->helper->setAddDoctypeAttributes(true);
-        $this->assertTrue($this->helper->getAddDoctypeAttributes());
+        $this->helper->setUseNamespaces(true);
+        $this->assertTrue($this->helper->getUseNamespaces());
     }
 
-    public function testAppropriateDoctypeAttributesArePresetIfFlagIsOn()
+    public function testAppropriateNamespaceAttributesAreSetIfFlagIsOn()
     {
         $this->view->plugin('doctype')->setDoctype('xhtml');
 
@@ -122,7 +122,7 @@ class HtmlTagTest extends \PHPUnit_Framework_TestCase
             'prefix' => 'og: http://ogp.me/ns#',
         );
 
-        $this->helper->setAddDoctypeAttributes(true)->setAttributes($attribs);
+        $this->helper->setUseNamespaces(true)->setAttributes($attribs);
 
         $tag = $this->helper->openTag();
 

--- a/tests/ZendTest/View/Helper/HtmlTagTest.php
+++ b/tests/ZendTest/View/Helper/HtmlTagTest.php
@@ -107,4 +107,30 @@ class HtmlTagTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('</html>', $this->helper->closeTag());
     }
+
+    public function testDoctypeAttributesSetter()
+    {
+        $this->helper->setAddDoctypeAttributes(true);
+        $this->assertTrue($this->helper->getAddDoctypeAttributes());
+    }
+
+    public function testAppropriateDoctypeAttributesArePresetIfFlagIsOn()
+    {
+        $this->view->plugin('doctype')->setDoctype('xhtml');
+
+        $attribs = array(
+            'prefix' => 'og: http://ogp.me/ns#',
+        );
+
+        $this->helper->setAddDoctypeAttributes(true)->setAttributes($attribs);
+
+        $tag = $this->helper->openTag();
+
+        $escape = $this->view->plugin('escapehtmlattr');
+
+        $this->assertContains(sprintf('%s="%s"', 'xmlns', $escape('http://www.w3.org/1999/xhtml')), $tag);
+        foreach ($attribs as $name => $value) {
+            $this->assertContains(sprintf('%s="%s"', $name, $escape($value)), $tag);
+        }
+    }
 }


### PR DESCRIPTION
New view helper used for rendering `<html>` tag of a web page, to which some custom attributes can be added dynamically.
## Intent

Idea is to have ability to dynamically attach some attributes to the opening HTML tag in a layout. For example:
`<html xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://ogp.me/ns#">`
## Usage

Rendering tag in a layout:

``` php
echo $this->html()->openTag(); 
//...
echo $this->html()->closeTag();
```

Adding attributes:

``` php
//single
$this->html()->setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');

//multiple
$this->html()->setAttributes(array(
    'xmlns' => 'http://www.w3.org/1999/xhtml',
    'prefix' => 'og: http://ogp.me/ns#'
));

//shortcut method
$this->html(array(
    'xmlns' => 'http://www.w3.org/1999/xhtml',
    'prefix' => 'og: http://ogp.me/ns#'
));
```

There is also option to automatically pre-set appropriate namespace attributes, based on currently set DOCTYPE (`Doctype` helper):

``` php
//At some point:
$this->doctype('xhtml');

$this->html()
    ->setUseNamespaces(true) //'xmlns' attribute will be automatically set to 'http://www.w3.org/1999/xhtml'
    ->setAttributes(array(
        'prefix' => 'og: http://ogp.me/ns#'
    ));
```
