### PR TITLE
Fix for BC break #6645 where isValid() sets up old values

### DIFF
--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -570,7 +570,6 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function bindValues(array $values = array())
     {
-        $objectData = $this->extract();
         $hydrator = $this->getHydrator();
         $hydratableData = array();
 
@@ -588,8 +587,6 @@ class Fieldset extends Element implements FieldsetInterface
             // skip post values for disabled elements, get old value from object
             if(!$element->hasAttribute('disabled')) {
                 $hydratableData[$name] = $value;
-            } elseif(array_key_exists($name, $objectData)) {
-                $hydratableData[$name] = $objectData[$name];
             }
         }
 

--- a/tests/ZendTest/Form/FieldsetTest.php
+++ b/tests/ZendTest/Form/FieldsetTest.php
@@ -14,6 +14,7 @@ use Zend\Form\Element;
 use Zend\Form\Form;
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilter;
+use Zend\Stdlib\Hydrator;
 
 class FieldsetTest extends TestCase
 {
@@ -522,4 +523,27 @@ class FieldsetTest extends TestCase
         $this->assertTrue($allowed);
     }
 
+    /**
+     * @group 6645
+     */
+    public function testBindValuesPreservesNewValueAfterValidation()
+    {
+        $form = new Form();
+        $form->add(new Element('foo'));
+        $form->setHydrator(new Hydrator\ObjectProperty);
+
+        $object      = new \stdClass();
+        $object->foo = 'Initial value';
+        $form->bind($object);
+
+        $form->setData(array(
+            'foo' => 'New value'
+        ));
+
+        $this->assertSame('New value', $form->get('foo')->getValue());
+
+        $form->isValid();
+
+        $this->assertSame('New value', $form->get('foo')->getValue());
+    }
 }


### PR DESCRIPTION
PR #6295 (Fieldset ignore disabled elements) introduced a BC break: #6645 (isValid sets up old values?).

This PR fixes #6645 and as a result leads to less code for ignoring disabled elements.
