### PR TITLE
added NameNavigationFactory to create navigation from config key name

### DIFF
--- a/library/Zend/Navigation/Service/NameNavigationFactory.php
+++ b/library/Zend/Navigation/Service/NameNavigationFactory.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Navigation\Service;
+
+/**
+ * Name navigation factory.
+ *
+ * Creates navigation depending on given config key name
+ */
+class NameNavigationFactory extends AbstractNavigationFactory
+{
+    /**
+     * Config name
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Initialize object
+     *
+     * @param string $name Config name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns name
+     *
+     * @return string
+     */
+    protected function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/ZendTest/Navigation/ServiceFactoryTest.php
+++ b/tests/ZendTest/Navigation/ServiceFactoryTest.php
@@ -254,4 +254,15 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $container = $this->serviceManager->get('Navigation');
         $this->assertEquals(3, $container->count());
     }
+
+    /**
+     * @covers \Zend\Navigation\Service\NameNavigationFactory
+     */
+    public function testNameFactory()
+    {
+        $this->serviceManager->setFactory('Navigation', new \Zend\Navigation\Service\NameNavigationFactory('default'));
+
+        $container = $this->serviceManager->get('Navigation');
+        $this->assertEquals(3, $container->count());
+    }
 }


### PR DESCRIPTION
I use several navigation configs and i want to create navigation instances via config name. For example:

``` php
// navigation config e.g. in module.config.php
return array(
    // other stuff before
    'navigation' => array(
        'special' => array(
            array(
                'label' => 'Page 1',
                'uri' => 'page1.html'
            ),
            array(
                'label' => 'MVC Page',
                'route' => 'foo',
                'pages' => array(
                    array(
                        'label' => 'Sub MVC Page',
                        'route' => 'foo'
                    )
                )
            ),
            array(
                'label' => 'Page 3',
                'uri' => 'page3.html'
            )
        )
    )
);
```

So it's very easy to create new navigation instances which uses another config.

``` php
// service manager config e.g. in module.config.php
return array(
    // other stuff before
    'service_manager' => array(
        'factories' => array(
            'mymodule.navigation.special' => new \Zend\Navigation\Service\NameNavigationFactory('special'),
        ),
    ),
);
```

Maybe we could remove `\Zend\Navigation\Service\DefaultNavigationFactory` and set parameter `$name = 'default'` in `\Zend\Navigation\Service\NameNavigationFactory::__construct`, but this is a BC break.
