### PR TITLE
Missing error messages

### DIFF
--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -162,6 +162,7 @@ class Float extends AbstractValidator
 
         //We have seperators, and they are flipped. i.e. 2.000,000 for en-US
         if ($groupSeparatorPosition && $decSeparatorPosition && $groupSeparatorPosition > $decSeparatorPosition) {
+            $this->error(self::NOT_FLOAT);
             return false;
         }
 
@@ -237,6 +238,7 @@ class Float extends AbstractValidator
             return true;
         }
 
+        $this->error(self::NOT_FLOAT);
         return false;
     }
 }


### PR DESCRIPTION
Two times the error message is not returned. So in a form you just know, that the form field is not correct,but not what.
