### PR TITLE
Zend controller test contains

### DIFF
--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -362,6 +362,17 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentContains('div#content', 'bar');
     }
 
+    public function testAssertQueryContentContainsPartialMatch()
+    {
+        $this->dispatch('/tests');
+        $this->assertQueryContentContains('div#content', 'fo', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+
+        $this->setExpectedException(
+            'PHPUnit_Framework_ExpectationFailedException'
+        );
+        $this->assertQueryContentContains('div#content', 'ba', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+    }
+
     public function testAssertQueryContentContainsWithSecondElement()
     {
         $this->dispatch('/tests');
@@ -371,6 +382,17 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
             'PHPUnit_Framework_ExpectationFailedException'
         );
         $this->assertQueryContentContains('div.top', 'bar');
+    }
+
+    public function testAssertQueryContentContainsWithSecondElementPartialMatch()
+    {
+        $this->dispatch('/tests');
+        $this->assertQueryContentContains('div#content', 'fo', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+
+        $this->setExpectedException(
+            'PHPUnit_Framework_ExpectationFailedException'
+        );
+        $this->assertQueryContentContains('div#content', 'ba', self::CONTENT_CONTAINS_PARTIAL_MATCH);
     }
 
     public function testAssertXpathQueryContentContains()
@@ -391,6 +413,17 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotQueryContentContains('div#content', 'foo');
+    }
+
+    public function testAssertNotQueryContentContainsPartialMatch()
+    {
+        $this->dispatch('/tests');
+        $this->assertNotQueryContentContains('div#content', 'ba', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+
+        $this->setExpectedException(
+            'PHPUnit_Framework_ExpectationFailedException'
+        );
+        $this->assertNotQueryContentContains('div#content', 'fo', self::CONTENT_CONTAINS_PARTIAL_MATCH);
     }
 
     public function testAssertNotXpathQueryContentContains()

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -84,6 +84,18 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertResponseHeaderContains('Content-Type', 'text/json');
     }
 
+    public function testAssertResponseHeaderContainsPartialMatch()
+    {
+        $this->dispatch('/tests');
+        $this->assertResponseHeaderContains('Content-Type', 'html', self::CONTAINS_PARTIAL_MATCH);
+
+        $this->setExpectedException(
+            'PHPUnit_Framework_ExpectationFailedException',
+            'actual content is "text/html"' // check actual content is display
+        );
+        $this->assertResponseHeaderContains('Content-Type', 'json', self::CONTAINS_PARTIAL_MATCH);
+    }
+
     public function testAssertResponseHeaderContainsMultipleHeaderInterface()
     {
         $this->dispatch('/tests');
@@ -97,6 +109,15 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
 
         $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
         $this->assertNotResponseHeaderContains('Content-Type', 'text/html');
+    }
+
+    public function testAssertNotResponseHeaderContainsPartialMatch()
+    {
+        $this->dispatch('/tests');
+        $this->assertNotResponseHeaderContains('Content-Type', 'json', self::CONTAINS_PARTIAL_MATCH);
+
+        $this->setExpectedException('PHPUnit_Framework_ExpectationFailedException');
+        $this->assertNotResponseHeaderContains('Content-Type', 'html', self::CONTAINS_PARTIAL_MATCH);
     }
 
     public function testAssertNotResponseHeaderContainsMultipleHeaderInterface()
@@ -365,12 +386,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
     public function testAssertQueryContentContainsPartialMatch()
     {
         $this->dispatch('/tests');
-        $this->assertQueryContentContains('div#content', 'fo', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+        $this->assertQueryContentContains('div#content', 'fo', self::CONTAINS_PARTIAL_MATCH);
 
         $this->setExpectedException(
             'PHPUnit_Framework_ExpectationFailedException'
         );
-        $this->assertQueryContentContains('div#content', 'ba', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+        $this->assertQueryContentContains('div#content', 'ba', self::CONTAINS_PARTIAL_MATCH);
     }
 
     public function testAssertQueryContentContainsWithSecondElement()
@@ -407,12 +428,12 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
     public function testAssertNotQueryContentContainsPartialMatch()
     {
         $this->dispatch('/tests');
-        $this->assertNotQueryContentContains('div#content', 'ba', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+        $this->assertNotQueryContentContains('div#content', 'ba', self::CONTAINS_PARTIAL_MATCH);
 
         $this->setExpectedException(
             'PHPUnit_Framework_ExpectationFailedException'
         );
-        $this->assertNotQueryContentContains('div#content', 'fo', self::CONTENT_CONTAINS_PARTIAL_MATCH);
+        $this->assertNotQueryContentContains('div#content', 'fo', self::CONTAINS_PARTIAL_MATCH);
     }
 
     public function testAssertNotXpathQueryContentContains()

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractHttpControllerTestCaseTest.php
@@ -384,17 +384,6 @@ class AbstractHttpControllerTestCaseTest extends AbstractHttpControllerTestCase
         $this->assertQueryContentContains('div.top', 'bar');
     }
 
-    public function testAssertQueryContentContainsWithSecondElementPartialMatch()
-    {
-        $this->dispatch('/tests');
-        $this->assertQueryContentContains('div#content', 'fo', self::CONTENT_CONTAINS_PARTIAL_MATCH);
-
-        $this->setExpectedException(
-            'PHPUnit_Framework_ExpectationFailedException'
-        );
-        $this->assertQueryContentContains('div#content', 'ba', self::CONTENT_CONTAINS_PARTIAL_MATCH);
-    }
-
     public function testAssertXpathQueryContentContains()
     {
         $this->dispatch('/tests');


### PR DESCRIPTION
This allow to match a partial query node value content in AbstractHttpControllerTestCase:: assertQueryContentContains, and not only an exact match.
A node with the value "foo, bar, lol" would match "foo", "foo,", "bar, lol", etc...

@blanchonvincent
