### PR TITLE
Fixes cs : space after if and elseif in deep conditional

### DIFF
--- a/library/Zend/Code/Generator/FileGenerator.php
+++ b/library/Zend/Code/Generator/FileGenerator.php
@@ -478,7 +478,7 @@ class FileGenerator extends AbstractGenerator
         foreach ($classes as $class) {
             //check for duplicate use statements
             $uses = $class->getUses();
-            if(!empty($uses) && is_array($uses)) {
+            if (!empty($uses) && is_array($uses)) {
                 $classUses = array_merge($classUses, $uses);
             }
         }
@@ -497,7 +497,7 @@ class FileGenerator extends AbstractGenerator
                 }
 
                 //don't duplicate use statements
-                if(!in_array($tempOutput, $classUses)) {
+                if (!in_array($tempOutput, $classUses)) {
                     $useOutput .= "use ". $tempOutput .";";
                     $useOutput .= self::LINE_FEED;
                 }

--- a/library/Zend/Code/Reflection/MethodReflection.php
+++ b/library/Zend/Code/Reflection/MethodReflection.php
@@ -232,7 +232,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         //remove first entry which is php open tag
         array_shift($tokens);
 
-        if(!count($tokens)) {
+        if (!count($tokens)) {
             return '';
         }
 
@@ -254,11 +254,11 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                 case "T_FUNCTION":
                     // check to see if we have a valid function
                     // then check if we are inside function and have a closure
-                    if($this->isValidFunction($tokens, $key, $this->getName())) {
-                        if($bodyOnly === false) {
+                    if ($this->isValidFunction($tokens, $key, $this->getName())) {
+                        if ($bodyOnly === false) {
                             //if first instance of tokenType grab prefixed whitespace
                             //and append to body
-                            if($capture === false) {
+                            if ($capture === false) {
                                 $body .= $this->extractPrefixedWhitespace($tokens, $key);
                             }
                             $body .= $tokenValue;
@@ -267,7 +267,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                         $capture = true;
                     } else {
                         //closure test
-                        if($firstBrace && $tokenType == "T_FUNCTION") {
+                        if ($firstBrace && $tokenType == "T_FUNCTION") {
                             $body .= $tokenValue;
                             continue;
                         }
@@ -277,13 +277,13 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                     break;
 
                 case "{":
-                    if($capture === false) {
+                    if ($capture === false) {
                         continue;
                     }
 
-                    if($firstBrace === false) {
+                    if ($firstBrace === false) {
                         $firstBrace = true;
-                        if($bodyOnly === true) {
+                        if ($bodyOnly === true) {
                             continue;
                         }
                     }
@@ -292,14 +292,14 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                     break;
 
                 case "}":
-                    if($capture === false) {
+                    if ($capture === false) {
                         continue;
                     }
 
                     //check to see if this is the last brace
-                    if($this->isEndingBrace($tokens, $key)) {
+                    if ($this->isEndingBrace($tokens, $key)) {
                         //capture the end brace if not bodyOnly
-                        if($bodyOnly === false) {
+                        if ($bodyOnly === false) {
                             $body .= $tokenValue;
                         }
 
@@ -310,12 +310,12 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                     break;
 
                 default:
-                    if($capture === false) {
+                    if ($capture === false) {
                         continue;
                     }
 
                     // if returning body only wait for first brace before capturing
-                    if($bodyOnly === true && $firstBrace !== true) {
+                    if ($bodyOnly === true && $firstBrace !== true) {
                         continue;
                     }
 
@@ -339,7 +339,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
     {
         $content = '';
         $count = count($haystack);
-        if($position+1 == $count) {
+        if ($position+1 == $count) {
             return $content;
         }
 
@@ -348,7 +348,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             $tokenValue = (is_array($haystack[$i])) ? $haystack[$i][1] : $haystack[$i];
 
             //search only for whitespace
-            if($tokenType == "T_WHITESPACE") {
+            if ($tokenType == "T_WHITESPACE") {
                 $content .= $tokenValue;
             } else {
                 break;
@@ -372,7 +372,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
         //advance one position
         $position = $position+1;
 
-        if($position == $count) {
+        if ($position == $count) {
             return true;
         }
 
@@ -390,7 +390,7 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
                 case "T_FUNCTION":
                     // If a function is encountered and that function is not a closure
                     // then return true.  otherwise the function is a closure, return false
-                    if($this->isValidFunction($haystack, $i)) {
+                    if ($this->isValidFunction($haystack, $i)) {
                         return true;
                     }
                     return false;
@@ -443,16 +443,16 @@ class MethodReflection extends PhpReflectionMethod implements ReflectionInterfac
             $tokenValue = (is_array($haystack[$i])) ? $haystack[$i][1] : $haystack[$i];
 
             //check for occurance of ( or
-            if($tokenType == "T_STRING") {
+            if ($tokenType == "T_STRING") {
                 //check to see if function name is passed, if so validate against that
-                if($functionName !== null && $tokenValue != $functionName) {
+                if ($functionName !== null && $tokenValue != $functionName) {
                     $isValid = false;
                     break;
                 }
 
                 $isValid = true;
                 break;
-            } elseif($tokenValue == "(") {
+            } elseif ($tokenValue == "(") {
                 break;
             }
         }

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -800,7 +800,7 @@ class Di implements DependencyInjectionInterface
                 }
 
                 array_push($this->currentDependencies, $class);
-                if(isset($alias)) {
+                if (isset($alias)) {
                     array_push($this->currentAliasDependenencies, $alias);
                 }
 
@@ -816,7 +816,7 @@ class Di implements DependencyInjectionInterface
                     if ($methodRequirementType & self::RESOLVE_STRICT) {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
-                        if(isset($alias)) {
+                        if (isset($alias)) {
                             array_pop($this->currentAliasDependenencies);
                         }
                         // if this item was marked strict,
@@ -830,7 +830,7 @@ class Di implements DependencyInjectionInterface
                     } else {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
-                        if(isset($alias)) {
+                        if (isset($alias)) {
                             array_pop($this->currentAliasDependenencies);
                         }
                         return false;
@@ -840,7 +840,7 @@ class Di implements DependencyInjectionInterface
                     if ($methodRequirementType & self::RESOLVE_STRICT) {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
-                        if(isset($alias)) {
+                        if (isset($alias)) {
                             array_pop($this->currentAliasDependenencies);
                         }
                         // if this item was marked strict,
@@ -854,14 +854,14 @@ class Di implements DependencyInjectionInterface
                     } else {
                         //finally ( be aware to do at the end of flow)
                         array_pop($this->currentDependencies);
-                        if(isset($alias)) {
+                        if (isset($alias)) {
                             array_pop($this->currentAliasDependenencies);
                         }
                         return false;
                     }
                 }
                 array_pop($this->currentDependencies);
-                if(isset($alias)) {
+                if (isset($alias)) {
                     array_pop($this->currentAliasDependenencies);
                 }
             } elseif (!array_key_exists($fqParamPos, $computedParams['optional'])) {

--- a/library/Zend/Dom/Document/Query.php
+++ b/library/Zend/Dom/Document/Query.php
@@ -153,7 +153,7 @@ class Query
         );
 
         // Classes
-        if(false === strpos($expression, "[@")) {
+        if (false === strpos($expression, "[@")) {
             $expression = preg_replace(
                 '|\.([a-z][a-z0-9_-]*)|i',
                 "[contains(concat(' ', normalize-space(@class), ' '), ' \$1 ')]",

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -73,7 +73,7 @@ class RealPath extends AbstractFilter
      */
     public function filter($value)
     {
-        if (!is_string($value)){
+        if (!is_string($value)) {
             return $value;
         }
         $path = (string) $value;

--- a/library/Zend/Filter/RealPath.php
+++ b/library/Zend/Filter/RealPath.php
@@ -73,7 +73,7 @@ class RealPath extends AbstractFilter
      */
     public function filter($value)
     {
-        if(!is_string($value)){
+        if (!is_string($value)){
             return $value;
         }
         $path = (string) $value;

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -586,9 +586,9 @@ class Fieldset extends Element implements FieldsetInterface
             }
 
             // skip post values for disabled elements, get old value from object
-            if(!$element->hasAttribute('disabled')) {
+            if (!$element->hasAttribute('disabled')) {
                 $hydratableData[$name] = $value;
-            } elseif(array_key_exists($name, $objectData)) {
+            } elseif (array_key_exists($name, $objectData)) {
                 $hydratableData[$name] = $objectData[$name];
             }
         }

--- a/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
@@ -140,7 +140,7 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     {
         // Creating the SQLite database file
         $filePath = realpath(__DIR__) . "/_files/sqlite.db";
-        if(!file_exists($filePath)) {
+        if (!file_exists($filePath)) {
             touch($filePath);
         }
 


### PR DESCRIPTION
iirc, I already sent a request to php-cs-fixer repository for its feature but it won't be implemented because it require to much logic
