### PR TITLE
Di runtime definition optimisation - Cache result of processing and inline the check

### DIFF
--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -18,7 +18,6 @@ use Zend\Di\Di;
  */
 class RuntimeDefinition implements DefinitionInterface
 {
-
     /**
      * @var array
      */
@@ -38,6 +37,11 @@ class RuntimeDefinition implements DefinitionInterface
      * @var array
      */
     protected $injectionMethods = array();
+
+    /**
+     * @var array
+     */
+    protected $processedClass = array();
 
     /**
      * Constructor
@@ -177,21 +181,18 @@ class RuntimeDefinition implements DefinitionInterface
 
     /**
      * @param string $class
-     */
-    protected function hasProcessedClass($class)
-    {
-        return array_key_exists($class, $this->classes) && is_array($this->classes[$class]);
-    }
-
-    /**
-     * @param string $class
      * @param bool $forceLoad
      */
     protected function processClass($class, $forceLoad = false)
     {
-        if (!$forceLoad && $this->hasProcessedClass($class)) {
+        if (!isset($this->processedClass[$class]) || $this->processedClass[$class] === false) {
+            $this->processedClass[$class] = (array_key_exists($class, $this->classes) && is_array($this->classes[$class]));
+        }
+
+        if (!$forceLoad && $this->processedClass[$class]) {
             return;
         }
+
         $strategy = $this->introspectionStrategy; // localize for readability
 
         /** @var $rClass \Zend\Code\Reflection\ClassReflection */

--- a/library/Zend/Di/Definition/RuntimeDefinition.php
+++ b/library/Zend/Di/Definition/RuntimeDefinition.php
@@ -231,7 +231,7 @@ class RuntimeDefinition implements DefinitionInterface
             $rTarget = $rTargetParent;
         } while (true);
 
-        $def['supertypes'] = $supertypes;
+        $def['supertypes'] = array_keys(array_flip($supertypes));
 
         if ($def['instantiator'] == null) {
             if ($rClass->isInstantiable()) {


### PR DESCRIPTION
We noticed a long time was spent in runtime definitions on some of our requests and that calls to `processClass` could run into tens of thousands in some cases. As `hasProcessedClass()` was only called from one place, I've inlined it to reduce the method call and cached the result of the check, which has made a significant difference to requests that have significant numbers of calls to `processClass`.
