### PR TITLE
Input filter annotation fix

### DIFF
--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -215,6 +215,8 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
 
         if (!isset($formSpec['input_filter'])) {
             $formSpec['input_filter'] = $filterSpec;
+        } elseif (is_array($formSpec['input_filter'])) {
+            $formSpec['input_filter'] = ArrayUtils::merge($filterSpec->getArrayCopy(), $formSpec['input_filter']);
         }
 
         return $formSpec;

--- a/library/Zend/Form/Annotation/InputFilter.php
+++ b/library/Zend/Form/Annotation/InputFilter.php
@@ -18,7 +18,7 @@ namespace Zend\Form\Annotation;
  *
  * @Annotation
  */
-class InputFilter extends AbstractStringAnnotation
+class InputFilter extends AbstractArrayOrStringAnnotation
 {
     /**
      * Retrieve the input filter class

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -275,4 +275,13 @@ class AnnotationBuilderTest extends TestCase
         }
 
     }
+
+    public function testInputFilterAnnotationAllowsComposition()
+    {
+        $entity = new TestAsset\Annotation\EntityWithInputFilterAnnotation();
+        $builder = new Annotation\AnnotationBuilder();
+        $form = $builder->createForm($entity);
+        $inputFilter = $form->getInputFilter();
+        $this->assertCount(2, $inputFilter->get('username')->getValidatorChain());
+    }
 }

--- a/tests/ZendTest/Form/TestAsset/Annotation/EntityWithInputFilterAnnotation.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/EntityWithInputFilterAnnotation.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+/**
+ * @Annotation\InputFilter({"type":"Zend\InputFilter\InputFilter"})
+ */
+class EntityWithInputFilterAnnotation
+{
+    /**
+     * @Annotation\ErrorMessage("Invalid or missing username")
+     * @Annotation\Required(true)
+     * @Annotation\Filter({"name":"StringTrim"})
+     * @Annotation\Validator({"name":"NotEmpty"})
+     * @Annotation\Validator({"name":"StringLength","options":{"min":3,"max":25}})
+     */
+    public $username;
+
+    /**
+     * @Annotation\Filter({"name":"StringTrim"})
+     * @Annotation\Validator({"name":"EmailAddress"})
+     * @Annotation\Attributes({"type":"password","label":"Enter your password"})
+     */
+    public $password;
+}


### PR DESCRIPTION
This PR fixes an issue with the InputFilter form annotation, when applied to a form it causes the annotation builder to totally ignore any element level validation. 

This fix allows the annotation to take an array option, if it is specified as an array, element level validation is merged with the form level input filter options. 

The main purpose of this is to allow specifiying a custom input filter type that has different behaviour to the default without having to create form specific validation and filtering rules within that class.
