### PR TITLE
Added preserve_defined_order flag to annotation builder

### DIFF
--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -362,7 +362,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
     }
 
     /**
-     * @param boolean $preserveDefinedOrder
+     * @param bool $preserveDefinedOrder
      * @return $this
      */
     public function setPreserveDefinedOrder($preserveDefinedOrder)
@@ -372,7 +372,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function preserveDefinedOrder()
     {

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -73,6 +73,11 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
     );
 
     /**
+     * @var bool
+     */
+    protected $preserveDefinedOrder = false;
+
+    /**
      * Set form factory to use when building form from annotations
      *
      * @param  Factory $formFactory
@@ -346,19 +351,6 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
             }
             $formSpec['elements'][] = $elementSpec;
         }
-    }
-
-    /**
-     * @param array $options
-     * @return $this
-     */
-    public function setOptions(array $options)
-    {
-        if (isset($options['preserve_defined_order'])) {
-            $this->setPreserveDefinedOrder($options['preserve_defined_order']);
-        }
-
-        return $this;
     }
 
     /**

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -333,8 +333,9 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
             ? $elementSpec['spec']['type']
             : 'Zend\Form\Element';
 
-        // Compose as a fieldset or an element, based on specification type
-        if (is_subclass_of($type, 'Zend\Form\FieldsetInterface')) {
+        // Compose as a fieldset or an element, based on specification type.
+        // If preserve defined order is true, all elements are composed as elements to keep their ordering
+        if (!$this->preserveDefinedOrder() && is_subclass_of($type, 'Zend\Form\FieldsetInterface')) {
             if (!isset($formSpec['fieldsets'])) {
                 $formSpec['fieldsets'] = array();
             }
@@ -345,6 +346,37 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
             }
             $formSpec['elements'][] = $elementSpec;
         }
+    }
+
+    /**
+     * @param array $options
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
+        if (isset($options['preserve_defined_order'])) {
+            $this->setPreserveDefinedOrder($options['preserve_defined_order']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param boolean $preserveDefinedOrder
+     * @return $this
+     */
+    public function setPreserveDefinedOrder($preserveDefinedOrder)
+    {
+        $this->preserveDefinedOrder = (bool) $preserveDefinedOrder;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function preserveDefinedOrder()
+    {
+        return $this->preserveDefinedOrder;
     }
 
     /**

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -110,6 +110,29 @@ class AnnotationBuilderTest extends TestCase
         $this->assertInstanceOf('Zend\Stdlib\Hydrator\ObjectProperty', $hydrator);
     }
 
+    public function testFieldsetOrder()
+    {
+        $entity  = new TestAsset\Annotation\FieldsetOrderEntity();
+        $builder = new Annotation\AnnotationBuilder();
+        $form    = $builder->createForm($entity);
+
+        $element = $form->get('element');
+        $first  = $form->getIterator()->getIterator()->current();
+        $this->assertSame($element, $first, 'Test is element ' . $first->getName());
+    }
+
+    public function testFieldsetOrderWithPreserve()
+    {
+        $entity  = new TestAsset\Annotation\FieldsetOrderEntity();
+        $builder = new Annotation\AnnotationBuilder();
+        $builder->setOptions(array('preserve_defined_order' => true));
+        $form    = $builder->createForm($entity);
+
+        $fieldset = $form->get('fieldset');
+        $first  = $form->getIterator()->getIterator()->current();
+        $this->assertSame($fieldset, $first, 'Test is element ' . $first->getName());
+    }
+
     public function testCanRetrieveOnlyFormSpecification()
     {
         $entity  = new TestAsset\Annotation\ComplexEntity();

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -125,7 +125,7 @@ class AnnotationBuilderTest extends TestCase
     {
         $entity  = new TestAsset\Annotation\FieldsetOrderEntity();
         $builder = new Annotation\AnnotationBuilder();
-        $builder->setOptions(array('preserve_defined_order' => true));
+        $builder->setPreserveDefinedOrder(true);
         $form    = $builder->createForm($entity);
 
         $fieldset = $form->get('fieldset');

--- a/tests/ZendTest/Form/TestAsset/Annotation/FieldsetOrderEntity.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/FieldsetOrderEntity.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+class FieldsetOrderEntity
+{
+    /**
+     * @Annotation\Type("Zend\Form\Fieldset")
+     */
+    public $fieldset;
+
+    /**
+     * @Annotation\Type("Zend\Form\Element")
+     */
+    public $element;
+}


### PR DESCRIPTION
This flag when set preserve the elements in the order they are defined in the class as opposed to the default of putting fieldsets after elements.

Fixes https://github.com/zendframework/zf2/issues/6653
