### PR TITLE
Add options to mail file

### DIFF
--- a/library/Zend/Mail/Storage/Mbox.php
+++ b/library/Zend/Mail/Storage/Mbox.php
@@ -42,7 +42,7 @@ class Mbox extends AbstractStorage
      * @var string
      */
     protected $messageClass = '\Zend\Mail\Storage\Message\File';
-    
+
     protected $messageEOL;
 
     /**
@@ -110,17 +110,17 @@ class Mbox extends AbstractStorage
             || is_subclass_of($this->messageClass, '\Zend\Mail\Storage\Message\File')) {
             // TODO top/body lines
             $messagePos = $this->getPos($id);
-            
+
             $messageClassParams = array(
-                'file' => $this->fh, 
-                'startPos' => $messagePos['start'],                                  
+                'file' => $this->fh,
+                'startPos' => $messagePos['start'],
                 'endPos' => $messagePos['end']
             );
-            
+
             if ($this->messageEOL) {
                 $messageClassParams['EOL'] = $this->messageEOL;
             }
-            
+
             return new $this->messageClass($messageClassParams);
         }
 
@@ -195,7 +195,7 @@ class Mbox extends AbstractStorage
         if (!isset($params->filename)) {
             throw new Exception\InvalidArgumentException('no valid filename given in params');
         }
-        
+
         if (isset($params->messageEOL)) {
             $this->messageEOL = $params->messageEOL;
         }

--- a/library/Zend/Mail/Storage/Mbox.php
+++ b/library/Zend/Mail/Storage/Mbox.php
@@ -43,6 +43,10 @@ class Mbox extends AbstractStorage
      */
     protected $messageClass = '\Zend\Mail\Storage\Message\File';
 
+    /**
+     * end of Line for messages
+     * @var string
+     */
     protected $messageEOL;
 
     /**

--- a/library/Zend/Mail/Storage/Mbox.php
+++ b/library/Zend/Mail/Storage/Mbox.php
@@ -42,6 +42,8 @@ class Mbox extends AbstractStorage
      * @var string
      */
     protected $messageClass = '\Zend\Mail\Storage\Message\File';
+    
+    protected $messageEOL;
 
     /**
      * Count messages all messages in current box
@@ -108,8 +110,18 @@ class Mbox extends AbstractStorage
             || is_subclass_of($this->messageClass, '\Zend\Mail\Storage\Message\File')) {
             // TODO top/body lines
             $messagePos = $this->getPos($id);
-            return new $this->messageClass(array('file' => $this->fh, 'startPos' => $messagePos['start'],
-                                                  'endPos' => $messagePos['end']));
+            
+            $messageClassParams = array(
+                'file' => $this->fh, 
+                'startPos' => $messagePos['start'],                                  
+                'endPos' => $messagePos['end']
+            );
+            
+            if ($this->messageEOL) {
+                $messageClassParams['EOL'] = $this->messageEOL;
+            }
+            
+            return new $this->messageClass($messageClassParams);
         }
 
         $bodyLines = 0; // TODO: need a way to change that
@@ -182,6 +194,10 @@ class Mbox extends AbstractStorage
 
         if (!isset($params->filename)) {
             throw new Exception\InvalidArgumentException('no valid filename given in params');
+        }
+        
+        if (isset($params->messageEOL)) {
+            $this->messageEOL = $params->messageEOL;
         }
 
         $this->openMboxFile($params->filename);

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -26,7 +26,7 @@ class File extends Part
      * - startPos start position of message or part in file (default: current position)
      * - endPos   end position of message or part in file (default: end of file)
      * - EOL      end of Line for messages
-     * 
+     *
      * @param   array $params  full message with or without headers
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -25,7 +25,8 @@ class File extends Part
      * - file     filename or open file handler with message content (required)
      * - startPos start position of message or part in file (default: current position)
      * - endPos   end position of message or part in file (default: end of file)
-     *
+     * - EOL      end of Line for fields
+     * 
      * @param   array $params  full message with or without headers
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
@@ -53,7 +54,11 @@ class File extends Part
             $header .= $line;
         }
 
-        $this->headers = Headers::fromString($header);
+        if (isset($params['EOL'])){
+            $this->headers = Headers::fromString($header, $params['EOL']);
+        }else{
+            $this->headers = Headers::fromString($header);
+        }
 
         $this->contentPos[0] = ftell($this->fh);
         if ($endPos !== null) {

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -54,9 +54,9 @@ class File extends Part
             $header .= $line;
         }
 
-        if (isset($params['EOL'])){
+        if (isset($params['EOL'])) {
             $this->headers = Headers::fromString($header, $params['EOL']);
-        }else{
+        }else {
             $this->headers = Headers::fromString($header);
         }
 

--- a/library/Zend/Mail/Storage/Part/File.php
+++ b/library/Zend/Mail/Storage/Part/File.php
@@ -25,7 +25,7 @@ class File extends Part
      * - file     filename or open file handler with message content (required)
      * - startPos start position of message or part in file (default: current position)
      * - endPos   end position of message or part in file (default: end of file)
-     * - EOL      end of Line for fields
+     * - EOL      end of Line for messages
      * 
      * @param   array $params  full message with or without headers
      * @throws Exception\RuntimeException

--- a/tests/ZendTest/Mail/Storage/MboxTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxTest.php
@@ -166,10 +166,10 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     }
 */
 
-    public function testFetchMessageUnix()
+    public function testFetchMessageHeaderLinuxUnix()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));
-
+        
         $subject = $mail->getMessage(1)->subject;
         $this->assertEquals('Simple Message', $subject);
     }

--- a/tests/ZendTest/Mail/Storage/MboxTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxTest.php
@@ -44,13 +44,13 @@ class MboxTest extends \PHPUnit_Framework_TestCase
                 return;
             }
         }
-        
-        $this->_mboxOriginalFile = __DIR__ . '/../_files/test.mbox/INBOX'; 
+
+        $this->_mboxOriginalFile = __DIR__ . '/../_files/test.mbox/INBOX';
         $this->_mboxFile = $this->_tmpdir . 'INBOX';
 
         copy($this->_mboxOriginalFile, $this->_mboxFile);
-        
-        if (strpos($this->getName(), 'Unix')){
+
+        if (strpos($this->getName(), 'Unix')) {
             $this->_mboxOriginalFileLinux = __DIR__ . '/../_files/test.mbox/INBOX.unix';
             $this->_mboxFileUnix = $this->_tmpdir . 'INBOX.unix';
             copy($this->_mboxOriginalFileLinux, $this->_mboxFileUnix);
@@ -60,8 +60,8 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         unlink($this->_mboxFile);
-        
-        if ($this->_mboxFileUnix){
+
+        if ($this->_mboxFileUnix) {
             unlink($this->_mboxFileUnix);
         }
     }
@@ -173,7 +173,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
         $subject = $mail->getMessage(1)->subject;
         $this->assertEquals('Simple Message', $subject);
     }
-    
+
     public function testFetchMessageHeader()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFile));
@@ -190,7 +190,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
         list($content, ) = explode("\n", $content, 2);
         $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
     }
-    
+
     public function testFetchMessageBodyUnix()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));

--- a/tests/ZendTest/Mail/Storage/MboxTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxTest.php
@@ -166,7 +166,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     }
 */
 
-    public function testFetchMessageHeaderLinuxUnix()
+    public function testFetchMessageHeaderUnix()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));
         

--- a/tests/ZendTest/Mail/Storage/MboxTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxTest.php
@@ -169,7 +169,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     public function testFetchMessageHeaderUnix()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));
-        
+
         $subject = $mail->getMessage(1)->subject;
         $this->assertEquals('Simple Message', $subject);
     }

--- a/tests/ZendTest/Mail/Storage/MboxTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxTest.php
@@ -166,10 +166,10 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     }
 */
 
-    public function testFetchMessageHeaderLinuxUnix()
+    public function testFetchMessageUnix()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));
-        
+
         $subject = $mail->getMessage(1)->subject;
         $this->assertEquals('Simple Message', $subject);
     }

--- a/tests/ZendTest/Mail/Storage/MboxTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxTest.php
@@ -19,6 +19,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
 {
     protected $_mboxOriginalFile;
     protected $_mboxFile;
+    protected $_mboxFileUnix;
     protected $_tmpdir;
 
     public function setUp()
@@ -43,16 +44,26 @@ class MboxTest extends \PHPUnit_Framework_TestCase
                 return;
             }
         }
-
-        $this->_mboxOriginalFile = __DIR__ . '/../_files/test.mbox/INBOX';
+        
+        $this->_mboxOriginalFile = __DIR__ . '/../_files/test.mbox/INBOX'; 
         $this->_mboxFile = $this->_tmpdir . 'INBOX';
 
         copy($this->_mboxOriginalFile, $this->_mboxFile);
+        
+        if (strpos($this->getName(), 'Unix')){
+            $this->_mboxOriginalFileLinux = __DIR__ . '/../_files/test.mbox/INBOX.unix';
+            $this->_mboxFileUnix = $this->_tmpdir . 'INBOX.unix';
+            copy($this->_mboxOriginalFileLinux, $this->_mboxFileUnix);
+        }
     }
 
     public function tearDown()
     {
         unlink($this->_mboxFile);
+        
+        if ($this->_mboxFileUnix){
+            unlink($this->_mboxFileUnix);
+        }
     }
 
     public function testLoadOk()
@@ -155,6 +166,14 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     }
 */
 
+    public function testFetchMessageHeaderLinuxUnix()
+    {
+        $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));
+        
+        $subject = $mail->getMessage(1)->subject;
+        $this->assertEquals('Simple Message', $subject);
+    }
+    
     public function testFetchMessageHeader()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFile));
@@ -166,6 +185,15 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     public function testFetchMessageBody()
     {
         $mail = new Storage\Mbox(array('filename' => $this->_mboxFile));
+
+        $content = $mail->getMessage(3)->getContent();
+        list($content, ) = explode("\n", $content, 2);
+        $this->assertEquals('Fair river! in thy bright, clear flow', trim($content));
+    }
+    
+    public function testFetchMessageBodyUnix()
+    {
+        $mail = new Storage\Mbox(array('filename' => $this->_mboxFileUnix, 'messageEOL' => "\n"));
 
         $content = $mail->getMessage(3)->getContent();
         list($content, ) = explode("\n", $content, 2);

--- a/tests/ZendTest/Mail/_files/test.mbox/INBOX.unix
+++ b/tests/ZendTest/Mail/_files/test.mbox/INBOX.unix
@@ -1,0 +1,114 @@
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+Return-Path: <from@example.com>
+Delivered-To: to@example.com
+Received: by example.com
+	id 1; Sun, 30 Apr 2006 19:00:00 +0200 (CEST)
+Received: by localhost
+	id 1; Sun, 30 Apr 2006 19:10:00 +0200 (CEST)
+To: to@example.com
+Subject: Simple Message
+Message-Id: <20060430185000.1@example.com>
+Date: Sun, 30 Apr 2006 18:50:00 +0200 (CEST)
+From: from@example.com
+
+This is a simple test message
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+To: bar@example.com
+Subject: A Really Simple Message
+From: foo@example.com
+
+Message
+
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+To: river@example.com
+Subject: To the River
+Date: Sun, 01 Jan 1829 00:00:00 +0000
+From: poe@example.com
+Message-Id: <18290101000000.0000@example.com>
+Content-type: text/plain
+MIME-version: 1.0
+X-Twin: the good
+X-Twin: the evil
+
+Fair river! in thy bright, clear flow 
+Of crystal, wandering water,
+Thou art an emblem of the glow 
+Of beautythe unhidden heart
+The playful maziness of art
+In old Alberto's daughter; 
+
+But when within thy wave she looks
+Which glistens then, and trembles
+Why, then, the prettiest of brooks 
+Her worshipper resembles;
+For in his heart, as in thy stream, 
+Her image deeply lies
+His heart which trembles at the beam 
+Of her soul-searching eyes.
+
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+To: foo@example.com
+Subject: multipart
+Date: Sun, 01 Jan 2000 00:00:00 +0000
+From: crazy@example.com
+Content-type: multipart/alternative; boundary="crazy-multipart"
+MIME-version: 1.0
+
+multipart message
+--crazy-multipart
+Content-type: text/plain
+
+The first part 
+is horizontal
+
+--crazy-multipart
+Content-type: text/x-vertical
+
+T s p i v
+h e a s e
+e c r   r
+  o t   t
+  n     i
+  d     c
+        a
+        l
+--crazy-multipart--
+
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+To: foo@example.com
+Subject: multipart
+Date: Sun, 01 Jan 2000 01:00:00 +0000
+From: normal@example.com
+Content-type: multipart/alternative; boundary="normal-multipart"
+MIME-version: 1.0
+
+multipart message
+--normal-multipart
+Content-type: text/html
+
+<html>
+<head><style>
+body{background:#008;color:white}
+em{color:#f88}
+</style></head>
+<body>Again a <em>simple</em> message</body>
+</html>
+--normal-multipart
+Content-type: text/plain
+
+Again a simple message
+--normal-multipart--
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+To: foo@example.com
+Subject: no body
+Date: Sun, 01 Jan 2000 01:00:00 +0000
+From: short@example.com
+From next-message@example.com  Mon Jan 00 00:00:00 0000
+To: to@example.com
+Subject: Dot Test
+Date: Sun, 01 Jan 2000 01:00:00 +0000
+From: from@example.com
+
+Before the dot
+.
+is after the dot


### PR DESCRIPTION
I have issue with Mbox class on my Linux system: I cannot open Mbox file because i receive Zend\Mail\Exception\RuntimeException with message: "Return-Path: from@example.com Delivered-To: to@example.com... does not match header format!".
This exception due to the fact my mbox file used a "\n" symbol as EOL.
This PR adds way to change EOL for Mbox files.
