### PR TITLE
detach() is now inherited from AbstractListenerAgregate.

### DIFF
--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -85,21 +85,6 @@ class ViewManager extends AbstractListenerAggregate
     }
 
     /**
-     * Detach aggregate listeners from the specified event manager
-     *
-     * @param  EventManagerInterface $events
-     * @return void
-     */
-    public function detach(EventManagerInterface $events)
-    {
-        foreach ($this->listeners as $index => $listener) {
-            if ($events->detach($listener)) {
-                unset($this->listeners[$index]);
-            }
-        }
-    }
-
-    /**
      * Prepares the view layer
      *
      * @param  $event


### PR DESCRIPTION
Just removing duplicated code from inheritance.
