### PR TITLE
Test/Db/Adapter/Platform/SqlServerTest restore_error_handler();

### DIFF
--- a/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
@@ -148,10 +148,10 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
 
     public function testPlatformQuotesNullByteCharacter()
     {
-        $err = set_error_handler(function () {});
+        set_error_handler(function () {} );
         $string = "1\0";
         $value = $this->platform->quoteValue($string);
-        set_error_handler($err);
+        restore_error_handler();
         $this->assertEquals("'1\\000'", $value);
     }
 }


### PR DESCRIPTION
Error handler should be restore for the following tests
