### PR TITLE
Zend\Db: Allow adding native predicates to sql queries, respecting nextPredicateCombineOrder

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -383,6 +383,27 @@ class Predicate extends PredicateSet
     }
 
     /**
+     * Use given predicate directly
+     *
+     * Contrary to {@link addPredicate()} this method respects formerly set
+     * AND / OR combination operator, thus allowing generic predicates to be
+     * used fluently within where chains as any other concrete predicate.
+     *
+     * @param  PredicateInterface $predicate
+     * @return Predicate
+     */
+    public function predicate(PredicateInterface $predicate)
+    {
+        $this->addPredicate(
+            $predicate,
+            ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
+        );
+        $this->nextPredicateCombineOperator = null;
+
+        return $this;
+    }
+
+    /**
      * Overloading
      *
      * Overloads "or", "and", "nest", and "unnest"

--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -396,7 +396,7 @@ class Predicate extends PredicateSet
     {
         $this->addPredicate(
             $predicate,
-            ($this->nextPredicateCombineOperator) ?: $this->defaultCombination
+            $this->nextPredicateCombineOperator ?: $this->defaultCombination
         );
         $this->nextPredicateCombineOperator = null;
 

--- a/library/Zend/Db/Sql/Predicate/PredicateSet.php
+++ b/library/Zend/Db/Sql/Predicate/PredicateSet.php
@@ -61,6 +61,13 @@ class PredicateSet implements PredicateInterface, Countable
         return $this;
     }
 
+    /**
+     * Add predicates to set
+     *
+     * @param PredicateInterface|\Closure|string|array $predicates
+     * @param string $combination
+     * @return PredicateSet
+     */
     public function addPredicates($predicates, $combination = self::OP_AND)
     {
         if ($predicates === null) {

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -1234,6 +1234,32 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             'processJoins' => array(array(array('INNER', 'psql_function_which_returns_table AS "bar"', '"foo"."id" = "bar"."fooid"')))
         );
 
+        // Test raw predicate is appended with AND
+        $select50 = new Select;
+        $select50->from(new TableIdentifier('foo'))
+            ->where
+            ->nest
+                ->isNull('bar')
+                ->and
+                ->addPredicate(new Where())
+            ->unnest;
+        $sqlPrep50 = // same
+        $sqlStr50 = 'SELECT "foo".* FROM "foo" WHERE ("bar" IS NULL AND ())';
+        $internalTests50 = array();
+
+        // Test raw predicate is appended with OR
+        $select51 = new Select;
+        $select51->from(new TableIdentifier('foo'))
+            ->where
+            ->nest
+                ->isNull('bar')
+                ->or
+                ->addPredicate(new Where())
+            ->unnest;
+        $sqlPrep51 = // same
+        $sqlStr51 = 'SELECT "foo".* FROM "foo" WHERE ("bar" IS NULL OR ())';
+        $internalTests51 = array();
+
         /**
          * $select = the select object
          * $sqlPrep = the sql as a result of preparation
@@ -1294,6 +1320,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             array($select47, $sqlPrep47, $params47,  $sqlStr47, $internalTests47),
             array($select48, $sqlPrep48, array(),    $sqlStr48, $internalTests48),
             array($select49, $sqlPrep49, array(),    $sqlStr49, $internalTests49),
+            array($select50, $sqlPrep50, array(),    $sqlStr50, $internalTests50),
+            array($select51, $sqlPrep51, array(),    $sqlStr51, $internalTests51),
         );
     }
 }

--- a/tests/ZendTest/Db/Sql/SelectTest.php
+++ b/tests/ZendTest/Db/Sql/SelectTest.php
@@ -1234,30 +1234,30 @@ class SelectTest extends \PHPUnit_Framework_TestCase
             'processJoins' => array(array(array('INNER', 'psql_function_which_returns_table AS "bar"', '"foo"."id" = "bar"."fooid"')))
         );
 
-        // Test raw predicate is appended with AND
+        // Test generic predicate is appended with AND
         $select50 = new Select;
         $select50->from(new TableIdentifier('foo'))
             ->where
             ->nest
                 ->isNull('bar')
                 ->and
-                ->addPredicate(new Where())
+                ->predicate(new Predicate\Literal('1=1'))
             ->unnest;
         $sqlPrep50 = // same
-        $sqlStr50 = 'SELECT "foo".* FROM "foo" WHERE ("bar" IS NULL AND ())';
+        $sqlStr50 = 'SELECT "foo".* FROM "foo" WHERE ("bar" IS NULL AND 1=1)';
         $internalTests50 = array();
 
-        // Test raw predicate is appended with OR
+        // Test generic predicate is appended with OR
         $select51 = new Select;
         $select51->from(new TableIdentifier('foo'))
             ->where
             ->nest
                 ->isNull('bar')
                 ->or
-                ->addPredicate(new Where())
+                ->predicate(new Predicate\Literal('1=1'))
             ->unnest;
         $sqlPrep51 = // same
-        $sqlStr51 = 'SELECT "foo".* FROM "foo" WHERE ("bar" IS NULL OR ())';
+        $sqlStr51 = 'SELECT "foo".* FROM "foo" WHERE ("bar" IS NULL OR 1=1)';
         $internalTests51 = array();
 
         /**


### PR DESCRIPTION
Fix for #6800 
