### PR TITLE
Fix extra types specification

### DIFF
--- a/library/Zend/Db/Sql/Ddl/Column/Text.php
+++ b/library/Zend/Db/Sql/Ddl/Column/Text.php
@@ -33,7 +33,7 @@ class Text extends Column
         $spec   = $this->specification;
         $params = array();
 
-        $types    = array(self::TYPE_IDENTIFIER, self::TYPE_LITERAL);
+        $types    = array(self::TYPE_IDENTIFIER);
         $params[] = $this->name;
 
         $types[]  = self::TYPE_LITERAL;

--- a/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
@@ -32,7 +32,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
         
         $column->setDefault('default');
         $this->assertEquals(
-            array(array('%s TEXT %s %s', array('foo', 'NOT NULL', 'default'), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_VALUE))),
+            array(array('%s TEXT %s %s', array('foo', '', 'default'), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_VALUE))),
             $column->getExpressionData()
         );
     }

--- a/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
@@ -20,7 +20,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
     {
         $column = new Text('foo');
         $this->assertEquals(
-            array(array('%s TEXT %s %s', array('foo', 'NOT NULL', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_LITERAL, $column::TYPE_LITERAL))),
+            array(array('%s TEXT %s %s', array('foo', 'NOT NULL', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_LITERAL)),
             $column->getExpressionData()
         );
     }

--- a/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
@@ -20,7 +20,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
     {
         $column = new Text('foo');
         $this->assertEquals(
-            array(array('%s TEXT %s %s', array('foo', 'NOT NULL', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_LITERAL)),
+            array(array('%s TEXT %s %s', array('foo', 'NOT NULL', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_LITERAL))),
             $column->getExpressionData()
         );
     }

--- a/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
@@ -24,6 +24,12 @@ class TextTest extends \PHPUnit_Framework_TestCase
             $column->getExpressionData()
         );
         
+        $column->setNullable(true);
+        $this->assertEquals(
+            array(array('%s TEXT %s %s', array('foo', '', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, , $column::TYPE_LITERAL))),
+            $column->getExpressionData()
+        );
+        
         $column->setDefault('default');
         $this->assertEquals(
             array(array('%s TEXT %s %s', array('foo', 'NOT NULL', 'default'), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_VALUE))),

--- a/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
@@ -26,7 +26,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
         
         $column->setNullable(true);
         $this->assertEquals(
-            array(array('%s TEXT %s %s', array('foo', '', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, , $column::TYPE_LITERAL))),
+            array(array('%s TEXT %s %s', array('foo', '', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_LITERAL))),
             $column->getExpressionData()
         );
         

--- a/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/TextTest.php
@@ -23,5 +23,11 @@ class TextTest extends \PHPUnit_Framework_TestCase
             array(array('%s TEXT %s %s', array('foo', 'NOT NULL', ''), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_LITERAL))),
             $column->getExpressionData()
         );
+        
+        $column->setDefault('default');
+        $this->assertEquals(
+            array(array('%s TEXT %s %s', array('foo', 'NOT NULL', 'default'), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL, $column::TYPE_VALUE))),
+            $column->getExpressionData()
+        );
     }
 }


### PR DESCRIPTION
Fix issue from Char/Varchar being copied as Text where the length was removed from Text.
Cause of issue: Specification from Char/Varchar to Text changed from 4 to 3 types
Result of issue: default would always be considered as self::TYPE_LITERAL
