### PR TITLE
Corrects firstItemCount for empty result sets

### DIFF
--- a/library/Zend/Paginator/Paginator.php
+++ b/library/Zend/Paginator/Paginator.php
@@ -919,8 +919,8 @@ class Paginator implements Countable, IteratorAggregate
             $pages->currentItemCount = $this->getCurrentItemCount();
             $pages->itemCountPerPage = $this->getItemCountPerPage();
             $pages->totalItemCount   = $this->getTotalItemCount();
-            $pages->firstItemNumber  = (($currentPageNumber - 1) * $this->getItemCountPerPage()) + 1;
-            $pages->lastItemNumber   = $pages->firstItemNumber + $pages->currentItemCount - 1;
+            $pages->firstItemNumber  = $this->getTotalItemCount() ? (($currentPageNumber - 1) * $this->getItemCountPerPage()) + 1 : 0;
+            $pages->lastItemNumber   = $this->getTotalItemCount() ? $pages->firstItemNumber + $pages->currentItemCount - 1 : 0;
         }
 
         return $pages;

--- a/tests/ZendTest/Paginator/PaginatorTest.php
+++ b/tests/ZendTest/Paginator/PaginatorTest.php
@@ -791,5 +791,29 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($outputGetCacheId, 'Zend_Paginator_1_' . $outputGetCacheInternalId);
     }
+    
+    public function testItemCountsForEmptyItemSet()
+    {
+        $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(array()));
+        $paginator->setCurrentPageNumber(1);
+        
+        $expected = new stdClass();
+        $expected->pageCount        = 0;
+        $expected->itemCountPerPage = 10;
+        $expected->first            = 1;
+        $expected->current          = 1;
+        $expected->last             = 0;
+        $expected->pagesInRange     = array(1 => 1);
+        $expected->firstPageInRange = 1;
+        $expected->lastPageInRange  = 1;
+        $expected->currentItemCount = 0;
+        $expected->totalItemCount   = 0;
+        $expected->firstItemNumber  = 0;
+        $expected->lastItemNumber   = 0;
+        
+        $actual = $paginator->getPages();
+        
+        $this->assertEquals($expected, $actual);
+    }
 
 }


### PR DESCRIPTION
Fix for issue #6808
