### PR TITLE
Fixes #6812 : Zend\Paginator\Adapter\DbSelect::getItems should return array

### DIFF
--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -86,8 +86,13 @@ class DbSelect implements AdapterInterface
 
         $resultSet = clone $this->resultSetPrototype;
         $resultSet->initialize($result);
+        
+        $items = array();
+        foreach($resultSet as $key => $value) {
+            $items[$key] = $value;
+        }
 
-        return $resultSet;
+        return $items;
     }
 
     /**

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -87,7 +87,12 @@ class DbSelect implements AdapterInterface
         $resultSet = clone $this->resultSetPrototype;
         $resultSet->initialize($result);
 
-        return $resultSet;
+        $items = array();
+        foreach($resultSet as $key => $result) {
+            $items[] = $result;
+        }
+
+        return $items;
     }
 
     /**

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -15,7 +15,6 @@ use Zend\Db\Sql\Expression;
 use Zend\Db\Sql\Select;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\ResultSet\ResultSetInterface;
-use Zend\Stdlib\ArrayUtils;
 
 class DbSelect implements AdapterInterface
 {
@@ -88,7 +87,7 @@ class DbSelect implements AdapterInterface
         $resultSet = clone $this->resultSetPrototype;
         $resultSet->initialize($result);
 
-        return ArrayUtils::iteratorToArray($resultSet);
+        return iterator_to_array($resultSet);
     }
 
     /**

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -15,6 +15,7 @@ use Zend\Db\Sql\Expression;
 use Zend\Db\Sql\Select;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\ResultSet\ResultSetInterface;
+use Zend\Stdlib\ArrayUtils;
 
 class DbSelect implements AdapterInterface
 {
@@ -87,12 +88,7 @@ class DbSelect implements AdapterInterface
         $resultSet = clone $this->resultSetPrototype;
         $resultSet->initialize($result);
         
-        $items = array();
-        foreach ($resultSet as $key => $value) {
-            $items[$key] = $value;
-        }
-
-        return $items;
+        return ArrayUtils::iteratorToArray($resultSet);
     }
 
     /**

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -87,7 +87,7 @@ class DbSelect implements AdapterInterface
 
         $resultSet = clone $this->resultSetPrototype;
         $resultSet->initialize($result);
-        
+
         return ArrayUtils::iteratorToArray($resultSet);
     }
 

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -73,7 +73,7 @@ class DbSelect implements AdapterInterface
      *
      * @param  int $offset           Page offset
      * @param  int $itemCountPerPage Number of items per page
-     * @return array
+     * @return ResultSetInterface
      */
     public function getItems($offset, $itemCountPerPage)
     {
@@ -87,12 +87,7 @@ class DbSelect implements AdapterInterface
         $resultSet = clone $this->resultSetPrototype;
         $resultSet->initialize($result);
 
-        $items = array();
-        foreach($resultSet as $key => $result) {
-            $items[] = $result;
-        }
-
-        return $items;
+        return $resultSet;
     }
 
     /**

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -88,7 +88,7 @@ class DbSelect implements AdapterInterface
         $resultSet->initialize($result);
         
         $items = array();
-        foreach($resultSet as $key => $value) {
+        foreach ($resultSet as $key => $value) {
             $items[$key] = $value;
         }
 

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -73,7 +73,7 @@ class DbSelect implements AdapterInterface
      *
      * @param  int $offset           Page offset
      * @param  int $itemCountPerPage Number of items per page
-     * @return ResultSetInterface
+     * @return array
      */
     public function getItems($offset, $itemCountPerPage)
     {

--- a/library/Zend/Paginator/Paginator.php
+++ b/library/Zend/Paginator/Paginator.php
@@ -609,16 +609,6 @@ class Paginator implements Countable, IteratorAggregate
             $items = $filter->filter($items);
         }
 
-        if ($items instanceof AbstractResultSet) {
-            $temp = array();
-            foreach ($items as $key => $value) {
-                $temp[$key] = $value;
-            }
-
-            $items = $temp;
-            unset($temp);
-        }
-
         if (!$items instanceof Traversable) {
             $items = new ArrayIterator($items);
         }

--- a/library/Zend/Paginator/Paginator.php
+++ b/library/Zend/Paginator/Paginator.php
@@ -609,6 +609,16 @@ class Paginator implements Countable, IteratorAggregate
             $items = $filter->filter($items);
         }
 
+        if ($items instanceof AbstractResultSet) {
+            $temp = array();
+            foreach ($items as $key => $value) {
+                $temp[$key] = $value;
+            }
+
+            $items = $temp;
+            unset($temp);
+        }
+
         if (!$items instanceof Traversable) {
             $items = new ArrayIterator($items);
         }

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -74,7 +74,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
         $this->mockSelect->expects($this->once())->method('limit')->with($this->equalTo(10));
         $this->mockSelect->expects($this->once())->method('offset')->with($this->equalTo(2));
         $items = $this->dbSelect->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testCount()

--- a/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbSelectTest.php
@@ -74,7 +74,7 @@ class DbSelectTest extends \PHPUnit_Framework_TestCase
         $this->mockSelect->expects($this->once())->method('limit')->with($this->equalTo(10));
         $this->mockSelect->expects($this->once())->method('offset')->with($this->equalTo(2));
         $items = $this->dbSelect->getItems(2, 10);
-        $this->assertEquals(array(), $items);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
     }
 
     public function testCount()

--- a/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Paginator\Adapter;
 
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Paginator\Adapter\DbTableGateway;
-use Zend\Db\ResultSet\ResultSet;
 
 /**
  * @group Zend_Paginator
@@ -64,7 +63,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testCount()
@@ -97,7 +96,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testGetItemsWithWhereAndOrderAndGroup()
@@ -118,7 +117,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testGetItemsWithWhereAndOrderAndGroupAndHaving()
@@ -140,6 +139,6 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 }

--- a/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Paginator\Adapter;
 
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Paginator\Adapter\DbTableGateway;
-use Zend\Db\ResultSet\ResultSet;
 
 /**
  * @group Zend_Paginator

--- a/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
@@ -64,7 +64,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testCount()
@@ -97,7 +97,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testGetItemsWithWhereAndOrderAndGroup()
@@ -118,7 +118,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 
     public function testGetItemsWithWhereAndOrderAndGroupAndHaving()
@@ -140,6 +140,6 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
+        $this->assertEquals(array(), $items);
     }
 }

--- a/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
+++ b/tests/ZendTest/Paginator/Adapter/DbTableGatewayTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Paginator\Adapter;
 
 use Zend\Db\Adapter\Platform\Sql92;
 use Zend\Paginator\Adapter\DbTableGateway;
+use Zend\Db\ResultSet\ResultSet;
 
 /**
  * @group Zend_Paginator
@@ -63,7 +64,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertEquals(array(), $items);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
     }
 
     public function testCount()
@@ -96,7 +97,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertEquals(array(), $items);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
     }
 
     public function testGetItemsWithWhereAndOrderAndGroup()
@@ -117,7 +118,7 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
              ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertEquals(array(), $items);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
     }
 
     public function testGetItemsWithWhereAndOrderAndGroupAndHaving()
@@ -139,6 +140,6 @@ class DbTableGatewayTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($mockResult));
 
         $items = $this->dbTableGateway->getItems(2, 10);
-        $this->assertEquals(array(), $items);
+        $this->assertInstanceOf('Zend\Db\ResultSet\ResultSet', $items);
     }
 }

--- a/tests/ZendTest/Paginator/PaginatorTest.php
+++ b/tests/ZendTest/Paginator/PaginatorTest.php
@@ -425,6 +425,7 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
     
     /**
      * @group ZF2-6817
+     * @group ZF2-6812
      */
     public function testGetsItemsByPageHandleDbSelectAdapter()
     {


### PR DESCRIPTION
Fixes #6812 
