### PR TITLE
Add event manager to session for it is needed.

### DIFF
--- a/library/Zend/Session/composer.json
+++ b/library/Zend/Session/composer.json
@@ -15,12 +15,12 @@
     "target-dir": "Zend/Session",
     "require": {
         "php": ">=5.3.23",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-eventmanager": "self.version"
     },
     "require-dev": {
         "zendframework/zend-cache": "self.version",
         "zendframework/zend-db": "self.version",
-        "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-http": "self.version",
         "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-validator": "self.version"
@@ -28,7 +28,6 @@
     "suggest": {
         "zendframework/zend-cache": "Zend\\Cache component",
         "zendframework/zend-db": "Zend\\Db component",
-        "zendframework/zend-eventmanager": "Zend\\EventManager component",
         "zendframework/zend-http": "Zend\\Http component",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
         "zendframework/zend-validator": "Zend\\Validator component"


### PR DESCRIPTION
When downloading zend-session and trying to use it as standalone with the script

``` php
<?php
require __DIR__ . '/vendor/autoload.php';

use Zend\Session\Config\StandardConfig;
use Zend\Session\SessionManager;
use Zend\Session\Container;

$config = new StandardConfig();
$config->setOptions(array(
    'remember_me_seconds' => 3600,
    'name'                => 'zf2',
));
$manager = new SessionManager($config);

$manager->start();

$container = new Container('namespace');
if (isset($container->item)) {
    echo $container->item . ' Session is set ';
} else {
    $container->item = 'foo';
}
```

throws

``` bash
php -S localhost:8000 session.php 
PHP 5.5.9-1ubuntu4.4 Development Server started at Wed Oct 29 14:35:17 2014
Listening on http://localhost:8000
Document root is /var/www/github.com/harikt/zf2
Press Ctrl-C to quit.
[Wed Oct 29 14:35:25 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
[Wed Oct 29 14:35:25 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
[Wed Oct 29 14:35:25 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
[Wed Oct 29 14:35:26 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
[Wed Oct 29 14:35:27 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
[Wed Oct 29 14:35:28 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
[Wed Oct 29 14:35:28 2014] PHP Fatal error:  Class 'Zend\EventManager\EventManager' not found in /var/www/github.com/harikt/zf2/vendor/zendframework/zend-session/Zend/Session/ValidatorChain.php on line 19
```

I struggled to understand the documentation, may be better usage of standalone should be promoted. 

Thanks
