### PR TITLE
[Zend\ServiceManager] Improve error handling in the abstract plugin manager

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -55,7 +55,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * Add a default initializer to ensure the plugin is valid after instance
      * creation.
      *
-     * @param  null|ConfigInterface $configuration
+     * @param null|ConfigInterface $configuration
      */
     public function __construct(ConfigInterface $configuration = null)
     {
@@ -74,7 +74,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * Checks that the filter loaded is either a valid callback or an instance
      * of FilterInterface.
      *
-     * @param  mixed $plugin
+     * @param  mixed                      $plugin
      * @return void
      * @throws Exception\RuntimeException if invalid
      */
@@ -88,8 +88,8 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * constructor if not null and a non-empty array.
      *
      * @param  string $name
-     * @param  array $options
-     * @param  bool $usePeeringServiceManagers
+     * @param  array  $options
+     * @param  bool   $usePeeringServiceManagers
      * @return object
      */
     public function get($name, $options = array(), $usePeeringServiceManagers = true)
@@ -99,8 +99,8 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
             $serviceLocator = $this->getServiceLocator();
             if ($serviceLocator && $serviceLocator->has($name)) {
                 throw new Exception\ServiceLocatorUsageException(sprintf(
-                    'The service "%s" has been found in the parent service locator. ' .
-                    'You are not able to retrieve it by auto invokable class to avoid confusion. ' .
+                    'The service "%s" has been found in the parent service locator. '.
+                    'You are not able to retrieve it by auto invokable class to avoid confusion. '.
                     'Did you forget to use $serviceLocator = $serviceLocator->getServiceLocator() in your factory?',
                     $name
                 ));
@@ -109,14 +109,14 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
         }
 
         $this->creationOptions = $options;
-        
+
         try {
             $instance = parent::get($name, $usePeeringServiceManagers);
         } catch (Exception\ServiceNotFoundException $e) {
             $serviceLocator = $this->getServiceLocator();
             if ($serviceLocator && $serviceLocator->has($name)) {
                 throw new Exception\ServiceLocatorUsageException(sprintf(
-                    'The unavailable service "%s" has been found in the parent service locator. ' .
+                    'The unavailable service "%s" has been found in the parent service locator. '.
                     'Did you forget to use $serviceLocator = $serviceLocator->getServiceLocator() in your factory?',
                     $name
                 ), 0, $e);
@@ -126,6 +126,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
 
         $this->creationOptions = null;
         $this->validatePlugin($instance);
+
         return $instance;
     }
 
@@ -135,9 +136,9 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * Validates that the service object via validatePlugin() prior to
      * attempting to register it.
      *
-     * @param  string $name
-     * @param  mixed $service
-     * @param  bool $shared
+     * @param  string                                $name
+     * @param  mixed                                 $service
+     * @param  bool                                  $shared
      * @return AbstractPluginManager
      * @throws Exception\InvalidServiceNameException
      */
@@ -147,18 +148,20 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
             $this->validatePlugin($service);
         }
         parent::setService($name, $service, $shared);
+
         return $this;
     }
 
     /**
      * Set the main service locator so factories can have access to it to pull deps
      *
-     * @param ServiceLocatorInterface $serviceLocator
+     * @param  ServiceLocatorInterface $serviceLocator
      * @return AbstractPluginManager
      */
     public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
+
         return $this;
     }
 
@@ -178,8 +181,8 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * Overrides parent implementation by passing $creationOptions to the
      * constructor, if non-null.
      *
-     * @param  string $canonicalName
-     * @param  string $requestedName
+     * @param  string                               $canonicalName
+     * @param  string                               $requestedName
      * @return null|\stdClass
      * @throws Exception\ServiceNotCreatedException If resolved class does not exist
      */
@@ -204,8 +207,8 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
      * Overrides parent implementation by passing $creationOptions to the
      * constructor, if non-null.
      *
-     * @param  string $canonicalName
-     * @param  string $requestedName
+     * @param  string                               $canonicalName
+     * @param  string                               $requestedName
      * @return mixed
      * @throws Exception\ServiceNotCreatedException If factory is not callable
      */
@@ -230,7 +233,7 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
             $instance = $this->createServiceViaCallback($factory, $canonicalName, $requestedName);
         } else {
             throw new Exception\ServiceNotCreatedException(sprintf(
-                'While attempting to create %s%s an invalid factory was registered for this instance type.', $canonicalName, ($requestedName ? '(alias: ' . $requestedName . ')' : '')
+                'While attempting to create %s%s an invalid factory was registered for this instance type.', $canonicalName, ($requestedName ? '(alias: '.$requestedName.')' : '')
             ));
         }
 
@@ -240,9 +243,9 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     /**
      * Create service via callback
      *
-     * @param  callable $callable
-     * @param  string   $cName
-     * @param  string   $rName
+     * @param  callable                                   $callable
+     * @param  string                                     $cName
+     * @param  string                                     $rName
      * @throws Exception\ServiceNotCreatedException
      * @throws Exception\ServiceNotFoundException
      * @throws Exception\CircularDependencyFoundException

--- a/library/Zend/ServiceManager/Exception/ServiceLocatorUsageException.php
+++ b/library/Zend/ServiceManager/Exception/ServiceLocatorUsageException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager\Exception;
+
+class ServiceLocatorUsageException extends InvalidArgumentException
+{
+}

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -198,8 +198,24 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
         /** @var \Zend\ServiceManager\AbstractPluginManager $pluginManager */
         $pluginManager = new FooPluginManager();
+        $pluginManager->setServiceLocator($sm);
         $pluginManager->setFactory('foo', function($sm) {
             $sm->get('bar');
+        });
+
+        $pluginManager->get('foo');
+    }
+
+    public function testCanCheckInvalidServiceManagerIsUsedWithExistingClass()
+    {
+        $sm = new ServiceManager();
+        $sm->setService('stdClass', new \stdClass());
+
+        /** @var \Zend\ServiceManager\AbstractPluginManager $pluginManager */
+        $pluginManager = new FooPluginManager();
+        $pluginManager->setServiceLocator($sm);
+        $pluginManager->setFactory('foo', function($sm) {
+            $sm->get('stdClass');
         });
 
         $pluginManager->get('foo');

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -190,4 +190,18 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($fooDelegator, array_shift($barDelegator->instances));
 
     }
+
+    public function testCanCheckInvalidServiceManagerIsUsed()
+    {
+        $sm = new ServiceManager();
+        $sm->setService('bar', new \stdClass());
+
+        /** @var \Zend\ServiceManager\AbstractPluginManager $pluginManager */
+        $pluginManager = new FooPluginManager();
+        $pluginManager->setFactory('foo', function($sm) {
+            $sm->get('bar');
+        });
+
+        $pluginManager->get('foo');
+    }
 }

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -28,7 +28,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->serviceManager = new ServiceManager;
+        $this->serviceManager = new ServiceManager();
         $this->pluginManager = new FooPluginManager(new Config(array(
             'factories' => array(
                 'Foo' => 'ZendTest\ServiceManager\TestAsset\FooFactory',
@@ -200,7 +200,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         /** @var \Zend\ServiceManager\AbstractPluginManager $pluginManager */
         $pluginManager = new FooPluginManager();
         $pluginManager->setServiceLocator($sm);
-        $pluginManager->setFactory('foo', function($sm) {
+        $pluginManager->setFactory('foo', function ($sm) {
             $sm->get('bar');
         });
 
@@ -209,6 +209,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         } catch (ServiceNotCreatedException $e) {
             $this->assertNotNull($e->getPrevious());
             $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceLocatorUsageException', $e->getPrevious());
+
             return;
         }
 
@@ -223,10 +224,10 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         /** @var \Zend\ServiceManager\AbstractPluginManager $pluginManager */
         $pluginManager = new FooPluginManager();
         $pluginManager->setServiceLocator($sm);
-        $pluginManager->setFactory('foo', function($sm) {
+        $pluginManager->setFactory('foo', function ($sm) {
             $std = $sm->get('stdClass');
             $std->a = 1;
-            
+
             return $std;
         });
 
@@ -235,9 +236,10 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         } catch (ServiceNotCreatedException $e) {
             $this->assertNotNull($e->getPrevious());
             $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceLocatorUsageException', $e->getPrevious());
+
             return;
         }
-        
+
         $this->fail('A Zend\ServiceManager\Exception\ServiceNotCreatedException is expected');
     }
 }

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\ServiceManager;
 
 use ReflectionClass;
 use ReflectionObject;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Config;
 
@@ -203,7 +204,15 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
             $sm->get('bar');
         });
 
-        $pluginManager->get('foo');
+        try {
+            $pluginManager->get('foo');
+        } catch (ServiceNotCreatedException $e) {
+            $this->assertNotNull($e->getPrevious());
+            $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceLocatorUsageException', $e->getPrevious());
+            return;
+        }
+
+        $this->fail('A Zend\ServiceManager\Exception\ServiceNotCreatedException is expected');
     }
 
     public function testCanCheckInvalidServiceManagerIsUsedWithExistingClass()
@@ -215,9 +224,20 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $pluginManager = new FooPluginManager();
         $pluginManager->setServiceLocator($sm);
         $pluginManager->setFactory('foo', function($sm) {
-            $sm->get('stdClass');
+            $std = $sm->get('stdClass');
+            $std->a = 1;
+            
+            return $std;
         });
 
-        $pluginManager->get('foo');
+        try {
+            $pluginManager->get('foo');
+        } catch (ServiceNotCreatedException $e) {
+            $this->assertNotNull($e->getPrevious());
+            $this->assertInstanceOf('Zend\ServiceManager\Exception\ServiceLocatorUsageException', $e->getPrevious());
+            return;
+        }
+        
+        $this->fail('A Zend\ServiceManager\Exception\ServiceNotCreatedException is expected');
     }
 }


### PR DESCRIPTION
Currently, there is 2 problem with the abstract plugin manager :
- if a developer forget to use the parent service locator inside a factory defined in a abstract plugin manager, he can lost time to find the problem
- if a developer use a FQCN (for a dependence defined in the parent service locator) with the auto invokables, in his factory (related to a service defined in the abstract plugin manager) if he forget to call the parent service locator, the abstract plugin manager will auto add the service and, since this point, the developer will lost a lot of time

This PR will provide solution for the 2 issues with a more berbose exception.

The only minor BC is the case where a developer has defined a same service name with FQCN inside the abstract plugin manager AND the parent service locator. It does not make sense and will never happen, it's the only BC of this PR.
