### PR TITLE
[Zend\ServiceManager] Add alternatives services proposals when service not found is thrown

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -536,7 +536,7 @@ class ServiceManager implements ServiceLocatorInterface
                 ));
             }
 
-            $alternatives = [];
+            $alternatives = array();
             foreach ($this->canonicalNamesMapping as $full) {
                 $lev = levenshtein($name, $full);
                 if ($lev <= min(ceil(strlen($name) / 10), 3)) {

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1084,14 +1084,14 @@ class ServiceManagerTest extends TestCase
         $serviceManager->setFactory('Bar\Foo\Bar', 'ZendTest\ServiceManager\TestAsset\FooFactory');
         $serviceManager->setService('Bar\Foo\Foo', 'ZendTest\ServiceManager\TestAsset\FooFactory');
 
-        $expected = [
-            ['Bar\Foo\Baz' => 'Did you mean this: "Bar\Foo\Bar"?'],
-            ['Bar\Foo\baz' => 'Did you mean this: "Bar\Foo\Bar"?'],
-            ['Bar\Foo' => null],
-            ['Bar\Foo\Pip' => null],
-            ['Bar\Foo\foz' => 'Did you mean this: "Bar\Foo\Foo"?'],
-            ['Bar\Foo\Foz' => 'Did you mean one of these: "Bar\Foo\FooB", "Bar\Foo\Foo"?'],
-        ];
+        $expected = array(
+            array('Bar\Foo\Baz' => 'Did you mean this: "Bar\Foo\Bar"?'),
+            array('Bar\Foo\baz' => 'Did you mean this: "Bar\Foo\Bar"?'),
+            array('Bar\Foo' => null),
+            array('Bar\Foo\Pip' => null),
+            array('Bar\Foo\foz' => 'Did you mean this: "Bar\Foo\Foo"?'),
+            array('Bar\Foo\Foz' => 'Did you mean one of these: "Bar\Foo\FooB", "Bar\Foo\Foo"?'),
+        );
 
         foreach ($expected as $line) {
             foreach ($line as $name => $message) {


### PR DESCRIPTION
This idea comes from symfony, it would be good to add some details about services that are close (about name). This point can help developer to save time during the debug.
