### PR TITLE
[Zend\Test] Provide fix  when 2 mandatory strings are used in route console

### DIFF
--- a/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/Controller/AbstractControllerTestCase.php
@@ -208,7 +208,7 @@ abstract class AbstractControllerTestCase extends PHPUnit_Framework_TestCase
     {
         $request = $this->getRequest();
         if ($this->useConsoleRequest) {
-            preg_match_all('/(--\S+[= ]"\S*\s*\S*")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
+            preg_match_all('/(--\S+[= ]"[^\s"]*\s*[^\s"]*")|(--\S+=\S+|--\S+\s\S+|\S+)/', $url, $matches);
             $params = str_replace(array(' "', '"'), array('=', ''), $matches[0]);
             $request->params()->exchangeArray($params);
 

--- a/tests/ZendTest/Test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Controller/AbstractConsoleControllerTestCaseTest.php
@@ -100,6 +100,23 @@ class AbstractConsoleControllerTestCaseTest extends AbstractConsoleControllerTes
         $this->assertEquals("custom text", $routeMatch->getParam('text'));
     }
 
+    public function testAssertMatchedArgumentsWithMandatoryValue()
+    {
+        $this->dispatch("foo --bar='FOO' --baz='ARE'");
+        /** @var \Zend\Mvc\Router\Console\RouteMatch $routeMatch */
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        $this->assertNotNull($routeMatch);
+        $this->assertEquals('arguments-mandatory', $routeMatch->getMatchedRouteName());
+
+        $this->reset();
+
+        $this->dispatch('foo --bar="FOO" --baz="ARE"');
+        /** @var \Zend\Mvc\Router\Console\RouteMatch $routeMatch */
+        $routeMatch = $this->getApplication()->getMvcEvent()->getRouteMatch();
+        $this->assertNotNull($routeMatch);
+        $this->assertEquals('arguments-mandatory', $routeMatch->getMatchedRouteName());
+    }
+
     public function testAssertMatchedArgumentsWithValueWithoutEqualsSign()
     {
         $this->dispatch('filter --date "2013-03-07 00:00:00" --id=10 --text="custom text"');

--- a/tests/ZendTest/Test/_files/Baz/config/module.config.php
+++ b/tests/ZendTest/Test/_files/Baz/config/module.config.php
@@ -23,6 +23,16 @@ return array(
                         ),
                     ),
                 ),
+                'arguments-mandatory' => array(
+                    'type' => 'simple',
+                    'options' => array(
+                        'route'    => 'foo --bar= --baz=',
+                        'defaults' => array(
+                            'controller' => 'baz_index',
+                            'action'     => 'console',
+                        ),
+                    ),
+                )
             ),
         ),
     ),


### PR DESCRIPTION
`$this->dispatch("foo --bar='FOO' --baz='ARE'");` was good
`$this->dispatch('foo --bar="FOO" --baz="ARE"');` was wrong
