### PR TITLE
Feature/#6777 service manager constants

### DIFF
--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -20,7 +20,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
     /**
      * Configuration key for Adapter
      */
-    const CONFIGURATION = 'db';
+    const CONFIG = 'db';
 
     /**
      * Query Mode Constants

--- a/library/Zend/Db/Adapter/Adapter.php
+++ b/library/Zend/Db/Adapter/Adapter.php
@@ -18,6 +18,11 @@ use Zend\Db\ResultSet;
 class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
 {
     /**
+     * Configuration key for Adapter
+     */
+    const CONFIGURATION = 'db';
+
+    /**
      * Query Mode Constants
      */
     const QUERY_MODE_EXECUTE = 'execute';

--- a/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
@@ -78,14 +78,14 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         $config = $services->get('Config');
-        if (!isset($config['db'])
-            || !is_array($config['db'])
+        if (!isset($config[Adapter::CONFIGURATION])
+            || !is_array($config[Adapter::CONFIGURATION])
         ) {
             $this->config = array();
             return $this->config;
         }
 
-        $config = $config['db'];
+        $config = $config[Adapter::CONFIGURATION];
         if (!isset($config['adapters'])
             || !is_array($config['adapters'])
         ) {

--- a/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterAbstractServiceFactory.php
@@ -78,14 +78,14 @@ class AdapterAbstractServiceFactory implements AbstractFactoryInterface
         }
 
         $config = $services->get('Config');
-        if (!isset($config[Adapter::CONFIGURATION])
-            || !is_array($config[Adapter::CONFIGURATION])
+        if (!isset($config[Adapter::CONFIG])
+            || !is_array($config[Adapter::CONFIG])
         ) {
             $this->config = array();
             return $this->config;
         }
 
-        $config = $config[Adapter::CONFIGURATION];
+        $config = $config[Adapter::CONFIG];
         if (!isset($config['adapters'])
             || !is_array($config['adapters'])
         ) {

--- a/library/Zend/Db/Adapter/AdapterServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterServiceFactory.php
@@ -23,6 +23,6 @@ class AdapterServiceFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $config = $serviceLocator->get('Config');
-        return new Adapter($config[Adapter::CONFIGURATION]);
+        return new Adapter($config[Adapter::CONFIG]);
     }
 }

--- a/library/Zend/Db/Adapter/AdapterServiceFactory.php
+++ b/library/Zend/Db/Adapter/AdapterServiceFactory.php
@@ -23,6 +23,6 @@ class AdapterServiceFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $config = $serviceLocator->get('Config');
-        return new Adapter($config['db']);
+        return new Adapter($config[Adapter::CONFIGURATION]);
     }
 }

--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -23,7 +23,7 @@ class FilterPluginManager extends AbstractPluginManager
     /**
      * Configuration key for FilterPluginManager
      */
-    const CONFIGURATION = 'filters';
+    const CONFIG = 'filters';
 
     /**
      * Default set of filters

--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -21,6 +21,11 @@ use Zend\ServiceManager\AbstractPluginManager;
 class FilterPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for FilterPluginManager
+     */
+    const CONFIGURATION = 'filters';
+
+    /**
      * Default set of filters
      *
      * @var array

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -25,7 +25,7 @@ class FormElementManager extends AbstractPluginManager
     /**
      * Configuration key for FormElementManager
      */
-    const CONFIGURATION = 'form_elements';
+    const CONFIG = 'form_elements';
 
     /**
      * Default set of helpers

--- a/library/Zend/Form/FormElementManager.php
+++ b/library/Zend/Form/FormElementManager.php
@@ -23,6 +23,11 @@ use Zend\Stdlib\InitializableInterface;
 class FormElementManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for FormElementManager
+     */
+    const CONFIGURATION = 'form_elements';
+
+    /**
      * Default set of helpers
      *
      * @var array

--- a/library/Zend/InputFilter/InputFilterPluginManager.php
+++ b/library/Zend/InputFilter/InputFilterPluginManager.php
@@ -24,7 +24,7 @@ class InputFilterPluginManager extends AbstractPluginManager
     /**
      * Configuration key for InputFilterPluginManager
      */
-    const CONFIGURATION = 'input_filters';
+    const CONFIG = 'input_filters';
 
     /**
      * Default set of plugins

--- a/library/Zend/InputFilter/InputFilterPluginManager.php
+++ b/library/Zend/InputFilter/InputFilterPluginManager.php
@@ -22,6 +22,11 @@ use Zend\Stdlib\InitializableInterface;
 class InputFilterPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for InputFilterPluginManager
+     */
+    const CONFIGURATION = 'input_filters';
+
+    /**
      * Default set of plugins
      *
      * @var array

--- a/library/Zend/Log/ProcessorPluginManager.php
+++ b/library/Zend/Log/ProcessorPluginManager.php
@@ -16,7 +16,7 @@ class ProcessorPluginManager extends AbstractPluginManager
     /**
      * Configuration key for ProcessorPluginManager
      */
-    const CONFIGURATION = 'log_processors';
+    const CONFIG = 'log_processors';
 
     /**
      * Default set of processors

--- a/library/Zend/Log/ProcessorPluginManager.php
+++ b/library/Zend/Log/ProcessorPluginManager.php
@@ -14,6 +14,11 @@ use Zend\ServiceManager\AbstractPluginManager;
 class ProcessorPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for ProcessorPluginManager
+     */
+    const CONFIGURATION = 'log_processors';
+
+    /**
      * Default set of processors
      *
      * @var array

--- a/library/Zend/Log/WriterPluginManager.php
+++ b/library/Zend/Log/WriterPluginManager.php
@@ -16,7 +16,7 @@ class WriterPluginManager extends AbstractPluginManager
     /**
      * Configuration key for WriterPluginManager
      */
-    const CONFIGURATION = 'log_writers';
+    const CONFIG = 'log_writers';
 
     /**
      * Default set of writers

--- a/library/Zend/Log/WriterPluginManager.php
+++ b/library/Zend/Log/WriterPluginManager.php
@@ -14,6 +14,11 @@ use Zend\ServiceManager\AbstractPluginManager;
 class WriterPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for WriterPluginManager
+     */
+    const CONFIGURATION = 'log_writers';
+
+    /**
      * Default set of writers
      *
      * @var array

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -93,7 +93,7 @@ class ServiceListener implements ServiceListenerInterface
             'configuration'          => array(),
         );
 
-        if ($key === 'service_manager' && $this->defaultServiceConfig) {
+        if ($key === ServiceManager::CONFIGURATION && $this->defaultServiceConfig) {
             $this->serviceManagers[$smKey]['configuration']['default_config'] = $this->defaultServiceConfig;
         }
 

--- a/library/Zend/ModuleManager/Listener/ServiceListener.php
+++ b/library/Zend/ModuleManager/Listener/ServiceListener.php
@@ -93,7 +93,7 @@ class ServiceListener implements ServiceListenerInterface
             'configuration'          => array(),
         );
 
-        if ($key === ServiceManager::CONFIGURATION && $this->defaultServiceConfig) {
+        if ($key === ServiceManager::CONFIG && $this->defaultServiceConfig) {
             $this->serviceManagers[$smKey]['configuration']['default_config'] = $this->defaultServiceConfig;
         }
 

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -246,7 +246,7 @@ class Application implements
      */
     public static function init($configuration = array())
     {
-        $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
+        $smConfig = isset($configuration[ServiceManager::CONFIGURATION]) ? $configuration[ServiceManager::CONFIGURATION] : array();
         $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();

--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -246,7 +246,7 @@ class Application implements
      */
     public static function init($configuration = array())
     {
-        $smConfig = isset($configuration[ServiceManager::CONFIGURATION]) ? $configuration[ServiceManager::CONFIGURATION] : array();
+        $smConfig = isset($configuration[ServiceManager::CONFIG]) ? $configuration[ServiceManager::CONFIG] : array();
         $serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $serviceManager->setService('ApplicationConfig', $configuration);
         $serviceManager->get('ModuleManager')->loadModules();

--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -28,7 +28,7 @@ class ControllerManager extends AbstractPluginManager
     /**
      * Configuration key for ControllerManager
      */
-    const CONFIGURATION = 'controllers';
+    const CONFIG = 'controllers';
 
     /**
      * We do not want arbitrary classes instantiated as controllers.

--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -26,6 +26,11 @@ use Zend\Stdlib\DispatchableInterface;
 class ControllerManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for ControllerManager
+     */
+    const CONFIGURATION = 'controllers';
+
+    /**
      * We do not want arbitrary classes instantiated as controllers.
      *
      * @var bool

--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -24,7 +24,7 @@ class PluginManager extends AbstractPluginManager
     /**
      * Configuration key for PluginManager
      */
-    const CONFIGURATION = 'controller_plugins';
+    const CONFIG = 'controller_plugins';
 
     /**
      * Default set of plugins factories

--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -22,6 +22,11 @@ use Zend\Stdlib\DispatchableInterface;
 class PluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for PluginManager
+     */
+    const CONFIGURATION = 'controller_plugins';
+
+    /**
      * Default set of plugins factories
      *
      * @var array

--- a/library/Zend/Mvc/Router/Console/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/Console/SimpleRouteStack.php
@@ -22,7 +22,7 @@ class SimpleRouteStack extends BaseSimpleRouteStack
     /**
      * Configuration key for SimpleRouteStack
      */
-    const CONFIGURATION = 'router';
+    const CONFIG = 'router';
 
     /**
      * init(): defined by SimpleRouteStack.

--- a/library/Zend/Mvc/Router/Console/SimpleRouteStack.php
+++ b/library/Zend/Mvc/Router/Console/SimpleRouteStack.php
@@ -20,6 +20,11 @@ use Zend\Stdlib\ArrayUtils;
 class SimpleRouteStack extends BaseSimpleRouteStack
 {
     /**
+     * Configuration key for SimpleRouteStack
+     */
+    const CONFIGURATION = 'router';
+
+    /**
      * init(): defined by SimpleRouteStack.
      *
      * @see    BaseSimpleRouteStack::init()

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -23,6 +23,11 @@ use Zend\Uri\Http as HttpUri;
 class TreeRouteStack extends SimpleRouteStack
 {
     /**
+     * Configuration key for TreeRouteStack
+     */
+    const CONFIGURATION = 'router';
+
+    /**
      * Base URL.
      *
      * @var string

--- a/library/Zend/Mvc/Router/Http/TreeRouteStack.php
+++ b/library/Zend/Mvc/Router/Http/TreeRouteStack.php
@@ -25,7 +25,7 @@ class TreeRouteStack extends SimpleRouteStack
     /**
      * Configuration key for TreeRouteStack
      */
-    const CONFIGURATION = 'router';
+    const CONFIG = 'router';
 
     /**
      * Base URL.

--- a/library/Zend/Mvc/Router/RoutePluginManager.php
+++ b/library/Zend/Mvc/Router/RoutePluginManager.php
@@ -24,7 +24,7 @@ class RoutePluginManager extends AbstractPluginManager
     /**
      * Configuration key for RoutePluginManager
      */
-    const CONFIGURATION = 'route_manager';
+    const CONFIG = 'route_manager';
 
     /**
      * Do not share instances.

--- a/library/Zend/Mvc/Router/RoutePluginManager.php
+++ b/library/Zend/Mvc/Router/RoutePluginManager.php
@@ -22,6 +22,11 @@ use Zend\ServiceManager\AbstractPluginManager;
 class RoutePluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for RoutePluginManager
+     */
+    const CONFIGURATION = 'route_manager';
+
+    /**
      * Do not share instances.
      *
      * @var bool

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -58,79 +58,79 @@ class ModuleManagerFactory implements FactoryInterface
 
         $serviceListener->addServiceManager(
             $serviceLocator,
-            ServiceManager::CONFIGURATION,
+            ServiceManager::CONFIG,
             'Zend\ModuleManager\Feature\ServiceProviderInterface',
             'getServiceConfig'
         );
         $serviceListener->addServiceManager(
             'ControllerLoader',
-            ControllerManager::CONFIGURATION,
+            ControllerManager::CONFIG,
             'Zend\ModuleManager\Feature\ControllerProviderInterface',
             'getControllerConfig'
         );
         $serviceListener->addServiceManager(
             'ControllerPluginManager',
-            PluginManager::CONFIGURATION,
+            PluginManager::CONFIG,
             'Zend\ModuleManager\Feature\ControllerPluginProviderInterface',
             'getControllerPluginConfig'
         );
         $serviceListener->addServiceManager(
             'ViewHelperManager',
-            HelperPluginManager::CONFIGURATION,
+            HelperPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\ViewHelperProviderInterface',
             'getViewHelperConfig'
         );
         $serviceListener->addServiceManager(
             'ValidatorManager',
-            ValidatorPluginManager::CONFIGURATION,
+            ValidatorPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\ValidatorProviderInterface',
             'getValidatorConfig'
         );
         $serviceListener->addServiceManager(
             'FilterManager',
-            FilterPluginManager::CONFIGURATION,
+            FilterPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\FilterProviderInterface',
             'getFilterConfig'
         );
         $serviceListener->addServiceManager(
             'FormElementManager',
-            FormElementManager::CONFIGURATION,
+            FormElementManager::CONFIG,
             'Zend\ModuleManager\Feature\FormElementProviderInterface',
             'getFormElementConfig'
         );
         $serviceListener->addServiceManager(
             'RoutePluginManager',
-            RoutePluginManager::CONFIGURATION,
+            RoutePluginManager::CONFIG,
             'Zend\ModuleManager\Feature\RouteProviderInterface',
             'getRouteConfig'
         );
         $serviceListener->addServiceManager(
             'SerializerAdapterManager',
-            AdapterPluginManager::CONFIGURATION,
+            AdapterPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\SerializerProviderInterface',
             'getSerializerConfig'
         );
         $serviceListener->addServiceManager(
             'HydratorManager',
-            HydratorPluginManager::CONFIGURATION,
+            HydratorPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\HydratorProviderInterface',
             'getHydratorConfig'
         );
         $serviceListener->addServiceManager(
             'InputFilterManager',
-            InputFilterPluginManager::CONFIGURATION,
+            InputFilterPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\InputFilterProviderInterface',
             'getInputFilterConfig'
         );
         $serviceListener->addServiceManager(
             'LogProcessorManager',
-            ProcessorPluginManager::CONFIGURATION,
+            ProcessorPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\LogProcessorProviderInterface',
             'getLogProcessorConfig'
         );
         $serviceListener->addServiceManager(
             'LogWriterManager',
-            WriterPluginManager::CONFIGURATION,
+            WriterPluginManager::CONFIG,
             'Zend\ModuleManager\Feature\LogWriterProviderInterface',
             'getLogWriterConfig'
         );

--- a/library/Zend/Mvc/Service/ModuleManagerFactory.php
+++ b/library/Zend/Mvc/Service/ModuleManagerFactory.php
@@ -9,12 +9,25 @@
 
 namespace Zend\Mvc\Service;
 
+use Zend\Filter\FilterPluginManager;
+use Zend\Form\FormElementManager;
+use Zend\InputFilter\InputFilterPluginManager;
+use Zend\Log\ProcessorPluginManager;
+use Zend\Log\WriterPluginManager;
 use Zend\ModuleManager\Listener\DefaultListenerAggregate;
 use Zend\ModuleManager\Listener\ListenerOptions;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ModuleManager\ModuleManager;
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\Mvc\Controller\PluginManager;
+use Zend\Mvc\Router\RoutePluginManager;
+use Zend\Serializer\AdapterPluginManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+use Zend\Validator\ValidatorPluginManager;
+use Zend\View\HelperPluginManager;
 
 class ModuleManagerFactory implements FactoryInterface
 {
@@ -45,79 +58,79 @@ class ModuleManagerFactory implements FactoryInterface
 
         $serviceListener->addServiceManager(
             $serviceLocator,
-            'service_manager',
+            ServiceManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\ServiceProviderInterface',
             'getServiceConfig'
         );
         $serviceListener->addServiceManager(
             'ControllerLoader',
-            'controllers',
+            ControllerManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\ControllerProviderInterface',
             'getControllerConfig'
         );
         $serviceListener->addServiceManager(
             'ControllerPluginManager',
-            'controller_plugins',
+            PluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\ControllerPluginProviderInterface',
             'getControllerPluginConfig'
         );
         $serviceListener->addServiceManager(
             'ViewHelperManager',
-            'view_helpers',
+            HelperPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\ViewHelperProviderInterface',
             'getViewHelperConfig'
         );
         $serviceListener->addServiceManager(
             'ValidatorManager',
-            'validators',
+            ValidatorPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\ValidatorProviderInterface',
             'getValidatorConfig'
         );
         $serviceListener->addServiceManager(
             'FilterManager',
-            'filters',
+            FilterPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\FilterProviderInterface',
             'getFilterConfig'
         );
         $serviceListener->addServiceManager(
             'FormElementManager',
-            'form_elements',
+            FormElementManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\FormElementProviderInterface',
             'getFormElementConfig'
         );
         $serviceListener->addServiceManager(
             'RoutePluginManager',
-            'route_manager',
+            RoutePluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\RouteProviderInterface',
             'getRouteConfig'
         );
         $serviceListener->addServiceManager(
             'SerializerAdapterManager',
-            'serializers',
+            AdapterPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\SerializerProviderInterface',
             'getSerializerConfig'
         );
         $serviceListener->addServiceManager(
             'HydratorManager',
-            'hydrators',
+            HydratorPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\HydratorProviderInterface',
             'getHydratorConfig'
         );
         $serviceListener->addServiceManager(
             'InputFilterManager',
-            'input_filters',
+            InputFilterPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\InputFilterProviderInterface',
             'getInputFilterConfig'
         );
         $serviceListener->addServiceManager(
             'LogProcessorManager',
-            'log_processors',
+            ProcessorPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\LogProcessorProviderInterface',
             'getLogProcessorConfig'
         );
         $serviceListener->addServiceManager(
             'LogWriterManager',
-            'log_writers',
+            WriterPluginManager::CONFIGURATION,
             'Zend\ModuleManager\Feature\LogWriterProviderInterface',
             'getLogWriterConfig'
         );

--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -10,6 +10,8 @@
 namespace Zend\Mvc\Service;
 
 use Zend\Console\Console;
+use Zend\Mvc\Router\Console\SimpleRouteStack;
+use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -33,7 +35,9 @@ class RouterFactory implements FactoryInterface
 
         // Defaults
         $routerClass        = 'Zend\Mvc\Router\Http\TreeRouteStack';
-        $routerConfig       = isset($config['router']) ? $config['router'] : array();
+        $routerConfig       = isset($config[TreeRouteStack::CONFIGURATION])
+            ? $config[TreeRouteStack::CONFIGURATION]
+            : array();
 
         // Console environment?
         if ($rName === 'ConsoleRouter'                       // force console router
@@ -41,7 +45,9 @@ class RouterFactory implements FactoryInterface
         ) {
             // We are in a console, use console router defaults.
             $routerClass = 'Zend\Mvc\Router\Console\SimpleRouteStack';
-            $routerConfig = isset($config['console']['router']) ? $config['console']['router'] : array();
+            $routerConfig = isset($config['console'][SimpleRouteStack::CONFIGURATION])
+                ? $config['console']['router']
+                : array();
         }
 
         // Obtain the configured router class, if any

--- a/library/Zend/Mvc/Service/RouterFactory.php
+++ b/library/Zend/Mvc/Service/RouterFactory.php
@@ -35,8 +35,8 @@ class RouterFactory implements FactoryInterface
 
         // Defaults
         $routerClass        = 'Zend\Mvc\Router\Http\TreeRouteStack';
-        $routerConfig       = isset($config[TreeRouteStack::CONFIGURATION])
-            ? $config[TreeRouteStack::CONFIGURATION]
+        $routerConfig       = isset($config[TreeRouteStack::CONFIG])
+            ? $config[TreeRouteStack::CONFIG]
             : array();
 
         // Console environment?
@@ -45,7 +45,7 @@ class RouterFactory implements FactoryInterface
         ) {
             // We are in a console, use console router defaults.
             $routerClass = 'Zend\Mvc\Router\Console\SimpleRouteStack';
-            $routerConfig = isset($config['console'][SimpleRouteStack::CONFIGURATION])
+            $routerConfig = isset($config['console'][SimpleRouteStack::CONFIG])
                 ? $config['console']['router']
                 : array();
         }

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -12,6 +12,7 @@ namespace Zend\Mvc\Service;
 use Zend\Console\Console;
 use Zend\Mvc\Exception;
 use Zend\Mvc\Router\RouteMatch;
+use Zend\Mvc\View\Http\ViewManager;
 use Zend\ServiceManager\ConfigInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Helper as ViewHelper;
@@ -80,8 +81,8 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
         $plugins->setFactory('basepath', function () use ($serviceLocator) {
             $config = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
             $basePathHelper = new ViewHelper\BasePath;
-            if (isset($config['view_manager']) && isset($config['view_manager']['base_path'])) {
-                $basePathHelper->setBasePath($config['view_manager']['base_path']);
+            if (isset($config[ViewManager::CONFIGURATION]) && isset($config[ViewManager::CONFIGURATION]['base_path'])) {
+                $basePathHelper->setBasePath($config[ViewManager::CONFIGURATION]['base_path']);
             } else {
                 $request = $serviceLocator->get('Request');
                 if (is_callable(array($request, 'getBasePath'))) {
@@ -100,7 +101,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
          */
         $plugins->setFactory('doctype', function () use ($serviceLocator) {
             $config = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
-            $config = isset($config['view_manager']) ? $config['view_manager'] : array();
+            $config = isset($config[ViewManager::CONFIGURATION]) ? $config[ViewManager::CONFIGURATION] : array();
             $doctypeHelper = new ViewHelper\Doctype;
             if (isset($config['doctype']) && $config['doctype']) {
                 $doctypeHelper->setDoctype($config['doctype']);

--- a/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
+++ b/library/Zend/Mvc/Service/ViewHelperManagerFactory.php
@@ -81,8 +81,8 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
         $plugins->setFactory('basepath', function () use ($serviceLocator) {
             $config = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
             $basePathHelper = new ViewHelper\BasePath;
-            if (isset($config[ViewManager::CONFIGURATION]) && isset($config[ViewManager::CONFIGURATION]['base_path'])) {
-                $basePathHelper->setBasePath($config[ViewManager::CONFIGURATION]['base_path']);
+            if (isset($config[ViewManager::CONFIG]) && isset($config[ViewManager::CONFIG]['base_path'])) {
+                $basePathHelper->setBasePath($config[ViewManager::CONFIG]['base_path']);
             } else {
                 $request = $serviceLocator->get('Request');
                 if (is_callable(array($request, 'getBasePath'))) {
@@ -101,7 +101,7 @@ class ViewHelperManagerFactory extends AbstractPluginManagerFactory
          */
         $plugins->setFactory('doctype', function () use ($serviceLocator) {
             $config = $serviceLocator->has('Config') ? $serviceLocator->get('Config') : array();
-            $config = isset($config[ViewManager::CONFIGURATION]) ? $config[ViewManager::CONFIGURATION] : array();
+            $config = isset($config[ViewManager::CONFIG]) ? $config[ViewManager::CONFIG] : array();
             $doctypeHelper = new ViewHelper\Doctype;
             if (isset($config['doctype']) && $config['doctype']) {
                 $doctypeHelper->setDoctype($config['doctype']);

--- a/library/Zend/Mvc/Service/ViewTemplateMapResolverFactory.php
+++ b/library/Zend/Mvc/Service/ViewTemplateMapResolverFactory.php
@@ -29,8 +29,8 @@ class ViewTemplateMapResolverFactory implements FactoryInterface
     {
         $config = $serviceLocator->get('Config');
         $map = array();
-        if (is_array($config) && isset($config[ViewManager::CONFIGURATION])) {
-            $config = $config[ViewManager::CONFIGURATION];
+        if (is_array($config) && isset($config[ViewManager::CONFIG])) {
+            $config = $config[ViewManager::CONFIG];
             if (is_array($config) && isset($config['template_map'])) {
                 $map = $config['template_map'];
             }

--- a/library/Zend/Mvc/Service/ViewTemplateMapResolverFactory.php
+++ b/library/Zend/Mvc/Service/ViewTemplateMapResolverFactory.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Service;
 
+use Zend\Mvc\View\Http\ViewManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Resolver as ViewResolver;
@@ -28,8 +29,8 @@ class ViewTemplateMapResolverFactory implements FactoryInterface
     {
         $config = $serviceLocator->get('Config');
         $map = array();
-        if (is_array($config) && isset($config['view_manager'])) {
-            $config = $config['view_manager'];
+        if (is_array($config) && isset($config[ViewManager::CONFIGURATION])) {
+            $config = $config[ViewManager::CONFIGURATION];
             if (is_array($config) && isset($config['template_map'])) {
                 $map = $config['template_map'];
             }

--- a/library/Zend/Mvc/Service/ViewTemplatePathStackFactory.php
+++ b/library/Zend/Mvc/Service/ViewTemplatePathStackFactory.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Mvc\Service;
 
+use Zend\Mvc\View\Http\ViewManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\View\Resolver as ViewResolver;
@@ -31,8 +32,8 @@ class ViewTemplatePathStackFactory implements FactoryInterface
 
         $templatePathStack = new ViewResolver\TemplatePathStack();
 
-        if (is_array($config) && isset($config['view_manager'])) {
-            $config = $config['view_manager'];
+        if (is_array($config) && isset($config[ViewManager::CONFIGURATION])) {
+            $config = $config[ViewManager::CONFIGURATION];
             if (is_array($config)) {
                 if (isset($config['template_path_stack'])) {
                     $templatePathStack->addPaths($config['template_path_stack']);

--- a/library/Zend/Mvc/Service/ViewTemplatePathStackFactory.php
+++ b/library/Zend/Mvc/Service/ViewTemplatePathStackFactory.php
@@ -32,8 +32,8 @@ class ViewTemplatePathStackFactory implements FactoryInterface
 
         $templatePathStack = new ViewResolver\TemplatePathStack();
 
-        if (is_array($config) && isset($config[ViewManager::CONFIGURATION])) {
-            $config = $config[ViewManager::CONFIGURATION];
+        if (is_array($config) && isset($config[ViewManager::CONFIG])) {
+            $config = $config[ViewManager::CONFIG];
             if (is_array($config)) {
                 if (isset($config['template_path_stack'])) {
                     $templatePathStack->addPaths($config['template_path_stack']);

--- a/library/Zend/Mvc/View/Console/ViewManager.php
+++ b/library/Zend/Mvc/View/Console/ViewManager.php
@@ -19,6 +19,11 @@ use Zend\Mvc\View\Http\ViewManager as BaseViewManager;
 class ViewManager extends BaseViewManager
 {
     /**
+     * Configuration key for ViewManager
+     */
+    const CONFIGURATION = 'view_manager';
+
+    /**
      * Prepares the view layer
      *
      * Overriding, as several operations are omitted in the console view
@@ -36,8 +41,8 @@ class ViewManager extends BaseViewManager
         $events       = $application->getEventManager();
         $sharedEvents = $events->getSharedManager();
 
-        $this->config   = isset($config['view_manager']) && (is_array($config['view_manager']) || $config['view_manager'] instanceof ArrayAccess)
-                        ? $config['view_manager']
+        $this->config   = isset($config[self::CONFIGURATION]) && (is_array($config[self::CONFIGURATION]) || $config[self::CONFIGURATION] instanceof ArrayAccess)
+                        ? $config[self::CONFIGURATION]
                         : array();
         $this->services = $services;
         $this->event    = $event;

--- a/library/Zend/Mvc/View/Console/ViewManager.php
+++ b/library/Zend/Mvc/View/Console/ViewManager.php
@@ -21,7 +21,7 @@ class ViewManager extends BaseViewManager
     /**
      * Configuration key for ViewManager
      */
-    const CONFIGURATION = 'view_manager';
+    const CONFIG = 'view_manager';
 
     /**
      * Prepares the view layer
@@ -41,8 +41,8 @@ class ViewManager extends BaseViewManager
         $events       = $application->getEventManager();
         $sharedEvents = $events->getSharedManager();
 
-        $this->config   = isset($config[self::CONFIGURATION]) && (is_array($config[self::CONFIGURATION]) || $config[self::CONFIGURATION] instanceof ArrayAccess)
-                        ? $config[self::CONFIGURATION]
+        $this->config   = isset($config[self::CONFIG]) && (is_array($config[self::CONFIG]) || $config[self::CONFIG] instanceof ArrayAccess)
+                        ? $config[self::CONFIG]
                         : array();
         $this->services = $services;
         $this->event    = $event;

--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -47,6 +47,11 @@ use Zend\View\View;
 class ViewManager extends AbstractListenerAggregate
 {
     /**
+     * Configuration key for ViewManager
+     */
+    const CONFIGURATION = 'view_manager';
+
+    /**
      * @var object application configuration service
      */
     protected $config;
@@ -113,8 +118,8 @@ class ViewManager extends AbstractListenerAggregate
         $events       = $application->getEventManager();
         $sharedEvents = $events->getSharedManager();
 
-        $this->config   = isset($config['view_manager']) && (is_array($config['view_manager']) || $config['view_manager'] instanceof ArrayAccess)
-                        ? $config['view_manager']
+        $this->config   = isset($config[self::CONFIGURATION]) && (is_array($config[self::CONFIGURATION]) || $config[self::CONFIGURATION] instanceof ArrayAccess)
+                        ? $config[self::CONFIGURATION]
                         : array();
         $this->services = $services;
         $this->event    = $event;

--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -49,7 +49,7 @@ class ViewManager extends AbstractListenerAggregate
     /**
      * Configuration key for ViewManager
      */
-    const CONFIGURATION = 'view_manager';
+    const CONFIG = 'view_manager';
 
     /**
      * @var object application configuration service
@@ -118,8 +118,8 @@ class ViewManager extends AbstractListenerAggregate
         $events       = $application->getEventManager();
         $sharedEvents = $events->getSharedManager();
 
-        $this->config   = isset($config[self::CONFIGURATION]) && (is_array($config[self::CONFIGURATION]) || $config[self::CONFIGURATION] instanceof ArrayAccess)
-                        ? $config[self::CONFIGURATION]
+        $this->config   = isset($config[self::CONFIG]) && (is_array($config[self::CONFIG]) || $config[self::CONFIG] instanceof ArrayAccess)
+                        ? $config[self::CONFIG]
                         : array();
         $this->services = $services;
         $this->event    = $event;

--- a/library/Zend/Serializer/AdapterPluginManager.php
+++ b/library/Zend/Serializer/AdapterPluginManager.php
@@ -23,7 +23,7 @@ class AdapterPluginManager extends AbstractPluginManager
     /**
      * Configuration key for AdapterPluginManager
      */
-    const CONFIGURATION = 'serializers';
+    const CONFIG = 'serializers';
 
     /**
      * Default set of adapters

--- a/library/Zend/Serializer/AdapterPluginManager.php
+++ b/library/Zend/Serializer/AdapterPluginManager.php
@@ -21,6 +21,11 @@ use Zend\ServiceManager\AbstractPluginManager;
 class AdapterPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for AdapterPluginManager
+     */
+    const CONFIGURATION = 'serializers';
+
+    /**
      * Default set of adapters
      *
      * @var array

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -13,6 +13,10 @@ use ReflectionClass;
 
 class ServiceManager implements ServiceLocatorInterface
 {
+    /**
+     * Configuration key for ServiceManager
+     */
+    const CONFIGURATION = 'service_manager';
 
     /**@#+
      * Constants

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -16,7 +16,7 @@ class ServiceManager implements ServiceLocatorInterface
     /**
      * Configuration key for ServiceManager
      */
-    const CONFIGURATION = 'service_manager';
+    const CONFIG = 'service_manager';
 
     /**@#+
      * Constants

--- a/library/Zend/Stdlib/Hydrator/HydratorPluginManager.php
+++ b/library/Zend/Stdlib/Hydrator/HydratorPluginManager.php
@@ -20,6 +20,11 @@ use Zend\Stdlib\Exception;
 class HydratorPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for HydratorPluginManager
+     */
+    const CONFIGURATION = 'hydrators';
+
+    /**
      * Whether or not to share by default
      *
      * @var bool

--- a/library/Zend/Stdlib/Hydrator/HydratorPluginManager.php
+++ b/library/Zend/Stdlib/Hydrator/HydratorPluginManager.php
@@ -22,7 +22,7 @@ class HydratorPluginManager extends AbstractPluginManager
     /**
      * Configuration key for HydratorPluginManager
      */
-    const CONFIGURATION = 'hydrators';
+    const CONFIG = 'hydrators';
 
     /**
      * Whether or not to share by default

--- a/library/Zend/Test/Util/ModuleLoader.php
+++ b/library/Zend/Test/Util/ModuleLoader.php
@@ -43,7 +43,7 @@ class ModuleLoader
             }
         }
 
-        $smConfig = isset($configuration[ServiceManager::CONFIGURATION]) ? $configuration[ServiceManager::CONFIGURATION] : array();
+        $smConfig = isset($configuration[ServiceManager::CONFIG]) ? $configuration[ServiceManager::CONFIG] : array();
         $this->serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $this->serviceManager->setService('ApplicationConfig', $configuration);
         $this->serviceManager->get('ModuleManager')->loadModules();

--- a/library/Zend/Test/Util/ModuleLoader.php
+++ b/library/Zend/Test/Util/ModuleLoader.php
@@ -43,7 +43,7 @@ class ModuleLoader
             }
         }
 
-        $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : array();
+        $smConfig = isset($configuration[ServiceManager::CONFIGURATION]) ? $configuration[ServiceManager::CONFIGURATION] : array();
         $this->serviceManager = new ServiceManager(new Service\ServiceManagerConfig($smConfig));
         $this->serviceManager->setService('ApplicationConfig', $configuration);
         $this->serviceManager->get('ModuleManager')->loadModules();

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -15,6 +15,11 @@ use Zend\ServiceManager\ConfigInterface;
 class ValidatorPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for ValidatorPluginManager
+     */
+    const CONFIGURATION = 'validators';
+
+    /**
      * Default set of validators
      *
      * @var array

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -17,7 +17,7 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Configuration key for ValidatorPluginManager
      */
-    const CONFIGURATION = 'validators';
+    const CONFIG = 'validators';
 
     /**
      * Default set of validators

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -25,7 +25,7 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Configuration key for HelperPluginManager
      */
-    const CONFIGURATION = 'view_helpers';
+    const CONFIG = 'view_helpers';
 
     /**
      * Default set of helpers factories

--- a/library/Zend/View/HelperPluginManager.php
+++ b/library/Zend/View/HelperPluginManager.php
@@ -23,6 +23,11 @@ use Zend\ServiceManager\ConfigInterface;
 class HelperPluginManager extends AbstractPluginManager
 {
     /**
+     * Configuration key for HelperPluginManager
+     */
+    const CONFIGURATION = 'view_helpers';
+
+    /**
      * Default set of helpers factories
      *
      * @var array


### PR DESCRIPTION
Added constants for all service manages created by the ModuleManagerFactory. Also added configuration keys for database adapters, router and view manager since they are also used a lot in the docs.

Corresponds to https://github.com/zendframework/zf2/issues/6777
