### PR TITLE
[WIP][ServiceManager] synchronized services

### DIFF
--- a/library/Zend/ServiceManager/ServiceLocatorSynchronizer.php
+++ b/library/Zend/ServiceManager/ServiceLocatorSynchronizer.php
@@ -30,7 +30,7 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
      */
     public function attach(\SplObserver $observer)
     {
-        $services = $observer->getServices();
+        $services = $observer->getSynchronizedServices();
         if (!is_array($services)) {
             $services = array($services);
         }
@@ -47,7 +47,7 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
      */
     public function detach(\SplObserver $observer)
     {
-        $services = $observer->getServices();
+        $services = $observer->getSynchronizedServices();
         if (!is_array($services)) {
             $services = array($services);
         }
@@ -56,7 +56,7 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
                 continue;
             }
 
-            $list = [];
+            $list = array();
             $factories = $this->synchronizedServices[$service];
             foreach ($factories as $factory) {
                 if ($observer === $factory) {

--- a/library/Zend/ServiceManager/ServiceLocatorSynchronizer.php
+++ b/library/Zend/ServiceManager/ServiceLocatorSynchronizer.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+class ServiceLocatorSynchronizer implements SynchronizerInterface
+{
+    /**
+     * A service name ready to synchronize
+     *
+     * @var string
+     */
+    protected $toSynchronize;
+    
+    /**
+     * List of services that should be synchronized when a service is updated
+     *
+     * @var array
+     */
+    protected $synchronizedServices = array();
+
+
+    /**
+     * @param SynchronizedFactoryInterface|\SplObserver $observer
+     */
+    public function attach(\SplObserver $observer)
+    {
+        $services = $observer->getServices();
+        foreach ($services as $service) {
+            if (empty($synchronizedServices[$service])) {
+                $synchronizedServices[$service] = array();
+            }
+            $synchronizedServices[$service][] = $observer;
+        }
+    }
+
+    /**
+     * @param SynchronizedFactoryInterface|\SplObserver $observer
+     */
+    public function detach(\SplObserver $observer)
+    {
+        $services = $observer->getServices();
+        foreach ($services as $service) {
+            if (empty($synchronizedServices[$service])) {
+                continue;
+            }
+            
+            $list = [];
+            $factories = $synchronizedServices[$service];
+            foreach ($factories as $factory) {
+                if ($observer === $factory) {
+                    continue;
+                }
+                $list[] = $factory;
+            }
+            $synchronizedServices[$service] = $list;
+        }
+    }
+
+    /**
+     * {@inheritDoc]
+     */
+    public function synchronize($service)
+    {
+        $this->toSynchronize = $service;
+        
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc]
+     */
+    public function toSynchronize()
+    {
+        return $this->toSynchronize;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function notify()
+    {
+        if (!empty($this->synchronizedServices[$this->toSynchronize])) {
+            /** @var \SplObserver[] $factories */
+            $factories = $this->synchronizedServices[$this->toSynchronize];
+            foreach ($factories as $factory) {
+                $factory->update($this);
+            }
+        }        
+        
+        $this->toSynchronize = array();
+    }
+}

--- a/library/Zend/ServiceManager/ServiceLocatorSynchronizer.php
+++ b/library/Zend/ServiceManager/ServiceLocatorSynchronizer.php
@@ -17,14 +17,13 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
      * @var string
      */
     protected $toSynchronize = array();
-    
+
     /**
      * List of services that should be synchronized when a service is updated
      *
      * @var array
      */
     protected $synchronizedServices = array();
-
 
     /**
      * @param SynchronizedFactoryInterface|\SplObserver $observer
@@ -75,7 +74,7 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
     public function synchronize($name, $service)
     {
         $this->toSynchronize = array($name, $service);
-        
+
         return $this;
     }
 
@@ -87,8 +86,9 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
         if (!$this->toSynchronize) {
             return null;
         }
-        
+
         list($name, $service) = $this->toSynchronize;
+
         return $service;
     }
 
@@ -104,8 +104,8 @@ class ServiceLocatorSynchronizer implements SynchronizerInterface
             foreach ($factories as $factory) {
                 $factory->update($this);
             }
-        }        
-        
+        }
+
         $this->toSynchronize = array();
     }
 

--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -426,7 +426,7 @@ class ServiceManager implements ServiceLocatorInterface
         $this->instances[$cName] = $service;
 
         $synchronizer = $this->getSynchronizer();
-        $synchronizer->synchronize($cName)->notify();
+        $synchronizer->synchronize($cName, $service)->notify();
 
         return $this;
     }

--- a/library/Zend/ServiceManager/SynchronizedFactoryInterface.php
+++ b/library/Zend/ServiceManager/SynchronizedFactoryInterface.php
@@ -14,7 +14,7 @@ interface SynchronizedFactoryInterface extends \SplObserver
     /**
      * Return a list of services that will be synchronized to the factory
      *
-     * @return array
+     * @return array|string
      */
-    public function getServices();
+    public function getSynchronizedServices();
 }

--- a/library/Zend/ServiceManager/SynchronizedFactoryInterface.php
+++ b/library/Zend/ServiceManager/SynchronizedFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+
+interface SynchronizedFactoryInterface extends \SplObserver
+{
+    /**
+     * Return a list of services that will be synchronized to the factory
+     * 
+     * @return array
+     */
+    public function getServices();
+}

--- a/library/Zend/ServiceManager/SynchronizedFactoryInterface.php
+++ b/library/Zend/ServiceManager/SynchronizedFactoryInterface.php
@@ -9,12 +9,11 @@
 
 namespace Zend\ServiceManager;
 
-
 interface SynchronizedFactoryInterface extends \SplObserver
 {
     /**
      * Return a list of services that will be synchronized to the factory
-     * 
+     *
      * @return array
      */
     public function getServices();

--- a/library/Zend/ServiceManager/SynchronizerInterface.php
+++ b/library/Zend/ServiceManager/SynchronizerInterface.php
@@ -13,7 +13,7 @@ interface SynchronizerInterface extends \SplSubject
 {
     /**
      * Set a service to synchronize
-     * 
+     *
      * @param $name
      * @param $service
      * @return self

--- a/library/Zend/ServiceManager/SynchronizerInterface.php
+++ b/library/Zend/ServiceManager/SynchronizerInterface.php
@@ -14,10 +14,11 @@ interface SynchronizerInterface extends \SplSubject
     /**
      * Set a service to synchronize
      * 
+     * @param $name
      * @param $service
      * @return self
      */
-    public function synchronize($service);
+    public function synchronize($name, $service);
 
     /**
      * @return array of services to synchronize

--- a/library/Zend/ServiceManager/SynchronizerInterface.php
+++ b/library/Zend/ServiceManager/SynchronizerInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ServiceManager;
+
+interface SynchronizerInterface extends \SplSubject
+{
+    /**
+     * Set a service to synchronize
+     * 
+     * @param $service
+     * @return self
+     */
+    public function synchronize($service);
+
+    /**
+     * @return array of services to synchronize
+     */
+    public function toSynchronize();
+}

--- a/tests/ZendTest/ServiceManager/ServiceLocatorSynchronizerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceLocatorSynchronizerTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+use Zend\ServiceManager\ServiceLocatorSynchronizer;
+use Zend\ServiceManager\ServiceManager;
+use ZendTest\ServiceManager\TestAsset\BarSynchronizedFactory;
+use ZendTest\ServiceManager\TestAsset\MultipleSynchronizedFactory;
+
+/**
+ * @group Zend_ServiceManager
+ */
+class ServiceLocatorSynchronizerTest extends TestCase
+{
+    /**
+     * @covers Zend\ServiceManager\ServiceLocatorSynchronizer::synchronize
+     * @covers Zend\ServiceManager\ServiceLocatorSynchronizer::toSynchronize
+     */
+    public function testCanSetAndRetrieveServiceToSynchronize()
+    {
+        $synchronizer = new ServiceLocatorSynchronizer();
+        $this->assertNull($synchronizer->toSynchronize());
+        
+        $synchronizer->synchronize('foo', $obj = new \StdClass());
+        $this->assertEquals($obj, $synchronizer->toSynchronize());
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceLocatorSynchronizer::attach
+     */
+    public function testCanAttachFactoriesWithSynchronizedServices()
+    {
+        $synchronizer = new ServiceLocatorSynchronizer();
+        $synchronizer->attach($barFactory = new BarSynchronizedFactory());
+        $synchronizer->attach($multipleFactory = new MultipleSynchronizedFactory());
+        
+        $services = $synchronizer->getSynchronizedServices();
+        $this->assertEquals(array(
+            'foo' => array($barFactory, $multipleFactory),
+            'bar' => array($multipleFactory),
+        ), $services);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceLocatorSynchronizer::detach
+     */
+    public function testCanDetachFactoriesWithSynchronizedServices()
+    {
+        $synchronizer = new ServiceLocatorSynchronizer();
+        $synchronizer->attach($barFactory = new BarSynchronizedFactory());
+        $synchronizer->attach($multipleFactory = new MultipleSynchronizedFactory());
+        $synchronizer->detach($barFactory);
+
+        $services = $synchronizer->getSynchronizedServices();
+        $this->assertEquals(array(
+            'foo' => array($multipleFactory),
+            'bar' => array($multipleFactory),
+        ), $services);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceLocatorSynchronizer::notify
+     */
+    public function testCanNotifyService()
+    {
+        $synchronizer = new ServiceLocatorSynchronizer();
+        $synchronizer->attach($barFactory = new BarSynchronizedFactory());
+
+        $bar = $barFactory->createService($this->getMock('Zend\ServiceManager\ServiceLocatorInterface'));
+        $this->assertEquals(array('foo'), $bar->foo);
+
+        $synchronizer->synchronize('foo', array('baz'));
+        $synchronizer->notify();
+
+        $this->assertEquals(array('baz'), $bar->foo);
+    }
+}

--- a/tests/ZendTest/ServiceManager/ServiceLocatorSynchronizerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceLocatorSynchronizerTest.php
@@ -29,7 +29,7 @@ class ServiceLocatorSynchronizerTest extends TestCase
     {
         $synchronizer = new ServiceLocatorSynchronizer();
         $this->assertNull($synchronizer->toSynchronize());
-        
+
         $synchronizer->synchronize('foo', $obj = new \StdClass());
         $this->assertEquals($obj, $synchronizer->toSynchronize());
     }
@@ -42,7 +42,7 @@ class ServiceLocatorSynchronizerTest extends TestCase
         $synchronizer = new ServiceLocatorSynchronizer();
         $synchronizer->attach($barFactory = new BarSynchronizedFactory());
         $synchronizer->attach($multipleFactory = new MultipleSynchronizedFactory());
-        
+
         $services = $synchronizer->getSynchronizedServices();
         $this->assertEquals(array(
             'foo' => array($barFactory, $multipleFactory),

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -14,10 +14,10 @@ use Zend\Di\Di;
 use Zend\Mvc\Service\DiFactory;
 use Zend\ServiceManager\Di\DiAbstractServiceFactory;
 use Zend\ServiceManager\Exception;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Config;
 
+use ZendTest\ServiceManager\TestAsset\BarSynchronizedFactory;
 use ZendTest\ServiceManager\TestAsset\FooCounterAbstractFactory;
 use ZendTest\ServiceManager\TestAsset\MockSelfReturningDelegatorFactory;
 
@@ -1074,6 +1074,36 @@ class ServiceManagerTest extends TestCase
 
         $this->assertSame($delegator, $service);
         $this->assertSame($realService, $service->real);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::getSynchronizer
+     */
+    public function testCanGetDefaultSynchronizer()
+    {
+        $serviceManager = new ServiceManager();
+        $synchronizer = $serviceManager->getSynchronizer();
+
+        $this->assertInstanceOf('Zend\ServiceManager\SynchronizerInterface', $synchronizer);
+        $this->assertInstanceOf('Zend\ServiceManager\ServiceLocatorSynchronizer', $synchronizer);
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::setService
+     */
+    public function testCanNotifyWhenAServiceIsUpdated()
+    {
+        $serviceManager = new ServiceManager();
+        $serviceManager->setFactory('bar', new BarSynchronizedFactory());
+
+        $bar = $serviceManager->get('bar');
+        $this->assertEquals(array('foo'), $bar->foo);
+
+        $serviceManager->setService('foo', array('baz'));
+
+        $this->assertEquals(array('baz'), $bar->foo);
+        $bar = $serviceManager->get('bar');
+        $this->assertEquals(array('baz'), $bar->foo);
     }
 
     /**

--- a/tests/ZendTest/ServiceManager/TestAsset/Bar.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/Bar.php
@@ -11,10 +11,14 @@ namespace ZendTest\ServiceManager\TestAsset;
 
 class Bar
 {
+    public $foo;
+    
     public function __construct(array $foo = null)
     {
         if (null === $foo) {
             throw new \RuntimeException();
         }
+        
+        $this->foo = $foo;
     }
 }

--- a/tests/ZendTest/ServiceManager/TestAsset/BarSynchronizedFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/BarSynchronizedFactory.php
@@ -45,7 +45,7 @@ class BarSynchronizedFactory implements FactoryInterface, SynchronizedFactoryInt
      *
      * @return array
      */
-    public function getServices()
+    public function getSynchronizedServices()
     {
         return 'foo';
     }

--- a/tests/ZendTest/ServiceManager/TestAsset/BarSynchronizedFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/BarSynchronizedFactory.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use SplSubject;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\SynchronizedFactoryInterface;
+use Zend\ServiceManager\SynchronizerInterface;
+
+class BarSynchronizedFactory implements FactoryInterface, SynchronizedFactoryInterface
+{
+    /**
+     * @var Bar
+     */
+    protected $bar;
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->bar = new Bar(array('foo'));
+
+        return $this->bar;
+    }
+
+    /**
+     * @param SplSubject|SynchronizerInterface $subject
+     */
+    public function update(SplSubject $subject)
+    {
+        $service = $subject->toSynchronize();
+
+        $this->bar->foo = $service;
+    }
+
+    /**
+     * Return a list of services that will be synchronized to the factory
+     *
+     * @return array
+     */
+    public function getServices()
+    {
+        return 'foo';
+    }
+}

--- a/tests/ZendTest/ServiceManager/TestAsset/MultipleSynchronizedFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/MultipleSynchronizedFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ServiceManager\TestAsset;
+
+use SplSubject;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\SynchronizedFactoryInterface;
+use Zend\ServiceManager\SynchronizerInterface;
+
+class MultipleSynchronizedFactory implements FactoryInterface, SynchronizedFactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new Foo();
+    }
+
+    /**
+     * @param SplSubject|SynchronizerInterface $subject
+     */
+    public function update(SplSubject $subject)
+    {
+        
+    }
+
+    /**
+     * Return a list of services that will be synchronized to the factory
+     *
+     * @return array
+     */
+    public function getServices()
+    {
+        return array('foo', 'bar');
+    }
+}

--- a/tests/ZendTest/ServiceManager/TestAsset/MultipleSynchronizedFactory.php
+++ b/tests/ZendTest/ServiceManager/TestAsset/MultipleSynchronizedFactory.php
@@ -26,17 +26,14 @@ class MultipleSynchronizedFactory implements FactoryInterface, SynchronizedFacto
     /**
      * @param SplSubject|SynchronizerInterface $subject
      */
-    public function update(SplSubject $subject)
-    {
-        
-    }
+    public function update(SplSubject $subject) {}
 
     /**
      * Return a list of services that will be synchronized to the factory
      *
      * @return array
      */
-    public function getServices()
+    public function getSynchronizedServices()
     {
         return array('foo', 'bar');
     }


### PR DESCRIPTION
Sometimes, when a services is updated in the ServiceManager, we need to notify all services that have a dependence to this service.

The idea there is to allow an interface to implement `Zend\ServiceManager\SynchronizedFactoryInterface` to update the service biult previously :

``` php
class BarSynchronizedFactory implements FactoryInterface, SynchronizedFactoryInterface
{
    /**
     * @var Bar
     */
    protected $bar;

    public function createService(ServiceLocatorInterface $serviceLocator)
    {
        $foo = $serviceLocator->get('foo');
        $this->bar = new Bar($foo);

        return $this->bar;
    }

    /**
     * @param SplSubject|SynchronizerInterface $subject
     */
    public function update(SplSubject $subject)
    {
        $foo = $subject->toSynchronize();

        $this->bar->foo = $foo;
    }

    /**
     * Return a list of services that will be synchronized to the factory
     *
     * @return array|string
     */
    public function getSynchronizedServices()
    {
        return 'foo';
    }
}
```

There is no BC, that's just a new feature.
