### PR TITLE
Db/Sql/Predicate/Expression: Fix method argument handling

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Expression.php
+++ b/library/Zend/Db/Sql/Predicate/Expression.php
@@ -30,13 +30,11 @@ class Expression extends BaseExpression implements PredicateInterface
             $this->setParameters($valueParameter);
         } else {
             $argNum = func_num_args();
-            if ($argNum > 2 || is_scalar($valueParameter)) {
-                $parameters = array();
-                for ($i = 1; $i < $argNum; $i++) {
-                    $parameters[] = func_get_arg($i);
-                }
-                $this->setParameters($parameters);
+            $parameters = array();
+            for ($i = 1; $i < $argNum; $i++) {
+                $parameters[] = func_get_arg($i);
             }
+            $this->setParameters($parameters);
         }
     }
 }

--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -60,9 +60,9 @@ class Predicate extends PredicateSet
         if ($this->unnest == null) {
             throw new RuntimeException('Not nested');
         }
-        $unnset       = $this->unnest;
+        $unnest       = $this->unnest;
         $this->unnest = null;
-        return $unnset;
+        return $unnest;
     }
 
     /**

--- a/tests/ZendTest/Db/Sql/Predicate/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/ExpressionTest.php
@@ -11,7 +11,7 @@ namespace ZendTest\Db\Sql\Predicate;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Db\Sql\Predicate\Expression;
-use Zend\Db\Sql\Predicate;
+use Zend\Db\Sql\Predicate\IsNull;
 
 class ExpressionTest extends TestCase
 {
@@ -50,27 +50,27 @@ class ExpressionTest extends TestCase
 
     public function testCanPassSinglePredicateParameterToConstructor()
     {
-        $predicate = new Predicate\IsNull('foo.baz');
+        $predicate = new IsNull('foo.baz');
         $expression = new Expression('?', $predicate);
         $this->assertEquals(array($predicate), $expression->getParameters());
     }
 
     public function testCanPassMultiScalarParametersToConstructor()
     {
-        $expression = new Expression('?', 'foo', 'bar');
+        $expression = new Expression('? OR ?', 'foo', 'bar');
         $this->assertEquals(array('foo', 'bar'), $expression->getParameters());
     }
 
     public function testCanPassMultiNullParametersToConstructor()
     {
-        $expression = new Expression('?', null, null);
+        $expression = new Expression('? OR ?', null, null);
         $this->assertEquals(array(null, null), $expression->getParameters());
     }
 
     public function testCanPassMultiPredicateParametersToConstructor()
     {
-        $predicate = new Predicate\IsNull('foo.baz');
-        $expression = new Expression('?', $predicate, $predicate);
+        $predicate = new IsNull('foo.baz');
+        $expression = new Expression('? OR ?', $predicate, $predicate);
         $this->assertEquals(array($predicate, $predicate), $expression->getParameters());
     }
 
@@ -82,7 +82,7 @@ class ExpressionTest extends TestCase
 
     public function testCanPassArrayOfMultiScalarsParameterToConstructor()
     {
-        $expression = new Expression('?', array('foo', 'bar'));
+        $expression = new Expression('? OR ?', array('foo', 'bar'));
         $this->assertEquals(array('foo', 'bar'), $expression->getParameters());
     }
 
@@ -94,21 +94,21 @@ class ExpressionTest extends TestCase
 
     public function testCanPassArrayOfMultiNullsParameterToConstructor()
     {
-        $expression = new Expression('?', array(null, null));
+        $expression = new Expression('? OR ?', array(null, null));
         $this->assertEquals(array(null, null), $expression->getParameters());
     }
 
     public function testCanPassArrayOfOnePredicateParameterToConstructor()
     {
-        $predicate = new Predicate\IsNull('foo.baz');
+        $predicate = new IsNull('foo.baz');
         $expression = new Expression('?', array($predicate));
         $this->assertEquals(array($predicate), $expression->getParameters());
     }
 
     public function testCanPassArrayOfMultiPredicatesParameterToConstructor()
     {
-        $predicate = new Predicate\IsNull('foo.baz');
-        $expression = new Expression('?', array($predicate, $predicate));
+        $predicate = new IsNull('foo.baz');
+        $expression = new Expression('? OR ?', array($predicate, $predicate));
         $this->assertEquals(array($predicate, $predicate), $expression->getParameters());
     }
 

--- a/tests/ZendTest/Db/Sql/Predicate/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/ExpressionTest.php
@@ -140,4 +140,3 @@ class ExpressionTest extends TestCase
         $this->assertEquals($expected, $test, var_export($test, 1));
     }
 }
-

--- a/tests/ZendTest/Db/Sql/Predicate/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/ExpressionTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Db\Sql\Predicate;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Db\Sql\Predicate\Expression;
+use Zend\Db\Sql\Predicate;
 
 class ExpressionTest extends TestCase
 {
@@ -22,12 +23,93 @@ class ExpressionTest extends TestCase
         $this->assertEmpty($expression->getParameters());
     }
 
-    public function testCanPassLiteralAndParameterToConstructor()
+    public function testCanPassLiteralAndSingleScalarParameterToConstructor()
     {
-        $expression = new Expression();
-        $predicate = new Expression('foo.bar = ?', 'bar');
-        $this->assertEquals('foo.bar = ?', $predicate->getExpression());
-        $this->assertEquals(array('bar'), $predicate->getParameters());
+        $expression = new Expression('foo.bar = ?', 'bar');
+        $this->assertEquals('foo.bar = ?', $expression->getExpression());
+        $this->assertEquals(array('bar'), $expression->getParameters());
+    }
+
+    public function testCanPassNoParameterToConstructor()
+    {
+        $expression = new Expression('foo.bar');
+        $this->assertEquals(array(), $expression->getParameters());
+    }
+
+    public function testCanPassSingleNullParameterToConstructor()
+    {
+        $expression = new Expression('?', null);
+        $this->assertEquals(array(null), $expression->getParameters());
+    }
+
+    public function testCanPassSingleZeroParameterValueToConstructor()
+    {
+        $predicate = new Expression('?', 0);
+        $this->assertEquals(array(0), $predicate->getParameters());
+    }
+
+    public function testCanPassSinglePredicateParameterToConstructor()
+    {
+        $predicate = new Predicate\IsNull('foo.baz');
+        $expression = new Expression('?', $predicate);
+        $this->assertEquals(array($predicate), $expression->getParameters());
+    }
+
+    public function testCanPassMultiScalarParametersToConstructor()
+    {
+        $expression = new Expression('?', 'foo', 'bar');
+        $this->assertEquals(array('foo', 'bar'), $expression->getParameters());
+    }
+
+    public function testCanPassMultiNullParametersToConstructor()
+    {
+        $expression = new Expression('?', null, null);
+        $this->assertEquals(array(null, null), $expression->getParameters());
+    }
+
+    public function testCanPassMultiPredicateParametersToConstructor()
+    {
+        $predicate = new Predicate\IsNull('foo.baz');
+        $expression = new Expression('?', $predicate, $predicate);
+        $this->assertEquals(array($predicate, $predicate), $expression->getParameters());
+    }
+
+    public function testCanPassArrayOfOneScalarParameterToConstructor()
+    {
+        $expression = new Expression('?', array('foo'));
+        $this->assertEquals(array('foo'), $expression->getParameters());
+    }
+
+    public function testCanPassArrayOfMultiScalarsParameterToConstructor()
+    {
+        $expression = new Expression('?', array('foo', 'bar'));
+        $this->assertEquals(array('foo', 'bar'), $expression->getParameters());
+    }
+
+    public function testCanPassArrayOfOneNullParameterToConstructor()
+    {
+        $expression = new Expression('?', array(null));
+        $this->assertEquals(array(null), $expression->getParameters());
+    }
+
+    public function testCanPassArrayOfMultiNullsParameterToConstructor()
+    {
+        $expression = new Expression('?', array(null, null));
+        $this->assertEquals(array(null, null), $expression->getParameters());
+    }
+
+    public function testCanPassArrayOfOnePredicateParameterToConstructor()
+    {
+        $predicate = new Predicate\IsNull('foo.baz');
+        $expression = new Expression('?', array($predicate));
+        $this->assertEquals(array($predicate), $expression->getParameters());
+    }
+
+    public function testCanPassArrayOfMultiPredicatesParameterToConstructor()
+    {
+        $predicate = new Predicate\IsNull('foo.baz');
+        $expression = new Expression('?', array($predicate, $predicate));
+        $this->assertEquals(array($predicate, $predicate), $expression->getParameters());
     }
 
     public function testLiteralIsMutable()
@@ -57,10 +139,5 @@ class ExpressionTest extends TestCase
         $test = $expression->getExpressionData();
         $this->assertEquals($expected, $test, var_export($test, 1));
     }
-
-    public function testAllowZeroParameterValue()
-    {
-        $predicate = new Expression('foo.bar > ?', 0);
-        $this->assertEquals(array(0), $predicate->getParameters());
-    }
 }
+


### PR DESCRIPTION
- Fix method argument handling of Predicate/Expression to allow single non-scalar values (e.g. null, Predicate instances) as only parameter
- Fix typo in Predicate/Predicate
