### PR TITLE
Removed impossible condition

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -185,15 +185,6 @@ class Curl implements HttpAdapter, StreamInterface
             $this->close();
         }
 
-        // If we are connected to a different server or port, disconnect first
-        if ($this->curl
-            && is_array($this->connectedTo)
-            && ($this->connectedTo[0] != $host
-            || $this->connectedTo[1] != $port)
-        ) {
-            $this->close();
-        }
-
         // Do the actual connection
         $this->curl = curl_init();
         if ($port != 80) {


### PR DESCRIPTION
If `$this->curl` would be true-ish when entering this method it would enter inside the first conditional block and inside `$this->close()` will be set to `null`. Then when checking the second condition, that I removed, it will always logically evaluate to false and the block will be never entered regardless of the input or context.
