### PR TITLE
Fix problem of decimals always visible when using currencyFormat view helper

### DIFF
--- a/library/Zend/I18n/View/Helper/CurrencyFormat.php
+++ b/library/Zend/I18n/View/Helper/CurrencyFormat.php
@@ -133,6 +133,7 @@ class CurrencyFormat extends AbstractHelper
         if ($showDecimals) {
             $this->formatters[$formatterId]->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
         } else {
+            $this->formatters[$formatterId]->setTextAttribute(NumberFormatter::CURRENCY_CODE, $currencyCode);
             $this->formatters[$formatterId]->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
         }
 


### PR DESCRIPTION
Apply comment visible in http://php.net/manual/en/numberformatter.formatcurrency.php :

When you want to format currency's without sub units and the currency is not the one used by the given locale you need to set the currency code before as TextAttribute _BEFORE_ setting the NumberFormatter::FRACTION_DIGITS

```php
$fmt = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
$fmt->setTextAttribute(NumberFormatter::CURRENCY_CODE, 'EUR');
$fmt->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
$fmt->formatCurrency(100, 'EUR');
```
