### PR TITLE
Allow Session\Container names to start with numbers

### DIFF
--- a/library/Zend/Session/AbstractContainer.php
+++ b/library/Zend/Session/AbstractContainer.php
@@ -63,7 +63,7 @@ abstract class AbstractContainer extends ArrayObject
      */
     public function __construct($name = 'Default', Manager $manager = null)
     {
-        if (!preg_match('/^[a-z][a-z0-9_\\\]+$/i', $name)) {
+        if (!preg_match('/^[a-z0-9][a-z0-9_\\\\]+$/i', $name)) {
             throw new Exception\InvalidArgumentException(
                 'Name passed to container is invalid; must consist of alphanumerics, backslashes and underscores only'
             );

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -89,6 +89,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $container->getName());
     }
 
+    public function testPassingNameStartingWithDigitToConstructorInstantiatesContainerWithThatName()
+    {
+        $container = new Container('0foo', $this->manager);
+        $this->assertEquals('0foo', $container->getName());
+    }
+
     public function testUsingOldZF1NameIsStillValid()
     {
         $container = new Container('Zend_Foo', $this->manager);

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -108,7 +108,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             'foo bar',
             '_foo',
             '__foo',
-            '0foo',
             '\foo',
             '\\foo'
         );


### PR DESCRIPTION
Useful for names generated or prefixed with hashes or checksums.
Also adds another backslash for better readability.
