### PR TITLE
Fixes #6828 move zend\serializer deps how required

### DIFF
--- a/library/Zend/Cache/composer.json
+++ b/library/Zend/Cache/composer.json
@@ -17,10 +17,10 @@
         "php": ">=5.3.23",
         "zendframework/zend-stdlib": "self.version",
         "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-serializer": "self.version",
         "zendframework/zend-eventmanager": "self.version"
     },
     "require-dev": {
-        "zendframework/zend-serializer": "self.version",
         "zendframework/zend-session": "self.version"
     },
     "suggest": {


### PR DESCRIPTION
Zend\Serializer for Zend\Cache component is only required-dev?

https://github.com/zendframework/Component_ZendCache/search?utf8=%E2%9C%93&q=Serializer
