### PR TITLE
Hostname route should throw an exception if route definition contains disallowed character

### DIFF
--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -116,6 +116,9 @@ class Hostname implements RouteInterface
 
         while ($currentPos < $length) {
             preg_match('(\G(?P<literal>[a-z0-9-.]*)(?P<token>[:{\[\]]|$))', $def, $matches, 0, $currentPos);
+            if (empty($matches)) {
+                throw new Exception\RuntimeException('Matched hostname literal contains a disallowed character');
+            }
 
             $currentPos += strlen($matches[0]);
 

--- a/library/Zend/Mvc/Router/Http/Hostname.php
+++ b/library/Zend/Mvc/Router/Http/Hostname.php
@@ -115,8 +115,7 @@ class Hostname implements RouteInterface
         $level      = 0;
 
         while ($currentPos < $length) {
-            preg_match('(\G(?P<literal>[a-z0-9-.]*)(?P<token>[:{\[\]]|$))', $def, $matches, 0, $currentPos);
-            if (empty($matches)) {
+            if (!preg_match('(\G(?P<literal>[a-z0-9-.]*)(?P<token>[:{\[\]]|$))', $def, $matches, 0, $currentPos)) {
                 throw new Exception\RuntimeException('Matched hostname literal contains a disallowed character');
             }
 

--- a/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/HostnameTest.php
@@ -240,4 +240,13 @@ class HostnameTest extends TestCase
             )
         );
     }
+    
+    /**
+     * @group zf5656
+     */
+    public function testFailedHostnameSegmentMatchDoesNotEmitErrors()
+    {
+        $this->setExpectedException('Zend\Mvc\Router\Exception\RuntimeException');
+        $route = new Hostname(':subdomain.with_underscore.com');
+    }
 }


### PR DESCRIPTION
If a hostname route is constructed with a route containing a disallowed character (one outside of `[a-z0-9-.]`) a RuntimeException should be thrown, as the route is misconfigured. 

Fixes #5656
