### PR TITLE
Memcached returns FALSE on failure

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Memcached.php
+++ b/library/Zend/Cache/Storage/Adapter/Memcached.php
@@ -222,7 +222,7 @@ class Memcached extends AbstractAdapter implements
         }
 
         $success = true;
-        if ($result === false || $result === null) {
+        if ($result === false) {
             $rsCode = $memc->getResultCode();
             if ($rsCode == MemcachedResource::RES_NOTFOUND) {
                 $result = null;
@@ -280,7 +280,7 @@ class Memcached extends AbstractAdapter implements
     {
         $memc  = $this->getMemcachedResource();
         $value = $memc->get($this->namespacePrefix . $normalizedKey);
-        if ($value === false || $value === null) {
+        if ($value === false) {
             $rsCode = $memc->getResultCode();
             if ($rsCode == MemcachedResource::RES_SUCCESS) {
                 return true;


### PR DESCRIPTION
... so it's not required to check for NULL, too.
The note Memcached returns NULL was a miss information in changelog of memcached-2.0

PS: It's not a bug - it's an improvement as the result will be same ;)
