### PR TITLE
CS Fix: string access and guard clauses

### DIFF
--- a/library/Zend/Barcode/Object/Upce.php
+++ b/library/Zend/Barcode/Object/Upce.php
@@ -59,8 +59,8 @@ class Upce extends Ean13
     public function getText()
     {
         $text = parent::getText();
-        if ($text{0} != 1) {
-            $text{0} = 0;
+        if ($text[0] != 1) {
+            $text[0] = 0;
         }
         return $text;
     }
@@ -191,8 +191,8 @@ class Upce extends Ean13
     public function getChecksum($text)
     {
         $text = $this->addLeadingZeros($text, true);
-        if ($text{0} != 1) {
-            $text{0} = 0;
+        if ($text[0] != 1) {
+            $text[0] = 0;
         }
         return parent::getChecksum($text);
     }

--- a/library/Zend/Soap/Client/Common.php
+++ b/library/Zend/Soap/Client/Common.php
@@ -11,11 +11,13 @@ namespace Zend\Soap\Client;
 
 use SoapClient;
 
-if (extension_loaded('soap')) {
+if (! extension_loaded('soap')) {
+    return;
+}
 
 class Common extends SoapClient
 {
-        /**
+    /**
      * doRequest() pre-processing method
      *
      * @var callable
@@ -56,6 +58,4 @@ class Common extends SoapClient
 
         return call_user_func($this->doRequestCallback, $this, ltrim($request), $location, $action, $version, $oneWay);
     }
-}
-
 }


### PR DESCRIPTION
In order to pass build (on master) we need to use brackes for string access ([as suggested by php doc](http://php.net/manual/en/language.types.string.php#language.types.string.substr)), and guard clause instead of conditional nesting for specific class declaration.
