### PR TITLE
Rebased and cleaned up #6279

### DIFF
--- a/library/Zend/Config/Reader/Xml.php
+++ b/library/Zend/Config/Reader/Xml.php
@@ -151,7 +151,11 @@ class Xml implements ReaderInterface
 
                 if ($attributes) {
                     if (!is_array($child)) {
-                        $child = array();
+                        if(is_string($child)){
+                            $child = array('_' => $child);
+                        }else{
+                            $child = array();
+                        }
                     }
 
                     $child = array_merge($child, $attributes);

--- a/library/Zend/Config/Reader/Xml.php
+++ b/library/Zend/Config/Reader/Xml.php
@@ -150,12 +150,11 @@ class Xml implements ReaderInterface
                 }
 
                 if ($attributes) {
-                    if (!is_array($child)) {
-                        if(is_string($child)){
-                            $child = array('_' => $child);
-                        }else{
-                            $child = array();
-                        }
+                    if (is_string($child)) {
+                        $child = array('_' => $child);
+                    }
+                    if ( !is_array($child) ) {
+                        $child = array();
                     }
 
                     $child = array_merge($child, $attributes);

--- a/tests/ZendTest/Config/Reader/TestAssets/Xml/attributes.xml
+++ b/tests/ZendTest/Config/Reader/TestAssets/Xml/attributes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config>
+    <one>bazbat</one>
+    <one foo="bar">bazbat</one>
+</config>

--- a/tests/ZendTest/Config/Reader/XmlTest.php
+++ b/tests/ZendTest/Config/Reader/XmlTest.php
@@ -96,4 +96,29 @@ ECS;
         $this->assertEquals('2', $config['six']['seven'][1]['nine']);
         $this->assertEquals('3', $config['six']['seven'][2]['nine']);
     }
+
+    /**
+     * @group zf6279
+     */
+    public function testElementWithBothAttributesAndAStringValueIsProcessedCorrectly()
+    {
+        $this->reader = new Xml();
+        $arrayXml = $this->reader->fromFile($this->getTestAssetPath('attributes'));
+        $this->assertArrayHasKey('one', $arrayXml);
+        $this->assertInternalType('array', $arrayXml['one']);
+        
+        // No attribute + text value == string
+        $this->assertArrayHasKey(0, $arrayXml['one']);
+        $this->assertEquals('bazbat', $arrayXml['one'][0]);
+        
+        // Attribute(s) + text value == array
+        $this->assertArrayHasKey(1, $arrayXml['one']);
+        $this->assertInternalType('array', $arrayXml['one'][1]);
+        // Attributes stored in named array keys
+        $this->assertArrayHasKey('foo', $arrayXml['one'][1]);
+        $this->assertEquals('bar', $arrayXml['one'][1]['foo']);
+        // Element value stored in special key '_'
+        $this->assertArrayHasKey('_', $arrayXml['one'][1]);
+        $this->assertEquals('bazbat', $arrayXml['one'][1]['_']);
+    }
 }


### PR DESCRIPTION
## Issue summary

In `Zend\Config\Reader\Xml`, loading an XML file with elements having both attributes and a node value the node value is lost:

Loading this XML file:

```
<?xml version="1.0"?>
<config>
    <one foo="bar">bazbat</one>
</config>
```

Would result in an array like this:

```
array(1) {
  'one' =>
  array(2) {
    [0] =>
    array(2) {
      'foo' =>
      string(3) "bar"
    }
  }
}
```
## Fix

If an element has attributes then read the node value and place it in the special array key `_`
## Ack

Fix contributed by @catalint
