### PR TITLE
Fix for #6263 (replaces PR #6518)

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -511,21 +511,23 @@ class Collection extends Fieldset
         $values = array();
 
         foreach ($this->object as $key => $value) {
-            if ($this->hydrator) {
+            if (!$this->targetElement instanceof FieldsetInterface) {
+                $values[$key] = $value;
+                if (!$this->createNewObjects() && $this->has($key)) {
+                    $this->get($key)->setValue($value);
+                }
+            } elseif ($this->hydrator) {
                 $values[$key] = $this->hydrator->extract($value);
-            } elseif ($value instanceof $this->targetElement->object) {
-                // @see https://github.com/zendframework/zf2/pull/2848
+            } elseif ($this->targetElement->allowObjectBinding($value)) {
                 $targetElement = clone $this->targetElement;
-                $targetElement->object = $value;
+                $targetElement->setObject($value);
                 $values[$key] = $targetElement->extract();
                 if (!$this->createNewObjects() && $this->has($key)) {
-                    $fieldset = $this->get($key);
-                    if ($fieldset instanceof Fieldset && $fieldset->allowObjectBinding($value)) {
-                        $fieldset->setObject($value);
-                    }
+                    $this->get($key)->setObject($value);
                 }
             }
         }
+
         return $values;
     }
 

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -1053,4 +1053,33 @@ class CollectionTest extends TestCase
         $collection->setObject($arrayCollection);
         $this->assertEquals(3, $collection->getCount());
     }
+    
+    /**
+     * @group zf6263
+     * @group zf6518
+     */
+    public function testCollectionProperlyHandlesAddingObjectsOfTypeElementInterface()
+    {
+        $form = new Form('test');
+        $text = new Element\Text('text');
+        $form->add(array(
+            'name' => 'text',
+            'type' => 'Zend\Form\Element\Collection',
+            'options' => array(
+                'target_element' => $text, 'count' => 2,
+            ),
+        ));
+        $object = new \ArrayObject(array('text' => array('Foo', 'Bar')));
+        $form->bind($object);
+        $this->assertTrue($form->isValid());
+        
+        $result = $form->getData();
+        $this->assertInstanceOf('ArrayAccess', $result);
+        $this->assertArrayHasKey('text', $result);
+        $this->assertInternalType('array', $result['text']);
+        $this->assertArrayHasKey(0, $result['text']);
+        $this->assertEquals('Foo', $result['text'][0]);
+        $this->assertArrayHasKey(1, $result['text']);
+        $this->assertEquals('Bar', $result['text'][1]);
+    }
 }

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -1082,4 +1082,45 @@ class CollectionTest extends TestCase
         $this->assertArrayHasKey(1, $result['text']);
         $this->assertEquals('Bar', $result['text'][1]);
     }
+    
+    /**
+     * Unit test to ensure behavior of extract() method is unaffected by refactor
+     *
+     * @group zf6263
+     * @group zf6518
+     */
+    public function testCollectionShouldSilentlyIgnorePopulatingFieldsetWithDisallowedObject()
+    {
+        $mainFieldset = new Fieldset();
+        $mainFieldset->add(new Element\Text('test'));
+        $mainFieldset->setObject(new \ArrayObject());
+        $mainFieldset->setHydrator(new ObjectPropertyHydrator());
+
+        $form = new Form();
+        $form->setObject(new \stdClass());
+        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->add(array(
+            'name' => 'collection',
+            'type' => 'Collection',
+            'options' => array(
+                'target_element' => $mainFieldset,
+                'count' => 2
+            ),
+        ));
+        
+        $model = new \stdClass();
+        $model->collection = array(new \ArrayObject(array('test' => 'bar')), new \stdClass());
+        
+        $form->bind($model);
+        $this->assertTrue($form->isValid());
+        
+        $result = $form->getData();
+        $this->assertInstanceOf('stdClass', $result);
+        $this->assertObjectHasAttribute('collection', $result);
+        $this->assertInternalType('array', $result->collection);
+        $this->assertCount(1, $result->collection);
+        $this->assertInstanceOf('ArrayObject', $result->collection[0]);
+        $this->assertArrayHasKey('test', $result->collection[0]);
+        $this->assertEquals('bar', $result->collection[0]['test']);
+    }
 }


### PR DESCRIPTION
## Issue summary

Elements of type `Zend\Form\ElementInterface` cannot be added directly to a Collection object due to the latter's setting of an object prototype on the supplied element, which is only defined on `Zend\Form\FieldsetInterface`.
## Fix

Handle `Zend\Form\ElementInterface` instances separately; call `setValue` instead of `setObject`.
## Ack

Fix and reproducing code snippet contributed by @SteveTalbot
