### PR TITLE
Set user and password in Http class

### DIFF
--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -66,7 +66,7 @@ class Http extends Uri
     {
         return $this->password;
     }
-    
+
     /**
      * Get the User-info (usually user:password) part
      *
@@ -102,7 +102,7 @@ class Http extends Uri
         $this->buildUserInfo();
         return $this;
     }
-    
+
     /**
      * Set the URI User-info part (usually user:password)
      *
@@ -159,22 +159,22 @@ class Http extends Uri
         $this->user = $user;
         $this->password = $password;
     }
-    
+
     /**
      * Build the user info based on user and password
-     * 
+     *
      * Builds the user info based on the given user and password values
-     * 
+     *
      * @return void
      */
     protected function buildUserInfo()
     {
         $userInfo = $this->user;
-        
+
         if (null !== $this->password) {
             $userInfo .= ':' . $this->password;
         }
-        
+
         $this->userInfo = $userInfo;
     }
 

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -48,20 +48,6 @@ class Http extends Uri
     protected $password;
 
     /**
-     * Check if the URI is a valid HTTP URI
-     *
-     * This applies additional HTTP specific validation rules beyond the ones
-     * required by the generic URI syntax
-     *
-     * @return bool
-     * @see    Uri::isValid()
-     */
-    public function isValid()
-    {
-        return parent::isValid();
-    }
-
-    /**
      * Get the username part (before the ':') of the userInfo URI part
      *
      * @return string|null

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -66,6 +66,16 @@ class Http extends Uri
     {
         return $this->password;
     }
+    
+    /**
+     * Get the User-info (usually user:password) part
+     *
+     * @return string|null
+     */
+    public function getUserInfo()
+    {
+        return $this->userInfo;
+    }
 
     /**
      * Set the username part (before the ':') of the userInfo URI part
@@ -76,6 +86,7 @@ class Http extends Uri
     public function setUser($user)
     {
         $this->user = $user;
+        $this->buildUserInfo();
         return $this;
     }
 
@@ -88,6 +99,22 @@ class Http extends Uri
     public function setPassword($password)
     {
         $this->password = $password;
+        $this->buildUserInfo();
+        return $this;
+    }
+    
+    /**
+     * Set the URI User-info part (usually user:password)
+     *
+     * @param  string $userInfo
+     * @return Uri
+     * @throws Exception\InvalidUriPartException If the schema definition
+     * does not have this part
+     */
+    public function setUserInfo($userInfo)
+    {
+        $this->userInfo = $userInfo;
+        $this->parseUserInfo();
         return $this;
     }
 
@@ -129,8 +156,26 @@ class Http extends Uri
 
         // Split on the ':', and set both user and password
         list($user, $password) = explode(':', $this->userInfo, 2);
-        $this->setUser($user);
-        $this->setPassword($password);
+        $this->user = $user;
+        $this->password = $password;
+    }
+    
+    /**
+     * Build the user info based on user and password
+     * 
+     * Builds the user info based on the given user and password values
+     * 
+     * @return void
+     */
+    protected function buildUserInfo()
+    {
+        $userInfo = $this->user;
+        
+        if (null !== $this->password) {
+            $userInfo .= ':' . $this->password;
+        }
+        
+        $this->userInfo = $userInfo;
     }
 
     /**

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -64,30 +64,20 @@ class Http extends Uri
     /**
      * Get the username part (before the ':') of the userInfo URI part
      *
-     * @return null|string
+     * @return string|null
      */
     public function getUser()
     {
-        if (null !== $this->user) {
-            return $this->user;
-        }
-
-        $this->parseUserInfo();
         return $this->user;
     }
 
     /**
      * Get the password part (after the ':') of the userInfo URI part
      *
-     * @return string
+     * @return string|null
      */
     public function getPassword()
     {
-        if (null !== $this->password) {
-            return $this->password;
-        }
-
-        $this->parseUserInfo();
         return $this->password;
     }
 

--- a/tests/ZendTest/Uri/HttpTest.php
+++ b/tests/ZendTest/Uri/HttpTest.php
@@ -252,4 +252,40 @@ class HttpTest extends TestCase
         $uri = new HttpUri('http://zf2_app.local');
         $this->assertTrue($uri->isValid());
     }
+    
+    public function testCanSetUserAndPasswordWithUserInfo()
+    {
+        $uri = new HttpUri('http://www.example.com/');
+        $uri->setUserInfo('user:pass');
+        
+        $this->assertEquals('user', $uri->getUser());
+        $this->assertEquals('pass', $uri->getPassword());
+    }
+    
+    public function testCanSetUserWithUserInfo()
+    {
+        $uri = new HttpUri('http://www.example.com/');
+        $uri->setUserInfo('user');
+        
+        $this->assertEquals('user', $uri->getUser());
+        $this->assertNull($uri->getPassword());
+    }
+    
+    public function testCanSetUserInfoWithUserAndPassword()
+    {
+        $uri = new HttpUri('http://www.example.com/');
+        $uri->setUser('user');
+        $uri->setPassword('pass');
+        
+        $this->assertEquals('user', $uri->getUser());
+        $this->assertEquals('pass', $uri->getPassword());
+        $this->assertEquals('user:pass', $uri->getUserInfo());
+    }
+    
+    public function testCanSetUserInfoWithUser()
+    {
+        $uri = new HttpUri('http://www.example.com/');
+        $uri->setUser('user');
+        $this->assertEquals('user', $uri->getUserInfo());
+    }
 }


### PR DESCRIPTION
Zend\Uri\Http is extending Zend\Uri\Uri and therefore is also having the getter and setter method for the user info from an URI. Also, the Http class has separate setter and getter for the user and password.

At the moment, when the user info is set, Http automatically is setting the properties for user and password.

``` php
$uri = new Http('http://example.com/');
$uri->normalize();
$uri->setUserInfo('user:pass');
$this->assertEquals('user', $uri->getUser());
$this->assertEquals('pass', $uri->getPassword());
```

But when values are set with setUser and setPassword, the user info is not updated. The following test fails:

``` php
$uri = new HttpUri('http://example.com/');
$uri->setUser('user');
$uri->setPassword('pass');
$this->assertEquals('user:pass', $uri->getUserInfo());
```

It is a strange behaviour that setting the user info is also setting the user and password in Http class, but the setter of user and password doesn't affect the user info value.

I created this pull request with a fix of this behaviour and add some more unittests for Http.
