### PR TITLE
Fixes Zend\Json\Json's composer.json containing single backslash

### DIFF
--- a/library/Zend/Json/composer.json
+++ b/library/Zend/Json/composer.json
@@ -24,7 +24,7 @@
     "suggest": {
         "zendframework/zend-http": "Zend\\Http component",
         "zendframework/zend-server": "Zend\\Server component",
-        "zendframework/zendxml": "To support Zend\Json\Json::fromXml() usage"
+        "zendframework/zendxml": "To support Zend\\Json\\Json::fromXml() usage"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
it comes from PR #6778 that changes composer.json
