### PR TITLE
Fix for https cases for Apache on IBM i

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -251,7 +251,7 @@ class Request extends HttpRequest
         $uri = new HttpUri();
 
         // URI scheme
-        if ((!empty($this->serverParams['HTTPS']) && $this->serverParams['HTTPS'] !== 'off')
+        if ((!empty($this->serverParams['HTTPS']) && strtolower($this->serverParams['HTTPS']) !== 'off')
             || (!empty($this->serverParams['HTTP_X_FORWARDED_PROTO']) && $this->serverParams['HTTP_X_FORWARDED_PROTO'] == 'https')
         ) {
             $scheme = 'https';


### PR DESCRIPTION
On Apache on IBM i the `$_SERVER['HTTPS']` is set to `OFF` instead of `off` (lowercase).
I've added the strtolower to prevent cases like that.
