### PR TITLE
Throw an ServiceNotFoundException in AbstractPluginManager when the invokable does not exist.

### DIFF
--- a/library/Zend/ServiceManager/AbstractPluginManager.php
+++ b/library/Zend/ServiceManager/AbstractPluginManager.php
@@ -164,6 +164,16 @@ abstract class AbstractPluginManager extends ServiceManager implements ServiceLo
     {
         $invokable = $this->invokableClasses[$canonicalName];
 
+        if (!class_exists($invokable)) {
+            throw new Exception\ServiceNotFoundException(sprintf(
+                '%s: failed retrieving "%s%s" via invokable class "%s"; class does not exist',
+                get_class($this) . '::' . __FUNCTION__,
+                $canonicalName,
+                ($requestedName ? '(alias: ' . $requestedName . ')' : ''),
+                $invokable
+            ));
+        }
+
         if (null === $this->creationOptions
             || (is_array($this->creationOptions) && empty($this->creationOptions))
         ) {

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -27,26 +27,26 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function setup()
     {
         $this->serviceManager = new ServiceManager;
-        $this->pluginManager = new FooPluginManager(new Config(array(
-            'factories' => array(
+        $this->pluginManager = new FooPluginManager(new Config([
+            'factories' => [
                 'Foo' => 'ZendTest\ServiceManager\TestAsset\FooFactory',
-            ),
-            'shared' => array(
+            ],
+            'shared' => [
                 'Foo' => false,
-            ),
-        )));
+            ],
+        ]));
     }
 
     public function testSetMultipleCreationOptions()
     {
-        $pluginManager = new FooPluginManager(new Config(array(
-            'factories' => array(
+        $pluginManager = new FooPluginManager(new Config([
+            'factories' => [
                 'Foo' => 'ZendTest\ServiceManager\TestAsset\FooFactory'
-            ),
-            'shared' => array(
+            ],
+            'shared' => [
                 'Foo' => false
-            )
-        )));
+            ]
+        ]));
 
         $refl         = new ReflectionClass($pluginManager);
         $reflProperty = $refl->getProperty('factories');
@@ -55,24 +55,36 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInternalType('string', $value['foo']);
 
-        $pluginManager->get('Foo', array('key1' => 'value1'));
+        $pluginManager->get('Foo', ['key1' => 'value1']);
 
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFactory', $value['foo']);
-        $this->assertEquals(array('key1' => 'value1'), $value['foo']->getCreationOptions());
+        $this->assertEquals(['key1' => 'value1'], $value['foo']->getCreationOptions());
 
-        $pluginManager->get('Foo', array('key2' => 'value2'));
+        $pluginManager->get('Foo', ['key2' => 'value2']);
 
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFactory', $value['foo']);
-        $this->assertEquals(array('key2' => 'value2'), $value['foo']->getCreationOptions());
+        $this->assertEquals(['key2' => 'value2'], $value['foo']->getCreationOptions());
+    }
+
+    /**
+     * @group issue-4208
+     */
+    public function testGetFaultyRegisteredInvokableThrowsException()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
+
+        $pluginManager = new FooPluginManager();
+        $pluginManager->setInvokableClass('helloWorld', 'IDoNotExist');
+        $pluginManager->get('helloWorld');
     }
 
     public function testAbstractFactoryWithMutableCreationOptions()
     {
-        $creationOptions = array('key1' => 'value1');
+        $creationOptions = ['key1' => 'value1'];
         $mock = 'ZendTest\ServiceManager\TestAsset\AbstractFactoryWithMutableCreationOptions';
-        $abstractFactory = $this->getMock($mock, array('setCreationOptions'));
+        $abstractFactory = $this->getMock($mock, ['setCreationOptions']);
         $abstractFactory->expects($this->once())
             ->method('setCreationOptions')
             ->with($creationOptions);
@@ -85,7 +97,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testMutableMethodNeverCalledWithoutCreationOptions()
     {
         $mock = 'ZendTest\ServiceManager\TestAsset\CallableWithMutableCreationOptions';
-        $callable = $this->getMock($mock, array('setCreationOptions'));
+        $callable = $this->getMock($mock, ['setCreationOptions']);
         $callable->expects($this->never())
             ->method('setCreationOptions');
 
@@ -98,9 +110,9 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testCallableObjectWithMutableCreationOptions()
     {
-        $creationOptions = array('key1' => 'value1');
+        $creationOptions = ['key1' => 'value1'];
         $mock = 'ZendTest\ServiceManager\TestAsset\CallableWithMutableCreationOptions';
-        $callable = $this->getMock($mock, array('setCreationOptions'));
+        $callable = $this->getMock($mock, ['setCreationOptions']);
         $callable->expects($this->once())
             ->method('setCreationOptions')
             ->with($creationOptions);
@@ -135,8 +147,8 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     {
         $delegatorFactory = $this->getMock('Zend\\ServiceManager\\DelegatorFactoryInterface');
         $pluginManager = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
-        $realService = $this->getMock('stdClass', array(), array(), 'RealService');
-        $delegator = $this->getMock('stdClass', array(), array(), 'Delegator');
+        $realService = $this->getMock('stdClass', [], [], 'RealService');
+        $delegator = $this->getMock('stdClass', [], [], 'Delegator');
 
         $delegatorFactory
             ->expects($this->once())

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -27,26 +27,26 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function setup()
     {
         $this->serviceManager = new ServiceManager;
-        $this->pluginManager = new FooPluginManager(new Config([
-            'factories' => [
+        $this->pluginManager = new FooPluginManager(new Config(array(
+            'factories' => array(
                 'Foo' => 'ZendTest\ServiceManager\TestAsset\FooFactory',
-            ],
-            'shared' => [
+            ),
+            'shared' => array(
                 'Foo' => false,
-            ],
-        ]));
+            ),
+        )));
     }
 
     public function testSetMultipleCreationOptions()
     {
-        $pluginManager = new FooPluginManager(new Config([
-            'factories' => [
+        $pluginManager = new FooPluginManager(new Config(array(
+            'factories' => array(
                 'Foo' => 'ZendTest\ServiceManager\TestAsset\FooFactory'
-            ],
-            'shared' => [
+            ),
+            'shared' => array(
                 'Foo' => false
-            ]
-        ]));
+            )
+        )));
 
         $refl         = new ReflectionClass($pluginManager);
         $reflProperty = $refl->getProperty('factories');
@@ -55,17 +55,17 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInternalType('string', $value['foo']);
 
-        $pluginManager->get('Foo', ['key1' => 'value1']);
+        $pluginManager->get('Foo', array('key1' => 'value1'));
 
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFactory', $value['foo']);
-        $this->assertEquals(['key1' => 'value1'], $value['foo']->getCreationOptions());
+        $this->assertEquals(array('key1' => 'value1'), $value['foo']->getCreationOptions());
 
-        $pluginManager->get('Foo', ['key2' => 'value2']);
+        $pluginManager->get('Foo', array('key2' => 'value2'));
 
         $value = $reflProperty->getValue($pluginManager);
         $this->assertInstanceOf('ZendTest\ServiceManager\TestAsset\FooFactory', $value['foo']);
-        $this->assertEquals(['key2' => 'value2'], $value['foo']->getCreationOptions());
+        $this->assertEquals(array('key2' => 'value2'), $value['foo']->getCreationOptions());
     }
 
     /**
@@ -82,9 +82,9 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testAbstractFactoryWithMutableCreationOptions()
     {
-        $creationOptions = ['key1' => 'value1'];
+        $creationOptions = array('key1' => 'value1');
         $mock = 'ZendTest\ServiceManager\TestAsset\AbstractFactoryWithMutableCreationOptions';
-        $abstractFactory = $this->getMock($mock, ['setCreationOptions']);
+        $abstractFactory = $this->getMock($mock, array('setCreationOptions'));
         $abstractFactory->expects($this->once())
             ->method('setCreationOptions')
             ->with($creationOptions);
@@ -97,7 +97,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testMutableMethodNeverCalledWithoutCreationOptions()
     {
         $mock = 'ZendTest\ServiceManager\TestAsset\CallableWithMutableCreationOptions';
-        $callable = $this->getMock($mock, ['setCreationOptions']);
+        $callable = $this->getMock($mock, array('setCreationOptions'));
         $callable->expects($this->never())
             ->method('setCreationOptions');
 
@@ -110,9 +110,9 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testCallableObjectWithMutableCreationOptions()
     {
-        $creationOptions = ['key1' => 'value1'];
+        $creationOptions = array('key1' => 'value1');
         $mock = 'ZendTest\ServiceManager\TestAsset\CallableWithMutableCreationOptions';
-        $callable = $this->getMock($mock, ['setCreationOptions']);
+        $callable = $this->getMock($mock, array('setCreationOptions'));
         $callable->expects($this->once())
             ->method('setCreationOptions')
             ->with($creationOptions);
@@ -147,8 +147,8 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
     {
         $delegatorFactory = $this->getMock('Zend\\ServiceManager\\DelegatorFactoryInterface');
         $pluginManager = $this->getMockForAbstractClass('Zend\ServiceManager\AbstractPluginManager');
-        $realService = $this->getMock('stdClass', [], [], 'RealService');
-        $delegator = $this->getMock('stdClass', [], [], 'Delegator');
+        $realService = $this->getMock('stdClass', array(), array(), 'RealService');
+        $delegator = $this->getMock('stdClass', array(), array(), 'Delegator');
 
         $delegatorFactory
             ->expects($this->once())


### PR DESCRIPTION
Mimic the same behaviour in the `AbstractPluginManager::createFromInvokable` as in the `ServiceManager::createFromInvokable`.

This could have been resolved by adding a check in the `ServiceManager::setInvokable` but that could potentially break a lot of peoples modules when they register **optional** invokables for extensions that are not loaded. 
