### PR TITLE
Use session_status when available to better detect if the session exists

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -58,9 +58,15 @@ class SessionManager extends AbstractManager
      */
     public function sessionExists()
     {
-        $sid = defined('SID') ? constant('SID') : false;
-        if ($sid !== false && $this->getId()) {
-            return true;
+        if (function_exists('session_status')) {
+            if (session_status() === PHP_SESSION_ACTIVE) {
+                return true;
+            }
+        } else {
+            $sid = defined('SID') ? constant('SID') : false;
+            if ($sid !== false && $this->getId()) {
+                return true;
+            }
         }
         if (headers_sent()) {
             return true;


### PR DESCRIPTION
In php 5.4.0 the [session_status()](http://nl1.php.net/manual/en/function.session-status.php) function was implemented which allows to determine if the session was already started without weird checks.

This patch makes `SessionManager::sessionExists` use this function when available and falls back to the old behaviour on php<5.4
