### PR TITLE
Hotfix: #6386 #6496 validator chain merge type mismatch

### DIFF
--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -262,7 +262,7 @@ class ValidatorChain implements
     public function merge(ValidatorChain $validatorChain)
     {
         foreach ($validatorChain->validators->toArray(PriorityQueue::EXTR_BOTH) as $item) {
-            $this->attach($item['data'], $item['priority']);
+            $this->attach($item['data']['instance'], $item['data']['breakChainOnFailure'], $item['priority']);
         }
 
         return $this;

--- a/library/Zend/Validator/ValidatorChain.php
+++ b/library/Zend/Validator/ValidatorChain.php
@@ -300,6 +300,14 @@ class ValidatorChain implements
     }
 
     /**
+     * Deep clone handling
+     */
+    public function __clone()
+    {
+        $this->validators = clone $this->validators;
+    }
+
+    /**
      * Prepare validator chain for serialization
      *
      * Plugin manager (property 'plugins') cannot

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -202,6 +202,26 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $this->validator->getValidators());
     }
 
+    /**
+     * @group 6386
+     * @group 6496
+     */
+    public function testValidatorChainIsCloneable()
+    {
+        $this->validator->attach(new NotEmpty());
+
+        $this->assertCount(1, $this->validator->getValidators());
+
+        $clonedValidatorChain = clone $this->validator;
+
+        $this->assertCount(1, $clonedValidatorChain->getValidators());
+
+        $clonedValidatorChain->attach(new NotEmpty());
+
+        $this->assertCount(1, $this->validator->getValidators());
+        $this->assertCount(2, $clonedValidatorChain->getValidators());
+    }
+
     public function testCountGivesCountOfAttachedValidators()
     {
         $this->populateValidatorChain();

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -186,6 +186,22 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('error', $messages);
     }
 
+    /**
+     * @group 6386
+     * @group 6496
+     */
+    public function testMergeValidatorChains()
+    {
+        $mergedValidatorChain = new ValidatorChain();
+
+        $mergedValidatorChain->attach($this->getValidatorTrue());
+        $this->validator->attach($this->getValidatorTrue());
+
+        $this->validator->merge($mergedValidatorChain);
+
+        $this->assertCount(2, $this->validator->getValidators());
+    }
+
     public function testCountGivesCountOfAttachedValidators()
     {
         $this->populateValidatorChain();


### PR DESCRIPTION
#6386 #6496 brought in a regression caused by Zend\Validator\ValidatorChain#merge() internal bugs. This PR fixes those implementation issues.

Based on previous PR #6910 #6911
