### PR TITLE
Fix: Remove unused parameter and class property

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Oci8/Oci8.php
+++ b/library/Zend/Db/Adapter/Driver/Oci8/Oci8.php
@@ -36,25 +36,15 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     protected $profiler = null;
 
     /**
-     * @var array
-     */
-    protected $options = array(
-
-    );
-
-    /**
      * @param array|Connection|\oci8 $connection
      * @param null|Statement $statementPrototype
      * @param null|Result $resultPrototype
-     * @param array $options
      */
-    public function __construct($connection, Statement $statementPrototype = null, Result $resultPrototype = null, array $options = array())
+    public function __construct($connection, Statement $statementPrototype = null, Result $resultPrototype = null)
     {
         if (!$connection instanceof Connection) {
             $connection = new Connection($connection);
         }
-
-        $options = array_intersect_key(array_merge($this->options, $options), $this->options);
 
         $this->registerConnection($connection);
         $this->registerStatementPrototype(($statementPrototype) ?: new Statement());


### PR DESCRIPTION
Injecting `$options` has no effect and class property `$options` is never used.
