### PR TITLE
Fix: More unused local variables

### DIFF
--- a/library/Zend/Db/Metadata/Source/SqliteMetadata.php
+++ b/library/Zend/Db/Metadata/Source/SqliteMetadata.php
@@ -260,8 +260,6 @@ class SqliteMetadata extends AbstractSource
     {
         static $re = null;
         if (null === $re) {
-            $identifier = $this->getIdentifierRegularExpression();
-            $identifierList = $this->getIdentifierListRegularExpression();
             $identifierChain = $this->getIdentifierChainRegularExpression();
             $re = $this->buildRegularExpression(array(
                 'CREATE',


### PR DESCRIPTION
Variables `$identifier` and `$identifierList` are never used.
