### PR TITLE
di/instanceManager ignores call time parameters of array

### DIFF
--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -238,7 +238,7 @@ class Di implements DependencyInjectionInterface
                 return $im->getSharedInstanceWithParameters(null, array(), $fastHash);
             }
         } elseif ($im->hasSharedInstance($name)) {
-                array_pop($this->instanceContext);
+            array_pop($this->instanceContext);
             return $im->getSharedInstance($name);
         }
 

--- a/library/Zend/Di/Di.php
+++ b/library/Zend/Di/Di.php
@@ -237,11 +237,9 @@ class Di implements DependencyInjectionInterface
                 array_pop($this->instanceContext);
                 return $im->getSharedInstanceWithParameters(null, array(), $fastHash);
             }
-        }
-
-        if ($im->hasSharedInstance($name, $callParameters)) {
-            array_pop($this->instanceContext);
-            return $im->getSharedInstance($name, $callParameters);
+        } elseif ($im->hasSharedInstance($name)) {
+                array_pop($this->instanceContext);
+            return $im->getSharedInstance($name);
         }
 
 

--- a/library/Zend/Di/InstanceManager.php
+++ b/library/Zend/Di/InstanceManager.php
@@ -502,7 +502,12 @@ class InstanceManager /* implements InstanceManagerInterface */
                     $hashValue .= $param . '|';
                     break;
                 case 'array':
-                    $hashValue .= 'Array|';
+                    try {
+                        $hashValue .= serialize($param) . '|';
+                    } catch (\Exception $ex) {
+                        //not serializable
+                        $hashValue .= 'Array|';
+                    }
                     break;
                 case 'resource':
                     $hashValue .= 'resource|';

--- a/tests/ZendTest/Di/DiTest.php
+++ b/tests/ZendTest/Di/DiTest.php
@@ -1029,72 +1029,57 @@ class DiTest extends \PHPUnit_Framework_TestCase
      * constructor injection consultation
      *
      * @group 4714
-     * @group 6388
      */
     public function testResolveMethodParametersDifferentParams()
     {
-        $config = array(
-            'instance' => array(
-                'preference' => array(
-                    'ZendTest\\Di\\TestAsset\\ConstructorInjection\\A' => 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\E',
-                ),
-            ),
-        );
-        $di = new Di(null, null, new Config($config));
+        $di = new Di;
         $ref = new \ReflectionObject($di);
         $method = $ref->getMethod('resolveMethodParameters');
         $method->setAccessible(true);
 
-        $args = array(
-            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
-            '__construct',
-            array(),
-            null,
-            Di::METHOD_IS_CONSTRUCTOR,
-            true
-        );
-        $res = $method->invokeArgs($di, $args);
-        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\E', $res[0], 'the first resolved parameter for constructor type preferenced');
-
-        //user provides params
-        $args = array(
-            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
-            '__construct',
-            array('a' => 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F'),
-            null,
-            Di::METHOD_IS_CONSTRUCTOR,
-            true
-        );
-        $res = $method->invokeArgs($di, $args);
-        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $res[0], 'the first resolved parameter user provided ');
+        $constructorInjectionClassName = 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B';
+        /**
+         * RuntimeDefinition get the label of Class B constructor
+         *  public function __construct(A $a)
+         */
+        $parameterName = 'a';
+        /**
+         * Class F as subclass of A gets the parameters as constructor injection
+         */
+        $paramsAwareSubClassName = 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F';
+        /**
+         * aliases having defferent parameters
+         */
+        $instanceAliasFoo = 'foo';
+        $instanceAliasBar = 'bar';
 
         //user provides alias name
         $im = $di->instanceManager();
-        $im->addAlias('foo', 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', array('params' => array('p' => 'v1')));
-        $im->addAlias('bar', 'ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', array('params' => array('p' => 'v2')));
+        $im->addAlias($instanceAliasFoo, $paramsAwareSubClassName, array('params' => array('p' => 'v1')));
+        $im->addAlias($instanceAliasBar, $paramsAwareSubClassName, array('params' => array('p' => 'v2')));
 
         $args = array(
-            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
+            $constructorInjectionClassName,
             '__construct',
-            array('a' => 'foo'),
+            array($parameterName => $instanceAliasFoo),
             null,
             Di::METHOD_IS_CONSTRUCTOR,
             true
         );
         $res = $method->invokeArgs($di, $args);
-        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $res[0], 'the first resolved parameter user provided with alias parameter');
+        $this->assertInstanceOf($paramsAwareSubClassName, $res[0], 'the first resolved parameter user provided with alias parameter');
         $this->assertEquals('v1', $res[0]->params['p']);
 
         $args = array(
-            'ZendTest\\Di\\TestAsset\\ConstructorInjection\\B',
+            $constructorInjectionClassName,
             '__construct',
-            array('a' => 'bar'),
+            array($parameterName => $instanceAliasBar),
             null,
             Di::METHOD_IS_CONSTRUCTOR,
             true
         );
         $res = $method->invokeArgs($di, $args);
-        $this->assertInstanceOf('ZendTest\\Di\\TestAsset\\ConstructorInjection\\F', $res[0], 'the first resolved parameter user provided with alias parameter');
+        $this->assertInstanceOf($paramsAwareSubClassName, $res[0], 'the first resolved parameter user provided with alias parameter');
         $this->assertEquals('v2', $res[0]->params['p']);
     }
 

--- a/tests/ZendTest/Di/InstanceManagerTest.php
+++ b/tests/ZendTest/Di/InstanceManagerTest.php
@@ -39,6 +39,34 @@ class InstanceManagerTest extends TestCase
         $this->assertSame($obj3, $im->getSharedInstanceWithParameters('foo', array('foo' => 'baz')));
     }
 
+    public function testInstanceManagerCanPersistInstancesWithArrayParameters()
+    {
+        $im = new InstanceManager();
+        $obj1 = new TestAsset\BasicClass();
+        $obj2 = new TestAsset\BasicClass();
+        $obj3 = new TestAsset\BasicClass();
+
+        $im->addSharedInstance($obj1, 'foo');
+        $im->addSharedInstanceWithParameters($obj2, 'foo', array('foo' => array('bar')));
+
+        $this->assertSame($obj1, $im->getSharedInstance('foo'));
+        $this->assertSame($obj2, $im->getSharedInstanceWithParameters('foo', array('foo' => array('bar'))));
+        $this->assertFalse($im->hasSharedInstanceWithParameters('foo', array('foo' => array())));
+
+        $im->addSharedInstanceWithParameters($obj3, 'foo', array('foo' => array('baz')));
+
+        $this->assertSame($obj2, $im->getSharedInstanceWithParameters('foo', array('foo' => array('bar'))));
+        $this->assertSame($obj3, $im->getSharedInstanceWithParameters('foo', array('foo' => array('baz'))));
+    }
+
+    public function testInstanceManagerCanPersistInstanceWithArrayWithClosure()
+    {
+        $im = new InstanceManager();
+        $obj1 = new TestAsset\BasicClass();
+        $im->addSharedInstanceWithParameters($obj1, 'foo', array('foo' => array(function(){})));
+        $this->assertSame($obj1, $im->getSharedInstanceWithParameters('foo', array('foo' => array(function(){}))));
+    }
+
     /**
      * @group AliasAlias
      */

--- a/tests/ZendTest/Di/TestAsset/ConstructorInjection/E.php
+++ b/tests/ZendTest/Di/TestAsset/ConstructorInjection/E.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset\ConstructorInjection;
+
+class E extends A
+{
+}

--- a/tests/ZendTest/Di/TestAsset/ConstructorInjection/F.php
+++ b/tests/ZendTest/Di/TestAsset/ConstructorInjection/F.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Di\TestAsset\ConstructorInjection;
+
+class F extends A
+{
+    public $params;
+
+    public function __construct(array $params = array())
+    {
+        $this->params = $params;
+    }
+}


### PR DESCRIPTION
relative #4714

InstanceManager::sharedInstancesWithParams with Hash based management ignores entries of array.This causes #4717.
