### PR TITLE
Hydrator naming strategy zend filter dependency

### DIFF
--- a/library/Zend/Stdlib/composer.json
+++ b/library/Zend/Stdlib/composer.json
@@ -19,12 +19,14 @@
     "require-dev": {
         "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-serializer": "self.version",
-        "zendframework/zend-servicemanager": "self.version"
+        "zendframework/zend-servicemanager": "self.version",
+        "zendframework/zend-filter": "self.version"
     },
     "suggest": {
         "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
         "zendframework/zend-serializer": "Zend\\Serializer component",
-        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+        "zendframework/zend-servicemanager": "To support hydrator plugin manager usage",
+        "zendframework/zend-filter": "To support naming strategy hydrator usage"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Hydrator naming strategy not working without zend filter package (Anyway not sure how zf2 dependency works)

``` php
/**
 * Class UserHydrator
 *
 * @package AppAuth\Mapper
 */
class UserHydrator extends ClassMethods
{

    /**
     * @param object $object
     *
     * @return array
     * @throws Exception
     */
    public function extract($object)
    {
        if (!$object instanceof User) {
            throw new Exception('$object must be an instance of AppAuth\Entity\User');
        }

        $data = parent::extract($object);
        return $data;
    }
```

Error:
Class 'Zend\Filter\FilterChain' not found 
/vendor/zendframework/zend-stdlib/Zend/Stdlib/Hydrator/NamingStrategy/UnderscoreNamingStrategy.php

``` php
 protected function getCamelCaseToUnderscoreFilter()
{
if (static::$camelCaseToUnderscoreFilter instanceof FilterChain) {
return static::$camelCaseToUnderscoreFilter;
}
$filter = new FilterChain();
$filter->attachByName('WordCamelCaseToUnderscore');
$filter->attachByName('StringToLower');
```
