### PR TITLE
Added consts for left and right outer joins

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -44,6 +44,10 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     const JOIN_OUTER = 'outer';
     const JOIN_LEFT = 'left';
     const JOIN_RIGHT = 'right';
+    const JOIN_RIGHT_OUTER = 'outer right';
+    const JOIN_LEFT_OUTER  = 'outer left';
+    const JOIN_RIGHT_INNER = 'inner right';
+    const JOIN_LEFT_INNER = 'inner left';
     const SQL_STAR = '*';
     const ORDER_ASCENDING = 'ASC';
     const ORDER_DESCENDING = 'DESC';

--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -44,10 +44,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
     const JOIN_OUTER = 'outer';
     const JOIN_LEFT = 'left';
     const JOIN_RIGHT = 'right';
-    const JOIN_RIGHT_OUTER = 'outer right';
-    const JOIN_LEFT_OUTER  = 'outer left';
-    const JOIN_RIGHT_INNER = 'inner right';
-    const JOIN_LEFT_INNER = 'inner left';
+    const JOIN_OUTER_RIGHT = 'outer right';
+    const JOIN_OUTER_LEFT  = 'outer left';
     const SQL_STAR = '*';
     const ORDER_ASCENDING = 'ASC';
     const ORDER_DESCENDING = 'DESC';


### PR DESCRIPTION
Currently you have to pass string and manually specify the join type if it's not included in constants.
