### PR TITLE
fix #6814: ignore php 5.5 scalar class name resolution

### DIFF
--- a/library/Zend/File/ClassFileLocator.php
+++ b/library/Zend/File/ClassFileLocator.php
@@ -116,6 +116,10 @@ class ClassFileLocator extends FilterIterator
                     break;
                 case $t_trait:
                 case T_CLASS:
+                    // ignore T_CLASS after T_DOUBLE_COLON to allow PHP >=5.5 FQCN scalar resolution
+                    if ($i > 0 && is_array($tokens[$i-1]) && $tokens[$i-1][0] === T_DOUBLE_COLON) {
+                        break;
+                    }
                 case T_INTERFACE:
                     // Abstract class, class, interface or trait found
 

--- a/tests/ZendTest/File/ClassFileLocatorTest.php
+++ b/tests/ZendTest/File/ClassFileLocatorTest.php
@@ -132,4 +132,19 @@ class ClassFileLocatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($foundThird);
         $this->assertTrue($foundFourth);
     }
+
+    public function testIterationShouldNotCountFQCNScalarResolutionConstantAsClass()
+    {
+        if (version_compare(PHP_VERSION, "5.5", "<")) {
+            $this->markTestSkipped('Only applies to PHP >=5.5');
+        }
+
+        $locator = new ClassFileLocator(__DIR__ .'/TestAsset');
+        foreach ($locator as $file) {
+            if (! preg_match('/ClassNameResolutionCompatibility\.php$/', $file->getFilename())) {
+                continue;
+            }
+            $this->assertCount(1, $file->getClasses());
+        }
+    }
 }

--- a/tests/ZendTest/File/TestAsset/ClassNameResolutionCompatibility.php
+++ b/tests/ZendTest/File/TestAsset/ClassNameResolutionCompatibility.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\File\TestAsset;
+
+use stdClass;
+
+class ClassNameResolutionCompatibility
+{
+    protected $someClassNames = [
+        stdClass::class,
+        stdClass::class,
+    ];
+}


### PR DESCRIPTION
fix #6814: ignore php 5.5 scalar class name resolution
