### PR TITLE
change event type in BootstrapListenerInterface; implement more feature ...

### DIFF
--- a/library/Zend/ModuleManager/Feature/BootstrapListenerInterface.php
+++ b/library/Zend/ModuleManager/Feature/BootstrapListenerInterface.php
@@ -9,7 +9,7 @@
 
 namespace Zend\ModuleManager\Feature;
 
-use Zend\EventManager\EventInterface;
+use Zend\Mvc\MvcEvent;
 
 /**
  * Bootstrap listener provider interface
@@ -19,8 +19,8 @@ interface BootstrapListenerInterface
     /**
      * Listen to the bootstrap event
      *
-     * @param EventInterface $e
+     * @param MvcEvent $e
      * @return array
      */
-    public function onBootstrap(EventInterface $e);
+    public function onBootstrap(MvcEvent $e);
 }

--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -94,10 +94,10 @@ class LocatorRegistrationListener extends AbstractListener implements
      *
      * @TODO: Check the application / locator / etc a bit better to make sure
      * the env looks how we're expecting it to?
-     * @param Event $e
+     * @param MvcEvent $e
      * @return void
      */
-    public function onBootstrap(Event $e)
+    public function onBootstrap(MvcEvent $e)
     {
         $application = $e->getApplication();
         $services    = $application->getServiceManager();

--- a/library/Zend/Mvc/View/Console/ViewManager.php
+++ b/library/Zend/Mvc/View/Console/ViewManager.php
@@ -25,10 +25,10 @@ class ViewManager extends BaseViewManager
      * algorithms, as well as to ensure we pick up the Console variants
      * of several listeners and strategies.
      *
-     * @param  $event
+     * @param MvcEvent $event
      * @return void
      */
-    public function onBootstrap($event)
+    public function onBootstrap(MvcEvent $event)
     {
         $application  = $event->getApplication();
         $services     = $application->getServiceManager();

--- a/library/Zend/Mvc/View/Http/ViewManager.php
+++ b/library/Zend/Mvc/View/Http/ViewManager.php
@@ -87,10 +87,10 @@ class ViewManager extends AbstractListenerAggregate
     /**
      * Prepares the view layer
      *
-     * @param  $event
+     * @param MvcEvent $event
      * @return void
      */
-    public function onBootstrap($event)
+    public function onBootstrap(MvcEvent $event)
     {
         $application  = $event->getApplication();
         $services     = $application->getServiceManager();

--- a/tests/ZendTest/ModuleManager/TestAsset/ListenerTestModule/Module.php
+++ b/tests/ZendTest/ModuleManager/TestAsset/ListenerTestModule/Module.php
@@ -10,21 +10,26 @@
 namespace ListenerTestModule;
 
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
+use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Zend\ModuleManager\Feature\InitProviderInterface;
 use Zend\ModuleManager\Feature\LocatorRegisteredInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
-use Zend\EventManager\EventInterface;
+use Zend\ModuleManager\ModuleManagerInterface;
+use Zend\Mvc\MvcEvent;
 
 class Module implements
     AutoloaderProviderInterface,
-    LocatorRegisteredInterface,
-    BootstrapListenerInterface
+    BootstrapListenerInterface,
+    ConfigProviderInterface,
+    InitProviderInterface,
+    LocatorRegisteredInterface
 {
     public $initCalled = false;
     public $getConfigCalled = false;
     public $getAutoloaderConfigCalled = false;
     public $onBootstrapCalled = false;
 
-    public function init($moduleManager = null)
+    public function init(ModuleManagerInterface $moduleManager = null)
     {
         $this->initCalled = true;
     }
@@ -49,7 +54,7 @@ class Module implements
         );
     }
 
-    public function onBootstrap(EventInterface $e)
+    public function onBootstrap(MvcEvent $e)
     {
         $this->onBootstrapCalled = true;
     }

--- a/tests/ZendTest/Mvc/TestAsset/MockViewManager.php
+++ b/tests/ZendTest/Mvc/TestAsset/MockViewManager.php
@@ -20,7 +20,7 @@ class MockViewManager extends AbstractListenerAggregate
         $this->listeners[] = $events->attach(MvcEvent::EVENT_BOOTSTRAP, array($this, 'onBootstrap'), 10000);
     }
 
-    public function onBootstrap($e)
+    public function onBootstrap(MvcEvent $e)
     {
     }
 }

--- a/tests/ZendTest/Mvc/TestAsset/StubBootstrapListener.php
+++ b/tests/ZendTest/Mvc/TestAsset/StubBootstrapListener.php
@@ -42,7 +42,7 @@ class StubBootstrapListener implements ListenerAggregateInterface
         return $this->listeners;
     }
 
-    public function onBootstrap($e)
+    public function onBootstrap(MvcEvent $e)
     {
     }
 }

--- a/tests/ZendTest/Test/_files/ModuleWithEvents/Module.php
+++ b/tests/ZendTest/Test/_files/ModuleWithEvents/Module.php
@@ -9,18 +9,19 @@
 
 namespace ModuleWithEvents;
 
+use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\Mvc\MvcEvent;
 
-class Module
+class Module implements BootstrapListenerInterface
 {
-    public function onBootstrap($e)
+    public function onBootstrap(MvcEvent $e)
     {
         $application = $e->getApplication();
         $events      = $application->getEventManager();
         $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onRoute'), -1000);
     }
 
-    public function onRoute($e)
+    public function onRoute(MvcEvent $e)
     {
         $routeMatch = $e->getRouteMatch();
         if ($routeMatch->getMatchedRouteName() == "myroutebis") {


### PR DESCRIPTION
As discussed in #6944, this PR specializes the event type accepted by the `onBootsrap` method from `Zend\EventManager\EventInterface` to `Zend\Mvc\MvcEvent`. It make sense as the `Zend\Mvc\MvcEvent` has additional methods. Also add some provider interfaces in the unittests.
