### PR TITLE
Use hydrator variable only when hydrator variable is assigned

### DIFF
--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -440,21 +440,21 @@ class Factory
 
         if (is_string($hydratorOrName)) {
             $hydrator = $this->getHydratorFromName($hydratorOrName);
-
-            if (!$hydrator instanceof Hydrator\HydratorInterface) {
-                throw new Exception\DomainException(sprintf(
-                    '%s expects a valid implementation of Zend\Stdlib\Hydrator\HydratorInterface; received "%s"',
-                    $method,
-                    $hydratorOrName
-                ));
-            }
-
-            if (!empty($hydratorOptions) && $hydrator instanceof Hydrator\HydratorOptionsInterface) {
-                $hydrator->setOptions($hydratorOptions);
-            }
-
-            $fieldset->setHydrator($hydrator);
         }
+
+        if (!isset($hydrator) || !$hydrator instanceof Hydrator\HydratorInterface) {
+            throw new Exception\DomainException(sprintf(
+                '%s expects a valid implementation of Zend\Stdlib\Hydrator\HydratorInterface; received "%s"',
+                $method,
+                $hydratorOrName
+            ));
+        }
+
+        if (!empty($hydratorOptions) && $hydrator instanceof Hydrator\HydratorOptionsInterface) {
+            $hydrator->setOptions($hydratorOptions);
+        }
+
+        $fieldset->setHydrator($hydrator);
     }
 
     /**

--- a/library/Zend/Form/Factory.php
+++ b/library/Zend/Form/Factory.php
@@ -440,21 +440,21 @@ class Factory
 
         if (is_string($hydratorOrName)) {
             $hydrator = $this->getHydratorFromName($hydratorOrName);
-        }
 
-        if (!$hydrator instanceof Hydrator\HydratorInterface) {
-            throw new Exception\DomainException(sprintf(
-                '%s expects a valid implementation of Zend\Stdlib\Hydrator\HydratorInterface; received "%s"',
-                $method,
-                $hydratorOrName
-            ));
-        }
+            if (!$hydrator instanceof Hydrator\HydratorInterface) {
+                throw new Exception\DomainException(sprintf(
+                    '%s expects a valid implementation of Zend\Stdlib\Hydrator\HydratorInterface; received "%s"',
+                    $method,
+                    $hydratorOrName
+                ));
+            }
 
-        if (!empty($hydratorOptions) && $hydrator instanceof Hydrator\HydratorOptionsInterface) {
-            $hydrator->setOptions($hydratorOptions);
-        }
+            if (!empty($hydratorOptions) && $hydrator instanceof Hydrator\HydratorOptionsInterface) {
+                $hydrator->setOptions($hydratorOptions);
+            }
 
-        $fieldset->setHydrator($hydrator);
+            $fieldset->setHydrator($hydrator);
+        }
     }
 
     /**

--- a/tests/ZendTest/Form/FactoryTest.php
+++ b/tests/ZendTest/Form/FactoryTest.php
@@ -718,6 +718,19 @@ class FactoryTest extends TestCase
         $this->assertSame($fieldset->getFormFactory()->getFormElementManager(), $this->factory->getFormElementManager());
     }
 
+
+    /**
+     * @expectedException \Zend\Form\Exception\DomainException
+     */
+    public function testPrepareAndInjectWillThrowAndException()
+    {
+        $fieldset = $this->factory->createFieldset(array('name' => 'myFieldset'));
+        $spec = array(
+            'hydrator' => 0
+        );
+        $this->factory->configureFieldset($fieldset, $spec);
+    }
+
     public function testCanCreateFormWithNullElements()
     {
         $form = $this->factory->createForm(array(


### PR DESCRIPTION
The hydrator variable is not in use before $this->getHydratorFromName() is called. i just fixed the structure.
