### PR TITLE
Move error view model generation methods to abstract controller

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -12,7 +12,6 @@ namespace Zend\Mvc\Controller;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
-use Zend\View\Model\ConsoleModel;
 use Zend\View\Model\ViewModel;
 
 /**
@@ -85,33 +84,5 @@ abstract class AbstractActionController extends AbstractController
         $e->setResult($actionResponse);
 
         return $actionResponse;
-    }
-
-    /**
-     * Create an HTTP view model representing a "not found" page
-     *
-     * @param  HttpResponse $response
-     * @return ViewModel
-     */
-    protected function createHttpNotFoundModel(HttpResponse $response)
-    {
-        $response->setStatusCode(404);
-        return new ViewModel(array(
-            'content' => 'Page not found',
-        ));
-    }
-
-    /**
-     * Create a console view model representing a "not found" action
-     *
-     * @param  \Zend\Stdlib\ResponseInterface $response
-     * @return ConsoleModel
-     */
-    protected function createConsoleNotFoundModel($response)
-    {
-        $viewModel = new ConsoleModel();
-        $viewModel->setErrorLevel(1);
-        $viewModel->setResult('Page not found');
-        return $viewModel;
     }
 }

--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -85,4 +85,14 @@ abstract class AbstractActionController extends AbstractController
 
         return $actionResponse;
     }
+
+    protected function CreateHttpNotFoundModel(HttpResponse $response)
+    {
+        return $this->__call('createHttpNotFoundModel', array($response));
+    }
+
+    protected function CreateConsoleNotFoundModel($response)
+    {
+        return $this->__call('createConsoleNotFoundModel', array($response));
+    }
 }

--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -13,6 +13,8 @@ use Zend\Http\Response as HttpResponse;
 use Zend\Mvc\Exception;
 use Zend\Mvc\MvcEvent;
 use Zend\View\Model\ViewModel;
+use Zend\View\Model\ConsoleModel;
+use Zend\Stdlib\ResponseInterface;
 
 /**
  * Basic action controller
@@ -31,9 +33,9 @@ abstract class AbstractActionController extends AbstractController
      */
     public function indexAction()
     {
-        return new ViewModel(array(
+        return new ViewModel([
             'content' => 'Placeholder page'
-        ));
+        ]);
     }
 
     /**
@@ -86,13 +88,25 @@ abstract class AbstractActionController extends AbstractController
         return $actionResponse;
     }
 
+    /**
+     * Create an HTTP view model representing a "not found" page
+     *
+     * @param  HttpResponse $response
+     * @return ViewModel
+     */
     protected function CreateHttpNotFoundModel(HttpResponse $response)
     {
-        return $this->__call('createHttpNotFoundModel', array($response));
+        return $this->__call('createHttpNotFoundModel', [$response]);
     }
 
+    /**
+     * Create a console view model representing a "not found" action
+     *
+     * @param  ResponseInterface $response
+     * @return ConsoleModel
+     */
     protected function CreateConsoleNotFoundModel($response)
     {
-        return $this->__call('createConsoleNotFoundModel', array($response));
+        return $this->__call('createConsoleNotFoundModel', [$response]);
     }
 }

--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -94,7 +94,7 @@ abstract class AbstractActionController extends AbstractController
      * @param  HttpResponse $response
      * @return ViewModel
      */
-    protected function CreateHttpNotFoundModel(HttpResponse $response)
+    protected function createHttpNotFoundModel(HttpResponse $response)
     {
         return $this->__call('createHttpNotFoundModel', [$response]);
     }
@@ -105,7 +105,7 @@ abstract class AbstractActionController extends AbstractController
      * @param  ResponseInterface $response
      * @return ConsoleModel
      */
-    protected function CreateConsoleNotFoundModel($response)
+    protected function createConsoleNotFoundModel($response)
     {
         return $this->__call('createConsoleNotFoundModel', [$response]);
     }

--- a/library/Zend/Mvc/Controller/AbstractActionController.php
+++ b/library/Zend/Mvc/Controller/AbstractActionController.php
@@ -33,9 +33,9 @@ abstract class AbstractActionController extends AbstractController
      */
     public function indexAction()
     {
-        return new ViewModel([
+        return new ViewModel(array(
             'content' => 'Placeholder page'
-        ]);
+        ));
     }
 
     /**
@@ -96,7 +96,7 @@ abstract class AbstractActionController extends AbstractController
      */
     protected function createHttpNotFoundModel(HttpResponse $response)
     {
-        return $this->__call('createHttpNotFoundModel', [$response]);
+        return $this->__call('createHttpNotFoundModel', array($response));
     }
 
     /**
@@ -107,6 +107,6 @@ abstract class AbstractActionController extends AbstractController
      */
     protected function createConsoleNotFoundModel($response)
     {
-        return $this->__call('createConsoleNotFoundModel', [$response]);
+        return $this->__call('createConsoleNotFoundModel', array($response));
     }
 }

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -22,8 +22,6 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\DispatchableInterface as Dispatchable;
 use Zend\Stdlib\RequestInterface as Request;
 use Zend\Stdlib\ResponseInterface as Response;
-use Zend\View\Model\ConsoleModel;
-use Zend\View\Model\ViewModel;
 
 /**
  * Abstract controller
@@ -91,7 +89,6 @@ abstract class AbstractController implements
      * @return mixed
      */
     abstract public function onDispatch(MvcEvent $e);
-
 
     /**
      * Dispatch a request
@@ -333,33 +330,5 @@ abstract class AbstractController implements
         $method .= 'Action';
 
         return $method;
-    }
-
-    /**
-     * Create an HTTP view model representing a "not found" page
-     *
-     * @param  HttpResponse $response
-     * @return ViewModel
-     */
-    protected function createHttpNotFoundModel(HttpResponse $response)
-    {
-        $response->setStatusCode(404);
-        return new ViewModel(array(
-            'content' => 'Page not found',
-        ));
-    }
-
-    /**
-     * Create a console view model representing a "not found" action
-     *
-     * @param  \Zend\Stdlib\ResponseInterface $response
-     * @return ConsoleModel
-     */
-    protected function createConsoleNotFoundModel($response)
-    {
-        $viewModel = new ConsoleModel();
-        $viewModel->setErrorLevel(1);
-        $viewModel->setResult('Page not found');
-        return $viewModel;
     }
 }

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -40,6 +40,8 @@ use Zend\Stdlib\ResponseInterface as Response;
  * @method \Zend\Http\Response|array postRedirectGet(string $redirect = null, bool $redirectToUrl = false)
  * @method \Zend\Mvc\Controller\Plugin\Redirect redirect()
  * @method \Zend\Mvc\Controller\Plugin\Url url()
+ * @method \Zend\Mvc\Controller\Plugin\CreateConsoleNotFoundModel createConsoleNotFoundModel()
+ * @method \Zend\Mvc\Controller\Plugin\CreateHttpNotFoundModel createHttpNotFoundModel()
  */
 abstract class AbstractController implements
     Dispatchable,

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -22,6 +22,8 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\DispatchableInterface as Dispatchable;
 use Zend\Stdlib\RequestInterface as Request;
 use Zend\Stdlib\ResponseInterface as Response;
+use Zend\View\Model\ConsoleModel;
+use Zend\View\Model\ViewModel;
 
 /**
  * Abstract controller
@@ -331,5 +333,33 @@ abstract class AbstractController implements
         $method .= 'Action';
 
         return $method;
+    }
+
+    /**
+     * Create an HTTP view model representing a "not found" page
+     *
+     * @param  HttpResponse $response
+     * @return ViewModel
+     */
+    protected function createHttpNotFoundModel(HttpResponse $response)
+    {
+        $response->setStatusCode(404);
+        return new ViewModel(array(
+            'content' => 'Page not found',
+        ));
+    }
+
+    /**
+     * Create a console view model representing a "not found" action
+     *
+     * @param  \Zend\Stdlib\ResponseInterface $response
+     * @return ConsoleModel
+     */
+    protected function createConsoleNotFoundModel($response)
+    {
+        $viewModel = new ConsoleModel();
+        $viewModel->setErrorLevel(1);
+        $viewModel->setResult('Page not found');
+        return $viewModel;
     }
 }

--- a/library/Zend/Mvc/Controller/Plugin/CreateConsoleNotFoundModel.php
+++ b/library/Zend/Mvc/Controller/Plugin/CreateConsoleNotFoundModel.php
@@ -3,21 +3,23 @@
 namespace Zend\Mvc\Controller\Plugin;
 
 use Zend\View\Model\ConsoleModel;
+use Zend\Feed\Reader\Http\ResponseInterface;
 
 /**
  * Create a console view model representing a "not found" action
  */
- class CreateConsoleNotFoundModel extends AbstractPlugin
+class CreateConsoleNotFoundModel extends AbstractPlugin
 {
-     /**
-      * @param  \Zend\Stdlib\ResponseInterface $response
-      * @return ConsoleModel
-      */
-     public function __invoke($response)
-     {
-         $viewModel = new ConsoleModel();
-         $viewModel->setErrorLevel(1);
-         $viewModel->setResult('Page not found');
-         return $viewModel;
-     }
-} 
+    /**
+     * @param  ResponseInterface $response
+     * @return ConsoleModel
+     */
+    public function __invoke($response)
+    {
+        $viewModel = new ConsoleModel();
+        $viewModel->setErrorLevel(1);
+        $viewModel->setResult('Page not found');
+
+        return $viewModel;
+    }
+}

--- a/library/Zend/Mvc/Controller/Plugin/CreateConsoleNotFoundModel.php
+++ b/library/Zend/Mvc/Controller/Plugin/CreateConsoleNotFoundModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zend\Mvc\Controller\Plugin;
+
+use Zend\View\Model\ConsoleModel;
+
+/**
+ * Create a console view model representing a "not found" action
+ */
+ class CreateConsoleNotFoundModel extends AbstractPlugin
+{
+     /**
+      * @param  \Zend\Stdlib\ResponseInterface $response
+      * @return ConsoleModel
+      */
+     public function __invoke($response)
+     {
+         $viewModel = new ConsoleModel();
+         $viewModel->setErrorLevel(1);
+         $viewModel->setResult('Page not found');
+         return $viewModel;
+     }
+} 

--- a/library/Zend/Mvc/Controller/Plugin/CreateConsoleNotFoundModel.php
+++ b/library/Zend/Mvc/Controller/Plugin/CreateConsoleNotFoundModel.php
@@ -3,7 +3,7 @@
 namespace Zend\Mvc\Controller\Plugin;
 
 use Zend\View\Model\ConsoleModel;
-use Zend\Feed\Reader\Http\ResponseInterface;
+use Zend\Stdlib\ResponseInterface;
 
 /**
  * Create a console view model representing a "not found" action

--- a/library/Zend/Mvc/Controller/Plugin/CreateHttpNotFoundModel.php
+++ b/library/Zend/Mvc/Controller/Plugin/CreateHttpNotFoundModel.php
@@ -19,9 +19,9 @@ class CreateHttpNotFoundModel extends AbstractPlugin
         $response->setStatusCode(404);
 
         return new ViewModel(
-            [
+            array(
                 'content' => 'Page not found',
-            ]
+            )
         );
     }
 }

--- a/library/Zend/Mvc/Controller/Plugin/CreateHttpNotFoundModel.php
+++ b/library/Zend/Mvc/Controller/Plugin/CreateHttpNotFoundModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Zend\Mvc\Controller\Plugin;
+
+use Zend\Http\PhpEnvironment\Response;
+use Zend\View\Model\ViewModel;
+
+/**
+ * Create an HTTP view model representing a "not found" page
+ */
+class CreateHttpNotFoundModel extends AbstractPlugin
+{
+    /**
+     * @param  Response $response
+     * @return ViewModel
+     */
+    public function __invoke(Response $response)
+    {
+        $response->setStatusCode(404);
+
+        return new ViewModel([
+            'content' => 'Page not found',
+        ]);
+    }
+} 

--- a/library/Zend/Mvc/Controller/Plugin/CreateHttpNotFoundModel.php
+++ b/library/Zend/Mvc/Controller/Plugin/CreateHttpNotFoundModel.php
@@ -18,8 +18,10 @@ class CreateHttpNotFoundModel extends AbstractPlugin
     {
         $response->setStatusCode(404);
 
-        return new ViewModel([
-            'content' => 'Page not found',
-        ]);
+        return new ViewModel(
+            [
+                'content' => 'Page not found',
+            ]
+        );
     }
-} 
+}

--- a/library/Zend/Mvc/Controller/PluginManager.php
+++ b/library/Zend/Mvc/Controller/PluginManager.php
@@ -45,6 +45,8 @@ class PluginManager extends AbstractPluginManager
         'postredirectget'             => 'Zend\Mvc\Controller\Plugin\PostRedirectGet',
         'redirect'                    => 'Zend\Mvc\Controller\Plugin\Redirect',
         'url'                         => 'Zend\Mvc\Controller\Plugin\Url',
+        'createhttpnotfoundmodel'     => 'Zend\Mvc\Controller\Plugin\CreateHttpNotFoundModel',
+        'createconsolenotfoundmodel'  => 'Zend\Mvc\Controller\Plugin\CreateConsoleNotFoundModel',
     );
 
     /**

--- a/tests/ZendTest/Mvc/Controller/Plugin/CreateConsoleNotFoundModelTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/CreateConsoleNotFoundModelTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ZendTest\Mvc\Controller\Plugin;
+
+use PHPUnit_framework_TestCase as TestCase;
+use Zend\Console\Request;
+use Zend\Console\Response;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\Console\RouteMatch;
+use ZendTest\Mvc\Controller\TestAsset\SampleController;
+
+class CreateConsoleNotFoundModelTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new Request;
+        $event         = new MvcEvent;
+
+        $event->setRequest($this->request);
+        $event->setResponse(new Response);
+        $event->setRouteMatch(new RouteMatch(array()));
+
+        $this->controller = new SampleController;
+        $this->controller->setEvent($event);
+
+        $this->plugin = $this->controller->plugin('createConsoleNotFoundModel');
+    }
+
+    public function testIfCanReturnModelWithErrorMessageAndErrorLevel()
+    {
+        $response = $this->controller->getEvent()->getResponse();
+        $model    = $this->plugin->__invoke($response);
+
+        $this->assertInstanceOf('Zend\View\Model\ConsoleModel', $model);
+        $this->assertSame("Page not found", $model->getResult());
+        $this->assertSame(1, $model->getErrorLevel());
+    }
+} 

--- a/tests/ZendTest/Mvc/Controller/Plugin/CreateConsoleNotFoundModelTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/CreateConsoleNotFoundModelTest.php
@@ -35,4 +35,4 @@ class CreateConsoleNotFoundModelTest extends TestCase
         $this->assertSame("Page not found", $model->getResult());
         $this->assertSame(1, $model->getErrorLevel());
     }
-} 
+}

--- a/tests/ZendTest/Mvc/Controller/Plugin/CreateHttpNotFoundModelTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/CreateHttpNotFoundModelTest.php
@@ -35,4 +35,4 @@ class CreateHttpNotFoundModelTest extends TestCase
         $this->assertSame("Page not found", $model->getVariable('content'));
         $this->assertSame(404, $response->getStatusCode());
     }
-} 
+}

--- a/tests/ZendTest/Mvc/Controller/Plugin/CreateHttpNotFoundModelTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/CreateHttpNotFoundModelTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ZendTest\Mvc\Controller\Plugin;
+
+use PHPUnit_framework_TestCase as TestCase;
+use Zend\Http\Request;
+use Zend\Http\PhpEnvironment\Response;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\Http\RouteMatch;
+use ZendTest\Mvc\Controller\TestAsset\SampleController;
+
+class CreateHttpNotFoundModelTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new Request;
+        $event         = new MvcEvent;
+
+        $event->setRequest($this->request);
+        $event->setResponse(new Response);
+        $event->setRouteMatch(new RouteMatch(array()));
+
+        $this->controller = new SampleController;
+        $this->controller->setEvent($event);
+
+        $this->plugin = $this->controller->plugin('createHttpNotFoundModel');
+    }
+
+    public function testIfCanReturnModelWithErrorMessageAndSetResponseStatusCode()
+    {
+        $response = $this->controller->getEvent()->getResponse();
+        $model    = $this->plugin->__invoke($response);
+
+        $this->assertInstanceOf('Zend\View\Model\ViewModel', $model);
+        $this->assertSame("Page not found", $model->getVariable('content'));
+        $this->assertSame(404, $response->getStatusCode());
+    }
+} 


### PR DESCRIPTION
I want those methods to be moved from the AbstractActionController to AbstractController since they're important even if you want to dispatch directly instead of having many actions (which is what i'm doing). 

Otherwise, i'll have to create my own extension of AbstractController or a trait and use it in all my project controllers, which would make necessary to have a "base" module.

The tests will still pass because the methods will be still be available in AbstractActionController, since it is an extension of AbstractController. I chose not to move the notFoundAction since it is an action and should stay in AbstractActionController.

With this update, we'll be able to:

``` php
@var MvcEvent $e
$e->setResponse($this->createHttpNotFoundModel($this->response));
```
