### PR TITLE
Bug #6958 Make sure encoding type is set when sending Request

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -864,6 +864,9 @@ class Client implements Stdlib\DispatchableInterface
             // method
             $method = $this->getRequest()->getMethod();
 
+            // this is so the correct Encoding Type is set
+            $this->setMethod($method);
+
             // body
             $body = $this->prepareBody();
 

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -406,4 +406,15 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->send($request);
     }
+
+    public function testClientRequestMethod()
+    {
+        $request = new Request;
+        $request->setMethod(Request::METHOD_POST);
+        $request->getPost()->set('data', 'random');
+
+        $client = new Client;
+        $client->setAdapter('Zend\Http\Client\Adapter\Test');
+        $client->send($request);
+    }
 }


### PR DESCRIPTION
Call Http\Client::setMethod() so Encoding Type is set.
