### PR TITLE
Added WhitelistFilter

### DIFF
--- a/library/Zend/Filter/Whitelist.php
+++ b/library/Zend/Filter/Whitelist.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
+class Whitelist extends AbstractFilter
+{
+    const TYPE_WHITELIST = 1;
+    const TYPE_BLACKLIST = 2;
+
+    /**
+     * @var array
+     */
+    protected $types = array(
+        'whitelist' => self::TYPE_WHITELIST,
+        'blacklist' => self::TYPE_BLACKLIST,
+    );
+
+    /**
+     * @var array
+     */
+    protected $options = array(
+        'type' => self::TYPE_WHITELIST,
+        'list' => array(),
+    );
+
+    /**
+     * @param null|array|Traversable $options
+     */
+    public function __construct($options = null)
+    {
+        if (!is_null($options)) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * Set list type
+     *
+     * @param $type
+     * @throws Exception\InvalidArgumentException
+     * @return self
+     */
+    public function setType($type)
+    {
+        if (is_string($type) && array_key_exists($type, $this->types)) {
+            $type = $this->types[$type];
+        }
+
+        if ($type !== self::TYPE_WHITELIST && $type !== self::TYPE_BLACKLIST) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Unknown type value.',
+                $type,
+                gettype($type)
+            ));
+        }
+
+        $this->options['type'] = $type;
+        return $this;
+    }
+
+    /**
+     * Returns the defined list type
+     *
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->options['type'];
+    }
+
+    /**
+     * Set the list of items to white/black list
+     *
+     * @param array $list
+     * @return $this
+     */
+    public function setList($list = array())
+    {
+        if ($list instanceof Traversable) {
+            $list = ArrayUtils::iteratorToArray($list);
+        }
+
+        if (is_null($list)) {
+            $list = array();
+        }
+
+        if (!is_array($list)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'List must be an array or an instance of Traversable (received "%s")',
+                gettype($list)
+            ));
+        }
+
+        $this->options['list'] = $list;
+        return $this;
+    }
+
+
+    /**
+     * Get the list of items to white/black list
+     *
+     * @return mixed
+     */
+    public function getList()
+    {
+        return $this->options['list'];
+    }
+
+    /**
+     * Will return $value if its present (whitelist mode) or absent (blacklist mode) from the value list.
+     *
+     * If $value is rejected then it will return null.
+     *
+     * @param  mixed $value
+     * @return mixed
+     */
+    public function filter($value)
+    {
+        $type = $this->getType();
+        $list = $this->getList();
+
+        $exists = in_array($value, $list);
+        $allow = $type == self::TYPE_WHITELIST ?
+            $exists :
+            !$exists;
+
+        return $allow ? $value : null;
+    }
+}

--- a/tests/ZendTest/Filter/WhitelistTest.php
+++ b/tests/ZendTest/Filter/WhitelistTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Filter;
+
+use Zend\Filter\Whitelist as WhitelistFilter;
+
+/**
+ * @group      Zend_Filter
+ */
+class WhitelistTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructorOptions()
+    {
+        $filter = new WhitelistFilter(array(
+            'type'    => WhitelistFilter::TYPE_BLACKLIST,
+            'list'    => array('test', 1),
+        ));
+
+        $this->assertEquals(WhitelistFilter::TYPE_BLACKLIST, $filter->getType());
+        $this->assertEquals($filter->getList(), array('test', 1));
+    }
+
+    public function testConstructorDefaults()
+    {
+        $filter = new WhitelistFilter();
+
+        $this->assertEquals(WhitelistFilter::TYPE_WHITELIST, $filter->getType());
+        $this->assertEquals($filter->getList(), array());
+    }
+
+    /**
+     * @param mixed $value
+     * @param bool  $expected
+     * @dataProvider defaultTestProvider
+     */
+    public function testDefault($value, $expected)
+    {
+        $filter = new WhitelistFilter();
+        $this->assertSame($expected, $filter->filter($value));
+    }
+
+    /**
+     * @param int $type
+     * @param array $testData
+     * @dataProvider typeTestProvider
+     */
+    public function testTypes($type, $testData)
+    {
+        $filter = new WhitelistFilter(array(
+            'type' => $type
+        ));
+        foreach ($testData as $data) {
+            list($value, $expected) = $data;
+            $message = sprintf(
+                '%s (%s) is not filtered as %s; type = %s',
+                var_export($value, true),
+                gettype($value),
+                var_export($expected, true),
+                $type
+            );
+            $this->assertSame($expected, $filter->filter($value), $message);
+        }
+    }
+
+    public function testSettingFalseType()
+    {
+        $filter = new WhitelistFilter();
+        $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Unknown type value');
+        $filter->setType(false);
+    }
+
+    public function testSettingTypeByName()
+    {
+        $filter = new WhitelistFilter(array(
+            'type' => 'blacklist',
+        ));
+        $this->assertEquals(WhitelistFilter::TYPE_BLACKLIST, $filter->getType());
+    }
+
+    public function testGettingDefaultType()
+    {
+        $filter = new WhitelistFilter();
+        $this->assertEquals(1, $filter->getType());
+    }
+
+    public static function defaultTestProvider()
+    {
+        return array(
+            array('test', null),
+            array(0, null),
+            array(0.1, null),
+            array(array(), null),
+            array(null, null),
+        );
+    }
+
+    public static function typeTestProvider()
+    {
+        return array(
+            array('blacklist', array(
+                array('test', 'test'),
+                array(0, 0),
+                array(0.1, 0.1),
+                array(array(), array()),
+                array(null, null),
+            )),
+            array('whitelist', array(
+                array('test', null),
+                array(0, null),
+                array(0.1, null),
+                array(array(), null),
+                array(null, null),
+            )),
+        );
+    }
+
+}


### PR DESCRIPTION
This new filter will behave either as a blacklist or a whitelist. If the value being filtered exists in the list of known values, the filter will return the value if its a whitelist or `null` if its a blacklist. The opposite will happen if value is not in the list.
### Whitelist

``` php
$whitelist = new \Zend\Filter\Whitelist(array(
    'list' => array('allowed-1', 'allowed-2')
));
echo $whitelist->filter('allowed-2');   // => 'allowed-2'
echo $whitelist->filter('not-allowed'); // => null
```
### Blacklist

``` php
$blacklist = new \Zend\Filter\Whitelist(array(
    'type' => 'blacklist', // optional, default is 'whitelist'
    'list' => array('not-allowed-1', 'not-allowed-2')
));
echo $blacklist->filter('allowed');        // => 'allowed'
echo $blacklist->filter('not-allowed-2');  // => null
```
### Notes
1. Maybe calling the filter class `Whitelist` might be counter-intuitive if the desired behavior is that of a blacklist. But I couldn't think of a better way to name the filter - something like "AllowedList" would be a synonym of "whitelist" and something like "List" would just be too vague. Open to suggestions.
2. I decided to allow only one type of configuration in the constructor (by array of options) just to keep it simple. If you'd like to allow for a more dynamic constructor (like a few other filters do) let me know.

See #6960 for more info.
