### PR TITLE
fixes #6952 / phpdoc Zend/Http/Request

### DIFF
--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -279,7 +279,7 @@ class Request extends AbstractMessage implements RequestInterface
      * Return the Cookie header, this is the same as calling $request->getHeaders()->get('Cookie');
      *
      * @convenience $request->getHeaders()->get('Cookie');
-     * @return Header\Cookie
+     * @return Header\Cookie|bool
      */
     public function getCookie()
     {


### PR DESCRIPTION
hotfix for #6952

I preferred `Header\Cookie` to `Header\HeaderInterface|ArrayIterator` because it seems to be more helpful.
