### PR TITLE
Changing encode from View Helper is not passed to EscapeHtmlAttrHelper

### DIFF
--- a/library/Zend/Form/View/Helper/AbstractHelper.php
+++ b/library/Zend/Form/View/Helper/AbstractHelper.php
@@ -183,6 +183,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
     public function setEncoding($encoding)
     {
         $this->getEscapeHtmlHelper()->setEncoding($encoding);
+        $this->getEscapeHtmlAttrHelper()->setEncoding($encoding);
         return $this;
     }
 

--- a/tests/ZendTest/Form/View/Helper/AbstractHelperTest.php
+++ b/tests/ZendTest/Form/View/Helper/AbstractHelperTest.php
@@ -8,6 +8,7 @@
  */
 
 namespace ZendTest\Form\View\Helper;
+use Zend\Escaper\Escaper;
 
 /**
  * Tests for {@see \Zend\Form\View\Helper\AbstractHelper}
@@ -33,4 +34,29 @@ class AbstractHelperTest extends CommonTestCase
             $this->helper->createAttributesString(array('data-value' => 'breaking your HTML like a boss! \\'))
         );
     }
+
+    public function testWillEncodeValueAttributeValuesCorrectly()
+    {
+
+        $string = (new Escaper('iso-8859-1'))->escapeHtmlAttr('Título');
+
+        $this->helper->setEncoding('iso-8859-1');
+
+        $this->assertSame(
+            'data-value="' . $string . '"',
+            $this->helper->createAttributesString(array('data-value' => 'Título'))
+        );
+    }
+
+    public function testWillNotEncodeValueAttributeValuesCorrectly()
+    {
+
+        $string = (new Escaper('iso-8859-1'))->escapeHtmlAttr('Título');
+
+        $this->assertNotSame(
+            'data-value="' . $string . '"',
+            $this->helper->createAttributesString(array('data-value' => 'Título'))
+        );
+    }
+
 }

--- a/tests/ZendTest/Form/View/Helper/CommonTestCase.php
+++ b/tests/ZendTest/Form/View/Helper/CommonTestCase.php
@@ -71,6 +71,17 @@ abstract class CommonTestCase extends TestCase
         $this->assertEquals('iso-8859-1', $escape->getEncoding());
     }
 
+    public function testInjectingEncodingProxiesToAttrEscapeHelper()
+    {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
+        $escape = $this->renderer->plugin('escapehtmlattr');
+        $this->helper->setEncoding('iso-8859-1');
+        $this->assertEquals('iso-8859-1', $escape->getEncoding());
+    }
+
     public function testAssumesHtml4LooseDoctypeByDefault()
     {
         if (!extension_loaded('intl')) {


### PR DESCRIPTION
Previously #6707

Ideal where using ZF2 Components on non UTF-8 encoded projects (like onto ISO-8859-1 files), because this throws a Fatal Error at Zend/Escaper/Escaper.php on line 325.
## Sample
- http://pastebin.com/8uZHm5BM
- http://pastebin.com/pwjQdFe9

Will add a Test if needed
## Stack Trace

| Nr | Function | Location |
| --- | --- | --- |
| 2 | Zend\Form\View\Helper\FormSelect->render( ) | ../zf2-select.php:12 |
| 3 | Zend\Form\View\Helper\AbstractHelper->createAttributesString( ) | ../FormSelect.php:134 |
| 4 | Zend\View\Helper\Escaper\AbstractHelper->__invoke( ) | ../AbstractHelper.php:232 |
| 5 | Zend\View\Helper\EscapeHtmlAttr->escape( ) | ../AbstractHelper.php:49 |
| 6 | Zend\Escaper\Escaper->escapeHtmlAttr( ) | ../EscapeHtmlAttr.php:26 |
| 7 | Zend\Escaper\Escaper->toUtf8( ) | ../Escaper.php:16 |
