### PR TITLE
Fixing prepended `NotEmpty` validator

### DIFF
--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -372,7 +372,14 @@ class Input implements InputInterface, EmptyContextInterface
             }
         }
 
-        $chain->prependByName('NotEmpty', array(), true);
         $this->notEmptyValidator = true;
+
+        if (class_exists('Zend\ServiceManager\AbstractPluginManager')) {
+            $chain->prependByName('NotEmpty', array(), true);
+
+            return;
+        }
+
+        $chain->prependValidator(new NotEmpty(), true);
     }
 }


### PR DESCRIPTION
When using `InputFilter` standalone (without dev dependencies), [this](https://github.com/zendframework/zf2/blob/master/library/Zend/InputFilter/Input.php#L375) is broken because [this line](https://github.com/zendframework/zf2/blob/master/library/Zend/Validator/ValidatorChain.php#L186) calls `ValidatorPluginManager`, and this class inherits `AbstractPluginManager`, that is `suggested` at [composer.json](https://github.com/zendframework/zf2/blob/master/library/Zend/InputFilter/composer.json#L26), not required.

Then the following error is thrown:
`PHP Fatal error:  Class 'Zend\ServiceManager\AbstractPluginManager' not found in /zf2/library/Zend/Validator/ValidatorPluginManager.php on line 16
`

I just changed the `prependByName` method (that uses PluginManager) to `prependValidator`, instantiating the validator by hand.
