### PR TITLE
Adapt Json\Json for better prettyPrint support

### DIFF
--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -121,7 +121,7 @@ class Json
 
             $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
 
-            if (PHP_VERSION_ID >= 50400 && $prettyPrint) {
+            if (defined(JSON_PRETTY_PRINT) && $prettyPrint) {
                 $encodeOptions |= JSON_PRETTY_PRINT;
                 $prettyPrint = false;
             }

--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -114,14 +114,28 @@ class Json
             $valueToEncode = static::_recursiveJsonExprFinder($valueToEncode, $javascriptExpressions);
         }
 
+        $prettyPrint = (isset($options['prettyPrint']) && ($options['prettyPrint'] == true));
+
         // Encoding
         if (function_exists('json_encode') && static::$useBuiltinEncoderDecoder !== true) {
+
+            $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
+
+            if (version_compare(phpversion(), '5.4', '>=') && $prettyPrint) {
+                $encodeOptions |= JSON_PRETTY_PRINT;
+                $prettyPrint = false;
+            }
+
             $encodedResult = json_encode(
                 $valueToEncode,
-                JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+                $encodeOptions
             );
         } else {
             $encodedResult = Encoder::encode($valueToEncode, $cycleCheck, $options);
+        }
+
+        if ($prettyPrint) {
+            $encodedResult = self::prettyPrint($encodedResult, array("intent" => "    "));
         }
 
         //only do post-processing to revert back the Zend\Json\Expr if any.
@@ -348,15 +362,20 @@ class Json
         $result = "";
         $indent = 0;
 
-        $ind = "\t";
+        $ind = "    ";
         if (isset($options['indent'])) {
             $ind = $options['indent'];
         }
 
         $inLiteral = false;
         foreach ($tokens as $token) {
+            $token = trim($token);
             if ($token == "") {
                 continue;
+            }
+
+            if (preg_match('/^("(?:.*)"):[ ]?(.*)$/', $token, $matches)) {
+                $token = $matches[1] . ': ' . $matches[2];
             }
 
             $prefix = str_repeat($ind, $indent);

--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -121,7 +121,7 @@ class Json
 
             $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
 
-            if (version_compare(phpversion(), '5.4', '>=') && $prettyPrint) {
+            if (PHP_VERSION_ID >= 50400 && $prettyPrint) {
                 $encodeOptions |= JSON_PRETTY_PRINT;
                 $prettyPrint = false;
             }

--- a/library/Zend/Json/Json.php
+++ b/library/Zend/Json/Json.php
@@ -121,7 +121,7 @@ class Json
 
             $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
 
-            if (defined(JSON_PRETTY_PRINT) && $prettyPrint) {
+            if ($prettyPrint && defined('JSON_PRETTY_PRINT')) {
                 $encodeOptions |= JSON_PRETTY_PRINT;
                 $prettyPrint = false;
             }

--- a/library/Zend/View/Model/JsonModel.php
+++ b/library/Zend/View/Model/JsonModel.php
@@ -61,9 +61,13 @@ class JsonModel extends ViewModel
             $variables = ArrayUtils::iteratorToArray($variables);
         }
 
+        $options = array(
+            'prettyPrint' => $this->getOption('prettyPrint'),
+        );
+
         if (null !== $this->jsonpCallback) {
-            return $this->jsonpCallback.'('.Json::encode($variables).');';
+            return $this->jsonpCallback.'('.Json::encode($variables, false, $options).');';
         }
-        return Json::encode($variables);
+        return Json::encode($variables, false, $options);
     }
 }

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -867,23 +867,28 @@ class JsonTest extends \PHPUnit_Framework_TestCase
                 'far'=>'boo',
                 'faz'=>array(
                     'obj'=>$o
-                )
+                ),
+                'fay'=>array('foo', 'bar')
             )
         );
         $pretty = Json\Json::prettyPrint(Json\Json::encode($test), array("indent"  => " "));
         $expected = <<<EOB
 {
- "simple":"simple test string",
- "stringwithjsonchars":"\\\\\\u0022[1,2]",
- "complex":{
-  "foo":"bar",
-  "far":"boo",
-  "faz":{
-   "obj":{
-    "test":1,
-    "faz":"fubar"
+ "simple": "simple test string",
+ "stringwithjsonchars": "\\\\\\u0022[1,2]",
+ "complex": {
+  "foo": "bar",
+  "far": "boo",
+  "faz": {
+   "obj": {
+    "test": 1,
+    "faz": "fubar"
    }
-  }
+  },
+  "fay": [
+   "foo",
+   "bar"
+  ]
  }
 }
 EOB;
@@ -893,14 +898,79 @@ EOB;
     public function testPrettyPrintDoublequoteFollowingEscapedBackslashShouldNotBeTreatedAsEscaped()
     {
         $this->assertEquals(
-            "[\n\t1,\n\t\"\\\\\",\n\t3\n]",
+            "[\n    1,\n    \"\\\\\",\n    3\n]",
             Json\Json::prettyPrint(Json\Json::encode(array(1, '\\', 3)))
         );
 
         $this->assertEquals(
-            "{\n\t\"a\":\"\\\\\"\n}",
+            "{\n    \"a\": \"\\\\\"\n}",
            Json\Json::prettyPrint(Json\Json::encode(array('a' => '\\')))
         );
+    }
+
+    public function testPrettyPrintRePrettyPrint()
+    {
+        $expected = <<<EOB
+{
+ "simple": "simple test string",
+ "stringwithjsonchars": "\\\\\\u0022[1,2]",
+ "complex": {
+  "foo": "bar",
+  "far": "boo",
+  "faz": {
+   "obj": {
+    "test": 1,
+    "faz": "fubar"
+   }
+  }
+ }
+}
+EOB;
+
+        $this->assertSame(
+            $expected,
+            Json\Json::prettyPrint($expected, array("indent"  => " "))
+        );
+    }
+
+    public function testEncodeWithPrettyPrint()
+    {
+        $o = new \stdClass();
+        $o->test = 1;
+        $o->faz = 'fubar';
+
+        // The escaped double-quote in item 'stringwithjsonchars' ensures that
+        // escaped double-quotes don't throw off prettyPrint's string literal detection
+        $test = array(
+            'simple'=>'simple test string',
+            'stringwithjsonchars'=>'\"[1,2]',
+            'complex'=>array(
+                'foo'=>'bar',
+                'far'=>'boo',
+                'faz'=>array(
+                    'obj'=>$o
+                )
+            )
+        );
+        $pretty = Json\Json::encode($test, false, array("prettyPrint" => true));
+
+        $expected = <<<EOB
+{
+    "simple": "simple test string",
+    "stringwithjsonchars": "\\\\\\u0022[1,2]",
+    "complex": {
+        "foo": "bar",
+        "far": "boo",
+        "faz": {
+            "obj": {
+                "test": 1,
+                "faz": "fubar"
+            }
+        }
+    }
+}
+EOB;
+        $this->assertSame($expected, $pretty);
     }
 
     /**

--- a/tests/ZendTest/View/Model/JsonModelTest.php
+++ b/tests/ZendTest/View/Model/JsonModelTest.php
@@ -30,12 +30,25 @@ class JsonModelTest extends TestCase
         $this->assertEquals(Json::encode($array), $model->serialize());
     }
 
-
     public function testCanSerializeWithJsonpCallback()
     {
         $array = array('foo' => 'bar');
         $model = new JsonModel($array);
         $model->setJsonpCallback('callback');
         $this->assertEquals('callback(' . Json::encode($array) . ');', $model->serialize());
+    }
+
+    public function testPrettyPrint()
+    {
+        $array = array(
+            'simple'=>'simple test string',
+            'stringwithjsonchars'=>'\"[1,2]',
+            'complex'=>array(
+                'foo'=>'bar',
+                'far'=>'boo'
+            )
+        );
+        $model = new JsonModel($array, array('prettyPrint' => true));
+        $this->assertEquals(Json::encode($array, false, array('prettyPrint' => true)), $model->serialize());
     }
 }


### PR DESCRIPTION
I adapted the Json::prettyPrint to generate the same output as json_encode

also I added a "prettyPrint" option to Json::encode to take advantage of the json_encode pretty print and align the functionality to json_encode

This is my first pull request ever, so please be kind :-)
