### PR TITLE
#6414-Add a condition for captcha element

### DIFF
--- a/library/Zend/Form/View/Helper/FormRow.php
+++ b/library/Zend/Form/View/Helper/FormRow.php
@@ -11,6 +11,7 @@ namespace Zend\Form\View\Helper;
 
 use Zend\Form\Element\Button;
 use Zend\Form\Element\MonthSelect;
+use Zend\Form\Element\Captcha;
 use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 use Zend\Form\LabelAwareInterface;
@@ -180,6 +181,7 @@ class FormRow extends AbstractHelper
             if ($type === 'multi_checkbox'
                 || $type === 'radio'
                 || $element instanceof MonthSelect
+                || $element instanceof Captcha
             ) {
                 $markup = sprintf(
                     '<fieldset><legend>%s</legend>%s</fieldset>',

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Form\View\Helper;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element;
+use Zend\Captcha\Factory as Captcha;
 use Zend\Form\View\HelperConfig;
 use Zend\Form\View\Helper\FormRow as FormRowHelper;
 use Zend\View\Renderer\PhpRenderer;
@@ -428,5 +429,23 @@ class FormRowTest extends TestCase
 
         $markup = $this->helper->render($element);
         $this->assertRegexp('#^<label><span>baz</span><input name="foo" id="bar" type="text" value=""\/?></label>$#', $markup);
+    }
+
+    public function testWrapFieldsetAroundCaptchaWithLabel()
+    {
+        $captcha = Captcha::factory(array(
+            'class' => 'dumb'
+            ));
+
+        $label = 'baz';
+
+        $element = new Element\Captcha('captcha', array(
+          'captcha' => $captcha,
+          'label' => $label
+            ));
+
+        $markup = $this->helper->render($element);
+
+        $this->assertRegexp('#^<fieldset><legend>' . $label . '</legend>Please type this word backwards <b>[a-z0-9]{8}</b><input name="captcha&\#x5B;id&\#x5D;" type="hidden" value="[a-z0-9]{32}"><input name="captcha&\#x5B;input&\#x5D;" type="text"></fieldset>$#', $markup);
     }
 }

--- a/tests/ZendTest/Form/View/Helper/FormRowTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRowTest.php
@@ -435,17 +435,21 @@ class FormRowTest extends TestCase
     {
         $captcha = Captcha::factory(array(
             'class' => 'dumb'
-            ));
+        ));
 
         $label = 'baz';
 
         $element = new Element\Captcha('captcha', array(
           'captcha' => $captcha,
           'label' => $label
-            ));
+        ));
 
         $markup = $this->helper->render($element);
 
-        $this->assertRegexp('#^<fieldset><legend>' . $label . '</legend>Please type this word backwards <b>[a-z0-9]{8}</b><input name="captcha&\#x5B;id&\#x5D;" type="hidden" value="[a-z0-9]{32}"><input name="captcha&\#x5B;input&\#x5D;" type="text"></fieldset>$#', $markup);
+        $this->assertRegexp('#^<fieldset><legend>' . $label . '<\/legend>'
+                            . 'Please type this word backwards <b>[a-z0-9]{8}<\/b>'
+                            . '<input name="captcha&\#x5B;id&\#x5D;" type="hidden" value="[a-z0-9]{32}"\/?>'
+                            . '<input name="captcha&\#x5B;input&\#x5D;" type="text"\/?>'
+                            . '<\/fieldset>$#', $markup);
     }
 }


### PR DESCRIPTION
I added a condition when the element is a Captcha. This way, no more validator errors. Just reCaptcha trigger an error validation about the usage of frameborder attribute in iframe tag, but it is reCaptcha related. Not zf2 responsibility.

I didn't write any tests, given the fact it is related to html validation. But I run the usual tests, and nothing goes wrong.

I hope I didn't messed up everything, since it is my first PR.

Tell me if something wrong.

Thanks.
Julien.
