### PR TITLE
fixed #7031: use of undefined variable in ZendCacheStorageAdapterApc

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -362,15 +362,16 @@ class Apc extends AbstractAdapter implements
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
         if ($namespace === '') {
+            $prefixL = 0;
             $pattern = '/^(' . implode('|', $keysRegExp) . ')' . '$/';
         } else {
             $prefix  = $namespace . $options->getNamespaceSeparator();
+            $prefixL = strlen($prefix);
             $pattern = '/^' . preg_quote($prefix, '/') . '(' . implode('|', $keysRegExp) . ')' . '$/';
         }
         $format  = APC_ITER_ALL ^ APC_ITER_VALUE ^ APC_ITER_TYPE ^ APC_ITER_REFCOUNT;
         $it      = new BaseApcIterator('user', $pattern, $format, 100, APC_LIST_ACTIVE);
         $result  = array();
-        $prefixL = strlen($prefix);
         foreach ($it as $internalKey => $metadata) {
             // @see http://pecl.php.net/bugs/bug.php?id=22564
             if (!apc_exists($internalKey)) {
@@ -378,7 +379,7 @@ class Apc extends AbstractAdapter implements
             }
 
             $this->normalizeMetadata($metadata);
-            $result[substr($internalKey, $prefixL)] = & $metadata;
+            $result[substr($internalKey, $prefixL)] = $metadata;
         }
 
         return $result;

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -377,7 +377,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMetadatas()
     {
-        $capabilities = $this->_storage->getCapabilities();
+        $capabilities       = $this->_storage->getCapabilities();
         $supportedMetadatas = $capabilities->getSupportedMetadata();
 
         $items = array(
@@ -395,6 +395,12 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
                 $this->assertArrayHasKey($supportedMetadata, $metadata);
             }
         }
+    }
+
+    public function testGetMetadatasWithEmptyNamespace()
+    {
+        $this->_options->setNamespace('');
+        $this->testGetMetadatas();
     }
 
     public function testGetMetadatasReturnsEmptyArrayIfNonReadable()


### PR DESCRIPTION
...::internalGetMetadatas()

fixes #7031
