### PR TITLE
Cache: fixed some minor documentation issues

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/AdapterOptions.php
@@ -25,7 +25,7 @@ class AdapterOptions extends AbstractOptions
     /**
      * The adapter using these options
      *
-     * @var null|Filesystem
+     * @var null|StorageInterface
      */
     protected $adapter;
 

--- a/library/Zend/Cache/Storage/Adapter/DbaIterator.php
+++ b/library/Zend/Cache/Storage/Adapter/DbaIterator.php
@@ -17,7 +17,7 @@ class DbaIterator implements IteratorInterface
     /**
      * The apc storage instance
      *
-     * @var Apc
+     * @var Dba
      */
     protected $storage;
 

--- a/library/Zend/Cache/Storage/Adapter/XCache.php
+++ b/library/Zend/Cache/Storage/Adapter/XCache.php
@@ -45,7 +45,7 @@ class XCache extends AbstractAdapter implements
     /**
      * Constructor
      *
-     * @param  null|array|Traversable|ApcOptions $options
+     * @param  null|array|Traversable|XCacheOptions $options
      * @throws Exception\ExceptionInterface
      */
     public function __construct($options = null)
@@ -74,7 +74,7 @@ class XCache extends AbstractAdapter implements
     /**
      * Set options.
      *
-     * @param  array|Traversable|ApcOptions $options
+     * @param  array|Traversable|XCacheOptions $options
      * @return XCache
      * @see    getOptions()
      */

--- a/library/Zend/Cache/Storage/Plugin/IgnoreUserAbort.php
+++ b/library/Zend/Cache/Storage/Plugin/IgnoreUserAbort.php
@@ -85,7 +85,7 @@ class IgnoreUserAbort extends AbstractPlugin
     public function onBefore(Event $event)
     {
         if ($this->activatedTarget === null && !ignore_user_abort(true)) {
-            $this->activatedTarget = $event->getTarget();
+            $this->activatedTarget = $event->getStorage();
         }
     }
 
@@ -101,7 +101,7 @@ class IgnoreUserAbort extends AbstractPlugin
      */
     public function onAfter(Event $event)
     {
-        if ($this->activatedTarget === $event->getTarget()) {
+        if ($this->activatedTarget === $event->getStorage()) {
             // exit if connection aborted
             if ($this->getOptions()->getExitOnAbort() && connection_aborted()) {
                 exit;


### PR DESCRIPTION
Now within plugin `IgnoreUserAbort` the method `getStorage()` will be used instead of `getTarget()`. The methods are aliases but `getStorage()` is described to return an `StorageInterface` but `getTarget()` is inherited by the default event and can return nearly everything.
