### PR TITLE
MongoDB to MongoDb

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/MongoDb.php
+++ b/library/Zend/Cache/Storage/Adapter/MongoDb.php
@@ -17,7 +17,7 @@ use Zend\Cache\Exception;
 use Zend\Cache\Storage\Capabilities;
 use Zend\Cache\Storage\FlushableInterface;
 
-class MongoDB extends AbstractAdapter implements FlushableInterface
+class MongoDb extends AbstractAdapter implements FlushableInterface
 {
     /**
      * Has this instance be initialized
@@ -29,7 +29,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
     /**
      * the mongodb resource manager
      *
-     * @var null|MongoDBResourceManager
+     * @var null|MongoDbResourceManager
      */
     private $resourceManager;
 
@@ -55,7 +55,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
     public function __construct($options = null)
     {
         if (!class_exists('Mongo') || !class_exists('MongoClient')) {
-            throw new Exception\ExtensionNotLoadedException('MongoDB extension not loaded or Mongo polyfill not included');
+            throw new Exception\ExtensionNotLoadedException('MongoDb extension not loaded or Mongo polyfill not included');
         }
 
         parent::__construct($options);
@@ -75,7 +75,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
      *
      * @return MongoResource
      */
-    private function getMongoDBResource()
+    private function getMongoDbResource()
     {
         if (! $this->initialized) {
             $options = $this->getOptions();
@@ -95,11 +95,14 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
      */
     public function setOptions($options)
     {
-        return parent::setOptions($options instanceof MongoDBOptions ? $options : new MongoDBOptions($options));
+        return parent::setOptions($options instanceof MongoDbOptions ? $options : new MongoDbOptions($options));
     }
 
     /**
-     * {@inheritDoc}
+     * Get options.
+     *
+     * @return MongoDbOptions
+     * @see    setOptions()
      */
     public function getOptions()
     {
@@ -158,7 +161,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
      */
     protected function internalSetItem(& $normalizedKey, & $value)
     {
-        $mongo     = $this->getMongoDBResource();
+        $mongo     = $this->getMongoDbResource();
         $key       = $this->namespacePrefix . $normalizedKey;
         $ttl       = $this->getOptions()->getTTl();
         $expires   = null;
@@ -192,7 +195,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
     protected function internalRemoveItem(& $normalizedKey)
     {
         try {
-            $result = $this->getMongoDBResource()->remove(array('key' => $this->namespacePrefix . $normalizedKey));
+            $result = $this->getMongoDbResource()->remove(array('key' => $this->namespacePrefix . $normalizedKey));
         } catch (MongoResourceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
@@ -207,7 +210,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
      */
     public function flush()
     {
-        $result = $this->getMongoDBResource()->drop();
+        $result = $this->getMongoDbResource()->drop();
 
         return ((double) 1) === $result['ok'];
     }
@@ -274,7 +277,7 @@ class MongoDB extends AbstractAdapter implements FlushableInterface
     private function fetchFromCollection(& $normalizedKey)
     {
         try {
-            return $this->getMongoDBResource()->findOne(array('key' => $this->namespacePrefix . $normalizedKey));
+            return $this->getMongoDbResource()->findOne(array('key' => $this->namespacePrefix . $normalizedKey));
         } catch (MongoResourceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
         }

--- a/library/Zend/Cache/Storage/Adapter/MongoDbOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MongoDbOptions.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
-class MongoDBOptions extends AdapterOptions
+class MongoDbOptions extends AdapterOptions
 {
     /**
      * The namespace separator
@@ -65,11 +65,11 @@ class MongoDBOptions extends AdapterOptions
     /**
      * Set the mongodb resource manager to use
      *
-     * @param null|MongoDBResourceManager $resourceManager
+     * @param null|MongoDbResourceManager $resourceManager
      *
      * @return self
      */
-    public function setResourceManager(MongoDBResourceManager $resourceManager = null)
+    public function setResourceManager(MongoDbResourceManager $resourceManager = null)
     {
         if ($this->resourceManager !== $resourceManager) {
             $this->triggerOptionEvent('resource_manager', $resourceManager);
@@ -83,11 +83,11 @@ class MongoDBOptions extends AdapterOptions
     /**
      * Get the mongodb resource manager
      *
-     * @return MongoDBResourceManager
+     * @return MongoDbResourceManager
      */
     public function getResourceManager()
     {
-        return $this->resourceManager ?: $this->resourceManager = new MongoDBResourceManager();
+        return $this->resourceManager ?: $this->resourceManager = new MongoDbResourceManager();
     }
 
     /**

--- a/library/Zend/Cache/Storage/Adapter/MongoDbResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/MongoDbResourceManager.php
@@ -15,7 +15,7 @@ use Traversable;
 use Zend\Cache\Exception;
 use Zend\Stdlib\ArrayUtils;
 
-class MongoDBResourceManager
+class MongoDbResourceManager
 {
     /**
      * Registered resources

--- a/library/Zend/Cache/Storage/AdapterPluginManager.php
+++ b/library/Zend/Cache/Storage/AdapterPluginManager.php
@@ -34,7 +34,7 @@ class AdapterPluginManager extends AbstractPluginManager
         'memcache'       => 'Zend\Cache\Storage\Adapter\Memcache',
         'memcached'      => 'Zend\Cache\Storage\Adapter\Memcached',
         'memory'         => 'Zend\Cache\Storage\Adapter\Memory',
-        'mongodb'        => 'Zend\Cache\Storage\Adapter\MongoDB',
+        'mongodb'        => 'Zend\Cache\Storage\Adapter\MongoDb',
         'redis'          => 'Zend\Cache\Storage\Adapter\Redis',
         'session'        => 'Zend\Cache\Storage\Adapter\Session',
         'xcache'         => 'Zend\Cache\Storage\Adapter\XCache',

--- a/library/Zend/Cache/composer.json
+++ b/library/Zend/Cache/composer.json
@@ -29,7 +29,7 @@
         "ext-apc": "APC >= 3.1.6 to use the APC storage adapter",
         "ext-dba": "DBA, to use the DBA storage adapter",
         "ext-memcached": "Memcached >= 1.0.0 to use the Memcached storage adapter",
-        "ext-mongo": "Mongo, to use MongoDB storage adapter",
+        "ext-mongo": "Mongo, to use MongoDb storage adapter",
         "ext-wincache": "WinCache, to use the WinCache storage adapter",
         "mongofill/mongofill": "Alternative to ext-mongo - a pure PHP implementation designed as a drop in replacement"
     },

--- a/tests/ZendTest/Cache/Storage/Adapter/MongoDbOptionsTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/MongoDbOptionsTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Cache\Storage\Adapter;
 
-use Zend\Cache\Storage\Adapter\MongoDBOptions;
-use Zend\Cache\Storage\Adapter\MongoDBResourceManager;
+use Zend\Cache\Storage\Adapter\MongoDbOptions;
+use Zend\Cache\Storage\Adapter\MongoDbResourceManager;
 
 /**
  * @group      Zend_Cache
  */
-class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
+class MongoDbOptionsTest extends \PHPUnit_Framework_TestCase
 {
     protected $object;
 
@@ -30,7 +30,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped("Mongo extension is not loaded");
         }
 
-        $this->object = new MongoDBOptions();
+        $this->object = new MongoDbOptions();
     }
 
     public function testSetNamespaceSeparator()
@@ -59,7 +59,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertAttributeEquals(null, 'resourceManager', $this->object);
 
-        $resourceManager = new MongoDBResourceManager();
+        $resourceManager = new MongoDbResourceManager();
 
         $this->object->setResourceManager($resourceManager);
 
@@ -69,10 +69,10 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
     public function testGetResourceManager()
     {
         $this->assertInstanceOf(
-            '\Zend\Cache\Storage\Adapter\MongoDBResourceManager', $this->object->getResourceManager()
+            '\Zend\Cache\Storage\Adapter\MongoDbResourceManager', $this->object->getResourceManager()
         );
 
-        $resourceManager = new MongoDBResourceManager();
+        $resourceManager = new MongoDbResourceManager();
 
         $this->object->setResourceManager($resourceManager);
 
@@ -103,7 +103,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
 
     public function testSetLibOptions()
     {
-        $resourceManager = new MongoDBResourceManager();
+        $resourceManager = new MongoDbResourceManager();
         $this->object->setResourceManager($resourceManager);
 
         $this->assertAttributeEmpty('resources', $this->object->getResourceManager());

--- a/tests/ZendTest/Cache/Storage/Adapter/MongoDbResourceManagerTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/MongoDbResourceManagerTest.php
@@ -10,13 +10,13 @@
 namespace ZendTest\Cache\Storage\Adapter;
 
 use Zend\Cache\Exception;
-use Zend\Cache\Storage\Adapter\MongoDBResourceManager;
+use Zend\Cache\Storage\Adapter\MongoDbResourceManager;
 use Zend\Config\Config;
 
 /**
  * @group      Zend_Cache
  */
-class MongoDBResourceManagerTest extends \PHPUnit_Framework_TestCase
+class MongoDbResourceManagerTest extends \PHPUnit_Framework_TestCase
 {
     protected $object;
 
@@ -31,7 +31,7 @@ class MongoDBResourceManagerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped("Mongo extension is not loaded");
         }
 
-        $this->object = new MongoDBResourceManager();
+        $this->object = new MongoDbResourceManager();
     }
 
     public function testSetResourceAlreadyCreated()

--- a/tests/ZendTest/Cache/Storage/Adapter/MongoDbTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/MongoDbTest.php
@@ -10,13 +10,13 @@
 namespace ZendTest\Cache\Storage\Adapter;
 
 use MongoClient;
-use Zend\Cache\Storage\Adapter\MongoDB;
-use Zend\Cache\Storage\Adapter\MongoDBOptions;
+use Zend\Cache\Storage\Adapter\MongoDb;
+use Zend\Cache\Storage\Adapter\MongoDbOptions;
 
 /**
  * @group      Zend_Cache
  */
-class MongoDBTest extends CommonAdapterTest
+class MongoDbTest extends CommonAdapterTest
 {
     public function setUp()
     {
@@ -37,9 +37,9 @@ class MongoDBTest extends CommonAdapterTest
             ),
         );
 
-        $this->_options = new MongoDBOptions($optionsArray);
+        $this->_options = new MongoDbOptions($optionsArray);
 
-        $this->_storage = new MongoDB();
+        $this->_storage = new MongoDb();
         $this->_storage->setOptions($this->_options);
         $this->_storage->flush();
 
@@ -55,7 +55,7 @@ class MongoDBTest extends CommonAdapterTest
         parent::tearDown();
     }
 
-    public function testSetOptionsNotMongoDBOptions()
+    public function testSetOptionsNotMongoDbOptions()
     {
         $options = array(
             'libOptions' => array(
@@ -67,7 +67,7 @@ class MongoDBTest extends CommonAdapterTest
 
         $this->_storage->setOptions($options);
 
-        $this->assertInstanceOf('\Zend\Cache\Storage\Adapter\MongoDBOptions', $this->_storage->getOptions());
+        $this->assertInstanceOf('\Zend\Cache\Storage\Adapter\MongoDbOptions', $this->_storage->getOptions());
     }
 
     public function testCachedItemsExpire()


### PR DESCRIPTION
Our coding style defines names to be in CamelCase but this one was MIXEDCase.
The cache adapter wasn't released until now so this is no BC break but the session save handler and the log writer i thing. But normally PHP classes and methods are case-insensitive so this can only be an issue with some autoloaders on case-sensitive fs.

I think it's OK for the next minor release.

@Ocramius thoughts ?
