### PR TITLE
Fixed Select input filter specification, prerequisite for #6784

### DIFF
--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -295,7 +295,11 @@ class Select extends Element implements InputProviderInterface
         if ($this->useHiddenElement() && $this->isMultiple()) {
             $unselectedValue = $this->getUnselectedValue();
 
-            $spec['allow_empty'] = true;
+            if ($unselectedValue == '') {
+                $spec['allow_empty'] = true;
+            } else {
+                $spec['allow_empty'] = false;
+            }
             $spec['continue_if_empty'] = true;
             $spec['filters'] = array(array(
                 'name'    => 'Callback',

--- a/library/Zend/Form/Element/Select.php
+++ b/library/Zend/Form/Element/Select.php
@@ -295,11 +295,7 @@ class Select extends Element implements InputProviderInterface
         if ($this->useHiddenElement() && $this->isMultiple()) {
             $unselectedValue = $this->getUnselectedValue();
 
-            if ($unselectedValue == '') {
-                $spec['allow_empty'] = true;
-            } else {
-                $spec['allow_empty'] = false;
-            }
+            $spec['allow_empty'] = ($unselectedValue == '') ? true : false;
             $spec['continue_if_empty'] = true;
             $spec['filters'] = array(array(
                 'name'    => 'Callback',


### PR DESCRIPTION
The input filter for Zend\Form\Element\Select relies on erratic behavior of the allow_empty option which has been fixed by #6784. This breaks testFormWithSelectMultipleAndEmptyUnselectedValue(). See the discussion for a detailed explanation.

This PR fixes the input filter specification to work with either InputFilter implementation.
