### PR TITLE
Cache: better compatibility with APCu

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -717,20 +717,16 @@ class Apc extends AbstractAdapter implements
      */
     protected function normalizeMetadata(array & $metadata)
     {
-        $metadata['internal_key'] = $metadata['key'];
-        $metadata['ctime']        = $metadata['creation_time'];
-        $metadata['atime']        = $metadata['access_time'];
-        $metadata['rtime']        = $metadata['deletion_time'];
-        $metadata['size']         = $metadata['mem_size'];
-        $metadata['hits']         = $metadata['num_hits'];
-
-        unset(
-            $metadata['key'],
-            $metadata['creation_time'],
-            $metadata['access_time'],
-            $metadata['deletion_time'],
-            $metadata['mem_size'],
-            $metadata['num_hits']
+        $apcMetadata = $metadata;
+        $metadata = array(
+            'internal_key' => isset($metadata['key']) ? $metadata['key'] : $metadata['info'],
+            'atime'        => isset($metadata['access_time']) ? $metadata['access_time'] : $metadata['atime'],
+            'ctime'        => isset($metadata['creation_time']) ? $metadata['creation_time'] : $metadata['ctime'],
+            'mtime'        => isset($metadata['modified_time']) ? $metadata['modified_time'] : $metadata['mtime'],
+            'rtime'        => isset($metadata['deletion_time']) ? $metadata['deletion_time'] : $metadata['dtime'],
+            'size'         => $metadata['mem_size'],
+            'hits'         => isset($metadata['nhits']) ? $metadata['nhits'] : $metadata['num_hits'],
+            'ttl'          => $metadata['ttl'],
         );
     }
 


### PR DESCRIPTION
This makes the `Apc` cache adapter more compatible with `APCu` even if `APCu` was compiled in full compatibility mode.
