### PR TITLE
PHP CS Fixer - correct link

### DIFF
--- a/README-GIT.md
+++ b/README-GIT.md
@@ -74,7 +74,7 @@ repository.
 ### Pre-Commit Hook (Optional)
 
 The ZF2 Travis-CI will confirm that code style standards are met
-by using ```php-cs-fixer``` (https://github.com/fabpot/PHP-CS-Fixer) during its build runs.
+by using ```php-cs-fixer``` (https://github.com/FriendsOfPHP/PHP-CS-Fixer) during its build runs.
 
 To reduce the number of red Travis-CI builds, the following Git pre-commit hook
 can help catch code style issues before committing. Save it as
@@ -89,7 +89,7 @@ can help catch code style issues before committing. Save it as
  * This pre-commit hooks will check for PHP errors (lint), and make sure the
  * code is PSR-2 compliant.
  *
- * Dependency: PHP-CS-Fixer (https://github.com/fabpot/PHP-CS-Fixer)
+ * Dependency: PHP-CS-Fixer (https://github.com/FriendsOfPHP/PHP-CS-Fixer)
  *
  * @author  Mardix  http://github.com/mardix
  * @author  Matthew Weier O'Phinney http://mwop.net/


### PR DESCRIPTION
Long time ago PHP CS Fixer project moved from @fabpot into @FriendsOfPHP
