### PR TITLE
.php_cs - add encoding fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -32,6 +32,7 @@ $config->fixers(
         'braces',
         'elseif',
         'empty_return',
+        'encoding',
         'eof_ending',
         'function_call_space',
         'function_declaration',


### PR DESCRIPTION
PHP code MUST use only UTF-8 without BOM (remove BOM).
