### PR TITLE
Move common DB adapter platform functionality to a base class

### DIFF
--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class IbmDb2 implements PlatformInterface
+class IbmDb2 extends AbstractSql92BasedPlatform
 {
     protected $quoteValueAllowed = false;
 
@@ -51,16 +51,6 @@ class IbmDb2 implements PlatformInterface
     }
 
     /**
-     * Get quote indentifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
      * Quote identifier
      *
      * @param  string $identifier
@@ -71,7 +61,7 @@ class IbmDb2 implements PlatformInterface
         if ($this->quoteIdentifiers === false) {
             return $identifier;
         }
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
+        return parent::quoteIdentifier($identifier);
     }
 
     /**
@@ -90,16 +80,6 @@ class IbmDb2 implements PlatformInterface
             $identifierChain = implode('"' . $this->identifierSeparator . '"', $identifierChain);
         }
         return '"' . $identifierChain . '"';
-    }
-
-    /**
-     * Get quote value symbol
-     *
-     * @return string
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
     }
 
     /**
@@ -137,25 +117,6 @@ class IbmDb2 implements PlatformInterface
     }
 
     /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
      * Get identifier separator
      *
      * @return string
@@ -177,31 +138,6 @@ class IbmDb2 implements PlatformInterface
         if ($this->quoteIdentifiers === false) {
             return $identifier;
         }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-
-        return implode('', $parts);
+        return parent::quoteIdentifierInFragment($identifier, $safeWords);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -14,7 +14,7 @@ use Zend\Db\Adapter\Driver\Mysqli;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class Mysql implements PlatformInterface
+class Mysql extends AbstractSql92BasedPlatform
 {
     /** @var \mysqli|\PDO */
     protected $resource = null;
@@ -93,16 +93,6 @@ class Mysql implements PlatformInterface
     }
 
     /**
-     * Get quote value symbol
-     *
-     * @return string
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
      * Quote value
      *
      * @param  string $value
@@ -119,11 +109,7 @@ class Mysql implements PlatformInterface
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return parent::quoteValue($value);
     }
 
     /**
@@ -145,36 +131,7 @@ class Mysql implements PlatformInterface
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
-     * Get identifier separator
-     *
-     * @return string
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
+        return parent::quoteTrustedValue($value);
     }
 
     /**
@@ -209,6 +166,7 @@ class Mysql implements PlatformInterface
                     $parts[$i] = '`' . str_replace('`', '``', $part) . '`';
             }
         }
+
         return implode('', $parts);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class Oracle implements PlatformInterface
+class Oracle extends AbstractSql92BasedPlatform
 {
     /**
      * @var bool
@@ -40,16 +40,6 @@ class Oracle implements PlatformInterface
     }
 
     /**
-     * Get quote identifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
      * Quote identifier
      *
      * @param  string $identifier
@@ -60,7 +50,7 @@ class Oracle implements PlatformInterface
         if ($this->quoteIdentifiers === false) {
             return $identifier;
         }
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
+        return parent::quoteIdentifier($identifier);
     }
 
     /**
@@ -74,78 +64,7 @@ class Oracle implements PlatformInterface
         if ($this->quoteIdentifiers === false) {
             return (is_array($identifierChain)) ? implode('.', $identifierChain) : $identifierChain;
         }
-        $identifierChain = str_replace('"', '\\"', $identifierChain);
-        if (is_array($identifierChain)) {
-            $identifierChain = implode('"."', $identifierChain);
-        }
-        return '"' . $identifierChain . '"';
-    }
-
-    /**
-     * Get quote value symbol
-     *
-     * @return string
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * Quote value
-     *
-     * @param  string $value
-     * @return string
-     */
-    public function quoteValue($value)
-    {
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote Trusted Value
-     *
-     * The ability to quote values without notices
-     *
-     * @param $value
-     * @return mixed
-     */
-    public function quoteTrustedValue($value)
-    {
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
-     * Get identifier separator
-     *
-     * @return string
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
+        return parent::quoteIdentifierChain($identifierChain);
     }
 
     /**
@@ -160,28 +79,6 @@ class Oracle implements PlatformInterface
         if ($this->quoteIdentifiers === false) {
             return $identifier;
         }
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
+        return parent::quoteIdentifierInFragment($identifier, $safeWords);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -14,7 +14,7 @@ use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Driver\Pgsql;
 use Zend\Db\Adapter\Exception;
 
-class Postgresql implements PlatformInterface
+class Postgresql extends AbstractSql92BasedPlatform
 {
     /** @var resource|\PDO */
     protected $resource = null;
@@ -56,52 +56,6 @@ class Postgresql implements PlatformInterface
     }
 
     /**
-     * Get quote indentifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
-    }
-
-    /**
-     * Quote identifier chain
-     *
-     * @param string|string[] $identifierChain
-     * @return string
-     */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        $identifierChain = str_replace('"', '\\"', $identifierChain);
-        if (is_array($identifierChain)) {
-            $identifierChain = implode('"."', $identifierChain);
-        }
-        return '"' . $identifierChain . '"';
-    }
-
-    /**
-     * Get quote value symbol
-     *
-     * @return string
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
      * Quote value
      *
      * @param  string $value
@@ -118,11 +72,7 @@ class Postgresql implements PlatformInterface
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return parent::quoteValue($value);
     }
 
     /**
@@ -144,69 +94,6 @@ class Postgresql implements PlatformInterface
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
-     * Get identifier separator
-     *
-     * @return string
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
+        return parent::quoteTrustedValue($value);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Db\Adapter\Platform;
 
-class Sql92 implements PlatformInterface
+class Sql92 extends AbstractSql92BasedPlatform
 {
     /**
      * Get name
@@ -19,52 +19,6 @@ class Sql92 implements PlatformInterface
     public function getName()
     {
         return 'SQL92';
-    }
-
-    /**
-     * Get quote indentifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
-    }
-
-    /**
-     * Quote identifier chain
-     *
-     * @param string|string[] $identifierChain
-     * @return string
-     */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        $identifierChain = str_replace('"', '\\"', $identifierChain);
-        if (is_array($identifierChain)) {
-            $identifierChain = implode('"."', $identifierChain);
-        }
-        return '"' . $identifierChain . '"';
-    }
-
-    /**
-     * Get quote value symbol
-     *
-     * @return string
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
     }
 
     /**
@@ -79,83 +33,5 @@ class Sql92 implements PlatformInterface
             'Attempting to quote a value without specific driver level support can introduce security vulnerabilities in a production environment.'
         );
         return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote Trusted Value
-     *
-     * The ability to quote values without notices
-     *
-     * @param $value
-     * @return mixed
-     */
-    public function quoteTrustedValue($value)
-    {
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
-     * Get identifier separator
-     *
-     * @return string
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-
-        return implode('', $parts);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -13,7 +13,7 @@ use Zend\Db\Adapter\Driver\DriverInterface;
 use Zend\Db\Adapter\Driver\Pdo;
 use Zend\Db\Adapter\Exception;
 
-class Sqlite implements PlatformInterface
+class Sqlite extends AbstractSql92BasedPlatform
 {
     /** @var \PDO */
     protected $resource = null;
@@ -53,52 +53,6 @@ class Sqlite implements PlatformInterface
     }
 
     /**
-     * Get quote identifier symbol
-     *
-     * @return string
-     */
-    public function getQuoteIdentifierSymbol()
-    {
-        return '"';
-    }
-
-    /**
-     * Quote identifier
-     *
-     * @param  string $identifier
-     * @return string
-     */
-    public function quoteIdentifier($identifier)
-    {
-        return '"' . str_replace('"', '\\' . '"', $identifier) . '"';
-    }
-
-    /**
-     * Quote identifier chain
-     *
-     * @param string|string[] $identifierChain
-     * @return string
-     */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        $identifierChain = str_replace('"', '\\"', $identifierChain);
-        if (is_array($identifierChain)) {
-            $identifierChain = implode('"."', $identifierChain);
-        }
-        return '"' . $identifierChain . '"';
-    }
-
-    /**
-     * Get quote value symbol
-     *
-     * @return string
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
      * Quote value
      *
      * @param  string $value
@@ -116,11 +70,7 @@ class Sqlite implements PlatformInterface
             return $resource->quote($value);
         }
 
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return parent::quoteValue($value);
     }
 
     /**
@@ -143,68 +93,6 @@ class Sqlite implements PlatformInterface
             return $resource->quote($value);
         }
 
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * Quote value list
-     *
-     * @param string|string[] $valueList
-     * @return string
-     */
-    public function quoteValueList($valueList)
-    {
-        if (!is_array($valueList)) {
-            return $this->quoteValue($valueList);
-        }
-        $value = reset($valueList);
-        do {
-            $valueList[key($valueList)] = $this->quoteValue($value);
-        } while ($value = next($valueList));
-        return implode(', ', $valueList);
-    }
-
-    /**
-     * Get identifier separator
-     *
-     * @return string
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
-    }
-
-    /**
-     * Quote identifier in fragment
-     *
-     * @param  string $identifier
-     * @param  array $safeWords
-     * @return string
-     */
-    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
-    {
-        $parts = preg_split('#([\.\s\W])#', $identifier, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        if ($safeWords) {
-            $safeWords = array_flip($safeWords);
-            $safeWords = array_change_key_case($safeWords, CASE_LOWER);
-        }
-        foreach ($parts as $i => $part) {
-            if ($safeWords && isset($safeWords[strtolower($part)])) {
-                continue;
-            }
-            switch ($part) {
-                case ' ':
-                case '.':
-                case '*':
-                case 'AS':
-                case 'As':
-                case 'aS':
-                case 'as':
-                    break;
-                default:
-                    $parts[$i] = '"' . str_replace('"', '\\' . '"', $part) . '"';
-            }
-        }
-        return implode('', $parts);
+        return parent::quoteTrustedValue($value);
     }
 }


### PR DESCRIPTION
The Zend\Db\Adapter\Platform classes are all implemented from scratch, resulting in a lot of duplicated code and making even simple changes needlessly complicated because they would need to be propagated across all platforms. This is unnecessary because most functionality is identical across multiple platforms.

One example would be a fix for #5160. The requested functionality is simple and portable, yet only implemented for some platforms. Fixing this without copying everything all over would be desirable.

I created an abstract class "AbstractSql92BasedPlatform" which implements PlatformInterface except for getName(). It is mostly identical to the old Sql92 class. All platform classes extend this abstract class and implement only platform-specific differences. This results in a lot less code. It's also more flexible - implementing a new platform would become much simpler.

The changes are fully backward compatible - all methods are still in place and behave identically. The only difference is inheritance from the new base class.

I did not change the tests, though many tests would be redundant now. However, the existing tests are simple and document the full platform interface. I also ran the integration tests without problems, except for SqlServerIntegrationTest because I don't have a test platform available.
