### PR TITLE
Removed hard coded dependency to Zend\Mvc from Zend\ModuleManager

### DIFF
--- a/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
+++ b/library/Zend/ModuleManager/Listener/LocatorRegistrationListener.php
@@ -14,7 +14,7 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\ModuleManager\Feature\LocatorRegisteredInterface;
 use Zend\ModuleManager\ModuleEvent;
-use Zend\Mvc\MvcEvent;
+use Zend\ModuleManager\ModuleManager;
 
 /**
  * Locator registration listener
@@ -67,7 +67,7 @@ class LocatorRegistrationListener extends AbstractListener implements
         }
 
         // Shared instance for module manager
-        $events->attach('Zend\Mvc\Application', MvcEvent::EVENT_BOOTSTRAP, function ($e) use ($moduleManager) {
+        $events->attach('Zend\Mvc\Application', ModuleManager::EVENT_BOOTSTRAP, function ($e) use ($moduleManager) {
             $moduleClassName = get_class($moduleManager);
             $moduleClassNameArray = explode('\\', $moduleClassName);
             $moduleClassNameAlias = end($moduleClassNameArray);
@@ -83,7 +83,7 @@ class LocatorRegistrationListener extends AbstractListener implements
         }
 
         // Attach to the bootstrap event if there are modules we need to process
-        $events->attach('Zend\Mvc\Application', MvcEvent::EVENT_BOOTSTRAP, array($this, 'onBootstrap'), 1000);
+        $events->attach('Zend\Mvc\Application', ModuleManager::EVENT_BOOTSTRAP, array($this, 'onBootstrap'), 1000);
     }
 
     /**

--- a/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
+++ b/library/Zend/ModuleManager/Listener/OnBootstrapListener.php
@@ -11,7 +11,7 @@ namespace Zend\ModuleManager\Listener;
 
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\ModuleEvent;
-use Zend\Mvc\MvcEvent;
+use Zend\ModuleManager\ModuleManager;
 
 /**
  * Autoloader listener
@@ -34,6 +34,6 @@ class OnBootstrapListener extends AbstractListener
         $moduleManager = $e->getTarget();
         $events        = $moduleManager->getEventManager();
         $sharedEvents  = $events->getSharedManager();
-        $sharedEvents->attach('Zend\Mvc\Application', MvcEvent::EVENT_BOOTSTRAP, array($module, 'onBootstrap'));
+        $sharedEvents->attach('Zend\Mvc\Application', ModuleManager::EVENT_BOOTSTRAP, array($module, 'onBootstrap'));
     }
 }

--- a/library/Zend/ModuleManager/ModuleManager.php
+++ b/library/Zend/ModuleManager/ModuleManager.php
@@ -18,6 +18,12 @@ use Zend\EventManager\EventManagerInterface;
  */
 class ModuleManager implements ModuleManagerInterface
 {
+    /**#@+
+     * Reference to Zend\Mvc\MvcEvent::EVENT_BOOTSTRAP
+     */
+    const EVENT_BOOTSTRAP = 'bootstrap';
+    /**#@-*/
+
     /**
      * @var array An array of Module classes of loaded modules
      */

--- a/library/Zend/ModuleManager/composer.json
+++ b/library/Zend/ModuleManager/composer.json
@@ -22,7 +22,6 @@
         "zendframework/zend-config": "self.version",
         "zendframework/zend-console": "self.version",
         "zendframework/zend-loader": "self.version",
-        "zendframework/zend-mvc": "self.version",
         "zendframework/zend-servicemanager": "self.version"
     },
     "suggest": {


### PR DESCRIPTION
Remove the hard coded dependency to the `Zend\Mvc\MvcEvent::EVENT_BOOTSTRAP` constant from `Zend\ModuleManager` component by adding a new constant to `Zend\ModuleManager\ModuleManager`.

Look at https://github.com/zendframework/zf2/issues/6933
