### PR TITLE
Cache: fixed CAS-Feature broken for APC adapter since 2.3.0

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/Apc.php
+++ b/library/Zend/Cache/Storage/Adapter/Apc.php
@@ -746,6 +746,10 @@ class Apc extends AbstractAdapter implements
      */
     protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
     {
-        return apc_cas($normalizedKey, $token, $value);
+        if (is_int($token) && is_int($value)) {
+            return apc_cas($normalizedKey, $token, $value);
+        }
+
+        return parent::internalCheckAndSetItem($token, $normalizedKey, $value);
     }
 }


### PR DESCRIPTION
see #4844
