### PR TITLE
Travis optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ before_script:
 
 script:
   # Run tests for the various components in parallel
-  - ls -d tests/ZendTest/* | parallel --gnu --keep-order 'echo "Running {} tests"; ./vendor/bin/phpunit -c tests/phpunit.xml.dist --coverage-php build/coverage/coverage-{/.}.cov {};' || exit 1
+  - ls -d tests/ZendTest/* | grep -v 'tests/ZendTest/_files' | grep -v 'tests/ZendTest/AllTests' | parallel --gnu -P 0 'echo "Running {} tests"; php -d zend.enable_gc=0 ./vendor/bin/phpunit -c tests/phpunit.xml.dist --coverage-php build/coverage/coverage-{/.}.cov {};' || exit 1
+
   # Run coding standard checks in parallel
-  - ls -d library/Zend/* tests/ZendTest/* bin | parallel --gnu --keep-order 'echo "Running {} CS checks"; ./vendor/bin/php-cs-fixer fix {} -v --dry-run --config-file=.php_cs;' || exit 1
+  - ls -d library/Zend/* tests/ZendTest/* bin | parallel --gnu -P 0 'echo "Running {} CS checks"; php -d zend.enable_gc=0 ./vendor/bin/php-cs-fixer fix {} -v --dry-run --config-file=.php_cs;' || exit 1
 
 after_script:
   # Merges the individual clover reports of each component into a single clover.xml


### PR DESCRIPTION
- disabled GC on running unit tests and cs fixer
- allow to run more parallel processes than CPUs
- ignore special folders ('_files' and 'AllTests') to run with phpunit
- no longer keep order of parallel processes
  - this one isn't for all over performance but for humans - If you wait for a specific test case you will be informed asap the component has been ready

This should be make little performance improvements.

A much better performance improvement would be to run all unit tests and cs fixer in parallel, too.
But I currently haven't a good idea how to do that simplified.
