### PR TITLE
Hotfix/encrypt numbers

### DIFF
--- a/library/Zend/Filter/Encrypt.php
+++ b/library/Zend/Filter/Encrypt.php
@@ -123,7 +123,7 @@ class Encrypt extends AbstractFilter
      */
     public function filter($value)
     {
-        if (!is_string($value)) {
+        if (!is_string($value) && !is_numeric($value)) {
             return $value;
         }
 

--- a/tests/ZendTest/Filter/EncryptTest.php
+++ b/tests/ZendTest/Filter/EncryptTest.php
@@ -38,7 +38,11 @@ class EncryptTest extends \PHPUnit_Framework_TestCase
         $valuesExpected = array(
             'STRING' => 'STRING',
             'ABC1@3' => 'ABC1@3',
-            'A b C'  => 'A B C'
+            'A b C'  => 'A B C',
+            1        => 1,
+            -1       => -1,
+            1.0      => 1.0,
+            -1.0     => -1.0,
         );
 
         $enc = $filter->getEncryption();


### PR DESCRIPTION
PR https://github.com/zendframework/zf2/pull/5436/files#diff-acc52fa0c89428ade03c42a52bd93c19 introduced a ~~BC break~~ bug to the Filter\Encrypt ~~and Filter\Decrypt~~. Before was allowed to encrypt/~~decrypt~~ ~~integers~~ numbers, after that PR it's restricted to strings only.

https://github.com/zendframework/zf2/blob/4b496e98fcb2a40165a738459a17fb885474d717/library/Zend/Filter/Encrypt.php#L126
~~https://github.com/zendframework/zf2/blob/4b496e98fcb2a40165a738459a17fb885474d717/library/Zend/Filter/Decrypt.php#L27~~

And I can't mention that silently returning a value when that condition isn't met is nasty, debugging that was annoying.
