### PR TITLE
Feature/number parse option for number form element

### DIFF
--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -31,12 +31,12 @@ class Number extends Element implements InputProviderInterface
     /**
      * @var array
      */
-    protected $validators;
+    protected $validators = array();
 
     /**
      * @var array
      */
-    protected $filters;
+    protected $filters = array();
 
     /**
      * Get validator
@@ -84,7 +84,7 @@ class Number extends Element implements InputProviderInterface
         }
 
         $this->validators = $validators;
-        
+
         return $this->validators;
     }
 

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -86,7 +86,7 @@ class Number extends Element implements InputProviderInterface
         $this->validators = $validators;
         return $this->validators;
     }
-
+    
     protected function getFilters()
     {
         if ($this->filters) {
@@ -96,7 +96,7 @@ class Number extends Element implements InputProviderInterface
         $filters = array();
 
         if (isset($this->options['format'])) {
-            $filters[] =  array(
+            $filters[] = array(
                 'name' => 'NumberParse',
                 'options' => array(
                     'locale' => 'en',

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Form\Element;
 
+use Zend\Filter\FilterInterface;
 use Zend\Filter\StringTrim;
 use Zend\Form\Element;
 use Zend\I18n\Filter\NumberParse;
@@ -17,6 +18,7 @@ use Zend\Validator\GreaterThan as GreaterThanValidator;
 use Zend\Validator\LessThan as LessThanValidator;
 use Zend\Validator\Regex as RegexValidator;
 use Zend\Validator\Step as StepValidator;
+use Zend\Validator\ValidatorInterface;
 
 class Number extends Element implements InputProviderInterface
 {
@@ -30,19 +32,19 @@ class Number extends Element implements InputProviderInterface
     );
 
     /**
-     * @var array
+     * @var array|null
      */
-    protected $validators = array();
+    protected $validators;
 
     /**
-     * @var array
+     * @var array|null
      */
-    protected $filters = array();
+    protected $filters;
 
     /**
      * Get validator
      *
-     * @return \Zend\Validator\ValidatorInterface[]
+     * @return ValidatorInterface[]
      */
     protected function getValidators()
     {
@@ -92,7 +94,7 @@ class Number extends Element implements InputProviderInterface
     /**
      * Get Filter Specification
      *
-     * @return array
+     * @return FilterInterface[]
      */
     protected function getFilters()
     {

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -84,6 +84,7 @@ class Number extends Element implements InputProviderInterface
         }
 
         $this->validators = $validators;
+        
         return $this->validators;
     }
 
@@ -113,6 +114,7 @@ class Number extends Element implements InputProviderInterface
         $filters[] = array('name' => 'StringTrim');
 
         $this->filters = $filters;
+
         return $this->filters;
     }
 

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Form\Element;
 
+use Zend\Filter\StringTrim;
 use Zend\Form\Element;
 use Zend\I18n\Filter\NumberParse;
 use Zend\InputFilter\InputProviderInterface;
@@ -74,12 +75,12 @@ class Number extends Element implements InputProviderInterface
             ));
         }
 
-        if (!isset($this->attributes['step'])
+        if ( ! isset($this->attributes['step'])
             || 'any' !== $this->attributes['step']
         ) {
             $validators[] = new StepValidator(array(
-                'baseValue' => (isset($this->attributes['min']))  ? $this->attributes['min'] : 0,
-                'step'      => (isset($this->attributes['step'])) ? $this->attributes['step'] : 1,
+                'baseValue' => (isset($this->attributes['min'])) ? $this->attributes['min'] : 0,
+                'step' => (isset($this->attributes['step'])) ? $this->attributes['step'] : 1,
             ));
         }
 
@@ -102,16 +103,13 @@ class Number extends Element implements InputProviderInterface
         $filters = array();
 
         if (isset($this->options['format'])) {
-            $filters[] = array(
-                'name' => 'NumberParse',
-                'options' => array(
-                    'locale' => 'en',
-                    'type' => $this->options['format']
-                )
-            );
+            $filters[] = new NumberParse(array(
+                'locale' => 'en',
+                'type' => $this->options['format']
+            ));
         }
 
-        $filters[] = array('name' => 'StringTrim');
+        $filters[] = new StringTrim();
 
         $this->filters = $filters;
 

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -52,12 +52,11 @@ class Number extends Element implements InputProviderInterface
             return $this->validators;
         }
 
-        $validators = array();
         // HTML5 always transmits values in the format "1000.01", without a
         // thousand separator. The prior use of the i18n Float validator
         // allowed the thousand separator, which resulted in wrong numbers
         // when casting to float.
-        $validators[] = new RegexValidator('(^-?\d*(\.\d+)?$)');
+        $this->validators[] = new RegexValidator('(^-?\d*(\.\d+)?$)');
 
         $inclusive = true;
         if (isset($this->attributes['inclusive'])) {
@@ -71,7 +70,7 @@ class Number extends Element implements InputProviderInterface
             ));
         }
         if (isset($this->attributes['max'])) {
-            $validators[] = new LessThanValidator(array(
+            $this->validators[] = new LessThanValidator(array(
                 'max' => $this->attributes['max'],
                 'inclusive' => $inclusive
             ));
@@ -80,13 +79,11 @@ class Number extends Element implements InputProviderInterface
         if ( ! isset($this->attributes['step'])
             || 'any' !== $this->attributes['step']
         ) {
-            $validators[] = new StepValidator(array(
+            $this->validators[] = new StepValidator(array(
                 'baseValue' => (isset($this->attributes['min'])) ? $this->attributes['min'] : 0,
                 'step' => (isset($this->attributes['step'])) ? $this->attributes['step'] : 1,
             ));
         }
-
-        $this->validators = $validators;
 
         return $this->validators;
     }
@@ -102,18 +99,16 @@ class Number extends Element implements InputProviderInterface
             return $this->filters;
         }
 
-        $filters = array(
+        $this->filters = array(
             new StringTrim()
         );
 
         if (isset($this->options['format'])) {
-            $filters[] = new NumberParse(array(
+            $this->filters[] = new NumberParse(array(
                 'locale' => 'en',
                 'type' => $this->options['format']
             ));
         }
-
-        $this->filters = $filters;
 
         return $this->filters;
     }

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -102,7 +102,9 @@ class Number extends Element implements InputProviderInterface
             return $this->filters;
         }
 
-        $filters = array();
+        $filters = array(
+            new StringTrim()
+        );
 
         if (isset($this->options['format'])) {
             $filters[] = new NumberParse(array(
@@ -110,8 +112,6 @@ class Number extends Element implements InputProviderInterface
                 'type' => $this->options['format']
             ));
         }
-
-        $filters[] = new StringTrim();
 
         $this->filters = $filters;
 

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -64,7 +64,7 @@ class Number extends Element implements InputProviderInterface
         }
 
         if (isset($this->attributes['min'])) {
-            $validators[] = new GreaterThanValidator(array(
+            $this->validators[] = new GreaterThanValidator(array(
                 'min' => $this->attributes['min'],
                 'inclusive' => $inclusive
             ));

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -86,7 +86,12 @@ class Number extends Element implements InputProviderInterface
         $this->validators = $validators;
         return $this->validators;
     }
-    
+
+    /**
+     * Get Filter Specification
+     *
+     * @return array
+     */
     protected function getFilters()
     {
         if ($this->filters) {

--- a/library/Zend/Form/Element/Number.php
+++ b/library/Zend/Form/Element/Number.php
@@ -10,6 +10,7 @@
 namespace Zend\Form\Element;
 
 use Zend\Form\Element;
+use Zend\I18n\Filter\NumberParse;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\GreaterThan as GreaterThanValidator;
 use Zend\Validator\LessThan as LessThanValidator;
@@ -31,6 +32,11 @@ class Number extends Element implements InputProviderInterface
      * @var array
      */
     protected $validators;
+
+    /**
+     * @var array
+     */
+    protected $filters;
 
     /**
      * Get validator
@@ -81,6 +87,30 @@ class Number extends Element implements InputProviderInterface
         return $this->validators;
     }
 
+    protected function getFilters()
+    {
+        if ($this->filters) {
+            return $this->filters;
+        }
+
+        $filters = array();
+
+        if (isset($this->options['format'])) {
+            $filters[] =  array(
+                'name' => 'NumberParse',
+                'options' => array(
+                    'locale' => 'en',
+                    'type' => $this->options['format']
+                )
+            );
+        }
+
+        $filters[] = array('name' => 'StringTrim');
+
+        $this->filters = $filters;
+        return $this->filters;
+    }
+
     /**
      * Provide default input rules for this element
      *
@@ -93,9 +123,7 @@ class Number extends Element implements InputProviderInterface
         return array(
             'name' => $this->getName(),
             'required' => true,
-            'filters' => array(
-                array('name' => 'Zend\Filter\StringTrim')
-            ),
+            'filters' => $this->getFilters(),
             'validators' => $this->getValidators(),
         );
     }

--- a/library/Zend/Form/composer.json
+++ b/library/Zend/Form/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": ">=5.3.23",
         "zendframework/zend-inputfilter": "self.version",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-i18n": "self.version"
     },
     "require-dev": {
         "zendframework/zend-captcha": "self.version",
         "zendframework/zend-code": "self.version",
         "zendframework/zend-eventmanager": "self.version",
         "zendframework/zend-filter": "self.version",
-        "zendframework/zend-i18n": "self.version",
         "zendframework/zend-servicemanager": "self.version",
         "zendframework/zend-validator": "self.version",
         "zendframework/zend-view": "self.version",

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -20,15 +20,21 @@ class NumberTest extends TestCase
 
         $inputSpec = $element->getInputSpecification();
         $this->assertArrayHasKey('validators', $inputSpec);
+        $this->assertArrayHasKey('filters', $inputSpec);
         $this->assertInternalType('array', $inputSpec['validators']);
+        $this->assertInternalType('array', $inputSpec['filters']);
 
-        $expectedClasses = array(
+        $expectedValidatorClasses = array(
             'Zend\Validator\Regex',
             'Zend\Validator\Step',
         );
+        $expectedFilterClasses    = array(
+            'Zend\Filter\StringTrim',
+        );
+
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertTrue(in_array($class, $expectedValidatorClasses), $class);
             switch ($class) {
                 case 'Zend\Validator\Step':
                     $this->assertEquals(1, $validator->getStep());
@@ -36,6 +42,11 @@ class NumberTest extends TestCase
                 default:
                     break;
             }
+        }
+
+        foreach ($inputSpec['filters'] as $filter) {
+            $class = get_class($filter);
+            $this->assertTrue(in_array($class, $expectedFilterClasses), $class);
         }
     }
 

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -57,9 +57,9 @@ class NumberTest extends TestCase
         $element = new NumberElement();
         $element->setAttributes(array(
             'inclusive' => true,
-            'min'       => 5,
-            'max'       => 10,
-            'step'      => 1,
+            'min' => 5,
+            'max' => 10,
+            'step' => 1,
         ));
 
         $inputSpec = $element->getInputSpecification();
@@ -98,7 +98,7 @@ class NumberTest extends TestCase
         $element = new NumberElement();
         $element->setAttributes(array(
             'inclusive' => false,
-            'min'       => 5,
+            'min' => 5,
         ));
 
         $inputSpec = $element->getInputSpecification();
@@ -114,7 +114,7 @@ class NumberTest extends TestCase
     {
         $element = new NumberElement();
         $element->setAttributes(array(
-            'min'       => 5,
+            'min' => 5,
         ));
 
         $inputSpec = $element->getInputSpecification();
@@ -157,6 +157,13 @@ class NumberTest extends TestCase
         $this->assertSame(NumberFormatter::TYPE_DOUBLE, $filter->getType());
         $this->assertSame('en', $filter->getLocale());
         $this->assertSame(1.1, $filter->filter('1.1'));
-        $this->assertSame((double) 1, $filter->filter('1'));
+        $this->assertSame((double)1, $filter->filter('1'));
+    }
+
+    public function testReturningSameSpecOnConsecutiveCalls()
+    {
+        $element = new NumberElement();
+
+        $this->assertSame($element->getInputSpecification(), $element->getInputSpecification());
     }
 }

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -151,7 +151,7 @@ class NumberTest extends TestCase
         $inputSpec = $element->getInputSpecification();
 
         /** @var NumberParse $filter */
-        $filter = $inputSpec['filters'][0];
+        $filter = $inputSpec['filters'][1];
 
         $this->assertInstanceOf('Zend\I18n\Filter\NumberParse', $filter);
         $this->assertSame(NumberFormatter::TYPE_DOUBLE, $filter->getType());

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -142,6 +142,9 @@ class NumberTest extends TestCase
         }
     }
 
+    /**
+     * @group 7084
+     */
     public function testCanRetrieveNumberParseFilter()
     {
         $element = new NumberElement(null, array(
@@ -160,6 +163,9 @@ class NumberTest extends TestCase
         $this->assertSame((double)1, $filter->filter('1'));
     }
 
+    /**
+     * @group 7084
+     */
     public function testReturningSameSpecOnConsecutiveCalls()
     {
         $element = new NumberElement();

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -11,6 +11,8 @@ namespace ZendTest\Form\Element;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Form\Element\Number as NumberElement;
+use Zend\I18n\Filter\NumberParse;
+use NumberFormatter;
 
 class NumberTest extends TestCase
 {
@@ -138,5 +140,23 @@ class NumberTest extends TestCase
                 break;
             }
         }
+    }
+
+    public function testCanRetrieveNumberParseFilter()
+    {
+        $element = new NumberElement(null, array(
+            'format' => NumberFormatter::TYPE_DOUBLE
+        ));
+
+        $inputSpec = $element->getInputSpecification();
+
+        /** @var NumberParse $filter */
+        $filter = $inputSpec['filters'][0];
+
+        $this->assertInstanceOf('Zend\I18n\Filter\NumberParse', $filter);
+        $this->assertSame(NumberFormatter::TYPE_DOUBLE, $filter->getType());
+        $this->assertSame('en', $filter->getLocale());
+        $this->assertSame(1.1, $filter->filter('1.1'));
+        $this->assertSame((double) 1, $filter->filter('1'));
     }
 }


### PR DESCRIPTION
Add a NumberParse option to number form element, plus set the default locale to "en" since the html5 number form element always return in this locale.
