### PR TITLE
#7055 - stricter validation of `TableIdentifier` parameters

### DIFF
--- a/library/Zend/Db/Sql/TableIdentifier.php
+++ b/library/Zend/Db/Sql/TableIdentifier.php
@@ -38,6 +38,10 @@ class TableIdentifier
 
         $this->table = (string) $table;
 
+        if ('' === $this->table) {
+            throw new Exception\InvalidArgumentException('$table must be a valid table name, empty string given');
+        }
+
         if (null === $schema) {
             $this->schema = null;
         } else {
@@ -49,6 +53,12 @@ class TableIdentifier
             }
 
             $this->schema = (string) $schema;
+        }
+
+        if ('' === $this->schema) {
+            throw new Exception\InvalidArgumentException(
+                '$schema must be a valid schema name or null, empty string given'
+            );
         }
     }
 

--- a/library/Zend/Db/Sql/TableIdentifier.php
+++ b/library/Zend/Db/Sql/TableIdentifier.php
@@ -29,8 +29,27 @@ class TableIdentifier
      */
     public function __construct($table, $schema = null)
     {
-        $this->table = $table;
-        $this->schema = $schema;
+        if (! (is_string($table) || is_callable(array($table, '__toString')))) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '$table must be a valid table name, parameter of type %s given',
+                is_object($table) ? get_class($table) : gettype($table)
+            ));
+        }
+
+        $this->table = (string) $table;
+
+        if (null === $schema) {
+            $this->schema = null;
+        } else {
+            if (! (is_string($schema) || is_callable(array($schema, '__toString')))) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    '$schema must be a valid schema name, parameter of type %s given',
+                    is_object($schema) ? get_class($schema) : gettype($schema)
+                ));
+            }
+
+            $this->schema = (string) $schema;
+        }
     }
 
     /**

--- a/library/Zend/Db/Sql/TableIdentifier.php
+++ b/library/Zend/Db/Sql/TableIdentifier.php
@@ -53,12 +53,12 @@ class TableIdentifier
             }
 
             $this->schema = (string) $schema;
-        }
 
-        if ('' === $this->schema) {
-            throw new Exception\InvalidArgumentException(
-                '$schema must be a valid schema name or null, empty string given'
-            );
+            if ('' === $this->schema) {
+                throw new Exception\InvalidArgumentException(
+                    '$schema must be a valid schema name or null, empty string given'
+                );
+            }
         }
     }
 

--- a/library/Zend/Db/Sql/TableIdentifier.php
+++ b/library/Zend/Db/Sql/TableIdentifier.php
@@ -19,13 +19,13 @@ class TableIdentifier
     protected $table;
 
     /**
-     * @var string
+     * @var null|string
      */
     protected $schema;
 
     /**
-     * @param string $table
-     * @param string $schema
+     * @param string      $table
+     * @param null|string $schema
      */
     public function __construct($table, $schema = null)
     {

--- a/library/Zend/Db/Sql/TableIdentifier.php
+++ b/library/Zend/Db/Sql/TableIdentifier.php
@@ -64,6 +64,8 @@ class TableIdentifier
 
     /**
      * @param string $table
+     *
+     * @deprecated please use the constructor and build a new {@see TableIdentifier} instead
      */
     public function setTable($table)
     {
@@ -88,6 +90,8 @@ class TableIdentifier
 
     /**
      * @param $schema
+     *
+     * @deprecated please use the constructor and build a new {@see TableIdentifier} instead
      */
     public function setSchema($schema)
     {

--- a/library/Zend/Db/TableGateway/TableGateway.php
+++ b/library/Zend/Db/TableGateway/TableGateway.php
@@ -20,11 +20,12 @@ class TableGateway extends AbstractTableGateway
     /**
      * Constructor
      *
-     * @param string $table
-     * @param AdapterInterface $adapter
-     * @param Feature\AbstractFeature|Feature\FeatureSet|Feature\AbstractFeature[] $features
-     * @param ResultSetInterface $resultSetPrototype
-     * @param Sql $sql
+     * @param string|TableIdentifier|array                                              $table
+     * @param AdapterInterface                                                          $adapter
+     * @param Feature\AbstractFeature|Feature\FeatureSet|Feature\AbstractFeature[]|null $features
+     * @param ResultSetInterface|null                                                   $resultSetPrototype
+     * @param Sql|null                                                                  $sql
+     *
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($table, AdapterInterface $adapter, $features = null, ResultSetInterface $resultSetPrototype = null, Sql $sql = null)

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -77,6 +77,18 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider invalidTableProvider
+     *
+     * @param mixed $invalidSchema
+     */
+    public function testRejectsInvalidSchema($invalidSchema)
+    {
+        $this->setExpectedException('Zend\Db\Sql\Exception\InvalidArgumentException');
+
+        new TableIdentifier('foo', $invalidSchema);
+    }
+
+    /**
      * Data provider
      *
      * @return mixed[][]
@@ -85,6 +97,20 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(null),
+            array(''),
+            array(new stdClass()),
+            array(array()),
+        );
+    }
+
+    /**
+     * Data provider
+     *
+     * @return mixed[][]
+     */
+    public function invalidSchemaProvider()
+    {
+        return array(
             array(''),
             array(new stdClass()),
             array(array()),

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -50,4 +50,16 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('castResult', $tableIdentifier->getTable());
         $this->assertSame('castResult', $tableIdentifier->getTable());
     }
+
+    public function testGetSchemaFromObjectStringCast()
+    {
+        $schema = $this->getMock('stdClass', array('__toString'));
+
+        $schema->expects($this->once())->method('__toString')->will($this->returnValue('castResult'));
+
+        $tableIdentifier = new TableIdentifier('foo', $schema);
+
+        $this->assertSame('castResult', $tableIdentifier->getSchema());
+        $this->assertSame('castResult', $tableIdentifier->getSchema());
+    }
 }

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql;
+
+use Zend\Db\Sql\Update;
+use Zend\Db\Sql\Where;
+use Zend\Db\Sql\Expression;
+use Zend\Db\Sql\TableIdentifier;
+use ZendTest\Db\TestAsset\TrustingSql92Platform;
+
+/**
+ * Tests for {@see \Zend\Db\Sql\TableIdentifier}
+ *
+ * @covers \Zend\Db\Sql\TableIdentifier
+ */
+class TableIdentifierTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTableName()
+    {
+        $tableIdentifier = new TableIdentifier('foo');
+
+        $this->assertSame('foo', $tableIdentifier->getTable());
+    }
+}

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -41,9 +41,9 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTableFromObjectStringCast()
     {
-        $table = $this->getMock('stdClass', '__invoke');
+        $table = $this->getMock('stdClass', array('__toString'));
 
-        $table->expects($this->once())->method('__invoke')->will($this->returnValue('castResult'));
+        $table->expects($this->once())->method('__toString')->will($this->returnValue('castResult'));
 
         $tableIdentifier = new TableIdentifier($table);
 

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Db\Sql;
 
+use stdClass;
 use Zend\Db\Sql\TableIdentifier;
 
 /**
@@ -61,5 +62,32 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('castResult', $tableIdentifier->getSchema());
         $this->assertSame('castResult', $tableIdentifier->getSchema());
+    }
+
+    /**
+     * @dataProvider invalidTableProvider
+     *
+     * @param mixed $invalidTable
+     */
+    public function testRejectsInvalidTable($invalidTable)
+    {
+        $this->setExpectedException('Zend\Db\Sql\Exception\InvalidArgumentException');
+
+        new TableIdentifier($invalidTable);
+    }
+
+    /**
+     * Data provider
+     *
+     * @return mixed[][]
+     */
+    public function invalidTableProvider()
+    {
+        return array(
+            array(null),
+            array(''),
+            array(new stdClass()),
+            array(array()),
+        );
     }
 }

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -77,7 +77,7 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider invalidTableProvider
+     * @dataProvider invalidSchemaProvider
      *
      * @param mixed $invalidSchema
      */

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -9,11 +9,7 @@
 
 namespace ZendTest\Db\Sql;
 
-use Zend\Db\Sql\Update;
-use Zend\Db\Sql\Where;
-use Zend\Db\Sql\Expression;
 use Zend\Db\Sql\TableIdentifier;
-use ZendTest\Db\TestAsset\TrustingSql92Platform;
 
 /**
  * Tests for {@see \Zend\Db\Sql\TableIdentifier}

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -41,12 +41,13 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTableFromObjectStringCast()
     {
-        $identifier = $this->getMock('stdClass', '__invoke');
+        $table = $this->getMock('stdClass', '__invoke');
 
-        $identifier->expects($this->once())->method('__invoke')->will($this->returnValue('castResult'));
+        $table->expects($this->once())->method('__invoke')->will($this->returnValue('castResult'));
 
-        $tableIdentifier = new TableIdentifier($identifier);
+        $tableIdentifier = new TableIdentifier($table);
 
+        $this->assertSame('castResult', $tableIdentifier->getTable());
         $this->assertSame('castResult', $tableIdentifier->getTable());
     }
 }

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -18,10 +18,24 @@ use Zend\Db\Sql\TableIdentifier;
  */
 class TableIdentifierTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetTableName()
+    public function testGetTable()
     {
         $tableIdentifier = new TableIdentifier('foo');
 
         $this->assertSame('foo', $tableIdentifier->getTable());
+    }
+
+    public function testGetDefaultSchema()
+    {
+        $tableIdentifier = new TableIdentifier('foo');
+
+        $this->assertNull($tableIdentifier->getSchema());
+    }
+
+    public function testGetSchema()
+    {
+        $tableIdentifier = new TableIdentifier('foo', 'bar');
+
+        $this->assertSame('bar', $tableIdentifier->getSchema());
     }
 }

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -38,4 +38,15 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('bar', $tableIdentifier->getSchema());
     }
+
+    public function testGetTableFromObjectStringCast()
+    {
+        $identifier = $this->getMock('stdClass', '__invoke');
+
+        $identifier->expects($this->once())->method('__invoke')->will($this->returnValue('castResult'));
+
+        $tableIdentifier = new TableIdentifier($identifier);
+
+        $this->assertSame('castResult', $tableIdentifier->getTable());
+    }
 }

--- a/tests/ZendTest/Db/Sql/TableIdentifierTest.php
+++ b/tests/ZendTest/Db/Sql/TableIdentifierTest.php
@@ -95,11 +95,9 @@ class TableIdentifierTest extends \PHPUnit_Framework_TestCase
      */
     public function invalidTableProvider()
     {
-        return array(
-            array(null),
-            array(''),
-            array(new stdClass()),
-            array(array()),
+        return array_merge(
+            array(array(null)),
+            $this->invalidSchemaProvider()
         );
     }
 


### PR DESCRIPTION
This PR invalidates #7055 by providing test coverage for the `TableIdentifier` VO.

Replaces PR #7058, which is incorrectly based on `master`.
