### PR TITLE
Scope objectKey in nested partialLoop call

### DIFF
--- a/library/Zend/View/Helper/PartialLoop.php
+++ b/library/Zend/View/Helper/PartialLoop.php
@@ -98,7 +98,8 @@ class PartialLoop extends Partial
     /**
      * Set object key in this loop and any child loop
      *
-     * @param string $key
+     * {@inheritDoc}
+     * @return PartialLoop
      */
     public function setObjectKey($key)
     {

--- a/tests/ZendTest/View/Helper/PartialLoopTest.php
+++ b/tests/ZendTest/View/Helper/PartialLoopTest.php
@@ -317,6 +317,33 @@ class PartialLoopTest extends TestCase
             }
         }
     }
+
+    public function testNestedCallsShouldNotOverrideObjectKey()
+    {
+        $data = array();
+        for ($i = 0; $i < 3; $i++) {
+            $obj = new \stdClass();
+            $obj->helper = $this->helper;
+            $obj->objectKey = "foo" . $i;
+            $obj->message = "bar";
+            $obj->data = array(
+                $obj
+            );
+            $data[] = $obj;
+        }
+
+        $view = new View();
+        $view->resolver()->addPath($this->basePath . '/application/views/scripts');
+        $this->helper->setView($view);
+
+        $this->helper->setObjectKey('obj');
+        $result = $this->helper->__invoke('partialLoopParentObject.phtml', $data);
+
+        foreach ($data as $item) {
+            $string = 'This is an iteration with objectKey: ' . $item->objectKey;
+            $this->assertContains($string, $result, $result);
+        }
+    }
 }
 
 class IteratorTest implements Iterator

--- a/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
+++ b/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
@@ -1,0 +1,7 @@
+<?php if (empty($this->vars())): ?>
+No object model passed
+<?php else:
+	$objKey = current($this->vars())->helper->getObjectKey();
+    echo 'This is an iteration with objectKey: ' . $objKey;
+endif;
+

--- a/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
+++ b/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
@@ -1,10 +1,10 @@
 <?php
-	$vars = $this->vars();
-	if (empty($vars)) :
-?>
-No object model passed
-<?php else:
-	$objKey = current($this->vars())->helper->getObjectKey();
-    echo 'This is an iteration with objectKey: ' . $objKey;
-endif;
 
+$vars = $this->vars();
+
+if (empty($vars)) {
+	echo "No object model passed";
+} else {
+	$objKey = current($this->vars())->helper->getObjectKey();
+	echo 'This is an iteration with objectKey: ' . $objKey;
+}

--- a/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
+++ b/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
@@ -1,4 +1,7 @@
-<?php if (empty($this->vars())): ?>
+<?php
+	$vars = $this->vars();
+	if (empty($vars)) :
+?>
 No object model passed
 <?php else:
 	$objKey = current($this->vars())->helper->getObjectKey();

--- a/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopParentObject.phtml
+++ b/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopParentObject.phtml
@@ -1,0 +1,8 @@
+<?php if (!isset($this->vars()->obj)): ?>
+No object model passed
+<?php else:
+	echo $this->obj->message;
+	$this->obj->helper->setObjectKey($this->vars()->obj->objectKey);
+	echo $this->obj->helper->__invoke('partialLoopChildObject.phtml', $obj->data); 
+endif;
+

--- a/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopParentObject.phtml
+++ b/tests/ZendTest/View/Helper/_files/modules/application/views/scripts/partialLoopParentObject.phtml
@@ -1,8 +1,9 @@
-<?php if (!isset($this->vars()->obj)): ?>
-No object model passed
-<?php else:
+<?php
+
+if (!isset($this->vars()->obj)) {
+	echo "No object model passed";
+} else {
 	echo $this->obj->message;
 	$this->obj->helper->setObjectKey($this->vars()->obj->objectKey);
 	echo $this->obj->helper->__invoke('partialLoopChildObject.phtml', $obj->data); 
-endif;
-
+}


### PR DESCRIPTION
This is a fix for #3758 and introduces an `objectKeyStack` which scopes the `objectKey` to a `nestingLevel`. This allows nested calls with the `PartialLoop` View Helper where each level of nesting uses it's own or a parent's `objectKey`.

It is not clear whether this is a bug fix or a feature request which introduces a BC break, but at least no tests are failing. I'd be happy to write a test case for this fix if necessary.

This is my first pull request ever, so please be gentle when providing feedback :)
