### PR TITLE
Fixes #6366: Session validators

### DIFF
--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -49,15 +49,25 @@ abstract class AbstractManager implements Manager
     protected $saveHandler;
 
     /**
+     * @var array
+     */
+    protected $validators;
+
+    /**
      * Constructor
      *
-     * @param  Config|null $config
-     * @param  Storage|null $storage
+     * @param  Config|null      $config
+     * @param  Storage|null     $storage
      * @param  SaveHandler|null $saveHandler
+     * @param  array            $validators
      * @throws Exception\RuntimeException
      */
-    public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
-    {
+    public function __construct(
+        Config $config = null,
+        Storage $storage = null,
+        SaveHandler $saveHandler = null,
+        array $validators = array()
+    ) {
         // init config
         if ($config === null) {
             if (!class_exists($this->defaultConfigClass)) {
@@ -106,6 +116,8 @@ abstract class AbstractManager implements Manager
         if ($saveHandler !== null) {
             $this->saveHandler = $saveHandler;
         }
+
+        $this->validators = $validators;
     }
 
     /**

--- a/library/Zend/Session/Service/SessionManagerFactory.php
+++ b/library/Zend/Session/Service/SessionManagerFactory.php
@@ -65,6 +65,7 @@ class SessionManagerFactory implements FactoryInterface
         $config        = null;
         $storage       = null;
         $saveHandler   = null;
+        $validators    = array();
         $managerConfig = $this->defaultManagerConfig;
 
         if ($services->has('Zend\Session\Config\ConfigInterface')) {
@@ -103,8 +104,6 @@ class SessionManagerFactory implements FactoryInterface
             }
         }
 
-        $manager = new SessionManager($config, $storage, $saveHandler);
-
         // Get session manager configuration, if any, and merge with default configuration
         if ($services->has('Config')) {
             $configService = $services->get('Config');
@@ -113,15 +112,13 @@ class SessionManagerFactory implements FactoryInterface
             ) {
                 $managerConfig = array_merge($managerConfig, $configService['session_manager']);
             }
-            // Attach validators to session manager, if any
+
             if (isset($managerConfig['validators'])) {
-                $chain = $manager->getValidatorChain();
-                foreach ($managerConfig['validators'] as $validator) {
-                    $validator = new $validator();
-                    $chain->attach('session.validate', array($validator, 'isValid'));
-                }
+                $validators = $managerConfig['validators'];
             }
         }
+
+        $manager = new SessionManager($config, $storage, $saveHandler, $validators);
 
         // If configuration enables the session manager as the default manager for container
         // instances, do so.

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -40,14 +40,19 @@ class SessionManager extends AbstractManager
     /**
      * Constructor
      *
-     * @param  Config\ConfigInterface|null $config
-     * @param  Storage\StorageInterface|null $storage
+     * @param  Config\ConfigInterface|null           $config
+     * @param  Storage\StorageInterface|null         $storage
      * @param  SaveHandler\SaveHandlerInterface|null $saveHandler
+     * @param  array                                 $validators
      * @throws Exception\RuntimeException
      */
-    public function __construct(Config\ConfigInterface $config = null, Storage\StorageInterface $storage = null, SaveHandler\SaveHandlerInterface $saveHandler = null)
-    {
-        parent::__construct($config, $storage, $saveHandler);
+    public function __construct(
+        Config\ConfigInterface $config = null,
+        Storage\StorageInterface $storage = null,
+        SaveHandler\SaveHandlerInterface $saveHandler = null,
+        array $validators = array()
+    ) {
+        parent::__construct($config, $storage, $saveHandler, $validators);
         register_shutdown_function(array($this, 'writeClose'));
     }
 
@@ -107,8 +112,29 @@ class SessionManager extends AbstractManager
             $storage->init($_SESSION);
         }
 
+        $this->initializeValidatorChain();
+
         if (!$this->isValid()) {
             throw new Exception\RuntimeException('Session validation failed');
+        }
+    }
+
+    /**
+     * Create validators, insert reference value and add them to the validator chain
+     */
+    protected function initializeValidatorChain()
+    {
+        $validatorChain = $this->getValidatorChain();
+        foreach ($this->validators as $validator) {
+            $validatorValues = $this->getStorage()->getMetadata('_VALID');
+
+            $referenceValue = null;
+            if (is_array($validatorValues) && array_key_exists($validator, $validatorValues)) {
+                $referenceValue = $validatorValues[$validator];
+            }
+
+            $validator      = new $validator($referenceValue);
+            $validatorChain->attach('session.validate', array($validator, 'isValid'));
         }
     }
 

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -124,16 +124,16 @@ class SessionManager extends AbstractManager
      */
     protected function initializeValidatorChain()
     {
-        $validatorChain = $this->getValidatorChain();
-        foreach ($this->validators as $validator) {
-            $validatorValues = $this->getStorage()->getMetadata('_VALID');
+        $validatorChain  = $this->getValidatorChain();
+        $validatorValues = $this->getStorage()->getMetadata('_VALID');
 
+        foreach ($this->validators as $validator) {
             $referenceValue = null;
             if (is_array($validatorValues) && array_key_exists($validator, $validatorValues)) {
                 $referenceValue = $validatorValues[$validator];
             }
 
-            $validator      = new $validator($referenceValue);
+            $validator = new $validator($referenceValue);
             $validatorChain->attach('session.validate', array($validator, 'isValid'));
         }
     }

--- a/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
+++ b/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
@@ -75,6 +75,9 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($manager, Container::getDefaultManager());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testFactoryWillAddValidatorViaConfiguration()
     {
         $config = array('session_manager' => array(
@@ -85,6 +88,65 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->services->setService('Config', $config);
         $manager = $this->services->get('Zend\Session\ManagerInterface');
 
+        $manager->start();
+
         $this->assertEquals(1, $manager->getValidatorChain()->getListeners('session.validate')->count());
+    }
+
+    /**
+     * @group 6366
+     */
+    public function testFactoryDoesNotOverwriteValidatorStorageValues()
+    {
+        $storage = new ArrayStorage();
+        $storage->setMetadata('_VALID', array(
+            'Zend\Session\Validator\HttpUserAgent' => 'Foo',
+            'Zend\Session\Validator\RemoteAddr'    => '1.2.3.4',
+        ));
+        $this->services->setService('Zend\Session\Storage\StorageInterface', $storage);
+
+        $config = array(
+            'session_manager' => array(
+                'validators' => array(
+                    'Zend\Session\Validator\HttpUserAgent',
+                    'Zend\Session\Validator\RemoteAddr',
+                ),
+            ),
+        );
+        $this->services->setService('Config', $config);
+
+        // This call is needed to make sure session storage data is not overwritten by the factory
+        $manager = $this->services->get('Zend\Session\ManagerInterface');
+
+        $validatorData = $storage->getMetaData('_VALID');
+        $this->assertSame('Foo'    , $validatorData['Zend\Session\Validator\HttpUserAgent']);
+        $this->assertSame('1.2.3.4', $validatorData['Zend\Session\Validator\RemoteAddr']);
+    }
+
+    /**
+     * @group 6366
+     * @runInSeparateProcess
+     */
+    public function testSessionValuesShouldNotExistBeforeCallingStart()
+    {
+        $config = array(
+            'session_manager' => array(
+                'validators' => array(
+                    'Zend\Session\Validator\RemoteAddr',
+                ),
+            )
+        );
+        $this->services->setService('Config', $config);
+
+        $manager = $this->services->get('Zend\Session\ManagerInterface');
+
+        $this->assertFalse($manager->sessionExists(), 'Session should not exist');
+
+        // ZF values should not exist before calling start()
+        $this->assertFalse(isset($_SESSION['__ZF']['_VALID']), 'ZF session values should not yet exist');
+
+        $manager->start();
+
+        $this->assertTrue(isset($_SESSION['__ZF']['_VALID']));
     }
 }

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -89,6 +89,19 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($saveHandler, $manager->getSaveHandler());
     }
 
+    /**
+     * @group 6366
+     */
+    public function testCanPassValidatorsToConstructor()
+    {
+        $validators = array(
+            'foo',
+            'bar',
+        );
+        $manager = new SessionManager(null, null, null, $validators);
+        $this->assertAttributeEquals($validators, 'validators', $manager);
+    }
+
     // Session-related functionality
 
     /**


### PR DESCRIPTION
Fix for issue #6366.

The session validators need the reference value at instantiation. The current implementation does _not_ insert the reference value ([`Zend\Session\Service\SessionManagerFactory` line 120](https://github.com/zendframework/zf2/blob/67f098af070b29d5042e89e936604df3193d2212/library/Zend/Session/Service/SessionManagerFactory.php#L120)) and therefore the default value is used and validation always returns true.

The session validators need to be set _after_ the session has started. The instantiation of the session validators can not be done in `Zend\Session\Service\SessionManagerFactory`, because the session has not started yet.

This PR fixes that issue and initializes the validators _after_ the session has started. This way the correct values are inserted into the validators.
