### PR TITLE
Fix form annotation options

### DIFF
--- a/library/Zend/Form/Annotation/ElementAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/ElementAnnotationsListener.php
@@ -140,9 +140,12 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
             }
             unset($specification['input_filter']);
 
+            // Merge options of composed object with the ones of the target object:
+            $options = $this->mergeOptions($elementSpec, $annotation);
+
             $elementSpec['spec']['type'] = 'Zend\Form\Element\Collection';
             $elementSpec['spec']['name'] = $name;
-            $elementSpec['spec']['options'] = new ArrayObject($annotation->getOptions());
+            $elementSpec['spec']['options'] = new ArrayObject($options);
             $elementSpec['spec']['options']['target_element'] = $specification;
             $elementSpec['spec']['options']['target_element']['options']['input_filter_spec'] = $inputFilter;
 
@@ -164,8 +167,7 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
             }
 
             // Merge options of composed object with the ones of the target object:
-            $options = (isset($elementSpec['spec']['options']) && is_array($elementSpec['spec']['options'])) ? $elementSpec['spec']['options'] : array();
-            $options = array_merge($options, $annotation->getOptions());
+            $options = $this->mergeOptions($elementSpec, $annotation);
 
             // Add element spec:
             $elementSpec['spec'] = $specification;
@@ -324,7 +326,8 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
         }
 
         $elementSpec = $e->getParam('elementSpec');
-        $elementSpec['spec']['options'] = $annotation->getOptions();
+        $options = $this->mergeOptions($elementSpec, $annotation);
+        $elementSpec['spec']['options'] = $options;
     }
 
     /**
@@ -395,5 +398,25 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
             $inputSpec['validators'] = array();
         }
         $inputSpec['validators'][] = $annotation->getValidator();
+    }
+
+    /**
+     * @param $elementSpec
+     * @param $annotation
+     * @return array
+     */
+    protected function mergeOptions($elementSpec, $annotation)
+    {
+        $options  = array();
+        if (isset($elementSpec['spec']['options'])) {
+            if (is_array($elementSpec['spec']['options'])) {
+                $options = $elementSpec['spec']['options'];
+            } elseif ($elementSpec['spec']['options'] instanceof ArrayObject) {
+                $options = $elementSpec['spec']['options']->getArrayCopy();
+            }
+        }
+
+        $options = array_merge($options, $annotation->getOptions());
+        return $options;
     }
 }

--- a/library/Zend/Form/Annotation/ElementAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/ElementAnnotationsListener.php
@@ -140,12 +140,9 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
             }
             unset($specification['input_filter']);
 
-            // Merge options of composed object with the ones of the target object:
-            $options = $this->mergeOptions($elementSpec, $annotation);
-
             $elementSpec['spec']['type'] = 'Zend\Form\Element\Collection';
             $elementSpec['spec']['name'] = $name;
-            $elementSpec['spec']['options'] = new ArrayObject($options);
+            $elementSpec['spec']['options'] = new ArrayObject($this->mergeOptions($elementSpec, $annotation));
             $elementSpec['spec']['options']['target_element'] = $specification;
             $elementSpec['spec']['options']['target_element']['options']['input_filter_spec'] = $inputFilter;
 
@@ -166,13 +163,10 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
                 $specification['type'] = 'Zend\Form\Fieldset';
             }
 
-            // Merge options of composed object with the ones of the target object:
-            $options = $this->mergeOptions($elementSpec, $annotation);
-
             // Add element spec:
             $elementSpec['spec'] = $specification;
             $elementSpec['spec']['name'] = $name;
-            $elementSpec['spec']['options'] = new ArrayObject($options);
+            $elementSpec['spec']['options'] = new ArrayObject($this->mergeOptions($elementSpec, $annotation));
         }
     }
 
@@ -326,8 +320,7 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
         }
 
         $elementSpec = $e->getParam('elementSpec');
-        $options = $this->mergeOptions($elementSpec, $annotation);
-        $elementSpec['spec']['options'] = $options;
+        $elementSpec['spec']['options'] = $this->mergeOptions($elementSpec, $annotation);
     }
 
     /**
@@ -405,7 +398,7 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
      * @param $annotation
      * @return array
      */
-    protected function mergeOptions($elementSpec, $annotation)
+    private function mergeOptions($elementSpec, $annotation)
     {
         $options  = array();
         if (isset($elementSpec['spec']['options'])) {
@@ -416,7 +409,6 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
             }
         }
 
-        $options = array_merge($options, $annotation->getOptions());
-        return $options;
+        return array_merge($options, $annotation->getOptions());
     }
 }

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -184,6 +184,28 @@ class AnnotationBuilderTest extends TestCase
         $this->assertTrue($target->has('password'));
     }
 
+    /**
+     * @dataProvider provideOptionsAnnotationAndComposedObjectAnnotation
+     * @param $childName
+     */
+    public function testOptionsAnnotationAndComposedObjectAnnotation($childName)
+    {
+        $entity  = new TestAsset\Annotation\EntityUsingComposedObjectAndOptions();
+        $builder = new Annotation\AnnotationBuilder();
+        $form    = $builder->createForm($entity);
+
+        $child = $form->get($childName);
+
+        $target = $child->getTargetElement();
+        $this->assertInstanceOf('Zend\Form\FieldsetInterface', $target);
+        $this->assertEquals('My label', $child->getLabel());
+    }
+
+    public function provideOptionsAnnotationAndComposedObjectAnnotation()
+    {
+        return [['child'], ['childTheSecond']];
+    }
+
     public function testCanHandleOptionsAnnotation()
     {
         $entity  = new TestAsset\Annotation\EntityUsingOptions();

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -203,7 +203,7 @@ class AnnotationBuilderTest extends TestCase
 
     public function provideOptionsAnnotationAndComposedObjectAnnotation()
     {
-        return [['child'], ['childTheSecond']];
+        return array(array('child'), array('childTheSecond'));
     }
 
     public function testCanHandleOptionsAnnotation()

--- a/tests/ZendTest/Form/TestAsset/Annotation/EntityUsingComposedObjectAndOptions.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/EntityUsingComposedObjectAndOptions.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+/**
+ * @Annotation\Name("hierarchical")
+ */
+class EntityUsingComposedObjectAndOptions
+{
+    /**
+     * @Annotation\Name("child")
+     * @Annotation\Options({"label": "My label"})
+     * @Annotation\ComposedObject({"target_object":"ZendTest\Form\TestAsset\Annotation\Entity", "is_collection":"true"})
+     */
+    public $child;
+
+    /**
+     * @Annotation\Name("childTheSecond")
+     * @Annotation\ComposedObject({"target_object":"ZendTest\Form\TestAsset\Annotation\Entity", "is_collection":"true"})
+     * @Annotation\Options({"label": "My label"})
+     */
+    public $childTheSecond;
+}


### PR DESCRIPTION
The options annotation and composed object annotation overwrite each other under certain conditions. The PR fixes this behaviour so that the specified options are merged.
