### PR TITLE
Improved disabled inputs testing when binding values into fieldset object

### DIFF
--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -586,7 +586,7 @@ class Fieldset extends Element implements FieldsetInterface
             }
 
             // skip post values for disabled elements, get old value from object
-            if (!$element->hasAttribute('disabled')) {
+            if (!$element->getAttribute('disabled')) {
                 $hydratableData[$name] = $value;
             } elseif (array_key_exists($name, $objectData)) {
                 $hydratableData[$name] = $objectData[$name];


### PR DESCRIPTION
It's not enough to test that 'disabled' attribute exists, should also check that its value is something else than null or false or empty.
