### PR TITLE
Fix for validation timeouts, issue #4960

### DIFF
--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -24,12 +24,12 @@ class DateStep extends Date
     /**
      * @var array
      */
-    protected $messageTemplates = [
+    protected $messageTemplates = array(
         self::INVALID      => "Invalid type given. String, integer, array or DateTime expected",
         self::INVALID_DATE => "The input does not appear to be a valid date",
         self::FALSEFORMAT  => "The input does not fit the date format '%format%'",
         self::NOT_STEP     => "The input is not a valid step",
-    ];
+    );
 
     /**
      * Optional base date value
@@ -59,7 +59,7 @@ class DateStep extends Date
      *
      * @param array $options
      */
-    public function __construct($options = [])
+    public function __construct($options = array())
     {
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
@@ -212,7 +212,7 @@ class DateStep extends Date
         $intervalParts = explode('|', $step->format('%y|%m|%d|%h|%i|%s'));
         $partCounts    = array_count_values($intervalParts);
 
-        $unitKeys = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
+        $unitKeys = array('years', 'months', 'days', 'hours', 'minutes', 'seconds');
         $intervalParts = array_combine($unitKeys, $intervalParts);
 
         // Get absolute time difference
@@ -233,7 +233,7 @@ class DateStep extends Date
             }
 
             // Check date units
-            if (in_array($intervalUnit, ['years', 'months', 'days'])) {
+            if (in_array($intervalUnit, array('years', 'months', 'days'))) {
                 switch ($intervalUnit) {
                     case 'years':
                         if (0 == $diffParts['months'] && 0 == $diffParts['days']
@@ -271,7 +271,7 @@ class DateStep extends Date
             }
 
             // Check time units
-            if (in_array($intervalUnit, ['hours', 'minutes', 'seconds'])) {
+            if (in_array($intervalUnit, array('hours', 'minutes', 'seconds'))) {
                 // Simple test if $stepValue is 1.
                 if (1 == $stepValue) {
                     if ('hours' === $intervalUnit

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -358,15 +358,13 @@ class DateStep extends Date
         // If we use PHP_INT_MAX DateInterval::__construct falls over with a bad format error
         // before we reach the max on 64 bit machines
         $maxInteger = min(pow(2,31), PHP_INT_MAX);
-        if ($minSteps * $maximumInterval > $maxInteger)
-        {
+        if ($minSteps * $maximumInterval > $maxInteger) {
             $stepIterationsRequired =  ceil(($minSteps * $maximumInterval) / $maxInteger);
             $minSteps = floor($minSteps / $stepIterationsRequired);
         }
 
-        $multipliedParts = [];
-        foreach($intervalParts as $unit => $value)
-        {
+        $multipliedParts = array();
+        foreach($intervalParts as $unit => $value) {
             $multipliedParts[$unit] = $value * $minSteps;
         }
         $multipliedIntervalString = sprintf('P%dY%dM%dDT%dH%dM%dS', $multipliedParts['years'],
@@ -375,7 +373,7 @@ class DateStep extends Date
         $minimumInterval = new DateInterval($multipliedIntervalString);
 
         if ($baseDate < $valueDate) {
-            if($minSteps > 0){
+            if($minSteps > 0) {
                 for($i =0; $i<$stepIterationsRequired; $i++)
                 {
                     $baseDate->add($minimumInterval);
@@ -388,7 +386,7 @@ class DateStep extends Date
                 }
             }
         } else {
-            if($minSteps > 0){
+            if($minSteps > 0) {
                 for($i=0; $i<$stepIterationsRequired; $i++)
                 {
                     $baseDate->sub($minimumInterval);

--- a/tests/ZendTest/Validator/DateStepTest.php
+++ b/tests/ZendTest/Validator/DateStepTest.php
@@ -70,6 +70,9 @@ class DateStepTest extends \PHPUnit_Framework_TestCase
             // complex
             array('P2M2DT12H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', true ),
             array('P2M2DT12M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', false),
+            // long interval
+            array('PT1M20S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:40Z', true), // 20,000,000 steps
+            array('PT1M20S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:41Z', false),
         );
 
         // bug in DateTime fixed in 5.3.7


### PR DESCRIPTION
The fallback for iterating through all possible steps from the base step until we equal or exceed the target value can take a long time (~30 seconds for me) when using a current timestamp and the default base value, which will occur when validating a Zend\Form\Element\DateTime with step != 1.

This change calculates a lower bound for the number of steps we will need to iterate over and skips to that timestamp before iterating as before. For me this brought the tests back down to under a second.

I have also added in a return false for the special case test where we have a step of 1 hour, 1 minute as if there are non-zero seconds (or non-zero minutes for step = 1 hour) then we know it isn't a valid step. I have also fixed a bug converting hours => seconds in the same day special case.
