### PR TITLE
Added trailing comma for multiline arrays

### DIFF
--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -374,7 +374,10 @@ class ValueGenerator extends AbstractGenerator
                     : ' ';
                 $output .= implode(',' . $padding, $outputParts);
                 if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
-                    $output .= ',' . self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
+                    if (count($outputParts) > 0) {
+                        $output .= ',';
+                    }
+                    $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
                 $output .= ')';
                 break;

--- a/library/Zend/Code/Generator/ValueGenerator.php
+++ b/library/Zend/Code/Generator/ValueGenerator.php
@@ -374,7 +374,7 @@ class ValueGenerator extends AbstractGenerator
                     : ' ';
                 $output .= implode(',' . $padding, $outputParts);
                 if ($this->outputMode == self::OUTPUT_MULTIPLE_LINE) {
-                    $output .= self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
+                    $output .= ',' . self::LINE_FEED . str_repeat($this->indentation, $this->arrayDepth);
                 }
                 $output .= ')';
                 break;

--- a/tests/ZendTest/Code/Generator/PropertyGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/PropertyGeneratorTest.php
@@ -103,7 +103,7 @@ class PropertyGeneratorTest extends \PHPUnit_Framework_TestCase
         'two' => '2',
         'null' => null,
         'true' => true,
-        'bar\'s' => 'bar\'s'
+        'bar\'s' => 'bar\'s',
     );
 EOS;
 

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -101,7 +101,7 @@ array(
         array(
             'baz1',
             'baz2',
-            'constant2' => ArrayObject::STD_PROP_LIST
+            'constant2' => ArrayObject::STD_PROP_LIST,
         ),
     ),
     PHP_EOL,

--- a/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ValueGeneratorTest.php
@@ -43,7 +43,7 @@ class ValueGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $expectedSource = <<<EOS
 array(
-    'foo'
+    'foo',
 )
 EOS;
 
@@ -102,9 +102,9 @@ array(
             'baz1',
             'baz2',
             'constant2' => ArrayObject::STD_PROP_LIST
-        )
+        ),
     ),
-    PHP_EOL
+    PHP_EOL,
 )
 EOS;
 
@@ -133,7 +133,7 @@ array(
     0 => 'b',
     'c',
     7 => 'd',
-    3 => 'e'
+    3 => 'e',
 )
 EOS;
 


### PR DESCRIPTION
This little fix makes sure that a trailing comma is added after the last item of an array created by `Zend\Code\Generator\ValueGenerator` when using the multiple line mode.

This trailing comma is suggested by the Coding Standards:

https://zf2-docs.readthedocs.org/en/latest/ref/coding.standard.html#associative-arrays 
