### PR TITLE
Feature: Added sslverifypeer to curl adapter

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -122,6 +122,11 @@ class Curl implements HttpAdapter, StreamInterface
             unset($options['proxyuser'], $options['proxypass']);
         }
 
+        if (isset($options['sslverifypeer'])) {
+            $this->setCurlOption(CURLOPT_SSL_VERIFYPEER, $options['sslverifypeer']);
+            unset($options['sslverifypeer']);
+        }
+
         foreach ($options as $k => $v) {
             $option = strtolower($k);
             switch ($option) {

--- a/tests/ZendTest/Http/Client/CurlTest.php
+++ b/tests/ZendTest/Http/Client/CurlTest.php
@@ -296,6 +296,24 @@ class CurlTest extends CommonHttpTests
         );
     }
 
+    public function testSslVerifyPeerCanSetOverOption()
+    {
+        $adapter = new Adapter\Curl();
+        $adapter->setOptions(array(
+            'sslverifypeer' => true
+        ));
+
+        $expected = array(
+            'curloptions' => array(
+                CURLOPT_SSL_VERIFYPEER => true
+            ),
+        );
+
+        $this->assertEquals(
+            $expected, $this->readAttribute($adapter, 'config')
+        );
+    }
+
     /**
      * @group ZF-7040
      */


### PR DESCRIPTION
the option can be set through the `curloptions` but in many projects this option is global shared through `sslverifypeer` as in every other adapter allready implement.
