### PR TITLE
SessionManagerFactory with ArrayStorage triggers undefined variable

### DIFF
--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -93,7 +93,10 @@ class SessionManager extends AbstractManager
             $this->registerSaveHandler($saveHandler);
         }
 
-        $oldSessionData = $_SESSION;
+        $oldSessionData = array();
+        if (isset($_SESSION)) {
+            $oldSessionData = $_SESSION;
+        }
 
         session_start();
 

--- a/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
+++ b/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
@@ -87,4 +87,16 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, $manager->getValidatorChain()->getListeners('session.validate')->count());
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testStartingSessionManagerFromFactoryDoesNotTriggerUndefinedVariable()
+    {
+        $storage = new ArrayStorage();
+        $this->services->setService('Zend\Session\Storage\StorageInterface', $storage);
+
+        $manager = $this->services->get('Zend\Session\ManagerInterface');
+        $manager->start();
+    }
 }

--- a/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
+++ b/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
@@ -98,5 +98,7 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
 
         $manager = $this->services->get('Zend\Session\ManagerInterface');
         $manager->start();
+
+        $this->assertSame($storage, $manager->getStorage());
     }
 }


### PR DESCRIPTION
When using `Zend\Session\Service\SessionManagerFactory` with `ArrayStorage` security fix ddbf43a triggers an undefined variable:

```
Undefined variable: _SESSION
```

This PR fixes that issue.
