### PR TITLE
SessionManagerFactory + session validators via config makes validation always fail

### DIFF
--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -49,15 +49,25 @@ abstract class AbstractManager implements Manager
     protected $saveHandler;
 
     /**
+     * @var array
+     */
+    protected $validators;
+
+    /**
      * Constructor
      *
-     * @param  Config|null $config
-     * @param  Storage|null $storage
+     * @param  Config|null      $config
+     * @param  Storage|null     $storage
      * @param  SaveHandler|null $saveHandler
+     * @param  array            $validators
      * @throws Exception\RuntimeException
      */
-    public function __construct(Config $config = null, Storage $storage = null, SaveHandler $saveHandler = null)
-    {
+    public function __construct(
+        Config $config = null,
+        Storage $storage = null,
+        SaveHandler $saveHandler = null,
+        array $validators = array()
+    ) {
         // init config
         if ($config === null) {
             if (!class_exists($this->defaultConfigClass)) {
@@ -106,6 +116,8 @@ abstract class AbstractManager implements Manager
         if ($saveHandler !== null) {
             $this->saveHandler = $saveHandler;
         }
+
+        $this->validators = $validators;
     }
 
     /**

--- a/library/Zend/Session/Service/SessionManagerFactory.php
+++ b/library/Zend/Session/Service/SessionManagerFactory.php
@@ -65,6 +65,7 @@ class SessionManagerFactory implements FactoryInterface
         $config        = null;
         $storage       = null;
         $saveHandler   = null;
+        $validators    = array();
         $managerConfig = $this->defaultManagerConfig;
 
         if ($services->has('Zend\Session\Config\ConfigInterface')) {
@@ -103,8 +104,6 @@ class SessionManagerFactory implements FactoryInterface
             }
         }
 
-        $manager = new SessionManager($config, $storage, $saveHandler);
-
         // Get session manager configuration, if any, and merge with default configuration
         if ($services->has('Config')) {
             $configService = $services->get('Config');
@@ -113,15 +112,13 @@ class SessionManagerFactory implements FactoryInterface
             ) {
                 $managerConfig = array_merge($managerConfig, $configService['session_manager']);
             }
-            // Attach validators to session manager, if any
+
             if (isset($managerConfig['validators'])) {
-                $chain = $manager->getValidatorChain();
-                foreach ($managerConfig['validators'] as $validator) {
-                    $validator = new $validator();
-                    $chain->attach('session.validate', array($validator, 'isValid'));
-                }
+                $validators = $managerConfig['validators'];
             }
         }
+
+        $manager = new SessionManager($config, $storage, $saveHandler, $validators);
 
         // If configuration enables the session manager as the default manager for container
         // instances, do so.

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -140,6 +140,11 @@ class SessionManager extends AbstractManager
         $validatorValues = $this->getStorage()->getMetadata('_VALID');
 
         foreach ($this->validators as $validator) {
+            // Ignore validators which are already present in Storage
+            if (is_array($validatorValues) && array_key_exists($validator, $validatorValues)) {
+                continue;
+            }
+
             $referenceValue = null;
             if (is_array($validatorValues) && array_key_exists($validator, $validatorValues)) {
                 $referenceValue = $validatorValues[$validator];

--- a/library/Zend/Session/SessionManager.php
+++ b/library/Zend/Session/SessionManager.php
@@ -41,14 +41,19 @@ class SessionManager extends AbstractManager
     /**
      * Constructor
      *
-     * @param  Config\ConfigInterface|null $config
-     * @param  Storage\StorageInterface|null $storage
+     * @param  Config\ConfigInterface|null           $config
+     * @param  Storage\StorageInterface|null         $storage
      * @param  SaveHandler\SaveHandlerInterface|null $saveHandler
+     * @param  array                                 $validators
      * @throws Exception\RuntimeException
      */
-    public function __construct(Config\ConfigInterface $config = null, Storage\StorageInterface $storage = null, SaveHandler\SaveHandlerInterface $saveHandler = null)
-    {
-        parent::__construct($config, $storage, $saveHandler);
+    public function __construct(
+        Config\ConfigInterface $config = null,
+        Storage\StorageInterface $storage = null,
+        SaveHandler\SaveHandlerInterface $saveHandler = null,
+        array $validators = array()
+    ) {
+        parent::__construct($config, $storage, $saveHandler, $validators);
         register_shutdown_function(array($this, 'writeClose'));
     }
 
@@ -119,8 +124,29 @@ class SessionManager extends AbstractManager
             $storage->init($_SESSION);
         }
 
+        $this->initializeValidatorChain();
+
         if (!$this->isValid()) {
             throw new Exception\RuntimeException('Session validation failed');
+        }
+    }
+
+    /**
+     * Create validators, insert reference value and add them to the validator chain
+     */
+    protected function initializeValidatorChain()
+    {
+        $validatorChain  = $this->getValidatorChain();
+        $validatorValues = $this->getStorage()->getMetadata('_VALID');
+
+        foreach ($this->validators as $validator) {
+            $referenceValue = null;
+            if (is_array($validatorValues) && array_key_exists($validator, $validatorValues)) {
+                $referenceValue = $validatorValues[$validator];
+            }
+
+            $validator = new $validator($referenceValue);
+            $validatorChain->attach('session.validate', array($validator, 'isValid'));
         }
     }
 

--- a/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
+++ b/tests/ZendTest/Session/Service/SessionManagerFactoryTest.php
@@ -75,6 +75,9 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($manager, Container::getDefaultManager());
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testFactoryWillAddValidatorViaConfiguration()
     {
         $config = array('session_manager' => array(
@@ -84,6 +87,8 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         ));
         $this->services->setService('Config', $config);
         $manager = $this->services->get('Zend\Session\ManagerInterface');
+
+        $manager->start();
 
         $this->assertEquals(1, $manager->getValidatorChain()->getListeners('session.validate')->count());
     }
@@ -100,5 +105,35 @@ class SessionManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $manager->start();
 
         $this->assertSame($storage, $manager->getStorage());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFactoryDoesNotOverwriteValidatorStorageValues()
+    {
+        $storage = new ArrayStorage();
+        $storage->setMetadata('_VALID', array(
+            'Zend\Session\Validator\HttpUserAgent' => 'Foo',
+            'Zend\Session\Validator\RemoteAddr'    => '1.2.3.4',
+        ));
+        $this->services->setService('Zend\Session\Storage\StorageInterface', $storage);
+
+        $config = array(
+            'session_manager' => array(
+                'validators' => array(
+                    'Zend\Session\Validator\HttpUserAgent',
+                    'Zend\Session\Validator\RemoteAddr',
+                ),
+            ),
+        );
+        $this->services->setService('Config', $config);
+
+        // This call is needed to make sure session storage data is not overwritten by the factory
+        $manager = $this->services->get('Zend\Session\ManagerInterface');
+
+        $validatorData = $storage->getMetaData('_VALID');
+        $this->assertSame('Foo'    , $validatorData['Zend\Session\Validator\HttpUserAgent']);
+        $this->assertSame('1.2.3.4', $validatorData['Zend\Session\Validator\RemoteAddr']);
     }
 }

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -90,6 +90,16 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($saveHandler, $manager->getSaveHandler());
     }
 
+    public function testCanPassValidatorsToConstructor()
+    {
+        $validators = array(
+            'foo',
+            'bar',
+        );
+        $manager = new SessionManager(null, null, null, $validators);
+        $this->assertAttributeEquals($validators, 'validators', $manager);
+    }
+
     // Session-related functionality
 
     /**


### PR DESCRIPTION
When using `Zend\Session\Service\SessionManagerFactory` validators can be added via config:

``` php
'session_manager' => array(
    'validators' => array(
        'Zend\Session\Validator\HttpUserAgent',
        'Zend\Session\Validator\RemoteAddr',
    ),
),
```

_Before_ security fix ddbf43a validators always returned true. _After_ the security fix validators always fail. This PR fixes that issue with `Zend\Session\Service\SessionManagerFactory` (not to be confused with standalone usage of `Zend\Session\SessionManager`).

It is the same fix as in #7094, but it got ignored because of the security issue.
