### PR TITLE
Tests for SessionManager preserveStorage flag

### DIFF
--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Session;
 
 use Zend\Session\SessionManager;
 use Zend\Session;
+use Zend\Session\Storage\ArrayStorage;
 use Zend\Session\Validator\RemoteAddr;
 
 /**
@@ -631,5 +632,47 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Zend\Session\Exception\RuntimeException', 'Session validation failed');
         $this->manager->start();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanPreserveStorageValues()
+    {
+        $storage = new ArrayStorage(array(
+            'foo' => 'bar',
+        ));
+        $this->manager->setStorage($storage);
+        $this->manager->start(true);
+
+        $this->assertSame('bar', $this->manager->getStorage()->getMetadata('foo'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanDisablePreserveStorageValues()
+    {
+        $storage = new ArrayStorage(array(
+            'foo' => 'bar',
+        ));
+        $this->manager->setStorage($storage);
+        $this->manager->start(false);
+
+        $this->assertNotSame('bar', $this->manager->getStorage()->getMetadata('foo'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPreserveStorageValuesIsDisabledByDefault()
+    {
+        $storage = new ArrayStorage(array(
+            'foo' => 'bar',
+        ));
+        $this->manager->setStorage($storage);
+        $this->manager->start();
+
+        $this->assertNotSame('bar', $this->manager->getStorage()->getMetadata('foo'));
     }
 }


### PR DESCRIPTION
`Zend/Session/SessionManager::start()` has an optional flag `$preserveStorage`: [`Zend/Session/SessionManager` line 84](https://github.com/zendframework/zf2/blob/037c62b140fa3dfd2b150563cd354bbb3230cd92/library/Zend/Session/SessionManager.php#L84)

> If set to true, current session storage will not be overwritten by the contents of $_SESSION.

This PR tests that functionality. Not all tests pass, because the `$preserveStorage` flag is not working as it should.
