### PR TITLE
Fixing deprecated preg_replace usage in classmap_generator.php

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -220,6 +220,9 @@ $content = str_replace('\\\\', '\\', $content);
 // Exchange "array (" width "array("
 $content = str_replace('array (', 'array(', $content);
 
+// Identing array content
+$content = preg_replace('(\n  )', "\n    ", $content);
+
 // Align "=>" operators to match coding standard
 preg_match_all('(\n\s+([^=]+)=>)', $content, $matches, PREG_SET_ORDER);
 $maxWidth = 0;
@@ -228,7 +231,11 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
-$content = preg_replace('(\n\s+([^=]+)=>)e', "'\n    \\1' . str_repeat(' ', " . $maxWidth . " - strlen('\\1')) . '=>'", $content);
+$content = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches)
+{
+    global $maxWidth;
+    return str_replace(' =>', str_repeat(' ', $maxWidth - strlen($matches[1])) . ' =>', $matches[0]);
+}, $content);
 
 // Make the file end by EOL
 $content = rtrim($content, "\n") . "\n";

--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -231,9 +231,9 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
-$content = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches)
-{
+$content = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches) {
     global $maxWidth;
+
     return str_replace(' =>', str_repeat(' ', $maxWidth - strlen($matches[1])) . ' =>', $matches[0]);
 }, $content);
 


### PR DESCRIPTION
With php >= 5.5, the /e parameter in preg_replace is deprecated and gives the warning:

```
Creating class file map for library in '<path>'...
PHP Deprecated:  preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in <path>/zf2/bin/classmap_generator.php on line 231

Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in <path>/zf2/bin/classmap_generator.php on line 231
Wrote classmap file to '<path>/autoload_classmap.php'
```

As suggested, this PR changes the preg_replace to preg_replace_callback.
