### PR TITLE
Request from string

### DIFF
--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -93,6 +93,13 @@ class Request extends AbstractMessage implements RequestInterface
         $request->setMethod($matches['method']);
         $request->setUri($matches['uri']);
 
+        $parsedUri = parse_url($matches['uri']);
+        if(array_key_exists('query', $parsedUri)) {
+            $parsedQuery = [];
+            parse_str($parsedUri['query'], $parsedQuery);
+            $request->setQuery(new Parameters($parsedQuery));
+        }
+
         if (isset($matches['version'])) {
             $request->setVersion($matches['version']);
         }

--- a/library/Zend/Http/Request.php
+++ b/library/Zend/Http/Request.php
@@ -95,7 +95,7 @@ class Request extends AbstractMessage implements RequestInterface
 
         $parsedUri = parse_url($matches['uri']);
         if(array_key_exists('query', $parsedUri)) {
-            $parsedQuery = [];
+            $parsedQuery = array();
             parse_str($parsedUri['query'], $parsedQuery);
             $request->setQuery(new Parameters($parsedQuery));
         }

--- a/tests/ZendTest/Http/RequestTest.php
+++ b/tests/ZendTest/Http/RequestTest.php
@@ -17,11 +17,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 {
     public function testRequestFromStringFactoryCreatesValidRequest()
     {
-        $string = "GET /foo HTTP/1.1\r\n\r\nSome Content";
+        $string = "GET /foo?myparam=myvalue HTTP/1.1\r\n\r\nSome Content";
         $request = Request::fromString($string);
 
         $this->assertEquals(Request::METHOD_GET, $request->getMethod());
-        $this->assertEquals('/foo', $request->getUri());
+        $this->assertEquals('/foo?myparam=myvalue', $request->getUri());
+        $this->assertEquals('myvalue', $request->getQuery()->get('myparam'));
         $this->assertEquals(Request::VERSION_11, $request->getVersion());
         $this->assertEquals('Some Content', $request->getContent());
     }


### PR DESCRIPTION
``` php
<?php
$request = \Zend\Http\Request::fromString(
    "GET /?foo=bar HTTP/1.1\r\n\r\n"
);

var_dump($request->getQuery()->get('foo'));
// Expected "bar", got null
```
