### PR TITLE
Email validator hostname check for not empty

### DIFF
--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -408,6 +408,7 @@ class EmailAddress extends AbstractValidator
             }
 
             if (!$res
+                && !empty($hostname)
                 && (checkdnsrr($hostname, "A")
                 || checkdnsrr($hostname, "AAAA")
                 || checkdnsrr($hostname, "A6"))


### PR DESCRIPTION
Sometimes there is a warning because of empty `hostname` parameter in `checkdnsrr` function.
