### PR TITLE
Implement BcryptSha Hashing & Harden Verification Checks

### DIFF
--- a/library/Zend/Crypt/Password/Apache.php
+++ b/library/Zend/Crypt/Password/Apache.php
@@ -11,6 +11,7 @@ namespace Zend\Crypt\Password;
 
 use Traversable;
 use Zend\Math\Rand;
+use Zend\Crypt\Utils;
 
 /**
  * Apache password authentication
@@ -126,7 +127,7 @@ class Apache implements PasswordInterface
     {
         if (substr($hash, 0, 5) === '{SHA}') {
             $hash2 = '{SHA}' . base64_encode(sha1($password, true));
-            return ($hash === $hash2);
+            return Utils::compareStrings($hash, $hash2);
         }
         if (substr($hash, 0, 6) === '$apr1$') {
             $token = explode('$', $hash);
@@ -136,7 +137,7 @@ class Apache implements PasswordInterface
                 );
             }
             $hash2 = $this->apr1Md5($password, $token[2]);
-            return ($hash === $hash2);
+            return Utils::compareStrings($hash, $hash2);
         }
         if (strlen($hash) > 13) { // digest
             if (empty($this->userName) || empty($this->authName)) {
@@ -145,9 +146,9 @@ class Apache implements PasswordInterface
                 );
             }
             $hash2 = md5($this->userName . ':' . $this->authName . ':' .$password);
-            return ($hash === $hash2);
+            return Utils::compareStrings($hash, $hash2);
         }
-        return (crypt($password, $hash) === $hash);
+        return Utils::compareStrings($hash, crypt($password, $hash));
     }
 
     /**

--- a/library/Zend/Crypt/Password/Bcrypt.php
+++ b/library/Zend/Crypt/Password/Bcrypt.php
@@ -12,6 +12,7 @@ namespace Zend\Crypt\Password;
 use Traversable;
 use Zend\Math\Rand;
 use Zend\Stdlib\ArrayUtils;
+use Zend\Crypt\Utils;
 
 /**
  * Bcrypt algorithm using crypt() function of PHP
@@ -101,10 +102,7 @@ class Bcrypt implements PasswordInterface
     public function verify($password, $hash)
     {
         $result = crypt($password, $hash);
-        if ($result === $hash) {
-            return true;
-        }
-        return false;
+        return Utils::compareStrings($hash, $result);
     }
 
     /**

--- a/library/Zend/Crypt/Password/BcryptSha.php
+++ b/library/Zend/Crypt/Password/BcryptSha.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Crypt\Password;
+
+use Traversable;
+use Zend\Math\Rand;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Crypt\Hash;
+
+/**
+ * Bcrypt algorithm using crypt() function of PHP with password
+ * hashed using SHA2 to allow for passwords >72 characters.
+ */
+class BcryptSha extends Bcrypt
+{
+
+    /**
+     * BcryptSha
+     *
+     * @param  string $password
+     * @throws Exception\RuntimeException
+     * @return string
+     */
+    public function create($password)
+    {
+        $hashedPassword = Hash::compute('sha256', $password);
+        return parent::create($hashedPassword);
+    }
+
+    /**
+     * Verify if a password is correct against a hash value
+     *
+     * @param  string $password
+     * @param  string $hash
+     * @throws Exception\RuntimeException when the hash is unable to be processed
+     * @return bool
+     */
+    public function verify($password, $hash)
+    {
+        $hashedPassword = Hash::compute('sha256', $password);
+        return parent::verify($hashedPassword, $hash);
+    }
+
+}

--- a/library/Zend/Crypt/Password/BcryptSha.php
+++ b/library/Zend/Crypt/Password/BcryptSha.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -30,8 +30,7 @@ class BcryptSha extends Bcrypt
      */
     public function create($password)
     {
-        $hashedPassword = Hash::compute('sha256', $password);
-        return parent::create($hashedPassword);
+        return parent::create(Hash::compute('sha256', $password));
     }
 
     /**
@@ -44,8 +43,7 @@ class BcryptSha extends Bcrypt
      */
     public function verify($password, $hash)
     {
-        $hashedPassword = Hash::compute('sha256', $password);
-        return parent::verify($hashedPassword, $hash);
+        return parent::verify(Hash::compute('sha256', $password), $hash);
     }
 
 }

--- a/tests/ZendTest/Crypt/Password/BcryptShaTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptShaTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Crypt\Password;
+
+use Zend\Crypt\Password\Bcrypt;
+use Zend\Crypt\Password\BcryptSha;
+use Zend\Config\Config;
+use Zend\Crypt\Password\Exception;
+
+/**
+ * @group      Zend_Crypt
+ */
+class BcryptShaTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Bcrypt */
+    public $bcrypt;
+    /** @var string */
+    public $salt;
+    /** @var string */
+    public $bcryptPassword;
+    /** @var string */
+    public $password;
+
+    public function setUp()
+    {
+        $this->bcrypt   = new BcryptSha();
+        $this->salt     = '1234567890123456';
+        $this->password = 'test';
+        $this->prefix = '$2y$';
+
+        $this->bcryptPassword = $this->prefix . '10$MTIzNDU2Nzg5MDEyMzQ1NeqZGfIabq2.v6vX10KI4/z0pMoIoDyVa';
+    }
+
+    public function testConstructByOptions()
+    {
+        $options = array(
+            'cost'       => '15',
+            'salt'       => $this->salt
+        );
+        $bcrypt  = new BcryptSha($options);
+        $this->assertTrue($bcrypt instanceof BcryptSha);
+        $this->assertEquals('15', $bcrypt->getCost());
+        $this->assertEquals($this->salt, $bcrypt->getSalt());
+    }
+
+    public function testConstructByConfig()
+    {
+        $options = array(
+            'cost'       => '15',
+            'salt'       => $this->salt
+        );
+        $config  = new Config($options);
+        $bcrypt  = new BcryptSha($config);
+        $this->assertTrue($bcrypt instanceof BcryptSha);
+        $this->assertEquals('15', $bcrypt->getCost());
+        $this->assertEquals($this->salt, $bcrypt->getSalt());
+    }
+
+    public function testWrongConstruct()
+    {
+        $this->setExpectedException('Zend\Crypt\Password\Exception\InvalidArgumentException',
+                                    'The options parameter must be an array or a Traversable');
+        $bcrypt = new BcryptSha('test');
+    }
+
+    public function testSetCost()
+    {
+        $this->bcrypt->setCost('16');
+        $this->assertEquals('16', $this->bcrypt->getCost());
+    }
+
+    public function testSetWrongCost()
+    {
+        $this->setExpectedException('Zend\Crypt\Password\Exception\InvalidArgumentException',
+                                    'The cost parameter of bcrypt must be in range 04-31');
+        $this->bcrypt->setCost('3');
+    }
+
+    public function testSetSalt()
+    {
+        $this->bcrypt->setSalt($this->salt);
+        $this->assertEquals($this->salt, $this->bcrypt->getSalt());
+    }
+
+    public function testSetSmallSalt()
+    {
+        $this->setExpectedException('Zend\Crypt\Password\Exception\InvalidArgumentException',
+                                    'The length of the salt must be at least ' . Bcrypt::MIN_SALT_SIZE . ' bytes');
+        $this->bcrypt->setSalt('small salt');
+    }
+
+    public function testCreateWithRandomSalt()
+    {
+        $password = $this->bcrypt->create('test');
+        $this->assertTrue(!empty($password));
+        $this->assertTrue(strlen($password) === 60);
+    }
+
+    public function testCreateWithSalt()
+    {
+        $this->bcrypt->setSalt($this->salt);
+        $password = $this->bcrypt->create($this->password);
+        $this->assertEquals($password, $this->bcryptPassword);
+    }
+
+    public function testVerify()
+    {
+        $this->assertTrue($this->bcrypt->verify($this->password, $this->bcryptPassword));
+        $this->assertFalse($this->bcrypt->verify(substr($this->password, -1), $this->bcryptPassword));
+    }
+
+    public function testPasswordWith8bitCharacter()
+    {
+        $password = 'test' . chr(128);
+        $this->bcrypt->setSalt($this->salt);
+
+        $this->assertEquals('$2y$10$MTIzNDU2Nzg5MDEyMzQ1NetiAf47gp.MSGw.8x1/hESvXYfMep1em',
+                                $this->bcrypt->create($password));
+    }
+}

--- a/tests/ZendTest/Crypt/Password/BcryptShaTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptShaTest.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -20,20 +20,20 @@ use Zend\Crypt\Password\Exception;
 class BcryptShaTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Bcrypt */
-    public $bcrypt;
+    private $bcrypt;
     /** @var string */
-    public $salt;
+    private $salt;
     /** @var string */
-    public $bcryptPassword;
+    private $bcryptPassword;
     /** @var string */
-    public $password;
+    private $password;
 
     public function setUp()
     {
         $this->bcrypt   = new BcryptSha();
         $this->salt     = '1234567890123456';
         $this->password = 'test';
-        $this->prefix = '$2y$';
+        $this->prefix   = '$2y$';
 
         $this->bcryptPassword = $this->prefix . '10$MTIzNDU2Nzg5MDEyMzQ1NeqZGfIabq2.v6vX10KI4/z0pMoIoDyVa';
     }


### PR DESCRIPTION
This PR, as discussed, implements several security improvements:
1. Offers a new Zend\Crypt\Password\BcryptSha class which is functionally identical to the Bcrypt class but will pre-hash incoming passwords using SHA256. This small step allows for passwords exceeding 72 bytes to have all 72 bytes utilised in a starting hash. At present, the use of Bcrypt will truncate any input to 72 bytes and effectively discard the remainder of the string. This is perfectly normal and valid behaviour in the bcrypt algorithm, but obviously not what users might expect when allowed to use long passwords.
2. It replaces the current set of identical comparisons with the pre-existing fixed time compare functionality to offset any risk of timing leaks about the hashes being compared.

Noting PR is against master at present.
