### PR TITLE
Exception message in Zend\Stdlib\AbstractOptions should use the actual used setter

### DIFF
--- a/library/Zend/Stdlib/AbstractOptions.php
+++ b/library/Zend/Stdlib/AbstractOptions.php
@@ -108,9 +108,10 @@ abstract class AbstractOptions implements ParameterObjectInterface
 
         if ($this->__strictMode__) {
             throw new Exception\BadMethodCallException(sprintf(
-                'The option "%s" does not have a matching "%s" setter method which must be defined',
+                'The option "%s" does not have a matching "%s" ("%s") setter method which must be defined',
                 $key,
-                'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)))
+                'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key))),
+                $setter
             ));
         }
     }

--- a/tests/ZendTest/Stdlib/OptionsTest.php
+++ b/tests/ZendTest/Stdlib/OptionsTest.php
@@ -100,4 +100,16 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $options = new TestOptions;
         $options->setFromArray('asd');
     }
+
+    public function testExceptionMessageContainsActualUsedSetter()
+    {
+        $this->setExpectedException(
+            'BadMethodCallException',
+            'The option "foo bar" does not have a matching "setFooBar" ("setfoo bar") setter method which must be defined'
+        );
+
+        new TestOptions(array(
+            'foo bar' => 'baz',
+        ));
+    }
 }


### PR DESCRIPTION
The current exception message uses some fabricated setter which is not even used in the actual test in [`Zend\Stdlib\AbstractOptions` line 103](https://github.com/zendframework/zf2/blob/67f098af070b29d5042e89e936604df3193d2212/library/Zend/Stdlib/AbstractOptions.php#L103).

This PR changes the exception message and makes it use the actual used setter and thus creates a more accurate message. See: https://github.com/zendframework/zf2/issues/7155#issuecomment-71451833
