### PR TITLE
Add Fix for CollectionsFilter Attachment

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -813,6 +813,19 @@ class Form extends Fieldset implements FormInterface
                     } else {
                         if ($fieldset instanceof Collection && $inputFilter instanceof CollectionInputFilter) {
                             continue;
+                        } elseif (
+                            $childFieldset instanceof Collection
+                            && $childFieldset->getTargetElement() instanceof FieldsetInterface
+                        ) {
+                            $childFilter = new InputFilter();
+                            $this->attachInputFilterDefaults($childFilter, $childFieldset->getTargetElement());
+
+                            $collectionFilter = new CollectionInputFilter();
+                            $collectionFilter->setInputFilter($childFilter);
+
+                            $inputFilter->add($collectionFilter, $name);
+
+                            continue;
                         } else {
                             $inputFilter->add(new InputFilter(), $name);
                         }


### PR DESCRIPTION
Collections don't seem to have CollectionFilters automatically
added to them.  This change makes it so we automatically connect
the CollectionFilter to them, and attach the defaults for it's
child fieldsets
