### PR TITLE
Use getEncoding() instead of accessing options array directly

### DIFF
--- a/library/Zend/Filter/StringToLower.php
+++ b/library/Zend/Filter/StringToLower.php
@@ -53,7 +53,7 @@ class StringToLower extends AbstractUnicode
         }
         $value = (string) $value;
 
-        if ($this->options['encoding'] !== null) {
+        if (null !== $this->getEncoding()) {
             return mb_strtolower($value, $this->options['encoding']);
         }
 

--- a/library/Zend/Filter/StringToUpper.php
+++ b/library/Zend/Filter/StringToUpper.php
@@ -53,7 +53,7 @@ class StringToUpper extends AbstractUnicode
         }
         $value = (string) $value;
 
-        if ($this->options['encoding'] !== null) {
+        if (null !== $this->getEncoding()) {
             return mb_strtoupper($value, $this->options['encoding']);
         }
 

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -183,7 +183,7 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilterUsesGetEncodingMethod()
     {
-        $filterMock = $this->getMock('\Zend\Filter\StringToLower', array('getEncoding'));
+        $filterMock = $this->getMock('Zend\Filter\StringToLower', array('getEncoding'));
         $filterMock->expects($this->once())
                    ->method('getEncoding')
                    ->with();

--- a/tests/ZendTest/Filter/StringToLowerTest.php
+++ b/tests/ZendTest/Filter/StringToLowerTest.php
@@ -177,4 +177,16 @@ class StringToLowerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($input, $this->_filter->filter($input));
     }
+
+    /**
+     * @group 7147
+     */
+    public function testFilterUsesGetEncodingMethod()
+    {
+        $filterMock = $this->getMock('\Zend\Filter\StringToLower', array('getEncoding'));
+        $filterMock->expects($this->once())
+                   ->method('getEncoding')
+                   ->with();
+        $filterMock->filter('foo');
+    }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -175,4 +175,16 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($input, $this->_filter->filter($input));
     }
+
+    /**
+     * @group 7147
+     */
+    public function testFilterUsesGetEncodingMethod()
+    {
+        $filterMock = $this->getMock('\Zend\Filter\StringToUpper', array('getEncoding'));
+        $filterMock->expects($this->once())
+                   ->method('getEncoding')
+                   ->with();
+        $filterMock->filter('foo');
+    }
 }

--- a/tests/ZendTest/Filter/StringToUpperTest.php
+++ b/tests/ZendTest/Filter/StringToUpperTest.php
@@ -181,7 +181,7 @@ class StringToUpperTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilterUsesGetEncodingMethod()
     {
-        $filterMock = $this->getMock('\Zend\Filter\StringToUpper', array('getEncoding'));
+        $filterMock = $this->getMock('Zend\Filter\StringToUpper', array('getEncoding'));
         $filterMock->expects($this->once())
                    ->method('getEncoding')
                    ->with();


### PR DESCRIPTION
Fix for issue #7147. Both `Zend\Filter\StringToLower` and `Zend\Filter\StringToUpper` extend `Zend\Filter\AbstractUnicode`.

No new tests, but that is because I don't see a way to test this change. If anyone got suggestions on how to test it, I will add the tests.
