### PR TITLE
Fixed wrong phpdoc type hint.

### DIFF
--- a/library/Zend/Paginator/Paginator.php
+++ b/library/Zend/Paginator/Paginator.php
@@ -140,7 +140,7 @@ class Paginator implements Countable, IteratorAggregate
     /**
      * Pages
      *
-     * @var array
+     * @var \stdClass
      */
     protected $pages = null;
 
@@ -665,7 +665,7 @@ class Paginator implements Countable, IteratorAggregate
      * Returns the page collection.
      *
      * @param  string $scrollingStyle Scrolling style
-     * @return array
+     * @return \stdClass
      */
     public function getPages($scrollingStyle = null)
     {


### PR DESCRIPTION
`$pages` variable can only has the type `stdClass`, because it is created with the function `_createPages()` (line 890), and this function returns `stdClass`
