### PR TITLE
Reduce iteration when attempt to authenticate user

### DIFF
--- a/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
+++ b/library/Zend/Authentication/Adapter/DbTable/CredentialTreatmentAdapter.php
@@ -95,6 +95,12 @@ class CredentialTreatmentAdapter extends AbstractAdapter
             ->columns(array('*', $credentialExpression))
             ->where(new SqlOp($this->identityColumn, '=', $this->identity));
 
+        if ($this->getAmbiguityIdentity()) {
+            $dbSelect->order(array(
+                'zend_auth_credential_match' => 'DESC'
+            ));
+        }
+
         return $dbSelect;
     }
 


### PR DESCRIPTION
In case of (many) ambiguous identities we can reduce iteration on _authenticate()_ method by setting ORDER clause to SELECT query
