### PR TITLE
Oracle quoting fix for values with single quotes

### DIFF
--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -104,7 +104,7 @@ class Oracle implements PlatformInterface
             'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
                 . 'can introduce security vulnerabilities in a production environment.'
         );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return '\'' . addcslashes(str_replace('\'', '\'\'', $value), "\x00\n\r\"\x1a") . '\'';
     }
 
     /**
@@ -117,7 +117,7 @@ class Oracle implements PlatformInterface
      */
     public function quoteTrustedValue($value)
     {
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return '\'' . addcslashes(str_replace('\'', '\'\'', $value), "\x00\n\r\"\x1a") . '\'';
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -97,10 +97,10 @@ class OracleTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals("'value'", $this->platform->quoteTrustedValue('value'));
         $this->assertEquals("'Foo O''Bar'", $this->platform->quoteTrustedValue("Foo O'Bar"));
-        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteTrustedValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals('\'\'\'; DELETE FROM some_table; -- \'', $this->platform->quoteTrustedValue('\'; DELETE FROM some_table; -- '));
 
         //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
-        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", $this->platform->quoteTrustedValue('\\\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("'\\''; DELETE FROM some_table; -- '", $this->platform->quoteTrustedValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -96,7 +96,7 @@ class OracleTest extends \PHPUnit_Framework_TestCase
     public function testQuoteTrustedValue()
     {
         $this->assertEquals("'value'", $this->platform->quoteTrustedValue('value'));
-        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteTrustedValue("Foo O'Bar"));
+        $this->assertEquals("'Foo O''Bar'", $this->platform->quoteTrustedValue("Foo O'Bar"));
         $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', $this->platform->quoteTrustedValue('\'; DELETE FROM some_table; -- '));
 
         //                   '\\\'; DELETE FROM some_table; -- '  <- actual below
@@ -112,7 +112,7 @@ class OracleTest extends \PHPUnit_Framework_TestCase
             'PHPUnit_Framework_Error',
             'Attempting to quote a value in Zend\Db\Adapter\Platform\Oracle without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        $this->assertEquals("'Foo O\\'Bar'", $this->platform->quoteValueList("Foo O'Bar"));
+        $this->assertEquals("'Foo O''Bar'", $this->platform->quoteValueList("Foo O'Bar"));
     }
 
     /**


### PR DESCRIPTION
Single quotes need to be handled differently

$str = 'foo \'bar';
echo 'select '.$oracleAdapterPlatform->quoteTrustedValue($str).'from dual';//sql string won't run in Oracle(11.2.0.4.0 in this case)

outputs: select 'foo \'bar' from dual

needs to output: select 'foo ''bar' from dual
