### PR TITLE
Fix: Inline variable

### DIFF
--- a/library/Zend/ModuleManager/Listener/ModuleResolverListener.php
+++ b/library/Zend/ModuleManager/Listener/ModuleResolverListener.php
@@ -29,7 +29,6 @@ class ModuleResolverListener extends AbstractListener
             return false;
         }
 
-        $module = new $class;
-        return $module;
+        return new $class;
     }
 }


### PR DESCRIPTION
This PR
- [x] returns the newly created instance of a module class directly, instead of assigning it to a variable first and then returning it
