### PR TITLE
FormButton $buttonContent parameter is now translated

### DIFF
--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -87,20 +87,14 @@ class FormButton extends FormInput
                     )
                 );
             }
-
-            if (null !== ($translator = $this->getTranslator())) {
-                $buttonContent = $translator->translate(
-                    $buttonContent,
-                    $this->getTranslatorTextDomain()
-                );
-            }
-        } else {
-            if (null !== ($translator = $this->getTranslator())) {
-                $buttonContent = $translator->translate(
-                    $buttonContent, $this->getTranslatorTextDomain()
-                );
-            }
         }
+        
+        if (null !== ($translator = $this->getTranslator())) {
+            $buttonContent = $translator->translate(
+                $buttonContent, $this->getTranslatorTextDomain()
+            );
+        }
+        
 
         if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
             $escapeHtmlHelper = $this->getEscapeHtmlHelper();

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -86,18 +86,14 @@ class FormButton extends FormInput
                 ));
             }
 
-            if (null !== ($translator = $this->getTranslator())) {
-                $buttonContent = $translator->translate(
-                    $buttonContent, $this->getTranslatorTextDomain()
-                );
-            }
-        } else {
-            if (null !== ($translator = $this->getTranslator())) {
-                $buttonContent = $translator->translate(
-                    $buttonContent, $this->getTranslatorTextDomain()
-                );
-            }
         }
+        
+        if (null !== ($translator = $this->getTranslator())) {
+            $buttonContent = $translator->translate(
+                $buttonContent, $this->getTranslatorTextDomain()
+            );
+        }
+        
 
         if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {
             $escapeHtmlHelper = $this->getEscapeHtmlHelper();

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -91,6 +91,12 @@ class FormButton extends FormInput
                     $buttonContent, $this->getTranslatorTextDomain()
                 );
             }
+        } else {
+            if (null !== ($translator = $this->getTranslator())) {
+                $buttonContent = $translator->translate(
+                    $buttonContent, $this->getTranslatorTextDomain()
+                );
+            }
         }
 
         if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {

--- a/library/Zend/Form/View/Helper/FormButton.php
+++ b/library/Zend/Form/View/Helper/FormButton.php
@@ -94,6 +94,12 @@ class FormButton extends FormInput
                     $this->getTranslatorTextDomain()
                 );
             }
+        } else {
+            if (null !== ($translator = $this->getTranslator())) {
+                $buttonContent = $translator->translate(
+                    $buttonContent, $this->getTranslatorTextDomain()
+                );
+            }
         }
 
         if (! $element instanceof LabelAwareInterface || ! $element->getLabelOption('disable_html_escape')) {

--- a/tests/ZendTest/Form/View/Helper/FormButtonTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormButtonTest.php
@@ -279,6 +279,22 @@ class FormButtonTest extends CommonTestCase
         $this->assertContains('>translated content<', $markup);
     }
 
+    public function testCanTranslateButtonContentParameter()
+    {
+        $element = new Element('foo');
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated content'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->__invoke($element, "translate me");
+        $this->assertContains('>translated content<', $markup);
+    }
+
     public function testTranslatorMethods()
     {
         $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');


### PR DESCRIPTION
In master if you pass in a `$buttonContent` parameter to `Zend\Form\View\Helper\FormButton` the `$buttonContent` is not translated. 

 `Zend\Form\View\Helper\FormButton->_invoke($element, "translate me")`

This pull requests creates a test to show the error and a fix to this issue.
