### PR TITLE
Test for array of PDO connection params

### DIFF
--- a/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pdo/ConnectionTest.php
@@ -55,4 +55,29 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($dsn, $responseString);
     }
+
+    /**
+     * @group 2622
+     */
+    public function testArrayOfConnectionParametersCreatesCorrectDsn()
+    {
+        $this->connection->setConnectionParameters(array(
+            'driver'  => 'pdo_mysql',
+            'host'    => '127.0.0.1',
+            'charset' => 'utf8',
+            'dbname'  => 'foo',
+            'port'    => '3306',
+        ));
+        try {
+            $this->connection->connect();
+        } catch (\Exception $e) {
+        }
+        $responseString = $this->connection->getDsn();
+
+        $this->assertStringStartsWith('mysql:', $responseString);
+        $this->assertContains('host=127.0.0.1', $responseString);
+        $this->assertContains('charset=utf8', $responseString);
+        $this->assertContains('dbname=foo', $responseString);
+        $this->assertContains('port=3306', $responseString);
+    }
 }


### PR DESCRIPTION
Looking at #7187 shows there is no test for creating a DSN via an array of connection parameters. The orginal PR #2622 never included any test. This PR adds the test.
