### PR TITLE
Composer autoloader

### DIFF
--- a/library/Zend/Loader/AutoloaderFactory.php
+++ b/library/Zend/Loader/AutoloaderFactory.php
@@ -78,12 +78,13 @@ abstract class AutoloaderFactory
 
         foreach ($options as $class => $autoloaderOptions) {
             if (!isset(static::$loaders[$class])) {
-                $autoloader = static::getStandardAutoloader();
-                if (!class_exists($class) && !$autoloader->autoload($class)) {
-                    require_once 'Exception/InvalidArgumentException.php';
-                    throw new Exception\InvalidArgumentException(
-                        sprintf('Autoloader class "%s" not loaded', $class)
-                    );
+                if (!class_exists($class)) {
+                    if (!static::getStandardAutoloader()->autoload($class)) {
+                        require_once 'Exception/InvalidArgumentException.php';
+                        throw new Exception\InvalidArgumentException(
+                            sprintf('Autoloader class "%s" not loaded', $class)
+                        );
+                    }
                 }
 
                 if (!is_subclass_of($class, 'Zend\Loader\SplAutoloader')) {
@@ -94,6 +95,7 @@ abstract class AutoloaderFactory
                 }
 
                 if ($class === static::STANDARD_AUTOLOADER) {
+                    $autoloader = static::getStandardAutoloader();
                     $autoloader->setOptions($autoloaderOptions);
                 } else {
                     $autoloader = new $class($autoloaderOptions);

--- a/library/Zend/Loader/ComposerAutoloader.php
+++ b/library/Zend/Loader/ComposerAutoloader.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Loader;
+
+use Composer\Autoload\ClassLoader;
+
+// Grab SplAutoloader interface
+require_once __DIR__ . '/SplAutoloader.php';
+
+/**
+ * Adapts Composer's autoloader so that it is used for class loading
+ * in the application.
+ *
+ * @author Nikola Posa <posa.nikola@gmail.com>
+ */
+class ComposerAutoloader implements SplAutoloader
+{
+    const LOAD_NS         = 'namespaces';
+    const LOAD_PSR4       = 'psr4';
+    const LOAD_CLASS_MAP  = 'classmap';
+
+    /**
+     * @var ClassLoader
+     */
+    protected $composerAutoloader;
+
+    /**
+     * Constructor
+     *
+     * @param  null|array|ClassLoader $options
+     */
+    public function __construct($options = null)
+    {
+        if (null !== $options) {
+            if (is_array($options) && isset($options['composer_autoloader'])) {
+                $options = $options['composer_autoloader'];
+            }
+
+            if ($options instanceof ClassLoader) {
+                $this->composerAutoloader = $options;
+                return;
+            }
+        }
+
+        throw new Exception\RuntimeException('Composer autloader instance must be supplied');
+    }
+
+    /**
+     * Configure autoloader
+     *
+     * Allows specifying both "namespace" and "prefix" pairs, using the
+     * following structure:
+     * <code>
+     * array(
+     *     'namespaces' => array(
+     *         'Zend'     => '/path/to/Zend/library',
+     *         'Doctrine' => '/path/to/Doctrine/library',
+     *     ),
+     *     'psr4' => array(
+     *         'Foo' => '/path/to/module/Foo/src',
+     *     ),
+     *     'classmap' => array(
+     *         'Foo/Service/Bar' => '/path/to/module/Foo/src/Service/Bar.php',
+     *     ),
+     * )
+     * </code>
+     *
+     * @param  array|\Traversable $options
+     * @throws Exception\InvalidArgumentException
+     * @return ComposerAutoloader
+     */
+    public function setOptions($options)
+    {
+        if (!is_array($options) && !($options instanceof \Traversable)) {
+            require_once __DIR__ . '/Exception/InvalidArgumentException.php';
+            throw new Exception\InvalidArgumentException('Options must be either an array or Traversable');
+        }
+
+        foreach ($options as $type => $pairs) {
+            if (!is_array($pairs)) {
+                continue;
+            }
+
+            switch ($type) {
+                case self::LOAD_NS :
+                    foreach ($pairs as $namespace => $path) {
+                        $this->composerAutoloader->set($namespace, $path);
+                    }
+                    break;
+                case self::LOAD_PSR4 :
+                    foreach ($pairs as $namespace => $path) {
+                        $this->composerAutoloader->setPsr4($namespace, $path);
+                    }
+                    break;
+                case self::LOAD_CLASS_MAP :
+                    $this->composerAutoloader->addClassMap($pairs);
+                    break;
+                default:
+                    // ignore
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Does nothing; relies on Composer autoloader.
+     *
+     * @return void
+     */
+    public function autoload($class)
+    {
+        return true;
+    }
+
+    /**
+     * Does nothing; Composer autoloader has already been registered.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        return;
+    }
+}

--- a/tests/ZendTest/Loader/ComposerAutoloaderTest.php
+++ b/tests/ZendTest/Loader/ComposerAutoloaderTest.php
@@ -62,10 +62,10 @@ class ComposerAutoloaderTest extends \PHPUnit_Framework_TestCase
     {
         $options = array(
             'namespaces' => array(
-                'Zend\\'   => dirname(__DIR__) . DIRECTORY_SEPARATOR,
+                'Zend\\' => array(dirname(__DIR__) . DIRECTORY_SEPARATOR),
             ),
             'psr4'   => array(
-                'Foo\\' => '/path/to/module/Foo/src',
+                'Foo\\' => array('/path/to/module/Foo/src'),
             ),
             'classmap' => array(
                 'Foo/Service/Bar' => '/path/to/module/Foo/src/Service/Bar.php',
@@ -82,26 +82,26 @@ class ComposerAutoloaderTest extends \PHPUnit_Framework_TestCase
 
     public function testPassingTraversableOptionsPopulatesProperties()
     {
-        $namespaces = new \ArrayObject(array(
-            'Zend\\'   => dirname(__DIR__) . DIRECTORY_SEPARATOR,
-        ));
-        $namespacesPsr4 = new \ArrayObject(array(
-            'Foo' => '/path/to/module/Foo/src',
-        ));
-        $classmap = new \ArrayObject(array(
+        $namespaces = array(
+            'Zend\\' => array(dirname(__DIR__) . DIRECTORY_SEPARATOR),
+        );
+        $namespacesPsr4 = array(
+            'Foo\\' => array('/path/to/module/Foo/src'),
+        );
+        $classmap = array(
             'Foo/Service/Bar' => '/path/to/module/Foo/src/Service/Bar.php',
-        ));
+        );
         $options = new \ArrayObject(array(
             'namespaces' => $namespaces,
             'psr4'   => $namespacesPsr4,
             'classmap' => $classmap,
         ));
 
-        $autoloader = new TestAsset\ComposerAutoloader();
+        $autoloader = new TestAsset\ComposerAutoloader(new ClassLoader());
         $autoloader->setOptions($options);
 
-        $this->assertEquals((array) $options['namespaces'], $autoloader->getNamespaces());
-        $this->assertEquals((array) $options['psr4'], $autoloader->getNamespacesPsr4());
+        $this->assertEquals($options['namespaces'], $autoloader->getNamespaces());
+        $this->assertEquals($options['psr4'], $autoloader->getNamespacesPsr4());
         $this->assertEquals((array) $options['classmap'], $autoloader->getClassMap());
     }
 }

--- a/tests/ZendTest/Loader/ComposerAutoloaderTest.php
+++ b/tests/ZendTest/Loader/ComposerAutoloaderTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Loader;
+
+use Zend\Loader\ComposerAutoloader;
+use Zend\Loader\Exception\InvalidArgumentException;
+use Zend\Loader\Exception\RuntimeException;
+use Composer\Autoload\ClassLoader;
+
+/**
+ * @author Nikola Posa <posa.nikola@gmail.com>
+ */
+class ComposerAutoloaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testComposerClassLoaderMustBeSuppliedThroughConstructor()
+    {
+        new ComposerAutoloader();
+    }
+
+    public function testSettingComposerClassLoaderThroughConstructor()
+    {
+        $classLoader = new ClassLoader();
+        $autoloader = new ComposerAutoloader($classLoader);
+        $this->assertAttributeEquals($classLoader, 'composerAutoloader', $autoloader);
+    }
+
+    public function testSettingComposerClassLoaderThroughConstructorAsArrayOption()
+    {
+        $classLoader = new ClassLoader();
+        $autoloader = new ComposerAutoloader(array(
+            'composer_autoloader' => $classLoader
+        ));
+        $this->assertAttributeEquals($classLoader, 'composerAutoloader', $autoloader);
+    }
+
+    public function testPassingNonTraversableOptionsToSetOptionsRaisesException()
+    {
+        $autoloader = new ComposerAutoloader(new ClassLoader());
+
+        $obj  = new \stdClass();
+        foreach (array(true, 'foo', $obj) as $arg) {
+            try {
+                $autoloader->setOptions(true);
+                $this->fail('Setting options with invalid type should fail');
+            } catch (InvalidArgumentException $e) {
+                $this->assertContains('array or Traversable', $e->getMessage());
+            }
+        }
+    }
+
+    public function testPassingArrayOptionsPopulatesProperties()
+    {
+        $options = array(
+            'namespaces' => array(
+                'Zend\\'   => dirname(__DIR__) . DIRECTORY_SEPARATOR,
+            ),
+            'psr4'   => array(
+                'Foo\\' => '/path/to/module/Foo/src',
+            ),
+            'classmap' => array(
+                'Foo/Service/Bar' => '/path/to/module/Foo/src/Service/Bar.php',
+            )
+        );
+
+        $autoloader = new TestAsset\ComposerAutoloader(new ClassLoader());
+        $autoloader->setOptions($options);
+
+        $this->assertEquals($options['namespaces'], $autoloader->getNamespaces());
+        $this->assertEquals($options['psr4'], $autoloader->getNamespacesPsr4());
+        $this->assertEquals($options['classmap'], $autoloader->getClassMap());
+    }
+
+    public function testPassingTraversableOptionsPopulatesProperties()
+    {
+        $namespaces = new \ArrayObject(array(
+            'Zend\\'   => dirname(__DIR__) . DIRECTORY_SEPARATOR,
+        ));
+        $namespacesPsr4 = new \ArrayObject(array(
+            'Foo' => '/path/to/module/Foo/src',
+        ));
+        $classmap = new \ArrayObject(array(
+            'Foo/Service/Bar' => '/path/to/module/Foo/src/Service/Bar.php',
+        ));
+        $options = new \ArrayObject(array(
+            'namespaces' => $namespaces,
+            'psr4'   => $namespacesPsr4,
+            'classmap' => $classmap,
+        ));
+
+        $autoloader = new TestAsset\ComposerAutoloader();
+        $autoloader->setOptions($options);
+
+        $this->assertEquals((array) $options['namespaces'], $autoloader->getNamespaces());
+        $this->assertEquals((array) $options['psr4'], $autoloader->getNamespacesPsr4());
+        $this->assertEquals((array) $options['classmap'], $autoloader->getClassMap());
+    }
+}

--- a/tests/ZendTest/Loader/TestAsset/ComposerAutoloader.php
+++ b/tests/ZendTest/Loader/TestAsset/ComposerAutoloader.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Loader\TestAsset;
+
+use Zend\Loader\ComposerAutoloader as RealComposerAutoloader;
+
+/**
+ * @author Nikola Posa <posa.nikola@gmail.com>
+ */
+class ComposerAutoloader extends RealComposerAutoloader
+{
+    public function getNamespaces()
+    {
+        return $this->composerAutoloader->getPrefixes();
+    }
+
+    public function getNamespacesPsr4()
+    {
+        return $this->composerAutoloader->getPrefixesPsr4();
+    }
+
+    public function getClassMap()
+    {
+        return $this->composerAutoloader->getClassMap();
+    }
+}


### PR DESCRIPTION
## Problem

Most of the ZF2-based applications relies on Composer autoloading mechanism for loading ZF2 classes itself, as well as classes of all the other vendor dependencies. On the other hand, ZF2 internally uses its own autoloading implementation, which ultimately registers appropriate autoloader strategies (`StandardAutoloader`, `ClassMapAutoloader`, etc.) with the `spl_autoload_register()`.

Composer pretty much handles all the autoloading-related aspects, thus it is kinda unnecessary to have all those custom autoloading solutions registered within the SPL __autoload queue.
## Solution

Autoloader implementation - `Zend\Loader\ComposerAutoloader`, which adapts Composer's autoloader so that it can be used for class loading in the application.
### Usage

Autoloading initialization (somewhere in the `index.php`)

``` php
$loader = require 'vendor/autoload.php';
Zend\Loader\AutoloaderFactory::factory(array(
    //Composer class loader instance is a mandatory dependency
    'Zend\Loader\ComposerAutoloader' => $loader 
));
```

Sample module:

``` php
namespace Application;

use Zend\Mvc\ModuleRouteListener;
use Zend\Mvc\MvcEvent;

class Module
{
    public function getConfig()
    {
        return include __DIR__ . '/config/module.config.php';
    }

    public function getAutoloaderConfig()
    {
        return array(
            'Zend\Loader\ComposerAutoloader' => array(
                'classmap' => include __DIR__ . '/autoload_classmap.php',
                'namespaces' => array(
                    __NAMESPACE__ => __DIR__ . '/src',
                ),
                //PSR-4 namespaces/paths are also supported
                'psr4' => array(
                    __NAMESPACE__ => __DIR__ . '/src',
                ),
            ),
        );
    }
}
```
