### PR TITLE
Fix for timing issue

### DIFF
--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -169,7 +169,13 @@ class DateStep extends Date
             $date = new DateTime;
             $date->setISODate($matches[1], $matches[2]);
         } else {
-            $date = DateTime::createFromFormat($this->format, $value, $this->timezone);
+            $format = $this->format;
+
+            if(stripos($format, '!') === false) {
+                $format = '!' . $format;
+            }
+
+            $date = DateTime::createFromFormat($format, $value, $this->timezone);
         }
 
         // Invalid dates can show up as warnings (ie. "2007-02-99")


### PR DESCRIPTION
Our application has some long running imports which showed seemingly randomly errors with the `DateStepValidator`. I have been able to track them down and wanted to write a test for it, but not sure how. 

Let me explain what happens and my solution proposition:
I am using the `Zend\Form\Element\Date` object, which by default configures a step validator and returns it. It has a format of `Y-m-d`, so by default the validator will have a `baseValue` of `1970-01-01`

Now I submit a value like `2015-02-01`. In the `isValid` function (lines 201, 202) those strings are converted to a `DateTime` object. 

```
    $valueDate = $this->convertToDateTime($value, false); // avoid duplicate errors
    $baseDate  = $this->convertToDateTime($this->baseValue, false);
```

Now the seemingly random event can happen. Because of the format of `Y-m-d` the created `DateTime` object will carry the current time for `H:i:s` and if in between those two lines a second passes the validation will fail, because now there is a diff with `23:59:59`

Now my solution is to change the `convertString` method of `Validator\DateStep` to use the `!` operator in front of the format which overwrites all nonset time parts with `0`.
