### PR TITLE
Cache: fix mongo options

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/MongoDbOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MongoDbOptions.php
@@ -121,17 +121,38 @@ class MongoDbOptions extends AdapterOptions
     }
 
     /**
-     * set mongo options
+     * Set the mongo DB server
      *
-     * @param array $libOptions
-     *
+     * @param string $server
      * @return self
      */
-    public function setLibOptions(array $libOptions)
+    public function setServer($server)
     {
-        $this->triggerOptionEvent('lib_option', $libOptions);
-        $this->getResourceManager()->setLibOptions($this->getResourceId(), $libOptions);
+        $this->getResourceManager()->setServer($this->getResourceId(), $server);
+        return $this;
+    }
 
+    public function setConnectionOptions(array $connectionOptions)
+    {
+        $this->getResourceManager()->setConnectionOptions($this->getResourceId(), $connectionOptions);
+        return $this;
+    }   
+    
+    public function setDriverOptions(array $driverOptions)
+    {
+        $this->getResourceManager()->setDriverOptions($this->getResourceId(), $driverOptions);
+        return $this;
+    }   
+    
+    public function setDatabase($database)
+    {
+        $this->getResourceManager()->setDatabase($this->getResourceId(), $database);
+        return $this;
+    }   
+    
+    public function setCollection($collection)
+    {
+        $this->getResourceManager()->setCollection($this->getResourceId(), $collection);
         return $this;
     }
 }

--- a/library/Zend/Cache/Storage/Adapter/MongoDbResourceManager.php
+++ b/library/Zend/Cache/Storage/Adapter/MongoDbResourceManager.php
@@ -40,7 +40,7 @@ class MongoDbResourceManager
      * Set a resource
      *
      * @param string $id
-     * @param array|Traversable|MongoCollection $resource
+     * @param array|MongoCollection $resource
      *
      * @return self
      *
@@ -50,44 +50,24 @@ class MongoDbResourceManager
     {
         if ($resource instanceof MongoCollection) {
             $this->resources[$id] = array(
-                'initialized' => true,
-                'resource'    => $resource,
+                'db'                  => (string) $resource->db,
+                'db_instance'         => $resource->db,
+                'collection'          => (string) $resource,
+                'collection_instance' => $resource,
             );
 
             return $this;
         }
 
-        $this->resources[$id] = array_merge(
-            array(
-                'server'            => 'mongodb://localhost:27017',
-                'collection'        => 'cache',
-                'database'          => 'zend',
-                'driverOptions'     => array(),
-                'connectionOptions' => array(
-                    /**
-                     * Journaling is enabled by default in 64bit builds of Mongo 2.0+
-                     * As such, we should default fsync to false and journal to true
-                     * See:
-                     * http://docs.mongodb.org/manual/tutorial/manage-journaling/
-                     * http://www.php.net/manual/en/mongoclient.construct.php
-                     */
-                    'fsync'   => false,
-                    'journal' => true,
-                ),
-            ),
-            ArrayUtils::iteratorToArray($resource),
-            // force initialized flag to false
-            array('initialized' => false)
-        );
-
+        $this->resources[$id] = $resource;
         return $this;
     }
 
     /**
+     * Instantiate and return the MongoCollection resource
+     *
      * @param string $id
-     *
      * @return MongoCollection
-     *
      * @throws Exception\RuntimeException
      */
     public function getResource($id)
@@ -96,52 +76,126 @@ class MongoDbResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        if (! $this->resources[$id]['initialized']) {
-            $clientClass = version_compare(phpversion('mongo'), '1.3.0', '<') ? 'Mongo' : 'MongoClient';
+        $resource = $this->resources[$id];
+        if (!isset($resource['collection_instance'])) {
 
             try {
-                /* @var $client \Mongo|\MongoClient */
-                $client = new $clientClass(
-                    $this->resources[$id]['server'],
-                    $this->resources[$id]['connectionOptions'],
-                    (array) $this->resources[$id]['driverOptions']
-                );
 
-                $collection = $client->selectCollection(
-                    $this->resources[$id]['database'],
-                    $this->resources[$id]['collection']
-                );
+                if (!isset($resource['db_instance'])) {
 
+                    if (!isset($resource['client_instance'])) {
+                        $clientClass = version_compare(phpversion('mongo'), '1.3.0', '<') ? 'Mongo' : 'MongoClient';
+                        $resource['client_instance'] = new $clientClass(
+                            isset($resource['server']) ? $resource['server'] : null,
+                            isset($resource['connection_options']) ? $resource['connection_options'] : array(),
+                            isset($resource['driver_options']) ? $resource['driver_options'] : array() 
+                        );
+                    }
+
+                    $resource['db_instance'] = $resource['client_instance']->selectDB(
+                        isset($resource['db']) ? $resource['db'] : ''
+                    );
+                }
+
+                $collection = $resource['db_instance']->selectCollection(
+                    isset($resource['collection']) ? $resource['collection'] : ''
+                );
                 $collection->ensureIndex(array('key' => 1));
 
-                $this->resources[$id]['resource'] = $collection;
+                $this->resources[$id]['collection_instance'] = $collection;
+
             } catch (MongoException $e) {
                 throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
             }
-
-            $this->resources[$id]['initialized'] = true;
         }
 
-        return $this->resources[$id]['resource'];
+        return $this->resources[$id]['collection_instance'];
     }
 
-    /**
-     * @param string $id
-     * @param array  $libOptions
-     *
-     * @return self
-     */
-    public function setLibOptions($id, array $libOptions)
+    public function setServer($id, $server)
+    {
+        $this->resources[$id]['server'] = (string)$server;
+
+        unset($this->resource[$id]['client_instance']);
+        unset($this->resource[$id]['db_instance']);
+        unset($this->resource[$id]['collection_instance']);
+    }
+
+    public function getServer($id)
     {
         if (!$this->hasResource($id)) {
-            return $this->setResource($id, $libOptions);
+            throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        unset($this->resources[$id]['resource']);
+        return isset($this->resources[$id]['server']) ? $this->resources[$id]['server'] : null;
+    }
 
-        $this->resources[$id]                = array_merge($this->resources[$id], $libOptions);
-        $this->resources[$id]['initialized'] = false;
+    public function setConnectionOptions($id, array $connectionOptions)
+    {
+        $this->resources[$id]['connection_options'] = $connectionOptions;
 
-        return $this;
+        unset($this->resource[$id]['client_instance']);
+        unset($this->resource[$id]['db_instance']);
+        unset($this->resource[$id]['collection_instance']);
+    }
+
+    public function getConnectionOptions($id)
+    {
+        if (!$this->hasResource($id)) {
+            throw new Exception\RuntimeException("No resource with id '{$id}'");
+        }   
+
+        return isset($this->resources[$id]['connection_options']) ? $this->resources[$id]['connection_options'] : array();
+    }
+
+    public function setDriverOptions($id, array $driverOptions)
+    {
+        $this->resources[$id]['driver_options'] = $driverOptions;
+
+        unset($this->resource[$id]['client_instance']);
+        unset($this->resource[$id]['db_instance']);
+        unset($this->resource[$id]['collection_instance']);
+    }
+
+    public function getDriverOptions($id)
+    {
+        if (!$this->hasResource($id)) {
+            throw new Exception\RuntimeException("No resource with id '{$id}'");
+        }   
+        
+        return isset($this->resources[$id]['driver_options']) ? $this->resources[$id]['driver_options'] : array();
+    }
+
+    public function setDatabase($id, $database)
+    {
+        $this->resources[$id]['db'] = (string)$database;
+
+        unset($this->resource[$id]['db_instance']);
+        unset($this->resource[$id]['collection_instance']);
+    }
+
+    public function getDatabase($id)
+    {
+        if (!$this->hasResource($id)) {
+            throw new Exception\RuntimeException("No resource with id '{$id}'");
+        }   
+        
+        return isset($this->resources[$id]['db']) ? $this->resources[$id]['db'] : '';
+    }
+
+    public function setCollection($id, $collection)
+    {
+        $this->resources[$id]['collection'] = (string)$collection;
+
+        unset($this->resource[$id]['collection_instance']);
+    }
+
+    public function getCollection($id)
+    {
+        if (!$this->hasResource($id)) {
+            throw new Exception\RuntimeException("No resource with id '{$id}'");
+        }
+        
+        return isset($this->resources[$id]['collection']) ? $this->resources[$id]['collection'] : '';
     }
 }

--- a/tests/ZendTest/Cache/Storage/Adapter/MongoDbOptionsTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/MongoDbOptionsTest.php
@@ -101,32 +101,17 @@ class MongoDbOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($resourceId, $this->object->getResourceId());
     }
 
-    public function testSetLibOptions()
+    public function testSetServer()
     {
         $resourceManager = new MongoDbResourceManager();
         $this->object->setResourceManager($resourceManager);
 
-        $this->assertAttributeEmpty('resources', $this->object->getResourceManager());
+        $resourceId = $this->object->getResourceId();
+        $server     = 'mongodb://test:1234';
 
-        $libOptions = array('foo' => 'bar');
+        $this->assertFalse($this->object->getResourceManager()->hasResource($resourceId));
 
-        $this->object->setLibOptions($libOptions);
-
-        $expected = array(
-            $this->object->getResourceId() => array(
-                'collection' => 'cache',
-                'database' => 'zend',
-                'driverOptions' => array(),
-                'foo' => 'bar',
-                'initialized' => false,
-                'options' => array(
-                    'fsync' => false,
-                    'journal' => true,
-                ),
-                'server' => 'mongodb://localhost:27017',
-            )
-        );
-
-        $this->assertAttributeEquals($expected, 'resources', $this->object->getResourceManager());
+        $this->object->setServer($server);
+        $this->assertSame($server, $this->object->getResourceManager()->getServer($resourceId));
     }
 }

--- a/tests/ZendTest/Cache/Storage/Adapter/MongoDbTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/MongoDbTest.php
@@ -29,15 +29,11 @@ class MongoDbTest extends CommonAdapterTest
             $this->markTestSkipped("Mongo extension is not loaded");
         }
 
-        $optionsArray = array(
-            'libOptions' => array(
-                'collection' => TESTS_ZEND_CACHE_MONGODB_COLLECTION,
-                'database' => TESTS_ZEND_CACHE_MONGODB_DATABASE,
-                'server' => TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING,
-            ),
-        );
-
-        $this->_options = new MongoDbOptions($optionsArray);
+        $this->_options = new MongoDbOptions(array(
+            'server'     => TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING,
+            'database'   => TESTS_ZEND_CACHE_MONGODB_DATABASE,
+            'collection' => TESTS_ZEND_CACHE_MONGODB_COLLECTION,
+        ));
 
         $this->_storage = new MongoDb();
         $this->_storage->setOptions($this->_options);
@@ -57,15 +53,11 @@ class MongoDbTest extends CommonAdapterTest
 
     public function testSetOptionsNotMongoDbOptions()
     {
-        $options = array(
-            'libOptions' => array(
-                'collection' => TESTS_ZEND_CACHE_MONGODB_COLLECTION,
-                'database' => TESTS_ZEND_CACHE_MONGODB_DATABASE,
-                'server' => TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING,
-            ),
-        );
-
-        $this->_storage->setOptions($options);
+        $this->_storage->setOptions(array(
+            'server'     => TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING,
+            'database'   => TESTS_ZEND_CACHE_MONGODB_DATABASE,
+            'collection' => TESTS_ZEND_CACHE_MONGODB_COLLECTION,
+        ));
 
         $this->assertInstanceOf('\Zend\Cache\Storage\Adapter\MongoDbOptions', $this->_storage->getOptions());
     }


### PR DESCRIPTION
This PR addresses the configuration of the mongo db storage adapter in the following form:
- removed option `lib_options` -> this was copied from moncached but the mongo db hasn't such an option
- moved `server`, `database`, `collection` into own configuration options (before part of `lib_options`)
- removed default server so the default will be auto detected by ext/mongo using INI options
- added own configuration options for `connection_options` and `driver_options`
- removed default `connection_options` so the default will be defined by ext/mongo.

As of the mongo db cache storage adapter is new in 2.4 this will be no BC break until 2.4 is out!!

ping @Ocramius Hopefully soon enough for 2.4
ping @alexdenvir please review as author of this adapter
