### PR TITLE
Error in FirePhp log writer

### DIFF
--- a/library/Zend/Log/Writer/FirePhp.php
+++ b/library/Zend/Log/Writer/FirePhp.php
@@ -14,7 +14,6 @@ use FirePHP as FirePHPService;
 use Zend\Log\Exception;
 use Zend\Log\Formatter\FirePhp as FirePhpFormatter;
 use Zend\Log\Logger;
-use FirePhp\FirePhpInterface;
 
 class FirePhp extends AbstractWriter
 {
@@ -42,7 +41,7 @@ class FirePhp extends AbstractWriter
             $instance = isset($instance['instance']) ? $instance['instance'] : null;
         }
 
-        if ($instance instanceof FirePhpInterface) {
+        if ($instance !== null && !($instance instanceof FirePhp\FirePhpInterface)) {
             throw new Exception\InvalidArgumentException('You must pass a valid FirePhp\FirePhpInterface');
         }
 

--- a/tests/ZendTest/Log/Writer/FirePhpTest.php
+++ b/tests/ZendTest/Log/Writer/FirePhpTest.php
@@ -89,4 +89,15 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $filters);
         $this->assertEquals($filter, $filters[0]);
     }
+
+    /**
+     * Verify behavior of __construct when 'instance' is not an FirePhpInterface
+     *
+     * @expectedException Zend\Log\Exception\InvalidArgumentException
+     * @expectedExceptionMessage You must pass a valid FirePhp\FirePhpInterface
+     */
+    public function testConstructWithInvalidInstance()
+    {
+        new FirePhp(new \StdClass());
+    }
 }


### PR DESCRIPTION
The use statement @ line 17 is trying to load a class with a relative namespace path. This is not valid in PHP.  if you use the full namespace the unit tests will fail. 

 I have removed the `use` statement and just used the namespace `FirePhp\FirePhpInterface` in the `instanceof` statement and reversed the condition.

Fixes #7202 
