### PR TITLE
Prototype fixing #6381: Order of resource based adapter options may cause Exception

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/MemcacheOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/MemcacheOptions.php
@@ -10,6 +10,7 @@
 namespace Zend\Cache\Storage\Adapter;
 
 use Zend\Cache\Exception;
+use Zend\Stdlib\AbstractOptions;
 
 /**
  * These are options specific to the Memcache adapter
@@ -42,6 +43,58 @@ class MemcacheOptions extends AdapterOptions
      * @var bool
      */
     protected $compression = false;
+
+    /**
+     * {inheritdoc}
+     */
+    public function setFromArray($options)
+    {
+        if ($options instanceof AbstractOptions) {
+            $options = $options->toArray();
+        }
+
+        if (!is_array($options) && !$options instanceof Traversable) {
+            throw new Exception\InvalidArgumentException(
+                sprintf(
+                    'Parameter provided to %s must be an %s, %s or %s',
+                    __METHOD__,
+                    'array',
+                    'Traversable',
+                    'Zend\Stdlib\AbstractOptions'
+                )
+            );
+        }
+
+        if ($options instanceof Traversable) {
+            $options = iterator_to_array($options);
+        }
+
+        $options  = array_change_key_case($options, CASE_LOWER);
+        $prioOpts = array();
+
+        if (isset($options['resource_manager'])) {
+            $prioOpts['resource_manager'] = $options['resource_manager'];
+            unset($options['resource_manager']);
+        }
+        if (isset($options['resourcemanager'])) {
+            $prioOpts['resourcemanager'] = $options['resourcemanager'];
+            unset($options['resourcemanager']);
+        }
+
+        if (isset($options['resource_id'])) {
+            $prioOpts['resource_id'] = $options['resource_id'];
+            unset($options['resource_id']);
+        }
+        if (isset($options['resourceid'])) {
+            $prioOpts['resourceid'] = $options['resourceid'];
+            unset($options['resourceid']);
+        }
+
+        parent::setFromArray($prioOpts);
+        parent::setFromArray($options);
+
+        return $this;
+    }
 
     /**
      * Set namespace.


### PR DESCRIPTION
This is a prototype!!!!

This would be duplicated in all Options classes requiring some ordering of options.

@Ocramius @weierophinney In my opinion the issue #6381 should be marked as won't fixed as the options will be applied in the order they are defined. This behavior should be documented but not changed into a adapter defined ordering like this prototype. Additionally this prototype shows it's more error prone than the current behavior and would be needed to be document3ed for each adapter what the defined order would resulting in other WTF moments.
