### PR TITLE
Added fix to prevent method lines to be intended again and again

### DIFF
--- a/library/Zend/Code/Generator/MethodGenerator.php
+++ b/library/Zend/Code/Generator/MethodGenerator.php
@@ -61,9 +61,38 @@ class MethodGenerator extends AbstractMemberGenerator
             $method->setParameter(ParameterGenerator::fromReflection($reflectionParameter));
         }
 
-        $method->setBody($reflectionMethod->getBody());
+        $method->setBody(self::clearBodyIndention($reflectionMethod->getBody()));
 
         return $method;
+    }
+
+    /**
+     * Identify the space indention from the first line and remove this indention
+     * from all lines
+     *
+     * @param string $body
+     *
+     * @return string
+     */
+    protected static function clearBodyIndention($body)
+    {
+        if (empty($body)) {
+            return $body;
+        }
+
+        $lines = explode(PHP_EOL, $body);
+
+        $indention = str_replace(trim($lines[1]), '', $lines[1]);
+
+        foreach ($lines as $key => $line) {
+            if (substr($line, 0, strlen($indention)) == $indention) {
+                $lines[$key] = substr($line, strlen($indention));
+            }
+        }
+
+        $body = implode(PHP_EOL, $lines);
+
+        return $body;
     }
 
     /**

--- a/library/Zend/Code/Generator/MethodGenerator.php
+++ b/library/Zend/Code/Generator/MethodGenerator.php
@@ -61,7 +61,7 @@ class MethodGenerator extends AbstractMemberGenerator
             $method->setParameter(ParameterGenerator::fromReflection($reflectionParameter));
         }
 
-        $method->setBody(self::clearBodyIndention($reflectionMethod->getBody()));
+        $method->setBody(static::clearBodyIndention($reflectionMethod->getBody()));
 
         return $method;
     }

--- a/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
@@ -100,6 +100,31 @@ EOS;
         $this->assertEquals($target, (string) $methodGenerator);
     }
 
+
+    public function testMethodFromReflectionMultiLinesIndention()
+    {
+        $ref = new MethodReflection('ZendTest\Code\Generator\TestAsset\TestSampleSingleClassMultiLines', 'someMethod');
+
+        $methodGenerator = MethodGenerator::fromReflection($ref);
+        $target = <<<EOS
+    /**
+     * Enter description here...
+     *
+     * @return bool
+     */
+    public function someMethod()
+    {
+        /* test test */
+
+        /* test test */
+
+        /* test test */
+    }
+
+EOS;
+        $this->assertEquals($target, (string) $methodGenerator);
+    }
+
     /**
      * @group ZF-6444
      */

--- a/tests/ZendTest/Code/Generator/TestAsset/TestSampleSingleClassMultiLines.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/TestSampleSingleClassMultiLines.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * File header here
+ * Zend Framework (http://framework.zend.com/)
  *
- * @author Ralph Schindler <ralph.schindler@zend.com>
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Code\Generator\TestAsset;

--- a/tests/ZendTest/Code/Generator/TestAsset/TestSampleSingleClassMultiLines.php
+++ b/tests/ZendTest/Code/Generator/TestAsset/TestSampleSingleClassMultiLines.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * File header here
+ *
+ * @author Ralph Schindler <ralph.schindler@zend.com>
+ */
+
+namespace ZendTest\Code\Generator\TestAsset;
+
+/**
+ * class docblock
+ */
+class TestSampleSingleClassMultiLines
+{
+
+    /**
+     * Enter description here...
+     *
+     * @return bool
+     */
+    public function someMethod()
+    {
+        /* test test */
+
+        /* test test */
+
+        /* test test */
+    }
+
+}


### PR DESCRIPTION
This PR fixes https://github.com/zendframework/zf2/issues/7209

It makes sure that all unnecessary leading spaces from all code lines within a method are removed properly. Please look into issue #7209 for more details.
