### PR TITLE
Fixed bug in comparison at AbstractTableGateway->executeInsert

### DIFF
--- a/library/Zend/Db/TableGateway/AbstractTableGateway.php
+++ b/library/Zend/Db/TableGateway/AbstractTableGateway.php
@@ -280,7 +280,15 @@ abstract class AbstractTableGateway implements TableGatewayInterface
     protected function executeInsert(Insert $insert)
     {
         $insertState = $insert->getRawState();
-        if ($insertState['table'] != $this->table) {
+        
+        // Make sure both variables are strings
+        $tableInsert = $insertState['table'] instanceof \Zend\Db\Sql\TableIdentifier ?
+            $insertState['table']->getTable() : $insertState['table'];
+        
+        $tableThis   = $this->table instanceof \Zend\Db\Sql\TableIdentifier ? 
+            $this->table->getTable() : $this->table;
+        
+        if ($tableInsert != $tableThis) {
             throw new Exception\RuntimeException('The table name of the provided Insert object must match that of the table');
         }
 


### PR DESCRIPTION
When executeInsert is called, sometimes `$insertState['table']` is string or `Zend\Db\Sql\TableIdentifier`, that also happens with `$this->table`.

I got to a case that `$insertState['table']` is string and `$this->table` is `Zend\Db\Sql\TableIdentifier` and that isn't mapped so a Exception is always thrown.

Example:

> $tableGateway = new \Zend\Db\TableGateway\TableGateway('table1', $dbAdapter);
> $sql                  = new \Zend\Db\Sql\Sql($dbAdapter);
> 
> // Prepare a insert with select
> $select = $sql->select('any_table');
> $select->columns(array('column1', 'column2'));
> $select->where('status' => 'active');
> 
> $insert = $sql->insert('table1');
> $insert->columns(array('column1', 'column2'));
> $insert->values($select); //could be $insert->select($select) too 
> 
> $tableGateway->insertWith($insert); // this will call AbstractTableGateway->executeInsert
