### PR TITLE
Fix for #7219 - Validation failure fr-CH in testValidationFailures

### DIFF
--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -166,7 +166,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
             'ar'    => array('10.1', '66notflot.6'),
             'ru'    => array('10.1', '66notflot.6', '2,000.00', '2 00'),
             'en'    => array('10,1', '66notflot.6', '2.000,00', '2 000', '2,00'),
-            'fr-CH' => array('10,1', '66notflot.6', '2,000.00', '2 000', "2'00")
+            'fr-CH' => array('10,1', '66notflot.6', '2,000.00', "2'00")
         );
 
         //Loop locales and examples for a more thorough set of "true" test data


### PR DESCRIPTION
Due to [change in CLDR 26](http://unicode.org/cldr/trac/ticket/7238). Just removed that one instance that is actually valid now.
