### PR TITLE
remove deprecated --dev in composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 install:
   - sudo apt-get install parallel
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 before_script:
   - mkdir -p build/coverage


### PR DESCRIPTION
Dev packages are installed by default now
