### PR TITLE
remove required dependencies

### DIFF
--- a/library/Zend/Code/composer.json
+++ b/library/Zend/Code/composer.json
@@ -14,12 +14,12 @@
     },
     "target-dir": "Zend/Code",
     "require": {
-        "php": ">=5.3.23",
-        "zendframework/zend-eventmanager": "self.version"
+        "php": ">=5.3.23"
     },
     "require-dev": {
         "doctrine/common": ">=2.1",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "self.version",
+        "zendframework/zend-eventmanager": "self.version"
     },
     "suggest": {
         "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",


### PR DESCRIPTION
Since only the https://github.com/zendframework/zf2/blob/master/library/Zend/Code/Annotation part uses the EventManager, please let us remove the dependency.

If the EventManager gets included, also the complete StdLib comes with the composer resolving....

I just build something similar to: https://github.com/EvanDotPro/EdpSuperluminal/blob/master/Module.php#L5-L7

And from Zend only those classes were actually autoloaded:

```
* AUTOLOAD Zend\Code\Reflection\ClassReflection
* AUTOLOAD Zend\Code\Reflection\ReflectionInterface
* AUTOLOAD Zend\Code\Scanner\FileScanner
* AUTOLOAD Zend\Code\Scanner\TokenArrayScanner
* AUTOLOAD Zend\Code\Scanner\ScannerInterface
* AUTOLOAD Zend\Code\Reflection\FileReflection
* AUTOLOAD Zend\Code\Scanner\CachingFileScanner
```
