### PR TITLE
DBA inifile is not supported for caching

### DIFF
--- a/library/Zend/Cache/Storage/Adapter/DbaOptions.php
+++ b/library/Zend/Cache/Storage/Adapter/DbaOptions.php
@@ -117,6 +117,12 @@ class DbaOptions extends AdapterOptions
             throw new Exception\ExtensionNotLoadedException("DBA-Handler '{$handler}' not supported");
         }
 
+        if ($handler === 'inifile') {
+            throw new Exception\ExtensionNotLoadedException(
+                "DBA-Handler 'inifile' does not reliably support write operations"
+            );
+        }
+
         $this->triggerOptionEvent('handler', $handler);
         $this->handler = $handler;
         return $this;

--- a/tests/ZendTest/Cache/Storage/Adapter/DbaInifileTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/DbaInifileTest.php
@@ -9,11 +9,20 @@
 
 namespace ZendTest\Cache\Storage\Adapter;
 
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Storage\Adapter\Dba;
 
 /**
  * @group      Zend_Cache
  */
-class DbaInifileTest extends AbstractDbaTest
+class DbaInifileTest extends TestCase
 {
-    protected $handler = 'inifile';
+    public function testSpecifyingInifileHandlerRaisesException()
+    {
+        $this->setExpectedException('Zend\Cache\Exception\ExtensionNotLoadedException', 'inifile');
+        $cache = new Dba(array(
+            'pathname' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('zfcache_dba_') . '.inifile',
+            'handler'  => 'inifile',
+        ));
+    }
 }


### PR DESCRIPTION
We recently noticed failures occuring for the DbaInifile cache storage tests.
The errors reported indicated an inability to perform `dba_replace()`
operations, with no indication of why this was.

On digging through the various DBA documentation on php.net, I discovered that
the `dba_replace` and `dba_insert()` functions are only reliable on GDBM and
QDBM handlers; any other handler may result in unexpected or unintended
behavior.

I have tested against flatfile, GDBM, DB4, and GDBM, and none of these show any
issues; however, inifile reliably has issues at this point. As such, we can no
longer support that version.

This patch raises an exception if the inifile handler is provided as a DBA
option, and the tests have been modified to ensure that the exception is raised.
