### PR TITLE
Skip tests in ZendTest\View if ext-intl is not installed

### DIFF
--- a/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php
@@ -173,6 +173,10 @@ class BreadcrumbsTest extends AbstractTest
 
     public function testTranslationUsingZendTranslateAndCustomTextDomain()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $this->_helper->setTranslator($this->_getTranslatorWithTextDomain());
 
         $expected = $this->_getExpected('bc/textdomain.html');

--- a/tests/ZendTest/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/MenuTest.php
@@ -228,6 +228,10 @@ class MenuTest extends AbstractTest
 
     public function testTranslationUsingZendTranslateWithTextDomain()
     {
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
         $translator = $this->_getTranslatorWithTextDomain();
         $this->_helper->setTranslator($translator);
 


### PR DESCRIPTION
``` bash
There were 2 errors:

1) ZendTest\View\Helper\Navigation\BreadcrumbsTest::testTranslationUsingZendTranslateAndCustomTextDomain
Zend\I18n\Exception\ExtensionNotLoadedException: Zend\I18n\Translator component requires the intl PHP extension

/home/gianarb/git/zf2/library/Zend/I18n/Translator/Translator.php:257
/home/gianarb/git/zf2/library/Zend/I18n/Translator/Translator.php:353
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/AbstractHelper.php:434
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/Breadcrumbs.php:113
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/Breadcrumbs.php:81
/home/gianarb/git/zf2/tests/ZendTest/View/Helper/Navigation/BreadcrumbsTest.php:179

2) ZendTest\View\Helper\Navigation\MenuTest::testTranslationUsingZendTranslateWithTextDomain
Zend\I18n\Exception\ExtensionNotLoadedException: Zend\I18n\Translator component requires the intl PHP extension

/home/gianarb/git/zf2/library/Zend/I18n/Translator/Translator.php:257
/home/gianarb/git/zf2/library/Zend/I18n/Translator/Translator.php:353
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/AbstractHelper.php:434
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/Menu.php:524
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/Menu.php:357
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/Menu.php:233
/home/gianarb/git/zf2/library/Zend/View/Helper/Navigation/Menu.php:110
/home/gianarb/git/zf2/tests/ZendTest/View/Helper/Navigation/MenuTest.php:235

FAILURES!
Tests: 862, Assertions: 1749, Errors: 2, Incomplete: 2, Skipped: 9.
```
