### PR TITLE
Detect https on reversed proxy

### DIFF
--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -112,6 +112,10 @@ class ServerUrl extends AbstractHelper
         }
 
         if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT']) {
+            if ($this->isReversedProxy()) {
+                $this->setPort(443);
+                return;
+            }
             $this->setPort($_SERVER['SERVER_PORT']);
             return;
         }
@@ -132,7 +136,7 @@ class ServerUrl extends AbstractHelper
             case (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)):
             case (isset($_SERVER['HTTP_SCHEME']) && ($_SERVER['HTTP_SCHEME'] == 'https')):
             case (443 === $this->getPort()):
-            case (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'):
+            case $this->isReversedProxy():
                 $scheme = 'https';
                 break;
             default:
@@ -141,6 +145,11 @@ class ServerUrl extends AbstractHelper
         }
 
         $this->setScheme($scheme);
+    }
+
+    protected function isReversedProxy()
+    {
+        return isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https';
     }
 
     /**

--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -132,6 +132,7 @@ class ServerUrl extends AbstractHelper
             case (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)):
             case (isset($_SERVER['HTTP_SCHEME']) && ($_SERVER['HTTP_SCHEME'] == 'https')):
             case (443 === $this->getPort()):
+            case (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'):
                 $scheme = 'https';
                 break;
             default:

--- a/tests/ZendTest/View/Helper/ServerUrlTest.php
+++ b/tests/ZendTest/View/Helper/ServerUrlTest.php
@@ -91,6 +91,7 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
         $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+        $_SERVER['SERVER_PORT'] = 80;
 
         $url = new Helper\ServerUrl();
         $this->assertEquals('https://example.com', $url->__invoke());

--- a/tests/ZendTest/View/Helper/ServerUrlTest.php
+++ b/tests/ZendTest/View/Helper/ServerUrlTest.php
@@ -87,6 +87,15 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://example.com:8181', $url->__invoke());
     }
 
+    public function testConstructorWithHostReversedProxyHttpsTrue()
+    {
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('https://example.com', $url->__invoke());
+    }
+
     public function testConstructorWithHttpHostIncludingPortAndPortSet()
     {
         $_SERVER['HTTP_HOST'] = 'example.com:8181';


### PR DESCRIPTION
I have application which works with reversed proxy. Generated urls by serverUrl view helper are with http on https pages. I have found that in $_SERVER exists key HTTP_X_FORWARDED_PROTO with information about scheme.
