### PR TITLE
return null if 'where' sql is empty

### DIFF
--- a/library/Zend/Db/Sql/Select.php
+++ b/library/Zend/Db/Sql/Select.php
@@ -778,7 +778,8 @@ class Select extends AbstractSql implements SqlInterface, PreparableSqlInterface
         if ($parameterContainer) {
             $parameterContainer->merge($whereParts->getParameterContainer());
         }
-        return array($whereParts->getSql());
+        $whereSql = $whereParts->getSql();
+        return ($whereSql == '()') ? null : array($whereSql);
     }
 
     protected function processGroup(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)


### PR DESCRIPTION
When a predicate object with no conditions is passed into 'select', it renders down into '()'.  This results in a query like this which is invalid sql:

select ... where ()
