### PR TITLE
Feature: Zend\Mvc\HttpMethodListener

### DIFF
--- a/library/Zend/Mvc/Application.php
+++ b/library/Zend/Mvc/Application.php
@@ -66,6 +66,7 @@ class Application implements
     protected $defaultListeners = array(
         'RouteListener',
         'DispatchListener',
+        'HttpMethodListener',
         'ViewManager',
         'SendResponseListener',
     );

--- a/library/Zend/Mvc/HttpMethodListener.php
+++ b/library/Zend/Mvc/HttpMethodListener.php
@@ -41,7 +41,7 @@ class HttpMethodListener extends AbstractListenerAggregate
      * @param bool  $enabled
      * @param array $allowedMethods
      */
-    public function __construct($enabled = true, array $allowedMethods = array())
+    public function __construct($enabled = true, $allowedMethods = array())
     {
         $this->setEnabled($enabled);
 

--- a/library/Zend/Mvc/HttpMethodListener.php
+++ b/library/Zend/Mvc/HttpMethodListener.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc;
+
+use Zend\EventManager\AbstractListenerAggregate;
+use Zend\EventManager\EventManagerInterface;
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+
+class HttpMethodListener extends AbstractListenerAggregate
+{
+    /**
+     * @var array
+     */
+    protected $allowedMethods = array(
+        HttpRequest::METHOD_CONNECT,
+        HttpRequest::METHOD_DELETE,
+        HttpRequest::METHOD_GET,
+        HttpRequest::METHOD_HEAD,
+        HttpRequest::METHOD_OPTIONS,
+        HttpRequest::METHOD_PATCH,
+        HttpRequest::METHOD_POST,
+        HttpRequest::METHOD_PUT,
+        HttpRequest::METHOD_PROPFIND,
+        HttpRequest::METHOD_TRACE,
+    );
+
+    /**
+     * @var bool
+     */
+    protected $enabled = true;
+
+    /**
+     * @param bool  $enabled
+     * @param array $allowedMethods
+     */
+    public function __construct($enabled = true, array $allowedMethods = array())
+    {
+        $this->setEnabled($enabled);
+
+        if (! empty($allowedMethods)) {
+            $this->setAllowedMethods($allowedMethods);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attach(EventManagerInterface $events)
+    {
+        if (! $this->isEnabled()) {
+            return;
+        }
+
+        $this->listeners[] = $events->attach(
+            MvcEvent::EVENT_ROUTE,
+            array($this, 'onRoute'),
+            10000
+        );
+    }
+
+    /**
+     * @param  MvcEvent $e
+     * @return void|HttpResponse
+     */
+    public function onRoute(MvcEvent $e)
+    {
+        $request = $e->getRequest();
+        $response = $e->getResponse();
+
+        if (! $request instanceof HttpRequest || ! $response instanceof HttpResponse) {
+            return;
+        }
+
+        $method = $request->getMethod();
+
+        if (in_array($method, $this->getAllowedMethods())) {
+            return;
+        }
+
+        $response->setStatusCode(405);
+
+        return $response;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAllowedMethods()
+    {
+        return $this->allowedMethods;
+    }
+
+    /**
+     * @param array $allowedMethods
+     */
+    public function setAllowedMethods(array $allowedMethods)
+    {
+        foreach ($allowedMethods as &$value) {
+            $value = strtoupper($value);
+        }
+        $this->allowedMethods = $allowedMethods;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = (bool) $enabled;
+    }
+}

--- a/library/Zend/Mvc/Service/HttpMethodListenerFactory.php
+++ b/library/Zend/Mvc/Service/HttpMethodListenerFactory.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Service;
+
+use Zend\Mvc\HttpMethodListener;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class HttpMethodListenerFactory implements FactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     * @return HttpMethodListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('config');
+
+        if (! isset($config['http_methods_listener'])) {
+            return new HttpMethodListener();
+        }
+
+        $listenerConfig  = $config['http_methods_listener'];
+        $enabled = array_key_exists('enabled', $listenerConfig)
+            ? $listenerConfig['enabled']
+            : true;
+        $allowedMethods = (isset($listenerConfig['allowed_methods']) && is_array($listenerConfig['allowed_methods']))
+            ? $listenerConfig['allowed_methods']
+            : null;
+
+        return new HttpMethodListener($enabled, $allowedMethods);
+    }
+}

--- a/library/Zend/Mvc/Service/ServiceListenerFactory.php
+++ b/library/Zend/Mvc/Service/ServiceListenerFactory.php
@@ -57,6 +57,7 @@ class ServiceListenerFactory implements FactoryInterface
             'FormAnnotationBuilder'          => 'Zend\Mvc\Service\FormAnnotationBuilderFactory',
             'FormElementManager'             => 'Zend\Mvc\Service\FormElementManagerFactory',
             'HttpRouter'                     => 'Zend\Mvc\Service\RouterFactory',
+            'HttpMethodListener'             => 'Zend\Mvc\Service\HttpMethodListenerFactory',
             'HttpViewManager'                => 'Zend\Mvc\Service\HttpViewManagerFactory',
             'HydratorManager'                => 'Zend\Mvc\Service\HydratorManagerFactory',
             'InjectTemplateListener'         => 'Zend\Mvc\Service\InjectTemplateListenerFactory',

--- a/tests/ZendTest/Mvc/ApplicationTest.php
+++ b/tests/ZendTest/Mvc/ApplicationTest.php
@@ -185,6 +185,24 @@ class ApplicationTest extends TestCase
         $this->assertSame(array($viewManager, 'onBootstrap'), $callback);
     }
 
+    public function testBootstrapCanRegisterHttpMethodListener()
+    {
+        $httpMethodListener = $this->serviceManager->get('HttpMethodListener');
+        $this->application->bootstrap(array('HttpMethodListener'));
+        $events = $this->application->getEventManager();
+        $listeners = $events->getListeners(MvcEvent::EVENT_ROUTE);
+        $foundListener = false;
+        foreach($listeners as $listener) {
+            $callback = $listener->getCallback();
+            $foundListener = $callback === array($httpMethodListener, 'onRoute');
+            if ($foundListener) {
+                break;
+            }
+        }
+
+        $this->assertTrue($foundListener);
+    }
+
     public function testBootstrapRegistersConfiguredMvcEvent()
     {
         $this->assertNull($this->application->getMvcEvent());

--- a/tests/ZendTest/Mvc/HttpMethodListenerTest.php
+++ b/tests/ZendTest/Mvc/HttpMethodListenerTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+use Zend\Mvc\HttpMethodListener;
+use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\Request;
+use Zend\Stdlib\Response;
+
+/**
+ * @covers Zend\Mvc\HttpMethodListener
+ */
+class HttpMethodListenerTest extends TestCase
+{
+    /**
+     * @var HttpMethodListener
+     */
+    protected $listener;
+
+    public function setUp()
+    {
+        $this->listener = new HttpMethodListener();
+    }
+
+    public function testConstructor()
+    {
+        $methods = array('foo', 'bar');
+        $listener = new HttpMethodListener(false, $methods);
+
+        $this->assertFalse($listener->isEnabled());
+        $this->assertSame(array('FOO', 'BAR'), $listener->getAllowedMethods());
+
+        $listener = new HttpMethodListener(true, array());
+        $this->assertNotEmpty($listener->getAllowedMethods());
+    }
+
+    public function testAttachesToRouteEvent()
+    {
+        $eventManager = $this->getMock('Zend\EventManager\EventManagerInterface');
+        $eventManager->expects($this->atLeastOnce())
+                     ->method('attach')
+                     ->with(MvcEvent::EVENT_ROUTE);
+
+        $this->listener->attach($eventManager);
+    }
+
+    public function testDoesntAttachIfDisabled()
+    {
+        $this->listener->setEnabled(false);
+
+        $eventManager = $this->getMock('Zend\EventManager\EventManagerInterface');
+        $eventManager->expects($this->never())
+                     ->method('attach');
+
+        $this->listener->attach($eventManager);
+    }
+
+    public function testOnRouteDoesNothingIfNotHttpEnvironment()
+    {
+        $event = new MvcEvent();
+        $event->setRequest(new Request());
+
+        $this->assertNull($this->listener->onRoute($event));
+
+        $event->setRequest(new HttpRequest());
+        $event->setResponse(new Response());
+
+        $this->assertNull($this->listener->onRoute($event));
+    }
+
+    public function testOnRouteDoesNothingIfIfMethodIsAllowed()
+    {
+        $event = new MvcEvent();
+        $request = new HttpRequest();
+        $request->setMethod('foo');
+        $event->setRequest($request);
+        $event->setResponse(new HttpResponse());
+
+        $this->listener->setAllowedMethods(array('foo'));
+
+        $this->assertNull($this->listener->onRoute($event));
+    }
+
+    public function testOnRouteReturns405ResponseIfMethodNotAllowed()
+    {
+        $event = new MvcEvent();
+        $request = new HttpRequest();
+        $request->setMethod('foo');
+        $event->setRequest($request);
+        $event->setResponse(new HttpResponse());
+
+        $response = $this->listener->onRoute($event);
+
+        $this->assertInstanceOf('Zend\Http\Response', $response);
+        $this->assertSame(405, $response->getStatusCode());
+    }
+}

--- a/tests/ZendTest/Mvc/Service/HttpMethodListenerFactoryTest.php
+++ b/tests/ZendTest/Mvc/Service/HttpMethodListenerFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Service;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\Mvc\Service\HttpMethodListenerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @covers Zend\Mvc\Service\HttpMethodListenerFactory
+ */
+class HttpMethodListenerFactoryTest extends TestCase
+{
+    /**
+     * @var ServiceLocatorInterface|MockObject
+     */
+    protected $serviceLocator;
+
+    public function setUp()
+    {
+        $this->serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+    }
+
+    public function testCreateWithDefaults()
+    {
+        $factory = new HttpMethodListenerFactory();
+        $listener = $factory->createService($this->serviceLocator);
+        $this->assertTrue($listener->isEnabled());
+        $this->assertNotEmpty($listener->getAllowedMethods());
+    }
+
+    public function testCreateWithConfig()
+    {
+        $config['http_methods_listener'] = array(
+            'enabled' => false,
+            'allowed_methods' => array('FOO', 'BAR')
+        );
+
+        $this->serviceLocator->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $factory = new HttpMethodListenerFactory();
+        $listener = $factory->createService($this->serviceLocator);
+
+        $listenerConfig = $config['http_methods_listener'];
+
+        $this->assertSame($listenerConfig['enabled'], $listener->isEnabled());
+        $this->assertSame($listenerConfig['allowed_methods'], $listener->getAllowedMethods());
+    }
+}


### PR DESCRIPTION
as suggested in #6385, here is the event listener to validate standard HTTP request methods and to make the application return a 405 empty response for unsupported methods.

the listener is ready to be registered via the `listeners` key in `application.config.php` with the name `HttpMethodListener`; however, for the time being it's not registered by default as originally suggested by @weierophinney.

to make that happen, we would have to add a key to `Zend\Mvc\Application::$defaultListeners`, and I discovered that this would cause some tests to fail because they assert there is _precisely one_ default listener per event, which is a bit odd. Personally, I would update [these tests](https://github.com/stefanotorresi/zf2/blob/6cc9d3e913bad2051de3ed1c28709dd325eabee7/tests/ZendTest/Mvc/ApplicationTest.php#L140-L186) with a [different assertion](https://github.com/stefanotorresi/zf2/blob/6cc9d3e913bad2051de3ed1c28709dd325eabee7/tests/ZendTest/Mvc/ApplicationTest.php#L195-L203) to make them not interfere with future default listeners additions.

[Here is a proposal to update the relevant tests](https://github.com/stefanotorresi/zf2/commit/edf61d7de77724edb1e4731da1280bac36971548) ready to merge into this PR.

I will wait for for further instructions on the matter.
