### PR TITLE
Removed non existing curl options

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -88,8 +88,6 @@ class Curl implements HttpAdapter, StreamInterface
             CURLOPT_PORT,
             CURLOPT_MAXREDIRS,
             CURLOPT_CONNECTTIMEOUT,
-            CURL_HTTP_VERSION_1_1,
-            CURL_HTTP_VERSION_1_0,
         );
     }
 


### PR DESCRIPTION
Fix for #7228.

`CURL_HTTP_VERSION_1_0` and `CURL_HTTP_VERSION_1_1` are not cURL options. They are cURL _values_ for the option `CURLOPT_HTTP_VERSION`.
