### PR TITLE
Add flexibility to FlashMessenger by determining hops as parameter.

### DIFF
--- a/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
+++ b/library/Zend/Mvc/Controller/Plugin/FlashMessenger.php
@@ -151,16 +151,17 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
      * Add a message
      *
      * @param  string         $message
+     * @param  int            $hops
      * @return FlashMessenger Provides a fluent interface
      */
-    public function addMessage($message)
+    public function addMessage($message, $hops = 1)
     {
         $container = $this->getContainer();
         $namespace = $this->getNamespace();
 
         if (!$this->messageAdded) {
             $this->getMessagesFromContainer();
-            $container->setExpirationHops(1, null);
+            $container->setExpirationHops($hops, null);
         }
 
         if (!isset($container->{$namespace})

--- a/tests/ZendTest/Mvc/Controller/Plugin/FlashMessengerTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/FlashMessengerTest.php
@@ -222,4 +222,15 @@ class FlashMessengerTest extends \PHPUnit_Framework_TestCase
         $this->seedMessages();
         $this->assertEquals(2, count($this->helper));
     }
+
+    public function testAddMessageWithLoops()
+    {
+        $helper  = new FlashMessenger();
+        $helper->addMessage('foo');
+        $helper->addMessage('bar', 2);
+        $helper->addMessage('baz', 5);
+        $this->assertEquals('3', count($helper->getCurrentMessages()));
+        $helper->clearCurrentMessages();
+        $this->assertEquals('0', count($helper->getCurrentMessages()));
+    }
 }


### PR DESCRIPTION
Additional flexibility for FlashMessenger. It's better to determine hops as parameter.
