### PR TITLE
[Navigation] Introducing NavigationAbstractServiceFactory

### DIFF
--- a/library/Zend/Navigation/Service/NavigationAbstractServiceFactory.php
+++ b/library/Zend/Navigation/Service/NavigationAbstractServiceFactory.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Navigation\Service;
+
+use Zend\Navigation\Navigation;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Navigation abstract service factory
+ *
+ * Allows configuring several navigation instances. If you have a navigation config key named "special" then you can
+ * use $serviceLocator->get('Zend\Navigation\Special') to retrieve a navigation instance with this configuration.
+ */
+final class NavigationAbstractServiceFactory implements AbstractFactoryInterface
+{
+    /**
+     * Top-level configuration key indicating navigation configuration
+     *
+     * @var string
+     */
+    const CONFIG_KEY = 'navigation';
+
+    /**
+     * Service manager factory prefix
+     *
+     * @var string
+     */
+    const SERVICE_PREFIX = 'Zend\Navigation\\';
+
+    /**
+     * Normalized name prefix
+     */
+    const NAME_PREFIX = 'zendnavigation';
+
+    /**
+     * Navigation configuration
+     *
+     * @var array
+     */
+    protected $config;
+
+    /**
+     * Can we create a navigation by the requested name?
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name Service name (as resolved by ServiceManager)
+     * @param string $requestedName Name by which service was requested, must start with Zend\Navigation\
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        if (0 !== strpos($name, self::NAME_PREFIX)) {
+            return false;
+        }
+        $config = $this->getConfig($serviceLocator);
+
+        return (!empty($config[$this->getConfigName($name)]));
+    }
+
+    /**
+     * Create a navigation container
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @param string $name Service name (as resolved by ServiceManager)
+     * @param string $requestedName Name by which service was requested
+     * @return Navigation
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        $config = $this->getConfig($serviceLocator);
+        $factory = new ConstructedNavigationFactory($config[$this->getConfigName($name)]);
+        return $factory->createService($serviceLocator);
+    }
+
+    /**
+     * Get navigation configuration, if any
+     *
+     * @param  ServiceLocatorInterface $services
+     * @return array
+     */
+    protected function getConfig(ServiceLocatorInterface $services)
+    {
+        if ($this->config !== null) {
+            return $this->config;
+        }
+
+        if (!$services->has('Config')) {
+            $this->config = array();
+            return $this->config;
+        }
+
+        $config = $services->get('Config');
+        if (!isset($config[self::CONFIG_KEY])
+            || !is_array($config[self::CONFIG_KEY])
+        ) {
+            $this->config = array();
+            return $this->config;
+        }
+
+        $this->config = $config[self::CONFIG_KEY];
+        return $this->config;
+    }
+
+    /**
+     * Extract config name from service name
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function getConfigName($name)
+    {
+        return substr($name, strlen(self::NAME_PREFIX));
+    }
+}

--- a/tests/ZendTest/Navigation/ServiceFactoryTest.php
+++ b/tests/ZendTest/Navigation/ServiceFactoryTest.php
@@ -15,7 +15,7 @@ use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\Navigation;
 use Zend\Navigation\Page\Mvc as MvcPage;
 use Zend\Navigation\Service\ConstructedNavigationFactory;
-use Zend\Navigation\Service\DefaultNavigationFactory;
+use Zend\Navigation\Service\NavigationAbstractServiceFactory;
 use Zend\ServiceManager\ServiceManager;
 
 /**
@@ -251,6 +251,30 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager->setFactory('Navigation', $factory);
 
         $container = $this->serviceManager->get('Navigation');
+        $this->assertEquals(3, $container->count());
+    }
+
+    /**
+     * @covers \Zend\Navigation\Service\NavigationAbstractServiceFactory
+     */
+    public function testNavigationAbstractServiceFactory()
+    {
+        $factory = new NavigationAbstractServiceFactory();
+
+        $this->assertTrue(
+            $factory->canCreateServiceWithName($this->serviceManager, 'zendnavigationfile', 'Zend\Navigation\File')
+        );
+        $this->assertFalse(
+            $factory->canCreateServiceWithName($this->serviceManager, 'zendnavigationunknown', 'Zend\Navigation\Unknown')
+        );
+
+        $container = $factory->createServiceWithName(
+            $this->serviceManager,
+            'zendnavigationfile',
+            'Zend\Navigation\File'
+        );
+
+        $this->assertInstanceOf('Zend\Navigation\Navigation', $container);
         $this->assertEquals(3, $container->count());
     }
 }


### PR DESCRIPTION
According to the feedback of #6717 I've created the Navigation Abstract Service Factory. If this abstract service factory is registered, a service with name `Zend\Navigation\Special` will use the `special` definition in configuration key `navigation`.

With one point I'm not satisfied. A service call must start with `Zend\Navigation\`  (e.g. `$sl->get('Zend\Navigation\Special')`). Maybe we could support `navigation.special` too?

I use the `ConstructedNavigationFactory` to create the Navigation Container. Is this ok or should I use the `AbstractNavigationFactory` (@weierophinney)? The problem here is that we have to implement the getName() and override the getPages() method. For the future (ZF 3.0) we could remove getName() and make getPages() abstract in `AbstractNavigationFactory`. This makes `DefaultNavigationFactory` and `ConstructedNavigationFactory` needless. But it's a BC break.

I will also update the documentation.
