### PR TITLE
Add input_filter_specs feature from zfcampus/zf-content-validation and associated tests

### DIFF
--- a/library/Zend/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/library/Zend/InputFilter/InputFilterAbstractServiceFactory.php
@@ -1,7 +1,10 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Zend\InputFilter;

--- a/library/Zend/InputFilter/InputFilterAbstractServiceFactory.php
+++ b/library/Zend/InputFilter/InputFilterAbstractServiceFactory.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace Zend\InputFilter;
+
+use Zend\Filter\FilterPluginManager;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Validator\ValidatorPluginManager;
+
+class InputFilterAbstractServiceFactory implements AbstractFactoryInterface
+{
+    /**
+     * @var Factory
+     */
+    protected $factory;
+
+    /**
+     * @param ServiceLocatorInterface $inputFilters
+     * @param string                  $cName
+     * @param string                  $rName
+     *
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $inputFilters, $cName, $rName)
+    {
+        $services = $inputFilters->getServiceLocator();
+        if (! $services instanceof ServiceLocatorInterface
+            || ! $services->has('Config')
+        ) {
+            return false;
+        }
+
+        $config = $services->get('Config');
+        if (!isset($config['input_filter_specs'][$rName])
+            || !is_array($config['input_filter_specs'][$rName])
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ServiceLocatorInterface $inputFilters
+     * @param string                  $cName
+     * @param string                  $rName
+     *
+     * @return \Zend\InputFilter\InputFilterInterface
+     */
+    public function createServiceWithName(ServiceLocatorInterface $inputFilters, $cName, $rName)
+    {
+        $services  = $inputFilters->getServiceLocator();
+        $allConfig = $services->get('Config');
+        $config    = $allConfig['input_filter_specs'][$rName];
+
+        $factory   = $this->getInputFilterFactory($services);
+
+        return $factory->createInputFilter($config);
+    }
+
+    /**
+     * @param ServiceLocatorInterface $services
+     *
+     * @return Factory
+     */
+    protected function getInputFilterFactory(ServiceLocatorInterface $services)
+    {
+        if ($this->factory instanceof Factory) {
+            return $this->factory;
+        }
+
+        $this->factory = new Factory();
+        $this->factory
+            ->getDefaultFilterChain()
+            ->setPluginManager($this->getFilterPluginManager($services));
+        $this->factory
+            ->getDefaultValidatorChain()
+            ->setPluginManager($this->getValidatorPluginManager($services));
+
+        return $this->factory;
+    }
+
+    /**
+     * @param ServiceLocatorInterface $services
+     *
+     * @return \Zend\ServiceManager\AbstractPluginManager
+     */
+    protected function getFilterPluginManager(ServiceLocatorInterface $services)
+    {
+        if ($services->has('FilterManager')) {
+            return $services->get('FilterManager');
+        }
+
+        return new FilterPluginManager();
+    }
+
+    /**
+     * @param ServiceLocatorInterface $services
+     *
+     * @return \Zend\ServiceManager\AbstractPluginManager
+     */
+    protected function getValidatorPluginManager(ServiceLocatorInterface $services)
+    {
+        if ($services->has('ValidatorManager')) {
+            return $services->get('ValidatorManager');
+        }
+
+        return new ValidatorPluginManager();
+    }
+}

--- a/library/Zend/InputFilter/InputFilterPluginManager.php
+++ b/library/Zend/InputFilter/InputFilterPluginManager.php
@@ -46,6 +46,7 @@ class InputFilterPluginManager extends AbstractPluginManager
         parent::__construct($configuration);
 
         $this->addInitializer(array($this, 'populateFactory'));
+        $this->addAbstractFactory('Zend\InputFilter\InputFilterAbstractServiceFactory');
     }
 
     /**

--- a/library/Zend/InputFilter/InputFilterPluginManager.php
+++ b/library/Zend/InputFilter/InputFilterPluginManager.php
@@ -46,7 +46,6 @@ class InputFilterPluginManager extends AbstractPluginManager
         parent::__construct($configuration);
 
         $this->addInitializer(array($this, 'populateFactory'));
-        $this->addAbstractFactory('Zend\InputFilter\InputFilterAbstractServiceFactory');
     }
 
     /**

--- a/tests/ZendTest/InputFilter/InputFilterAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterAbstractServiceFactoryTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZendTest\InputFilter;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Filter\FilterPluginManager;
+use Zend\InputFilter\InputFilterPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Validator\ValidatorPluginManager;
+use Zend\InputFilter\InputFilterAbstractServiceFactory;
+
+class InputFilterAbstractServiceFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->services = new ServiceManager();
+        $this->filters  = new InputFilterPluginManager();
+        $this->filters->setServiceLocator($this->services);
+        $this->services->setService('InputFilterManager', $this->filters);
+
+        $this->factory = new InputFilterAbstractServiceFactory();
+    }
+
+    public function testCannotCreateServiceIfNoConfigServicePresent()
+    {
+        $this->assertFalse($this->factory->canCreateServiceWithName($this->filters, 'filter', 'filter'));
+    }
+
+    public function testCannotCreateServiceIfConfigServiceDoesNotHaveInputFiltersConfiguration()
+    {
+        $this->services->setService('Config', array());
+        $this->assertFalse($this->factory->canCreateServiceWithName($this->filters, 'filter', 'filter'));
+    }
+
+    public function testCannotCreateServiceIfConfigInputFiltersDoesNotContainMatchingServiceName()
+    {
+        $this->services->setService('Config', array(
+            'input_filter_specs' => array(),
+        ));
+        $this->assertFalse($this->factory->canCreateServiceWithName($this->filters, 'filter', 'filter'));
+    }
+
+    public function testCanCreateServiceIfConfigInputFiltersContainsMatchingServiceName()
+    {
+        $this->services->setService('Config', array(
+            'input_filter_specs' => array(
+                'filter' => array(),
+            ),
+        ));
+        $this->assertTrue($this->factory->canCreateServiceWithName($this->filters, 'filter', 'filter'));
+    }
+
+    public function testCreatesInputFilterInstance()
+    {
+        $this->services->setService('Config', array(
+            'input_filter_specs' => array(
+                'filter' => array(),
+            ),
+        ));
+        $filter = $this->factory->createServiceWithName($this->filters, 'filter', 'filter');
+        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $filter);
+    }
+
+    /**
+     * @depends testCreatesInputFilterInstance
+     */
+    public function testUsesConfiguredValidationAndFilterManagerServicesWhenCreatingInputFilter()
+    {
+        $filters = new FilterPluginManager();
+        $filter  = function ($value) {
+        };
+        $filters->setService('foo', $filter);
+
+        $validators = new ValidatorPluginManager();
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $validators->setService('foo', $validator);
+
+        $this->services->setService('FilterManager', $filters);
+        $this->services->setService('ValidatorManager', $validators);
+        $this->services->setService('Config', array(
+            'input_filter_specs' => array(
+                'filter' => array(
+                    'input' => array(
+                        'name' => 'input',
+                        'required' => true,
+                        'filters' => array(
+                            array( 'name' => 'foo' ),
+                        ),
+                        'validators' => array(
+                            array( 'name' => 'foo' ),
+                        ),
+                    ),
+                ),
+            ),
+        ));
+
+        $inputFilter = $this->factory->createServiceWithName($this->filters, 'filter', 'filter');
+        $this->assertTrue($inputFilter->has('input'));
+
+        $input = $inputFilter->get('input');
+
+        $filterChain = $input->getFilterChain();
+        $this->assertSame($filters, $filterChain->getPluginManager());
+        $this->assertEquals(1, count($filterChain));
+        $this->assertSame($filter, $filterChain->plugin('foo'));
+        $this->assertEquals(1, count($filterChain));
+
+        $validatorChain = $input->getvalidatorChain();
+        $this->assertSame($validators, $validatorChain->getPluginManager());
+        $this->assertEquals(1, count($validatorChain));
+        $this->assertSame($validator, $validatorChain->plugin('foo'));
+        $this->assertEquals(1, count($validatorChain));
+    }
+
+    public function testRetrieveInputFilterFromInputFilterPluginManager()
+    {
+        $filters = new FilterPluginManager();
+        $filter  = function ($value) {
+        };
+        $filters->setService('foo', $filter);
+
+        $validators = new ValidatorPluginManager();
+        $validator  = $this->getMock('Zend\Validator\ValidatorInterface');
+        $validators->setService('foo', $validator);
+
+        $this->services->setService('FilterManager', $filters);
+        $this->services->setService('ValidatorManager', $validators);
+        $this->services->setService('Config', array(
+            'input_filter_specs' => array(
+                'foobar' => array(
+                    'input' => array(
+                        'name' => 'input',
+                        'required' => true,
+                        'filters' => array(
+                            array( 'name' => 'foo' ),
+                        ),
+                        'validators' => array(
+                            array( 'name' => 'foo' ),
+                        ),
+                    ),
+                ),
+            ),
+        ));
+        $inputFilter = $this->services->get('InputFilterManager')->get('foobar');
+        $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
+    }
+}

--- a/tests/ZendTest/InputFilter/InputFilterAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterAbstractServiceFactoryTest.php
@@ -1,7 +1,10 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\InputFilter;

--- a/tests/ZendTest/InputFilter/InputFilterAbstractServiceFactoryTest.php
+++ b/tests/ZendTest/InputFilter/InputFilterAbstractServiceFactoryTest.php
@@ -148,6 +148,8 @@ class InputFilterAbstractServiceFactoryTest extends TestCase
                 ),
             ),
         ));
+        $this->services->get('InputFilterManager')->addAbstractFactory('Zend\InputFilter\InputFilterAbstractServiceFactory');
+
         $inputFilter = $this->services->get('InputFilterManager')->get('foobar');
         $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
     }


### PR DESCRIPTION
I recently ask @weierophinney when input_filter_specs feature from zfcampus/zf-content-validation would be migrated to zendframework/zf2, as written in [zf-content-validation README](https://github.com/zfcampus/zf-content-validation/blob/master/README.md).
So we discuss about it on [Twitter](https://twitter.com/_JulienBenoit/status/568698101537611777), and he suggested me to do it by myself. And so I did it.

This PR covers only the [input_filter_specs](https://github.com/zfcampus/zf-content-validation#input_filter_spec) feature. When it will be accepted, I will update the ZF2 doc.
