### PR TITLE
Remove CURLOPT_POSTFIELDS from set of invalid curl options

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -82,7 +82,6 @@ class Curl implements HttpAdapter, StreamInterface
             CURLOPT_HEADER,
             CURLOPT_RETURNTRANSFER,
             CURLOPT_HTTPHEADER,
-            CURLOPT_POSTFIELDS,
             CURLOPT_INFILE,
             CURLOPT_INFILESIZE,
             CURLOPT_PORT,

--- a/tests/ZendTest/Http/Client/CurlTest.php
+++ b/tests/ZendTest/Http/Client/CurlTest.php
@@ -360,4 +360,19 @@ class CurlTest extends CommonHttpTests
         $this->client->send();
         $this->assertEquals('Success', $this->client->getResponse()->getBody());
     }
+
+    public function testSetCurlOptPostFields()
+    {
+        $this->client->setUri($this->baseuri . 'testRawPostData.php');
+        $adapter = new Adapter\Curl();
+        $adapter->setOptions(array(
+            'curloptions' => array(
+                CURLOPT_POSTFIELDS => 'foo=bar',
+            ),
+        ));
+        $this->client->setAdapter($adapter);
+        $this->client->setMethod('POST');
+        $this->client->send();
+        $this->assertEquals('foo=bar', $this->client->getResponse()->getBody());
+    }
 }


### PR DESCRIPTION
Right now there is no way to upload a file without loading the entire file into memory twice.
That is quite a bummer, because CURL supports it just fine. The CURLOPT_POSTFIELDS allows doing
just that.

Now it would of course be exellent if the built in file upload stuff in ZF would just use
said option. But as a workaround, it would be great to be able to override it.

Another thing: Getting this to work properly also requires messing around with the ENC_TYPE
in the client. Basically manually overriding it to ENC_FORMDATA.
