### PR TITLE
Fixed tests for quoteValue() methods in all Platform classes

### DIFF
--- a/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/IbmDb2Test.php
@@ -83,15 +83,26 @@ class IbmDb2Test extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         if (!function_exists('db2_escape_string')) {
             $this->setExpectedException(
-                'PHPUnit_Framework_Error',
+                'PHPUnit_Framework_Error_Notice',
                 'Attempting to quote a value in Zend\Db\Adapter\Platform\IbmDb2 without extension/driver support can introduce security vulnerabilities in a production environment'
             );
         }
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\IbmDb2::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O''Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals("'''; DELETE FROM some_table; -- '", @$this->platform->quoteValue("'; DELETE FROM some_table; -- "));
+        $this->assertEquals("'\\''; \nDELETE FROM some_table; -- '", @$this->platform->quoteValue("\\'; \nDELETE FROM some_table; -- "));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/MysqlTest.php
@@ -78,13 +78,24 @@ class MysqlTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\Mysql::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            'PHPUnit_Framework_Error_Notice',
             'Attempting to quote a value in Zend\Db\Adapter\Platform\Mysql without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Mysql::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', @$this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/OracleTest.php
@@ -80,13 +80,24 @@ class OracleTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\Oracle::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            'PHPUnit_Framework_Error_Notice',
             'Attempting to quote a value in Zend\Db\Adapter\Platform\Oracle without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Oracle::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O''Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\'\'; DELETE FROM some_table; -- \'', @$this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("'\\''; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/PostgresqlTest.php
@@ -74,13 +74,24 @@ class PostgresqlTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\Postgresql::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            'PHPUnit_Framework_Error_Notice',
             'Attempting to quote a value in Zend\Db\Adapter\Platform\Postgresql without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Postgresql::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("E'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("E'Foo O\\'Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('E\'\\\'; DELETE FROM some_table; -- \'', @$this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("E'\\\\\\'; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
+++ b/tests/ZendTest/Db/Adapter/Platform/Sql92Test.php
@@ -72,13 +72,24 @@ class Sql92Test extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\Sql92::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            'PHPUnit_Framework_Error_Notice',
             'Attempting to quote a value without specific driver level support can introduce security vulnerabilities in a production environment.'
         );
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Sql92::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', @$this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqlServerTest.php
@@ -73,13 +73,24 @@ class SqlServerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\SqlServer::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            'PHPUnit_Framework_Error_Notice',
             'Attempting to quote a value in Zend\Db\Adapter\Platform\SqlServer without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\SqlServer::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O''Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals("'''; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("'\\''; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
@@ -72,13 +72,24 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Zend\Db\Adapter\Platform\Sqlite::quoteValue
      */
-    public function testQuoteValue()
+    public function testQuoteValueRaisesNoticeWithoutPlatformSupport()
     {
         $this->setExpectedException(
-            'PHPUnit_Framework_Error',
+            'PHPUnit_Framework_Error_Notice',
             'Attempting to quote a value in Zend\Db\Adapter\Platform\Sqlite without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        $this->assertEquals("'value'", $this->platform->quoteValue('value'));
+        $this->platform->quoteValue('value');
+    }
+
+    /**
+     * @covers Zend\Db\Adapter\Platform\Sqlite::quoteValue
+     */
+    public function testQuoteValue()
+    {
+        $this->assertEquals("'value'", @$this->platform->quoteValue('value'));
+        $this->assertEquals("'Foo O\\'Bar'", @$this->platform->quoteValue("Foo O'Bar"));
+        $this->assertEquals('\'\\\'; DELETE FROM some_table; -- \'', @$this->platform->quoteValue('\'; DELETE FROM some_table; -- '));
+        $this->assertEquals("'\\\\\\'; DELETE FROM some_table; -- '", @$this->platform->quoteValue('\\\'; DELETE FROM some_table; -- '));
     }
 
     /**


### PR DESCRIPTION
The tests for quoteValue() are incomplete. When quoteValue() raises an E_USER_NOTICE, PHPUnit converts it to an exception which is tested. The tests try to check the return value, but neither the return value generating code nor the assertion are executed. The tests pass, but only the error message is effectively tested.

I split the tests: One test checks the exception as usual, but the return value is discarded (It would be NULL anyway within a PHPUnit environment - in other context a value would be returned, but that is difficult to test). I also tightened the exception type check from PHPUnit_Framework_Error to PHPUnit_Framework_Error_Notice.

The other test executes quoteValue() with error suppression so that the return value can be checked. Since quoteValue() and quoteTrustedValue() are implemented separately, I added the full set of test values to the test.
