### PR TITLE
Ship a StandaloneExtensionManager for Zend\Feed\Reader

### DIFF
--- a/library/Zend/Feed/Reader/Reader.php
+++ b/library/Zend/Feed/Reader/Reader.php
@@ -544,7 +544,7 @@ class Reader
     public static function getExtensionManager()
     {
         if (!isset(static::$extensionManager)) {
-            static::setExtensionManager(new ExtensionManager());
+            static::setExtensionManager(new StandaloneExtensionManager());
         }
         return static::$extensionManager;
     }

--- a/library/Zend/Feed/Reader/StandaloneExtensionManager.php
+++ b/library/Zend/Feed/Reader/StandaloneExtensionManager.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Feed\Reader;
+
+class StandaloneExtensionManager implements ExtensionManagerInterface
+{
+    private $extensions = array(
+        'Atom\Entry'            => 'Zend\Feed\Reader\Extension\Atom\Entry',
+        'Atom\Feed'             => 'Zend\Feed\Reader\Extension\Atom\Feed',
+        'Content\Entry'         => 'Zend\Feed\Reader\Extension\Content\Entry',
+        'CreativeCommons\Entry' => 'Zend\Feed\Reader\Extension\CreativeCommons\Entry',
+        'CreativeCommons\Feed'  => 'Zend\Feed\Reader\Extension\CreativeCommons\Feed',
+        'DublinCore\Entry'      => 'Zend\Feed\Reader\Extension\DublinCore\Entry',
+        'DublinCore\Feed'       => 'Zend\Feed\Reader\Extension\DublinCore\Feed',
+        'Podcast\Entry'         => 'Zend\Feed\Reader\Extension\Podcast\Entry',
+        'Podcast\Feed'          => 'Zend\Feed\Reader\Extension\Podcast\Feed',
+        'Slash\Entry'           => 'Zend\Feed\Reader\Extension\Slash\Entry',
+        'Syndication\Feed'      => 'Zend\Feed\Reader\Extension\Syndication\Feed',
+        'Thread\Entry'          => 'Zend\Feed\Reader\Extension\Thread\Entry',
+        'WellFormedWeb\Entry'   => 'Zend\Feed\Reader\Extension\WellFormedWeb\Entry',
+    );
+
+    /**
+     * Do we have the extension?
+     *
+     * @param  string $extension
+     * @return bool
+     */
+    public function has($extension)
+    {
+        return array_key_exists($extension, $this->extensions);
+    }
+
+    /**
+     * Retrieve the extension
+     *
+     * @param  string $extension
+     * @return Extension\AbstractEntry|Extension\AbstractFeed
+     */
+    public function get($extension)
+    {
+        $class = $this->extensions[$extension];
+        return new $class();
+    }
+}

--- a/tests/ZendTest/Feed/Reader/ReaderTest.php
+++ b/tests/ZendTest/Feed/Reader/ReaderTest.php
@@ -255,9 +255,10 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     {
         require_once __DIR__ . '/_files/My/Extension/JungleBooks/Entry.php';
         require_once __DIR__ . '/_files/My/Extension/JungleBooks/Feed.php';
-        $manager = Reader\Reader::getExtensionManager();
+        $manager = new Reader\ExtensionManager(new Reader\ExtensionPluginManager());
         $manager->setInvokableClass('JungleBooks\Entry', 'My\Extension\JungleBooks\Entry');
         $manager->setInvokableClass('JungleBooks\Feed', 'My\Extension\JungleBooks\Feed');
+        Reader\Reader::setExtensionManager($manager);
         Reader\Reader::registerExtension('JungleBooks');
 
         $this->assertTrue(Reader\Reader::isRegistered('JungleBooks'));

--- a/tests/ZendTest/Feed/Reader/ReaderTest.php
+++ b/tests/ZendTest/Feed/Reader/ReaderTest.php
@@ -332,7 +332,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
                 return $dir;
             }
         }
-        $tempFile = tempnam(md5(uniqid(rand(), TRUE)), '');
+        $tempFile = tempnam(md5(uniqid(rand(), true)), '');
         if ($tempFile) {
             $dir = realpath(dirname($tempFile));
             unlink($tempFile);

--- a/tests/ZendTest/Feed/Reader/StandaloneExtensionManagerTest.php
+++ b/tests/ZendTest/Feed/Reader/StandaloneExtensionManagerTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace ZendTest\Feed\Reader;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Feed\Reader\StandaloneExtensionManager;
+
+class StandaloneExtensionManagerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->extensions = new StandaloneExtensionManager();
+    }
+
+    public function testIsAnExtensionManagerImplementation()
+    {
+        $this->assertInstanceOf('Zend\Feed\Reader\ExtensionManagerInterface', $this->extensions);
+    }
+
+    public function defaultPlugins()
+    {
+        return array(
+            'Atom\Entry'            => array('Atom\Entry', 'Zend\Feed\Reader\Extension\Atom\Entry'),
+            'Atom\Feed'             => array('Atom\Feed', 'Zend\Feed\Reader\Extension\Atom\Feed'),
+            'Content\Entry'         => array('Content\Entry', 'Zend\Feed\Reader\Extension\Content\Entry'),
+            'CreativeCommons\Entry' => array(
+                'CreativeCommons\Entry',
+                'Zend\Feed\Reader\Extension\CreativeCommons\Entry'
+            ),
+            'CreativeCommons\Feed'  => array('CreativeCommons\Feed', 'Zend\Feed\Reader\Extension\CreativeCommons\Feed'),
+            'DublinCore\Entry'      => array('DublinCore\Entry', 'Zend\Feed\Reader\Extension\DublinCore\Entry'),
+            'DublinCore\Feed'       => array('DublinCore\Feed', 'Zend\Feed\Reader\Extension\DublinCore\Feed'),
+            'Podcast\Entry'         => array('Podcast\Entry', 'Zend\Feed\Reader\Extension\Podcast\Entry'),
+            'Podcast\Feed'          => array('Podcast\Feed', 'Zend\Feed\Reader\Extension\Podcast\Feed'),
+            'Slash\Entry'           => array('Slash\Entry', 'Zend\Feed\Reader\Extension\Slash\Entry'),
+            'Syndication\Feed'      => array('Syndication\Feed', 'Zend\Feed\Reader\Extension\Syndication\Feed'),
+            'Thread\Entry'          => array('Thread\Entry', 'Zend\Feed\Reader\Extension\Thread\Entry'),
+            'WellFormedWeb\Entry'   => array('WellFormedWeb\Entry', 'Zend\Feed\Reader\Extension\WellFormedWeb\Entry'),
+        );
+    }
+
+    /**
+     * @dataProvider defaultPlugins
+     */
+    public function testHasAllDefaultPlugins($pluginName, $pluginClass)
+    {
+        $this->assertTrue($this->extensions->has($pluginName));
+    }
+
+    /**
+     * @dataProvider defaultPlugins
+     */
+    public function testCanRetrieveDefaultPluginInstances($pluginName, $pluginClass)
+    {
+        $extension = $this->extensions->get($pluginName);
+        $this->assertInstanceOf($pluginClass, $extension);
+    }
+
+    /**
+     * @dataProvider defaultPlugins
+     */
+    public function testEachPluginRetrievalReturnsNewInstance($pluginName, $pluginClass)
+    {
+        $extension = $this->extensions->get($pluginName);
+        $this->assertInstanceOf($pluginClass, $extension);
+
+        $test = $this->extensions->get($pluginName);
+        $this->assertInstanceOf($pluginClass, $test);
+        $this->assertNotSame($extension, $test);
+    }
+}

--- a/tests/ZendTest/Feed/Reader/StandaloneExtensionManagerTest.php
+++ b/tests/ZendTest/Feed/Reader/StandaloneExtensionManagerTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
 namespace ZendTest\Feed\Reader;
 
 use PHPUnit_Framework_TestCase as TestCase;


### PR DESCRIPTION
In 2.2 or 2.3, we modified `Zend\Feed` to reduce the number of dependencies, and introduced a separated interface for the extension manager to allow using a non-ServiceManager variant (which allowed reducing dependencies).

This patch completes that work by introducing a `StandaloneExtensionManager` that provides the base capabilities necessary to serve the shipped feed and entry extensions. `Zend\Feed\Reader\Reader::getExtensionManager()` has been modified to lazy-load this class when no other extension manager has been set.

This implementation does NOT support registering custom extensions, as the `ExtensionManagerInterface` does not specify such capabilities. If users want to allow or support custom extensions, they would need to create their own implementation or extend the current implementation.

This patch replaces #7179 and will resolve #6419.
