### PR TITLE
Db Platform refactoring

### DIFF
--- a/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
@@ -78,6 +78,14 @@ abstract class AbstractPlatform implements PlatformInterface
     /**
      * {@inheritDoc}
      */
+    public function quoteIdentifierChain($identifierChain)
+    {
+        return '"' . implode('"."', (array) str_replace('"', '\\"', $identifierChain)) . '"';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getQuoteIdentifierSymbol()
     {
         return $this->quoteIdentifier[0];
@@ -86,8 +94,44 @@ abstract class AbstractPlatform implements PlatformInterface
     /**
      * {@inheritDoc}
      */
+    public function getQuoteValueSymbol()
+    {
+        return '\'';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function quoteValue($value)
+    {
+        trigger_error(
+            'Attempting to quote a value in ' . get_class($this) .
+            ' without extension/driver support can introduce security vulnerabilities in a production environment'
+        );
+        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function quoteTrustedValue($value)
+    {
+        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function quoteValueList($valueList)
     {
         return implode(', ', array_map(array($this, 'quoteValue'), (array) $valueList));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierSeparator()
+    {
+        return '.';
     }
 }

--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -12,11 +12,6 @@ namespace Zend\Db\Adapter\Platform;
 class IbmDb2 extends AbstractPlatform
 {
     /**
-     * @var bool
-     */
-    protected $quoteValueAllowed = false;
-
-    /**
      * @var string
      */
     protected $identifierSeparator = '.';
@@ -59,14 +54,6 @@ class IbmDb2 extends AbstractPlatform
             $identifierChain = implode('"' . $this->identifierSeparator . '"', $identifierChain);
         }
         return '"' . $identifierChain . '"';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Mysql.php
+++ b/library/Zend/Db/Adapter/Platform/Mysql.php
@@ -81,14 +81,6 @@ class Mysql extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         if ($this->resource instanceof DriverInterface) {
@@ -100,11 +92,7 @@ class Mysql extends AbstractPlatform
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return parent::quoteValue($value);
     }
 
     /**
@@ -121,14 +109,6 @@ class Mysql extends AbstractPlatform
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
+        return parent::quoteTrustedValue($value);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Oracle.php
+++ b/library/Zend/Db/Adapter/Platform/Oracle.php
@@ -47,14 +47,6 @@ class Oracle extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         trigger_error(
@@ -70,13 +62,5 @@ class Oracle extends AbstractPlatform
     public function quoteTrustedValue($value)
     {
         return '\'' . addcslashes(str_replace('\'', '\'\'', $value), "\x00\n\r\"\x1a") . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Postgresql.php
+++ b/library/Zend/Db/Adapter/Platform/Postgresql.php
@@ -76,14 +76,6 @@ class Postgresql extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         if ($this->resource instanceof DriverInterface) {
@@ -95,11 +87,7 @@ class Postgresql extends AbstractPlatform
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return 'E\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return 'E' . parent::quoteValue($value);
     }
 
     /**
@@ -116,14 +104,6 @@ class Postgresql extends AbstractPlatform
         if ($this->resource instanceof \PDO) {
             return $this->resource->quote($value);
         }
-        return 'E\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
+        return 'E' . parent::quoteTrustedValue($value);
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -22,43 +22,11 @@ class Sql92 extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        return '"' . implode('"."', (array) str_replace('"', '\\"', $identifierChain)) . '"';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         trigger_error(
             'Attempting to quote a value without specific driver level support can introduce security vulnerabilities in a production environment.'
         );
         return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function quoteTrustedValue($value)
-    {
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
     }
 }

--- a/library/Zend/Db/Adapter/Platform/SqlServer.php
+++ b/library/Zend/Db/Adapter/Platform/SqlServer.php
@@ -86,14 +86,6 @@ class SqlServer extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         if ($this->resource instanceof DriverInterface) {
@@ -122,13 +114,5 @@ class SqlServer extends AbstractPlatform
             return $this->resource->quote($value);
         }
         return '\'' . str_replace('\'', '\'\'', $value) . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
     }
 }

--- a/library/Zend/Db/Adapter/Platform/Sqlite.php
+++ b/library/Zend/Db/Adapter/Platform/Sqlite.php
@@ -69,22 +69,6 @@ class Sqlite extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
-    public function quoteIdentifierChain($identifierChain)
-    {
-        return '"' . implode('"."', (array) str_replace('"', '\\"', $identifierChain)) . '"';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getQuoteValueSymbol()
-    {
-        return '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function quoteValue($value)
     {
         $resource = $this->resource;
@@ -97,11 +81,7 @@ class Sqlite extends AbstractPlatform
             return $resource->quote($value);
         }
 
-        trigger_error(
-            'Attempting to quote a value in ' . __CLASS__ . ' without extension/driver support '
-                . 'can introduce security vulnerabilities in a production environment.'
-        );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return parent::quoteValue($value);
     }
 
     /**
@@ -119,14 +99,6 @@ class Sqlite extends AbstractPlatform
             return $resource->quote($value);
         }
 
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifierSeparator()
-    {
-        return '.';
+        return parent::quoteTrustedValue($value);
     }
 }


### PR DESCRIPTION
This is a follow-up to #7059 against the latest develop branch. A common base class (AbstractPlatform) with some common implementations is already present there. This PR moves more methods to the base class, reducing the amount of duplicated code.

I double-checked that the critical quoteIdentifierChain(), quoteValue() and quoteTrustedValue() methods are inherited the right way. A second set of eyeballs should verify this, since the unit tests don't cover all possible characters that need escaping. The other quoting methods had already been ported.
