### PR TITLE
Fix: Array to string conversion in Zend\Log\Writer\Db

### DIFF
--- a/library/Zend/Log/Writer/Db.php
+++ b/library/Zend/Log/Writer/Db.php
@@ -163,7 +163,12 @@ class Db extends AbstractWriter
             if (is_array($value)) {
                 foreach ($value as $key => $subvalue) {
                     if (isset($columnMap[$name][$key])) {
-                        $data[$columnMap[$name][$key]] = $subvalue;
+                        if (is_scalar($subvalue)) {
+                            $data[$columnMap[$name][$key]] = $subvalue;
+                            continue;
+                        }
+
+                        $data[$columnMap[$name][$key]] = var_export($subvalue, true);
                     }
                 }
             } elseif (isset($columnMap[$name])) {
@@ -189,7 +194,12 @@ class Db extends AbstractWriter
         foreach ($event as $name => $value) {
             if (is_array($value)) {
                 foreach ($value as $key => $subvalue) {
-                    $data[$name . $this->separator . $key] = $subvalue;
+                    if (is_scalar($subvalue)) {
+                        $data[$name . $this->separator . $key] = $subvalue;
+                        continue;
+                    }
+
+                    $data[$name . $this->separator . $key] = var_export($subvalue, true);
                 }
             } else {
                 $data[$name] = $value;

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -249,4 +249,97 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $registeredDb = self::readAttribute($writer, 'db');
         $this->assertSame($this->db, $registeredDb);
     }
+
+    /**
+     * @group 2589
+     */
+    public function testMapEventIntoColumnDoesNotTriggerArrayToStringConversion()
+    {
+        $this->writer = new DbWriter($this->db, $this->tableName, array(
+            'priority' => 'new-priority-field',
+            'message'  => 'new-message-field' ,
+            'extra'    => array(
+                'file'  => 'new-file',
+                'line'  => 'new-line',
+                'trace' => 'new-trace',
+            )
+        ));
+
+        // log to the mock db adapter
+        $priority = 2;
+        $message  = 'message-to-log';
+        $extra    = array(
+            'file'  => 'test.php',
+            'line'  => 1,
+            'trace' => array(
+                array(
+                    'function' => 'Bar',
+                    'class'    => 'Foo',
+                    'type'     => '->',
+                    'args'     => array(
+                        'baz',
+                    ),
+                ),
+            ),
+        );
+        $this->writer->write(array(
+            'priority' => $priority,
+            'message'  => $message,
+            'extra'    => $extra,
+        ));
+
+        $this->assertContains('query', array_keys($this->db->calls));
+        $this->assertEquals(1, count($this->db->calls['query']));
+
+        foreach ($this->db->calls['execute'][0][0] as $fieldName => $fieldValue) {
+            $this->assertInternalType('string', $fieldName);
+            $this->assertInternalType('string', (string) $fieldValue);
+        }
+    }
+
+    /**
+     * @group 2589
+     */
+    public function testMapEventIntoColumnMustReturnScalarValues()
+    {
+        $event = array(
+            'priority' => 2,
+            'message'  => 'message-to-log',
+            'extra'    => array(
+                'file'  => 'test.php',
+                'line'  => 1,
+                'trace' => array(
+                    array(
+                        'function' => 'Bar',
+                        'class'    => 'Foo',
+                        'type'     => '->',
+                        'args'     => array(
+                            'baz',
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $columnMap = array(
+            'priority' => 'new-priority-field',
+            'message'  => 'new-message-field' ,
+            'extra'    => array(
+                'file'  => 'new-file',
+                'line'  => 'new-line',
+                'trace' => 'new-trace',
+        ));
+
+        $method = new \ReflectionMethod($this->writer, 'mapEventIntoColumn');
+        $method->setAccessible(true);
+        $data = $method->invoke($this->writer, $event, $columnMap);
+
+        foreach ($data as $field => $value) {
+            $this->assertTrue(is_scalar($value), sprintf(
+                'Value of column "%s" should be scalar, %s given',
+                $field,
+                gettype($value)
+            ));
+        }
+    }
 }


### PR DESCRIPTION
Fix for issue #7244 where `Zend\Log\Writer\Db` can trigger an array to string conversion.

Because the method `eventIntoColumn` has the same issue as `mapEventIntoColumn`, I applied the patch to `eventIntoColumn` as well.
