### PR TITLE
Fixed documentation on $path property

### DIFF
--- a/library/Zend/Mail/Transport/FileOptions.php
+++ b/library/Zend/Mail/Transport/FileOptions.php
@@ -15,7 +15,7 @@ use Zend\Stdlib\AbstractOptions;
 class FileOptions extends AbstractOptions
 {
     /**
-     * @var string Local client hostname
+     * @var string Path to stored mail files
      */
     protected $path;
 


### PR DESCRIPTION
Fixed the docblock for `Zend\Mail\Transport\FileOptions::$path`
