### PR TITLE
AbstractOptions isset issue, #7286

### DIFF
--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -60,7 +60,7 @@ class FormCheckbox extends FormInput
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
                 'value' => $element->getUncheckedValue(),
-	        'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
+                'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
             );
 
             $rendered = sprintf(

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -60,7 +60,7 @@ class FormCheckbox extends FormInput
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
                 'value' => $element->getUncheckedValue(),
-		'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
+	        'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
             );
 
             $rendered = sprintf(

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -60,6 +60,7 @@ class FormCheckbox extends FormInput
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
                 'value' => $element->getUncheckedValue(),
+				'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
             );
 
             $rendered = sprintf(

--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -60,7 +60,7 @@ class FormCheckbox extends FormInput
             $hiddenAttributes = array(
                 'name'  => $attributes['name'],
                 'value' => $element->getUncheckedValue(),
-				'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
+		'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
             );
 
             $rendered = sprintf(

--- a/library/Zend/Stdlib/AbstractOptions.php
+++ b/library/Zend/Stdlib/AbstractOptions.php
@@ -147,7 +147,7 @@ abstract class AbstractOptions implements ParameterObjectInterface
      */
     public function __isset($key)
     {
-		$getter = 'get' . str_replace('_', '', $key);
+        $getter = 'get' . str_replace('_', '', $key);
         return method_exists($this, $getter) && null !== $this->__get($key);
     }
 

--- a/library/Zend/Stdlib/AbstractOptions.php
+++ b/library/Zend/Stdlib/AbstractOptions.php
@@ -147,7 +147,8 @@ abstract class AbstractOptions implements ParameterObjectInterface
      */
     public function __isset($key)
     {
-        return null !== $this->__get($key);
+		$getter = 'get' . str_replace('_', '', $key);
+        return method_exists($this, $getter) && null !== $this->__get($key);
     }
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
@@ -83,18 +83,14 @@ class FormCheckboxTest extends CommonTestCase
         $this->assertContains('name="0"', $markup);
     }
 
-	public function testDisabledOptionIssetOnHiddenElement()
-	{
-		$element = new Element\Checkbox('foo');
-		$element->setUseHiddenElement(true);
-		$element->setAttribute('disabled', true);
-
-
-		$markup = $this->helper->__invoke($element);
-		$this->assertRegexp('#type="checkbox".*?(disabled="disabled")#', $markup);
-
-
-	}
+    public function testDisabledOptionIssetOnHiddenElement()
+    {
+        $element = new Element\Checkbox('foo');
+        $element->setUseHiddenElement(true);
+        $element->setAttribute('disabled', true);
+        $markup = $this->helper->__invoke($element);
+        $this->assertRegexp('#type="checkbox".*?(disabled="disabled")#', $markup);
+    }
 
 
     /**

--- a/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
@@ -83,6 +83,20 @@ class FormCheckboxTest extends CommonTestCase
         $this->assertContains('name="0"', $markup);
     }
 
+	public function testDisabledOptionIssetOnHiddenElement()
+	{
+		$element = new Element\Checkbox('foo');
+		$element->setUseHiddenElement(true);
+		$element->setAttribute('disabled', true);
+
+
+		$markup = $this->helper->__invoke($element);
+		$this->assertRegexp('#type="checkbox".*?(disabled="disabled")#', $markup);
+
+
+	}
+
+
     /**
      * @group ZF2-457
      */

--- a/tests/ZendTest/Stdlib/OptionsTest.php
+++ b/tests/ZendTest/Stdlib/OptionsTest.php
@@ -114,35 +114,32 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-	public function testIssetFailsWhenNoGetter()
-	{
-		$options = new TestOptionsWithoutGetter(array('foo' => 'bar'));
-		$this->assertFalse(isset($options->foo));
+    public function testIssetFailsWhenNoGetter()
+    {
+        $options = new TestOptionsWithoutGetter(array('foo' => 'bar'));
+        $this->assertFalse(isset($options->foo));
+    }
 
-	}
+    public function testIssetDoesNotThrowExceptionWhenNoGetter()
+    {
+        $options = new TestOptionsWithoutGetter();
+        $ex = null;
 
-	public function testIssetDoesNotThrowExceptionWhenNoGetter()
-	{
-		$options = new TestOptionsWithoutGetter();
-
-		$ex = null;
-
-		try {
-			isset($options->foo);
-		} catch (\BadMethodCallException $ex) {}
-
-		$this->assertNull($ex, 'Unexpected BadMethodCallException');
-	}
+        try {
+            isset($options->foo);
+        } catch (\BadMethodCallException $ex) {}
+	
+	//check that the exception was not thrown.
+        $this->assertNull($ex, 'Unexpected BadMethodCallException');
+    }
 
 
-	public function testIssetPassesWithValidData()
-	{
+    public function testIssetPassesWithValidData()
+    {
 
 		$options = new TestOptions(array('test_field' => 1));
 
 		$this->assertTrue(isset($options->testField));
 
-	}
-
-
+    }
 }

--- a/tests/ZendTest/Stdlib/OptionsTest.php
+++ b/tests/ZendTest/Stdlib/OptionsTest.php
@@ -13,6 +13,7 @@ use ArrayObject;
 use ZendTest\Stdlib\TestAsset\TestOptions;
 use ZendTest\Stdlib\TestAsset\TestOptionsNoStrict;
 use Zend\Stdlib\Exception\InvalidArgumentException;
+use ZendTest\Stdlib\TestAsset\TestOptionsWithoutGetter;
 
 class OptionsTest extends \PHPUnit_Framework_TestCase
 {
@@ -112,4 +113,36 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
             'foo bar' => 'baz',
         ));
     }
+
+	public function testIssetFailsWhenNoGetter()
+	{
+		$options = new TestOptionsWithoutGetter(array('foo' => 'bar'));
+		$this->assertFalse(isset($options->foo));
+
+	}
+
+	public function testIssetDoesNotThrowExceptionWhenNoGetter()
+	{
+		$options = new TestOptionsWithoutGetter();
+
+		$ex = null;
+
+		try {
+			isset($options->foo);
+		} catch (\BadMethodCallException $ex) {}
+
+		$this->assertNull($ex, 'Unexpected BadMethodCallException');
+	}
+
+
+	public function testIssetPassesWithValidData()
+	{
+
+		$options = new TestOptions(array('test_field' => 1));
+
+		$this->assertTrue(isset($options->testField));
+
+	}
+
+
 }

--- a/tests/ZendTest/Stdlib/TestAsset/TestOptionsWithoutGetter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/TestOptionsWithoutGetter.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\AbstractOptions;
+
+/**
+ * Dummy TestOptions used to test Stdlib\Options
+ */
+class TestOptionsWithoutGetter extends AbstractOptions
+{
+    protected $foo;
+
+    public function setFoo($value)
+    {
+        $this->foo = $value;
+    }
+}


### PR DESCRIPTION
When calling isset() on an object variable that is a class extending AbstractOptions an exception is thrown.

An example useage of this is found in the EventManagerAwareTrait where the trait checks a class variable isset, if the class that is using the EventManagerAwareTrait extends AbstractOptions an exception is thrown.

This pull request fixes AbstractOptions by checking that the method exists and that the value is not equal to null, thus stopping the exception being thrown.

This pull request also fixes issue #7286 
