### PR TITLE
Default Expression $valueParameter to empty array

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Expression.php
+++ b/library/Zend/Db/Sql/Predicate/Expression.php
@@ -19,7 +19,7 @@ class Expression extends BaseExpression implements PredicateInterface
      * @param string $expression
      * @param int|float|bool|string|array $valueParameter
      */
-    public function __construct($expression = null, $valueParameter = null /*[, $valueParameter, ... ]*/)
+    public function __construct($expression = null, $valueParameter = array() /*[, $valueParameter, ... ]*/)
     {
         if ($expression) {
             $this->setExpression($expression);


### PR DESCRIPTION
Adding an expression to a where object without any parameters will throw an exception unless an empty array is passed.  

$select->where->expression('1 = 0', []);//works
$select->where->expression('1 = 0');//will throw an exception

No parameters are being specified, it would be nice not to have to pass an empty array.  Also, this was not an issue in earlier versions prior to the /_[, $valueParameter, ... ]_/ addition.
