### PR TITLE
Allow literal zero string as sql expression

### DIFF
--- a/library/Zend/Db/Sql/Expression.php
+++ b/library/Zend/Db/Sql/Expression.php
@@ -38,7 +38,7 @@ class Expression implements ExpressionInterface
      */
     public function __construct($expression = '', $parameters = null, array $types = array())
     {
-        if ($expression) {
+        if ($expression !== '') {
             $this->setExpression($expression);
         }
         if ($parameters) {

--- a/tests/ZendTest/Db/Sql/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/ExpressionTest.php
@@ -136,4 +136,10 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
             $expression->getExpressionData()
         );
     }
+    
+    public function testConstructorWithLiteralZero()
+    {
+        $expression = new Expression('0');
+        $this->assertSame('0', $expression->getExpression());
+    }
 }


### PR DESCRIPTION
A sql expression cannot currently be a literal zero (useful in certain unions) since setExpression will never be called.

$select = new Select('foo');
$select->columns([
   'bar' => new Expression('0') //fails, '0' is never set as the expression and the default empty string is used instead resulting in malformed sql
]);
