### PR TITLE
Add getExpression method to ExpressionInterface

### DIFF
--- a/library/Zend/Db/Sql/ExpressionInterface.php
+++ b/library/Zend/Db/Sql/ExpressionInterface.php
@@ -33,4 +33,9 @@ interface ExpressionInterface
      *
      */
     public function getExpressionData();
+    
+    /**
+     * @return string
+     */
+    public function getExpression();
 }


### PR DESCRIPTION
The Sql Select object expects this interface to have the method getExpression.
...
if ($joinName instanceof ExpressionInterface) {
                $joinName = $joinName->getExpression();
...
