### PR TITLE
Expression check $valueParameter !== null

### DIFF
--- a/library/Zend/Db/Sql/Predicate/Expression.php
+++ b/library/Zend/Db/Sql/Predicate/Expression.php
@@ -25,10 +25,6 @@ class Expression extends BaseExpression implements PredicateInterface
             $this->setExpression($expression);
         }
 
-        if ($valueParameter !== null) {
-            $this->setParameters(is_array($valueParameter) ? $valueParameter : array_slice(func_get_args(), 1));
-        } else {
-            $this->setParameters(array());
-        }
+        $this->setParameters(is_array($valueParameter) ? $valueParameter : array_slice(func_get_args(), 1));
     }
 }

--- a/library/Zend/Db/Sql/Predicate/Expression.php
+++ b/library/Zend/Db/Sql/Predicate/Expression.php
@@ -25,6 +25,10 @@ class Expression extends BaseExpression implements PredicateInterface
             $this->setExpression($expression);
         }
 
-        $this->setParameters(is_array($valueParameter) ? $valueParameter : array_slice(func_get_args(), 1));
+        if ($valueParameter !== null) {
+            $this->setParameters(is_array($valueParameter) ? $valueParameter : array_slice(func_get_args(), 1));
+        } else {
+            $this->setParameters(array());
+        }
     }
 }

--- a/library/Zend/Db/Sql/Predicate/Predicate.php
+++ b/library/Zend/Db/Sql/Predicate/Predicate.php
@@ -242,7 +242,7 @@ class Predicate extends PredicateSet
      * @param $parameters
      * @return $this
      */
-    public function expression($expression, $parameters)
+    public function expression($expression, $parameters = array())
     {
         $this->addPredicate(
             new Expression($expression, $parameters),

--- a/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
@@ -227,15 +227,20 @@ class PredicateTest extends TestCase
             array(array('foo = %s', array(0), array(Expression::TYPE_VALUE))),
             $predicate->getExpressionData()
         );
-
-        //test with no parameters
-        $predicate = new Predicate;
-        $this->assertSame($predicate, $predicate->expression('foo = bar'));
-        $this->assertEquals(
-            array(array('foo = bar', array(), array())),
-            $predicate->getExpressionData()
-        );
     }
+
+    /**
+    * @group 7293
+    */
+   public function testExpressionParametersDefaultToArray()
+   {
+       $predicate = new Predicate;
+       $this->assertSame($predicate, $predicate->expression('foo = bar'));
+       $this->assertEquals(
+           array(array('foo = bar', array(), array())),
+           $predicate->getExpressionData()
+       );
+   }
 
     /**
      * @testdox Unit test: Test literal() is chainable, returns proper values, and is backwards compatible with 2.0.*

--- a/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
+++ b/tests/ZendTest/Db/Sql/Predicate/PredicateTest.php
@@ -227,6 +227,14 @@ class PredicateTest extends TestCase
             array(array('foo = %s', array(0), array(Expression::TYPE_VALUE))),
             $predicate->getExpressionData()
         );
+
+        //test with no parameters
+        $predicate = new Predicate;
+        $this->assertSame($predicate, $predicate->expression('foo = bar'));
+        $this->assertEquals(
+            array(array('foo = bar', array(), array())),
+            $predicate->getExpressionData()
+        );
     }
 
     /**


### PR DESCRIPTION
Adding an expression to a where object without any parameters will throw an exception unless an empty array is passed.

$select->where->expression('1 = 0', []);//works
$select->where->expression('1 = 0');//will throw an exception

No parameters are being specified, it would be nice not to have to pass an empty array. Also, this was not an issue in earlier versions prior to the /[, $valueParameter, ... ]/ addition.
