### PR TITLE
Fix infinite loop when chaining peering service managers

### DIFF
--- a/library/Zend/ServiceManager/ServiceManager.php
+++ b/library/Zend/ServiceManager/ServiceManager.php
@@ -115,6 +115,11 @@ class ServiceManager implements ServiceLocatorInterface
     protected $canonicalNamesReplacements = array('-' => '', '_' => '', ' ' => '', '\\' => '', '/' => '');
 
     /**
+     * @var ServiceLocatorInterface
+     */
+    protected $serviceManagerCaller;
+
+    /**
      * Constructor
      *
      * @param ConfigInterface $config
@@ -446,7 +451,7 @@ class ServiceManager implements ServiceLocatorInterface
         if (!isset($this->shared[$cName])) {
             return $this->shareByDefault();
         }
-        
+
         return $this->shared[$cName];
     }
 
@@ -718,9 +723,16 @@ class ServiceManager implements ServiceLocatorInterface
         }
 
         if ($usePeeringServiceManagers) {
+
+            $caller = $this->serviceManagerCaller;
             foreach ($this->peeringServiceManagers as $peeringServiceManager) {
-                if ($peeringServiceManager->has($name)) {
-                    return true;
+                // ignore peering service manager if they are the same instance
+                if ($caller !== $peeringServiceManager) {
+                    $peeringServiceManager->serviceManagerCaller = $this;
+                    if ($peeringServiceManager->has($name)) {
+                        return true;
+                    }
+                    $peeringServiceManager->serviceManagerCaller = null;
                 }
             }
         }
@@ -987,11 +999,8 @@ class ServiceManager implements ServiceLocatorInterface
      */
     protected function retrieveFromPeeringManager($name)
     {
-        foreach ($this->peeringServiceManagers as $peeringServiceManager) {
-            if ($peeringServiceManager->has($name)) {
-                $this->shared[$name] = $peeringServiceManager->isShared($name);
-                return $peeringServiceManager->get($name);
-            }
+        if (null !== ($service = $this->loopPeeringServiceManagers($name))) {
+            return $service;
         }
 
         $name = $this->canonicalizeName($name);
@@ -1002,10 +1011,33 @@ class ServiceManager implements ServiceLocatorInterface
             } while ($this->hasAlias($name));
         }
 
+        if (null !== ($service = $this->loopPeeringServiceManagers($name))) {
+            return $service;
+        }
+
+        return null;
+    }
+
+    /**
+     * Loop over peering service managers.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    protected function loopPeeringServiceManagers($name)
+    {
+        $caller = $this->serviceManagerCaller;
+
         foreach ($this->peeringServiceManagers as $peeringServiceManager) {
-            if ($peeringServiceManager->has($name)) {
-                $this->shared[$name] = $peeringServiceManager->isShared($name);
-                return $peeringServiceManager->get($name);
+            // ignore peering service manager if they are the same instance
+            if ($caller !== $peeringServiceManager) {
+                // pass this instance to peering service manager
+                $peeringServiceManager->serviceManagerCaller = $this;
+                if ($peeringServiceManager->has($name)) {
+                    $this->shared[$name] = $peeringServiceManager->isShared($name);
+                    return $peeringServiceManager->get($name);
+                }
+                $peeringServiceManager->serviceManagerCaller = null;
             }
         }
 

--- a/tests/ZendTest/ServiceManager/ServiceManagerTest.php
+++ b/tests/ZendTest/ServiceManager/ServiceManagerTest.php
@@ -1189,4 +1189,53 @@ class ServiceManagerTest extends TestCase
         $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
         $this->serviceManager->isShared('foobarbazbat');
     }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::loopPeeringServiceManagers
+     * @covers Zend\ServiceManager\ServiceManager::setServiceManagerCaller
+     * @uses Zend\ServiceManager\ServiceManager::createScopedServiceManager
+     * @uses Zend\ServiceManager\ServiceManager::addPeeringServiceManager
+     * @uses Zend\ServiceManager\ServiceManager::get
+     */
+    public function testPeeringServiceManagersInBothDirectionsDontRunIntoInfiniteLoop()
+    {
+        $this->setExpectedException('Zend\ServiceManager\Exception\ServiceNotFoundException');
+        $peeredServiceManager = $this->serviceManager->createScopedServiceManager(ServiceManager::SCOPE_CHILD);
+        $peeredServiceManager->addPeeringServiceManager($this->serviceManager);
+        $this->serviceManager->get('foobarbazbat');
+    }
+
+    /**
+     * @covers Zend\ServiceManager\ServiceManager::loopPeeringServiceManagers
+     * @covers Zend\ServiceManager\ServiceManager::setServiceManagerCaller
+     * @covers Zend\ServiceManager\ServiceManager::has
+     * @uses Zend\ServiceManager\ServiceManager::addPeeringServiceManager
+     * @uses Zend\ServiceManager\ServiceManager::get
+     */
+    public function testServiceCanBeFoundFromPeeringServicesManagers()
+    {
+        $peeredServiceManager = new ServiceManager();
+        $peeredServiceManager->addPeeringServiceManager($this->serviceManager);
+        $this->serviceManager->addPeeringServiceManager($peeredServiceManager);
+
+        $secondParentServiceManager = new ServiceManager();
+        $secondParentServiceManager->addPeeringServiceManager($peeredServiceManager);
+        $peeredServiceManager->addPeeringServiceManager($secondParentServiceManager);
+
+        $expectedService = new \stdClass();
+        $secondParentServiceManager->setService('peered_service', $expectedService);
+
+        // check if service is direct child of secong parent service manager
+        $this->assertFalse($this->serviceManager->has('peered_service', true, false));
+        $this->assertFalse($peeredServiceManager->has('peered_service', true, false));
+        $this->assertTrue($secondParentServiceManager->has('peered_service', true, false));
+
+        // check if we can receive service from peered service managers
+        $this->assertTrue($this->serviceManager->has('peered_service'));
+        $this->assertTrue($peeredServiceManager->has('peered_service'));
+        $this->assertTrue($secondParentServiceManager->has('peered_service'));
+        $this->assertSame($expectedService, $this->serviceManager->get('peered_service'));
+        $this->assertSame($expectedService, $peeredServiceManager->get('peered_service'));
+        $this->assertSame($expectedService, $secondParentServiceManager->get('peered_service'));
+    }
 }


### PR DESCRIPTION
Hello,

we have a use case where we add a peering service manager (SM) to the SM of an ZF2 application. Also the peering SM becomes the SM of the application added as peering SM, which allows us to call services from the applications SM.

For services which can't be found this runs into a infinite loop. The applications SM calls the peering SM, which calls back the application SM and so on.

This PR tries to fix that by passing the current SM instance to the peering SM so they skip the caller SM when looping over `peeringServiceManagers`.
