### PR TITLE
Fix reflection for one line docblocks

### DIFF
--- a/library/Zend/Code/Reflection/DocBlockReflection.php
+++ b/library/Zend/Code/Reflection/DocBlockReflection.php
@@ -247,7 +247,7 @@ class DocBlockReflection implements ReflectionInterface
             return;
         }
 
-        $docComment = $this->docComment; // localize variable
+        $docComment = preg_replace('#[ ]{0,1}\*/$#', '', $this->docComment);
 
         // create a clean docComment
         $this->cleanDocComment = preg_replace("#[ \t]*(?:/\*\*|\*/|\*)[ ]{0,1}(.*)?#", '$1', $docComment);

--- a/tests/ZendTest/Code/Reflection/DocBlockReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/DocBlockReflectionTest.php
@@ -59,6 +59,20 @@ class DocBlockReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('mixed', $returnTag->getType());
     }
 
+    public function testShortDocBlocks()
+    {
+        $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass13');
+        $this->assertEquals(0, count($classReflection->getDocBlock()->getTags()));
+
+        $this->assertSame('Short Method Description', $classReflection->getMethod('doSomething')->getDocBlock()->getShortDescription());
+        $this->assertSame('Short Class Description', $classReflection->getDocBlock()->getShortDescription());
+
+        $returnTag = $classReflection->getMethod('returnSomething')->getDocBlock()->getTag('return');
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlock\Tag\TagInterface', $returnTag);
+        $this->assertEquals('Something', $returnTag->getType());
+        $this->assertEquals('This describes something', $returnTag->getDescription());
+    }
+
     public function testTabbedDocBlockTags()
     {
         $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass10');
@@ -85,8 +99,6 @@ class DocBlockReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testDocBlockLines()
     {
-        //$this->markTestIncomplete('Line numbers incomplete');
-
         $classReflection = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass5');
 
         $classDocBlock = $classReflection->getDocBlock();

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass13.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestSampleClass13.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ZendTest\Code\Reflection\TestAsset;
+
+/** Short Class Description */
+class TestSampleClass13
+{
+    /** Short Method Description */
+    public function doSomething()
+    {}
+
+    /** @return Something This describes something */
+    public function returnSomething()
+    {}
+}


### PR DESCRIPTION
This fixes an issue where the parsing of single line docblocks fail and results in a syntax error with Ocramius/ProxyManager.

/cc @Ocramius 
