### PR TITLE
added cache support to form annotation builder

### DIFF
--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -89,13 +89,16 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
      */
     protected $preserveDefinedOrder = false;
 
+    /**
+     * @param StorageInterface $cache
+     */
     public function setCache(StorageInterface $cache)
     {
         $this->cache = $cache;
     }
 
     /**
-     * @return \Zend\Cache\Storage\StorageInterface
+     * @return StorageInterface
      */
     public function getCache()
     {

--- a/library/Zend/Mvc/Service/FormAnnotationBuilderFactory.php
+++ b/library/Zend/Mvc/Service/FormAnnotationBuilderFactory.php
@@ -50,6 +50,11 @@ class FormAnnotationBuilderFactory implements FactoryInterface
                     $listener->attach($annotationBuilder->getEventManager());
                 }
             }
+
+            if (isset($config['cache'])) {
+                $cache = $serviceLocator->get($config['cache']);
+                $annotationBuilder->setCache($cache);
+            }
         }
 
         return $annotationBuilder;

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -352,4 +352,30 @@ class AnnotationBuilderTest extends TestCase
         $inputFilter = $form->getInputFilter();
         $this->assertCount(2, $inputFilter->get('username')->getValidatorChain());
     }
+
+    public function testCacheSave()
+    {
+        $cache = $this->getMock('Zend\Cache\Storage\StorageInterface');
+        $cache->expects($this->once())->method('hasItem')->willReturn(false);
+        $cache->expects($this->once())->method('setItem');
+
+        $entity  = new TestAsset\Annotation\Entity();
+        $builder = new Annotation\AnnotationBuilder();
+        $builder->setCache($cache);
+        $builder->getFormSpecification($entity);
+    }
+
+    public function testCacheLoad()
+    {
+        $cache = $this->getMock('Zend\Cache\Storage\StorageInterface');
+        $cache->expects($this->once())->method('hasItem')->willReturn(true);
+        $cache->expects($this->once())->method('getItem')->willReturn(['formSpec']);
+
+        $entity  = new TestAsset\Annotation\Entity();
+        $builder = new Annotation\AnnotationBuilder();
+        $builder->setCache($cache);
+        $spec = $builder->getFormSpecification($entity);
+
+        $this->assertEquals(['formSpec'], $spec);
+    }
 }

--- a/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
+++ b/tests/ZendTest/Form/Annotation/AnnotationBuilderTest.php
@@ -369,13 +369,13 @@ class AnnotationBuilderTest extends TestCase
     {
         $cache = $this->getMock('Zend\Cache\Storage\StorageInterface');
         $cache->expects($this->once())->method('hasItem')->willReturn(true);
-        $cache->expects($this->once())->method('getItem')->willReturn(['formSpec']);
+        $cache->expects($this->once())->method('getItem')->willReturn(array('formSpec'));
 
         $entity  = new TestAsset\Annotation\Entity();
         $builder = new Annotation\AnnotationBuilder();
         $builder->setCache($cache);
         $spec = $builder->getFormSpecification($entity);
 
-        $this->assertEquals(['formSpec'], $spec);
+        $this->assertEquals(array('formSpec'), $spec);
     }
 }


### PR DESCRIPTION
As title. I'm sure there was an issue raised in relation to caching the output of the form builder; but I can't find it.
