### PR TITLE
Allow ControllerManager to automatically add invokable classes

### DIFF
--- a/library/Zend/Mvc/Controller/ControllerManager.php
+++ b/library/Zend/Mvc/Controller/ControllerManager.php
@@ -26,13 +26,6 @@ use Zend\Stdlib\DispatchableInterface;
 class ControllerManager extends AbstractPluginManager
 {
     /**
-     * We do not want arbitrary classes instantiated as controllers.
-     *
-     * @var bool
-     */
-    protected $autoAddInvokableClass = false;
-
-    /**
      * Constructor
      *
      * After invoking parent constructor, add an initializer to inject the


### PR DESCRIPTION
I think the [ControllerManager#validatePlugin()](https://github.com/zendframework/zf2/blob/master/library/Zend/Mvc/Controller/ControllerManager.php#L101) is enough to make sure that it does not instantiate arbitrary classes as controllers, but only instances of `DispatchableInterface`. So that we can allow `ControllerManager` to automatically add invokable classes for convenience.

Also it comes in handy for beginners who do not understand the need to register the controller in so many places.
