### PR TITLE
Changed name (key) of validation message

### DIFF
--- a/library/Zend/Validator/StringLength.php
+++ b/library/Zend/Validator/StringLength.php
@@ -14,7 +14,7 @@ use Zend\Stdlib\StringWrapper\StringWrapperInterface as StringWrapper;
 
 class StringLength extends AbstractValidator
 {
-    const INVALID   = 'stringLengthInvalid';
+    const INVALID   = 'stringTypeInvalid';
     const TOO_SHORT = 'stringLengthTooShort';
     const TOO_LONG  = 'stringLengthTooLong';
 


### PR DESCRIPTION
Changed value of `INVALID` constant that is used as name for errors and key for validation messages from `stringLengthInvalid` to `stringTypeInvalid`.
This name is wrong since the error will occur on failed variable type validation [in the `is_string` method on line 189](https://github.com/zendframework/zf2/blob/master/library/Zend/Validator/StringLength.php#L189) and not on failed length validation.
