### PR TITLE
add getter method for object prototype to Zend\Db\ResultSet\HydratingResultSet

### DIFF
--- a/library/Zend/Db/ResultSet/HydratingResultSet.php
+++ b/library/Zend/Db/ResultSet/HydratingResultSet.php
@@ -56,6 +56,16 @@ class HydratingResultSet extends AbstractResultSet
     }
 
     /**
+     * Set the row object prototype
+     *
+     * @return object
+     */
+    public function getObjectPrototype()
+    {
+        return $this->objectPrototype;
+    }
+
+    /**
      * Set the hydrator to use for each row object
      *
      * @param HydratorInterface $hydrator

--- a/library/Zend/Db/ResultSet/HydratingResultSet.php
+++ b/library/Zend/Db/ResultSet/HydratingResultSet.php
@@ -56,7 +56,7 @@ class HydratingResultSet extends AbstractResultSet
     }
 
     /**
-     * Set the row object prototype
+     * Get the row object prototype
      *
      * @return object
      */

--- a/tests/ZendTest/Db/ResultSet/HydratingResultSetTest.php
+++ b/tests/ZendTest/Db/ResultSet/HydratingResultSetTest.php
@@ -24,6 +24,15 @@ class HydratingResultSetTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Zend\Db\ResultSet\HydratingResultSet::getObjectPrototype
+     */
+    public function testGetObjectPrototype()
+    {
+        $hydratingRs = new HydratingResultSet;
+        $this->assertInstanceOf('ArrayObject', $hydratingRs->getObjectPrototype($prototype));
+    }
+
+    /**
      * @covers Zend\Db\ResultSet\HydratingResultSet::setHydrator
      */
     public function testSetHydrator()

--- a/tests/ZendTest/Db/ResultSet/HydratingResultSetTest.php
+++ b/tests/ZendTest/Db/ResultSet/HydratingResultSetTest.php
@@ -29,7 +29,7 @@ class HydratingResultSetTest extends \PHPUnit_Framework_TestCase
     public function testGetObjectPrototype()
     {
         $hydratingRs = new HydratingResultSet;
-        $this->assertInstanceOf('ArrayObject', $hydratingRs->getObjectPrototype($prototype));
+        $this->assertInstanceOf('ArrayObject', $hydratingRs->getObjectPrototype());
     }
 
     /**


### PR DESCRIPTION
add getter method for object prototype to Zend\Db\ResultSet\HydratingResultSet

It needs for Table which have injected TableGateway to create factory method that will return new Entity:
public function getNew()
{
    return clone $this->tableGateway->getResultSetPrototype()->getObjectPrototype();
}
