### PR TITLE
Security filter extension for escapeHtmlAttr

### DIFF
--- a/library/Zend/Escaper/Escaper.php
+++ b/library/Zend/Escaper/Escaper.php
@@ -164,7 +164,7 @@ class Escaper
             return $string;
         }
 
-        $result = preg_replace_callback('/[^a-z0-9,\.\-_]/iSu', $this->htmlAttrMatcher, $string);
+        $result = preg_replace_callback('/[^a-z0-9À-ÿ,\.\-_]/iSu', $this->htmlAttrMatcher, $string);
         return $this->fromUtf8($result);
     }
 


### PR DESCRIPTION
Hello ZF2,
As you can see, my pull request is really simple, i just wanted to use characters with accents from the extended utf8 table in html entities, thus, i extended the regex filter to also does not match against À to ÿ

J
