### PR TITLE
added basic support for digest authentication on curl adapters

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -25,7 +25,7 @@ class Client implements Stdlib\DispatchableInterface
      * @const string Supported HTTP Authentication methods
      */
     const AUTH_BASIC  = 'basic';
-    const AUTH_DIGEST = 'digest';  // not implemented yet
+    const AUTH_DIGEST = 'digest';
 
     /**
      * @const string POST data encoding methods
@@ -1140,7 +1140,11 @@ class Client implements Stdlib\DispatchableInterface
                     }
                     break;
                 case self::AUTH_DIGEST :
-                    throw new Exception\RuntimeException("The digest authentication is not implemented yet");
+                    if(!$this->adapter instanceof Client\Adapter\Curl)
+                        throw new Exception\RuntimeException("The digest authentication is only available for curl adapters (Zend\\Http\\Client\\Adapter\\Curl)");
+
+                    $this->adapter->setCurlOption(CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+                    $this->adapter->setCurlOption(CURLOPT_USERPWD, $this->auth['user'] . ':' . $this->auth['password']);
             }
         }
 

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -375,6 +375,28 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('Content-Length', $headers);
     }
 
+    public function testPrepareHeadersCurlDigestAuthentication()
+    {
+        $body = json_encode(array('foofoo'=>'barbar'));
+
+        $client = new Client();
+        $prepareHeadersReflection = new \ReflectionMethod($client, 'prepareHeaders');
+        $prepareHeadersReflection->setAccessible(true);
+
+        $request = new Request();
+        $request->getHeaders()->addHeaderLine('Authorization: Digest');
+        $request->getHeaders()->addHeaderLine('content-type','application/json');
+        $request->getHeaders()->addHeaderLine('content-length',strlen($body));
+        $client->setRequest($request);
+
+        $this->assertSame($client->getRequest(), $request);
+
+        $headers = $prepareHeadersReflection->invoke($client, $body, new Http('http://localhost:5984'));
+
+        $this->assertArrayHasKey('Authorization', $headers);
+
+    }
+
     /**
      * @group 6231
      */

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -393,7 +393,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $headers = $prepareHeadersReflection->invoke($client, $body, new Http('http://localhost:5984'));
 
-        $this->assertArrayHasKey('Authorization', $headers);
+        $this->assertContains('Authorization: Digest', $headers);
 
     }
 


### PR DESCRIPTION
Missed it, added basic support for HTTP Digest authentication on cURL requests.
