### PR TITLE
feature: add bcrypt support to apache http basic auth

### DIFF
--- a/library/Zend/Crypt/Password/Apache.php
+++ b/library/Zend/Crypt/Password/Apache.php
@@ -141,7 +141,7 @@ class Apache implements PasswordInterface
             return Utils::compareStrings($hash, $hash2);
         }
 
-        $bcryptPattern = '/\$2[ay]?\$[0-9]{2}\$[' . addcslashes(static::BASE64, '+/') . ']{53}/';
+        $bcryptPattern = '/\$2[ay]?\$[0-9]{2}\$[' . addcslashes(static::BASE64, '+/') . '\.]{53}/';
 
         if (strlen($hash) > 13 && ! preg_match($bcryptPattern, $hash)) { // digest
             if (empty($this->userName) || empty($this->authName)) {

--- a/library/Zend/Crypt/Password/Apache.php
+++ b/library/Zend/Crypt/Password/Apache.php
@@ -129,6 +129,7 @@ class Apache implements PasswordInterface
             $hash2 = '{SHA}' . base64_encode(sha1($password, true));
             return Utils::compareStrings($hash, $hash2);
         }
+
         if (substr($hash, 0, 6) === '$apr1$') {
             $token = explode('$', $hash);
             if (empty($token[2])) {
@@ -139,7 +140,10 @@ class Apache implements PasswordInterface
             $hash2 = $this->apr1Md5($password, $token[2]);
             return Utils::compareStrings($hash, $hash2);
         }
-        if (strlen($hash) > 13) { // digest
+
+        $bcryptPattern = '/\$2[ay]?\$[0-9]{2}\$[' . addcslashes(static::BASE64, '+/') . ']{53}/';
+
+        if (strlen($hash) > 13 && ! preg_match($bcryptPattern, $hash)) { // digest
             if (empty($this->userName) || empty($this->authName)) {
                 throw new Exception\RuntimeException(
                     'You must specify UserName and AuthName (realm) to verify the digest'
@@ -148,6 +152,7 @@ class Apache implements PasswordInterface
             $hash2 = md5($this->userName . ':' . $this->authName . ':' .$password);
             return Utils::compareStrings($hash, $hash2);
         }
+
         return Utils::compareStrings($hash, crypt($password, $hash));
     }
 

--- a/tests/ZendTest/Authentication/Adapter/Http/ApacheResolverTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Http/ApacheResolverTest.php
@@ -39,6 +39,11 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
     protected $_badPath;
 
     /**
+     * @var Apache
+     */
+    protected $_apache;
+
+    /**
      * Sets the paths to files used in this test, and creates a shared resolver instance
      * having a valid path.
      *
@@ -104,7 +109,8 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
             array( $path . '/htbasic.plaintext' ),
             array( $path . '/htbasic.md5' ),
             array( $path . '/htbasic.sha1' ),
-            array( $path . '/htbasic.crypt' )
+            array( $path . '/htbasic.crypt' ),
+            array( $path . '/htbasic.bcrypt' ),
         );
     }
 

--- a/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.bcrypt
+++ b/tests/ZendTest/Authentication/Adapter/Http/TestAsset/htbasic.bcrypt
@@ -1,0 +1,1 @@
+test:$2y$05$BYMNSHjpDGCMWb9Qpv6z3eGLenGdw9eXmWHBpBDZyCF7YKuKlfqKy

--- a/tests/ZendTest/Crypt/Password/ApacheTest.php
+++ b/tests/ZendTest/Crypt/Password/ApacheTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Crypt\Password;
 
 use Zend\Crypt\Password\Apache;
+use Zend\Crypt\Password\Bcrypt;
 use Zend\Crypt\Password\Exception;
 
 /**
@@ -174,5 +175,12 @@ class ApacheTest extends \PHPUnit_Framework_TestCase
     {
         $this->apache->verify('myPassword', '$apr1$z0Hhe5Lq3$6YdJKbkrJg77Dvw2gpuSA1');
         $this->apache->verify('myPassword', '$apr1$z0Hhe5L&$6YdJKbkrJg77Dvw2gpuSA1');
+    }
+
+    public function testCanVerifyBcryptHashes()
+    {
+        $bcrypt = new Bcrypt();
+        $hash = $bcrypt->create('myPassword');
+        $this->assertTrue($this->apache->verify('myPassword', $hash));
     }
 }


### PR DESCRIPTION
since Apache 2.4 it is possible to use bcrypt algorithm in basic auth files via `htpasswd -B`.
this PR adds bcrypt hash verification support to `Zend\Crypt\Password\Apache` and updates `Zend\Authentication\Adapter\Http\ApacheResolver` integration tests accordingly.
