### PR TITLE
Allowing the route match controller to override the controller class

### DIFF
--- a/library/Zend/Mvc/View/Http/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/Http/InjectTemplateListener.php
@@ -33,6 +33,13 @@ class InjectTemplateListener extends AbstractListenerAggregate
     protected $controllerMap = array();
 
     /**
+     * Flag to force the use of the route match controller param
+     *
+     * @var boolean
+     */
+    protected $preferRouteMatchController = false;
+
+    /**
      * {@inheritDoc}
      */
     public function attach(Events $events)
@@ -66,8 +73,10 @@ class InjectTemplateListener extends AbstractListenerAggregate
         if (is_object($controller)) {
             $controller = get_class($controller);
         }
-        if (!$controller) {
-            $controller = $routeMatch->getParam('controller', '');
+
+        $routeMatchController = $routeMatch->getParam('controller', '');
+        if (!$controller || ($this->preferRouteMatchController && $routeMatchController)) {
+            $controller = $routeMatchController;
         }
 
         $template = $this->mapController($controller);
@@ -226,5 +235,24 @@ class InjectTemplateListener extends AbstractListenerAggregate
         }
 
         return $controller;
+    }
+
+    /**
+     * Sets the flag to instruct the listener to prefer the route match controller param
+     * over the class name
+     *
+     * @param boolean $preferRouteMatchController
+     */
+    public function setPreferRouteMatchController($preferRouteMatchController)
+    {
+        $this->preferRouteMatchController = (bool) $preferRouteMatchController;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPreferRouteMatchController()
+    {
+        return $this->preferRouteMatchController;
     }
 }

--- a/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
+++ b/tests/ZendTest/Mvc/View/InjectTemplateListenerTest.php
@@ -331,4 +331,19 @@ class InjectTemplateListenerTest extends TestCase
         $listeners = $events->getListeners(MvcEvent::EVENT_DISPATCH);
         $this->assertEquals(0, count($listeners));
     }
+
+    public function testPrefersRouteMatchController()
+    {
+        $this->assertFalse($this->listener->isPreferRouteMatchController());
+        $this->listener->setPreferRouteMatchController(true);
+        $this->routeMatch->setParam('controller', 'Some\Other\Service\Namespace\Controller\Sample');
+        $myViewModel  = new ViewModel();
+        $myController = new \ZendTest\Mvc\Controller\TestAsset\SampleController();
+
+        $this->event->setTarget($myController);
+        $this->event->setResult($myViewModel);
+        $this->listener->injectTemplate($this->event);
+
+        $this->assertEquals('some/sample', $myViewModel->getTemplate());
+    }
 }


### PR DESCRIPTION
Updates to InjectTemplateListener to allow for the RouteMatch "controller" parameter to override the controller's class.

Use case is to handle controllers that are built by abstract factories, which require extra rendering logic because this resolver will always use the get_class() method over what's in the RouteMatch (oftentimes a base or parent class). 

Also helpful with the reverse, which is extended or decorator controllers appearing (and rendering) as their parent controller.

The behavior is off by default for backwards compatibility (1 test broke, so close).
