### PR TITLE
Set disabled attribute also on checkbox hidden element

### DIFF
--- a/library/Zend/Form/View/Helper/FormCheckbox.php
+++ b/library/Zend/Form/View/Helper/FormCheckbox.php
@@ -58,8 +58,9 @@ class FormCheckbox extends FormInput
 
         if ($element->useHiddenElement()) {
             $hiddenAttributes = array(
-                'name'  => $attributes['name'],
-                'value' => $element->getUncheckedValue(),
+                'disabled' => isset($attributes['disabled']) ? $attributes['disabled'] : false,
+                'name'     => $attributes['name'],
+                'value'    => $element->getUncheckedValue(),
             );
 
             $rendered = sprintf(

--- a/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormCheckboxTest.php
@@ -92,4 +92,17 @@ class FormCheckboxTest extends CommonTestCase
         $this->setExpectedException('Zend\Form\Exception\InvalidArgumentException');
         $markup = $this->helper->render($element);
     }
+
+    /**
+     * @group 7286
+     */
+    public function testDisabledOptionIssetOnHiddenElement()
+    {
+        $element = new Element\Checkbox('foo');
+        $element->setUseHiddenElement(true);
+        $element->setAttribute('disabled', true);
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertRegexp('#type="hidden"[^>]?disabled="disabled"#', $markup);
+    }
 }


### PR DESCRIPTION
Fix for #7286. This mainly is a split up of #7287, but with a correct unittest.
