### PR TITLE
Do not throw exception when isset is used on AbstractOptions existing object variable

### DIFF
--- a/library/Zend/Stdlib/AbstractOptions.php
+++ b/library/Zend/Stdlib/AbstractOptions.php
@@ -147,7 +147,9 @@ abstract class AbstractOptions implements ParameterObjectInterface
      */
     public function __isset($key)
     {
-        return null !== $this->__get($key);
+        $getter = 'get' . str_replace('_', '', $key);
+
+        return method_exists($this, $getter) && null !== $this->__get($key);
     }
 
     /**

--- a/tests/ZendTest/Stdlib/OptionsTest.php
+++ b/tests/ZendTest/Stdlib/OptionsTest.php
@@ -10,9 +10,10 @@
 namespace ZendTest\Stdlib;
 
 use ArrayObject;
+use Zend\Stdlib\Exception;
 use ZendTest\Stdlib\TestAsset\TestOptions;
 use ZendTest\Stdlib\TestAsset\TestOptionsNoStrict;
-use Zend\Stdlib\Exception\InvalidArgumentException;
+use ZendTest\Stdlib\TestAsset\TestOptionsWithoutGetter;
 
 class OptionsTest extends \PHPUnit_Framework_TestCase
 {
@@ -57,7 +58,7 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     {
         try {
             $options = new TestOptions(null);
-        } catch (InvalidArgumentException $e) {
+        } catch (Exception\InvalidArgumentException $e) {
             $this->fail("Unexpected InvalidArgumentException raised");
         }
     }
@@ -111,5 +112,41 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         new TestOptions(array(
             'foo bar' => 'baz',
         ));
+    }
+
+    /**
+     * @group 7287
+     */
+    public function testIssetReturnsFalseWhenMatchingGetterDoesNotExist()
+    {
+        $options = new TestOptionsWithoutGetter(array(
+            'foo' => 'bar',
+        ));
+        $this->assertFalse(isset($options->foo));
+    }
+
+    /**
+     * @group 7287
+     */
+    public function testIssetDoesNotThrowExceptionWhenMatchingGetterDoesNotExist()
+    {
+        $options   = new TestOptionsWithoutGetter();
+
+        try {
+            isset($options->foo);
+        } catch (Exception\BadMethodCallException $exception) {
+            $this->fail("Unexpected BadMethodCallException raised");
+        }
+    }
+
+    /**
+     * @group 7287
+     */
+    public function testIssetReturnsTrueWithValidDataWhenMatchingGetterDoesNotExist()
+    {
+        $options = new TestOptions(array(
+            'test_field' => 1,
+        ));
+        $this->assertTrue(isset($options->testField));
     }
 }

--- a/tests/ZendTest/Stdlib/TestAsset/TestOptionsWithoutGetter.php
+++ b/tests/ZendTest/Stdlib/TestAsset/TestOptionsWithoutGetter.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Stdlib\TestAsset;
+
+use Zend\Stdlib\AbstractOptions;
+
+/**
+ * Dummy TestOptions used to test Stdlib\Options
+ */
+class TestOptionsWithoutGetter extends AbstractOptions
+{
+    protected $foo;
+
+    public function setFoo($value)
+    {
+        $this->foo = $value;
+    }
+}


### PR DESCRIPTION
Same fix as suggested by @rms230 in PR #7287. Split it up and slightly changed the assertion for `BadMethodCallException`.

Original description of #7287:

> When calling isset() on an object variable that is a class extending AbstractOptions an exception is thrown.
> 
> An example useage of this is found in the EventManagerAwareTrait where the trait checks a class variable isset, if the class that is using the EventManagerAwareTrait extends AbstractOptions an exception is thrown.
> 
> This pull request fixes AbstractOptions by checking that the method exists and that the value is not equal to null, thus stopping the exception being thrown.
