### PR TITLE
Remove `FormInterface` dependency from `Fieldset`

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -15,7 +15,6 @@ use Zend\Form\ElementInterface;
 use Zend\Form\Exception;
 use Zend\Form\Fieldset;
 use Zend\Form\FieldsetInterface;
-use Zend\Form\FormInterface;
 use Zend\Stdlib\ArrayUtils;
 
 class Collection extends Fieldset
@@ -464,10 +463,10 @@ class Collection extends Fieldset
     /**
      * Prepare the collection by adding a dummy template element if the user want one
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed|void
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         if (true === $this->shouldCreateChildrenOnPrepareElement) {
             if ($this->targetElement !== null && $this->count > 0) {

--- a/library/Zend/Form/Element/Csrf.php
+++ b/library/Zend/Form/Element/Csrf.php
@@ -11,7 +11,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
-use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Csrf as CsrfValidator;
 
@@ -149,7 +149,7 @@ class Csrf extends Element implements InputProviderInterface, ElementPrepareAwar
     /**
      * Prepare the form element
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         $this->getCsrfValidator()->getHash(true);
     }

--- a/library/Zend/Form/Element/DateSelect.php
+++ b/library/Zend/Form/Element/DateSelect.php
@@ -11,7 +11,7 @@ namespace Zend\Form\Element;
 
 use DateTime as PhpDateTime;
 use Zend\Form\Exception\InvalidArgumentException;
-use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\Date as DateValidator;
 use Exception;
@@ -132,10 +132,10 @@ class DateSelect extends MonthSelect
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         parent::prepareElement($form);
 

--- a/library/Zend/Form/Element/DateTimeSelect.php
+++ b/library/Zend/Form/Element/DateTimeSelect.php
@@ -11,7 +11,7 @@ namespace Zend\Form\Element;
 
 use DateTime as PhpDateTime;
 use Exception;
-use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
 use Zend\Form\Exception\InvalidArgumentException;
 use Zend\Validator\ValidatorInterface;
 use Zend\Validator\Date as DateValidator;
@@ -266,10 +266,10 @@ class DateTimeSelect extends DateSelect
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         parent::prepareElement($form);
 

--- a/library/Zend/Form/Element/File.php
+++ b/library/Zend/Form/Element/File.php
@@ -11,7 +11,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
-use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
 use Zend\InputFilter\InputProviderInterface;
 
 class File extends Element implements InputProviderInterface, ElementPrepareAwareInterface
@@ -28,10 +28,10 @@ class File extends Element implements InputProviderInterface, ElementPrepareAwar
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         // Ensure the form is using correct enctype
         $form->setAttribute('enctype', 'multipart/form-data');

--- a/library/Zend/Form/Element/MonthSelect.php
+++ b/library/Zend/Form/Element/MonthSelect.php
@@ -12,7 +12,7 @@ namespace Zend\Form\Element;
 use DateTime as PhpDateTime;
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
-use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Regex as RegexValidator;
 use Zend\Validator\ValidatorInterface;
@@ -290,10 +290,10 @@ class MonthSelect extends Element implements InputProviderInterface, ElementPrep
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         $name = $this->getName();
         $this->monthElement->setName($name . '[month]');

--- a/library/Zend/Form/Element/Password.php
+++ b/library/Zend/Form/Element/Password.php
@@ -11,7 +11,7 @@ namespace Zend\Form\Element;
 
 use Zend\Form\Element;
 use Zend\Form\ElementPrepareAwareInterface;
-use Zend\Form\FormInterface;
+use Zend\Form\FieldsetInterface;
 
 class Password extends Element implements ElementPrepareAwareInterface
 {
@@ -27,10 +27,10 @@ class Password extends Element implements ElementPrepareAwareInterface
     /**
      * Remove the password before rendering if the form fails in order to avoid any security issue
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         $this->setValue('');
     }

--- a/library/Zend/Form/ElementPrepareAwareInterface.php
+++ b/library/Zend/Form/ElementPrepareAwareInterface.php
@@ -14,8 +14,8 @@ interface ElementPrepareAwareInterface
     /**
      * Prepare the form element (mostly used for rendering purposes)
      *
-     * @param FormInterface $form
+     * @param FieldsetInterface $form
      * @return mixed
      */
-    public function prepareElement(FormInterface $form);
+    public function prepareElement(FieldsetInterface $form);
 }

--- a/library/Zend/Form/Fieldset.php
+++ b/library/Zend/Form/Fieldset.php
@@ -364,10 +364,10 @@ class Fieldset extends Element implements FieldsetInterface
      * Ensures state is ready for use. Here, we append the name of the fieldsets to every elements in order to avoid
      * name clashes if the same fieldset is used multiple times
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed|void
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         $name = $this->getName();
 

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -223,10 +223,10 @@ class Form extends Fieldset implements FormInterface
      * Ensures state is ready for use. Here, we append the name of the fieldsets to every elements in order to avoid
      * name clashes if the same fieldset is used multiple times
      *
-     * @param  FormInterface $form
+     * @param  FieldsetInterface $form
      * @return mixed|void
      */
-    public function prepareElement(FormInterface $form)
+    public function prepareElement(FieldsetInterface $form)
     {
         $name = $this->getName();
 


### PR DESCRIPTION
This eliminates the dependency of  `Fieldset` on `FormInterface` so it can be extended (see #7192 for background).
