### PR TITLE
Explode validator provides context to composed validator

### DIFF
--- a/library/Zend/Validator/Explode.php
+++ b/library/Zend/Validator/Explode.php
@@ -159,10 +159,11 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
      * Returns true if all values validate true
      *
      * @param  mixed $value
+     * @param  mixed $context Extra "context" to provide the composed validator
      * @return bool
      * @throws Exception\RuntimeException
      */
-    public function isValid($value)
+    public function isValid($value, $context = null)
     {
         $this->setValue($value);
 
@@ -195,7 +196,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
         }
 
         foreach ($values as $value) {
-            if (!$validator->isValid($value)) {
+            if (!$validator->isValid($value, $context)) {
                 $this->abstractOptions['messages'][] = $validator->getMessages();
 
                 if ($this->isBreakOnFirstFailure()) {

--- a/tests/ZendTest/Validator/ExplodeTest.php
+++ b/tests/ZendTest/Validator/ExplodeTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Validator;
 
 use Zend\Validator\Explode;
 use Zend\Validator\Regex;
+use Zend\Validator\Callback;
 
 /**
  * @group      Zend_Validator
@@ -152,5 +153,24 @@ class ExplodeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($validator->isValid('zf-devteam@zend.com,abc,defghij'));
         $this->assertEquals($messages, $validator->getMessages());
+    }
+
+    /**
+     * Assert context is passed to composed validator
+     */
+    public function testIsValidPassContext()
+    {
+        $context       = 'context';
+        $contextSame   = false;
+        $validator = new Explode(array(
+            'validator'           => new Callback(function ($v, $c) use ($context, &$contextSame) {
+                $contextSame = ($context === $c);
+                return true;
+            }),
+            'valueDelimiter'      => ',',
+            'breakOnFirstFailure' => false,
+        ));
+        $this->assertTrue($validator->isValid('a,b,c', $context));
+        $this->assertTrue($contextSame);
     }
 }


### PR DESCRIPTION
I have enabled the Zend\Validator\Explode::isValid to accept context as an optional argument (like in Zend\Validator\ValidatorChain class).  

The context then is provided to composed validator's isValid method. 

P.S. Tests fail in travis. See #7355
