### PR TITLE
Zend\Http\Client sends content-type: application/x-www-form-urlencoded with GET request

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -412,13 +412,16 @@ class Client implements Stdlib\DispatchableInterface
      */
     public function setEncType($encType, $boundary = null)
     {
-        if (!empty($encType)) {
-            if (!empty($boundary)) {
-                $this->encType = $encType . "; boundary={$boundary}";
-            } else {
-                $this->encType = $encType;
-            }
+        if (null === $encType || empty($encType)) {
+            $this->encType = null;
+            return $this;
         }
+
+        if (! empty($boundary)) {
+            $encType .= sprintf('; boundary=%s', $boundary);
+        }
+
+        $this->encType = $encType;
         return $this;
     }
 

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -465,4 +465,18 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(Client::ENC_URLENCODED, $client->getEncType());
     }
+
+    /**
+     * @group 7332
+     */
+    public function testAllowsClearingEncType()
+    {
+        $client = new Client();
+        $client->setEncType('application/x-www-form-urlencoded');
+
+        $this->assertEquals('application/x-www-form-urlencoded', $client->getEncType());
+
+        $client->setEncType(null);
+        $this->assertNull($client->getEncType());
+    }
 }


### PR DESCRIPTION
We have an api connection with Zend\Http\Client.

If we do a PUT request and with the same connection we do a GET 

```
    $request = new Request();
    $request->setMethod(Request::METHOD_GET);
    $request->setUri($url);

    $headers = $request->getHeaders();
    $headers->addHeaderLine('Accept: application/sellside.ad.list-v2+json, application/json');
    $headers->addHeaderLine('Authorization: Bearer ' . $this->getAccessToken());

    $response = $this->httpClient->send($request);
```

the Client class keeps the encType and sets the content type in the header to   'Content-Type' =>  "application/x-www-form-urlencoded" A GET shouldn't have this type. The provider of the API reports a HTTP 415 because of this issue.

We managed to solve this issue with Client->reset() but I think this isn't the solution to this.

This content-type is set at line 1150 in Zend\Http\Client.php

Thanks
