### PR TITLE
Zend\Http\Header\GenericHeader introduces BC break

### DIFF
--- a/library/Zend/Http/Header/GenericHeader.php
+++ b/library/Zend/Http/Header/GenericHeader.php
@@ -88,18 +88,16 @@ class GenericHeader implements HeaderInterface
             throw new Exception\InvalidArgumentException('Header name must be a string');
         }
 
-        // Pre-filter to normalize valid characters, change underscore to dash
-        $fieldName = str_replace('_', '-', $fieldName);
-
         /*
-         * Following RFC 2616 section 4.2
+         * Following RFC 7230 section 3.2
          *
-         * message-header = field-name ":" [ field-value ]
-         * field-name     = token
-         *
-         * @see http://tools.ietf.org/html/rfc2616#section-2.2 for token definition.
+         * header-field = field-name ":" [ field-value ]
+         * field-name   = token
+         * token        = 1*tchar
+         * tchar        = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+         *                "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
          */
-        if (!preg_match('/^[!#-\'*+\-\.0-9A-Z\^-z|~]+$/', $fieldName)) {
+        if (!preg_match('/^[!#$%&\'*+\-\.\^_`|~0-9a-zA-Z]+$/', $fieldName)) {
             throw new Exception\InvalidArgumentException(
                 'Header name must be a valid RFC 2616 (section 4.2) field-name.'
             );

--- a/library/Zend/Http/Header/GenericHeader.php
+++ b/library/Zend/Http/Header/GenericHeader.php
@@ -99,7 +99,7 @@ class GenericHeader implements HeaderInterface
          */
         if (!preg_match('/^[!#$%&\'*+\-\.\^_`|~0-9a-zA-Z]+$/', $fieldName)) {
             throw new Exception\InvalidArgumentException(
-                'Header name must be a valid RFC 2616 (section 4.2) field-name.'
+                'Header name must be a valid RFC 7230 (section 3.2) field-name.'
             );
         }
 

--- a/tests/ZendTest/Http/Header/GenericHeaderTest.php
+++ b/tests/ZendTest/Http/Header/GenericHeaderTest.php
@@ -26,7 +26,7 @@ class GenericHeaderTest extends TestCase
         } catch (InvalidArgumentException $e) {
             $this->assertEquals(
                 $e->getMessage(),
-                'Header name must be a valid RFC 2616 (section 4.2) field-name.'
+                'Header name must be a valid RFC 7230 (section 3.2) field-name.'
             );
             $this->fail('Allowed char rejected: ' . ord($name)); // For easy debug
         }
@@ -44,7 +44,7 @@ class GenericHeaderTest extends TestCase
         } catch (InvalidArgumentException $e) {
             $this->assertEquals(
                 $e->getMessage(),
-                'Header name must be a valid RFC 2616 (section 4.2) field-name.'
+                'Header name must be a valid RFC 7230 (section 3.2) field-name.'
             );
         }
     }

--- a/tests/ZendTest/Http/Header/GenericHeaderTest.php
+++ b/tests/ZendTest/Http/Header/GenericHeaderTest.php
@@ -25,8 +25,8 @@ class GenericHeaderTest extends TestCase
             new GenericHeader($name);
         } catch (InvalidArgumentException $e) {
             $this->assertEquals(
-                 $e->getMessage(),
-                     'Header name must be a valid RFC 2616 (section 4.2) field-name.'
+                $e->getMessage(),
+                'Header name must be a valid RFC 2616 (section 4.2) field-name.'
             );
             $this->fail('Allowed char rejected: ' . ord($name)); // For easy debug
         }
@@ -43,10 +43,19 @@ class GenericHeaderTest extends TestCase
             $this->fail('Invalid char allowed: ' . ord($name)); // For easy debug
         } catch (InvalidArgumentException $e) {
             $this->assertEquals(
-                 $e->getMessage(),
-                     'Header name must be a valid RFC 2616 (section 4.2) field-name.'
+                $e->getMessage(),
+                'Header name must be a valid RFC 2616 (section 4.2) field-name.'
             );
         }
+    }
+
+    /**
+     * @group 7295
+     */
+    public function testDoesNotReplaceUnderscoresWithDashes()
+    {
+        $header = new GenericHeader('X_Foo_Bar');
+        $this->assertEquals('X_Foo_Bar', $header->getFieldName());
     }
 
     /**


### PR DESCRIPTION
V2.3.4 (and possibly earlier) has a BC break to version 2.2.3 (and possibly later)
Links to: https://github.com/zendframework/zf2/pull/5301

This is caused by the insistence that underscores are converted to hyphens at L92.  It is debatable as to whether RFC2616 actually insists that underscores are not allowed.

Irrespective of that, the code 
- should not change header names under the covers
- should throw an exception as it does a few lines later for non RFC compliance, which would at least warn developers that something is wrong, rather than trying to figure out why their code suddenly breaks when a service endpoint is hit, and is consistent with the exception throwing later.

In addition, it would be useful to include a NonRfc2616Header that can be used in place of GenericHeader with appropriate documentation in the reference guide.
