### PR TITLE
Missing parameter annotation in PHPDoc in Zend\Http\PhpEnvironment\Request

### DIFF
--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -59,6 +59,8 @@ class Request extends HttpRequest
     /**
      * Construct
      * Instantiates request.
+     *
+     * @param bool $allowCustomMethods
      */
     public function __construct($allowCustomMethods = true)
     {


### PR DESCRIPTION
Missing parameter annotation in PHPDoc in Zend\Http\PhpEnvironment\Request
