### PR TITLE
PHP 7 on Travis-CI (re-redux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 .*.sw*
 .*.un~
 build/
-composer.lock
 nbproject
 tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - hhvm-nightly
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' ]]; then phpenv config-rm xdebug.ini;  fi
+  - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-rm xdebug.ini;  fi
   - IS_HHVM=`echo $TRAVIS_PHP_VERSION | grep "hhvm" | wc -l`
   - sudo apt-get install parallel libpcre3-dev
   - test $IS_HHVM == "1" || echo "" | pecl install apcu-beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
   - hhvm-nightly
 
@@ -43,5 +44,6 @@ notifications:
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 7
     - php: hhvm
     - php: hhvm-nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ php:
 install:
   - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-rm xdebug.ini;  fi
   - sudo apt-get install parallel libpcre3-dev
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then pecl install apcu-beta
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-add tests/travis.php.ini
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then pecl install apcu-beta; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-add tests/travis.php.ini;fi
   - composer install --no-interaction --prefer-source
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ php:
 
 install:
   - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-rm xdebug.ini;  fi
-  - IS_HHVM=`echo $TRAVIS_PHP_VERSION | grep "hhvm" | wc -l`
   - sudo apt-get install parallel libpcre3-dev
-  - if [[ $IS_HHVM != '1' && $TRAVIS_PHP_VERSION != '7' ]]; then pecl install apcu-beta
-  - if [[ $IS_HHVM != '1' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-add tests/travis.php.ini
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then pecl install apcu-beta
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-add tests/travis.php.ini
   - composer install --no-interaction --prefer-source
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,12 @@ php:
 install:
   - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-rm xdebug.ini;  fi
   - sudo apt-get install parallel libpcre3-dev
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then pecl install apcu-beta; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-add tests/travis.php.ini;fi
   - composer install --no-interaction --prefer-source
 
 before_script:
   - php --version
-  - sudo /etc/init.d/memcached start
-  - sudo start redis-server
-  - mkdir -p build/coverage
   - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then mkdir -p build/coverage; fi
 
 script:
   # Run tests for the various components in parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-rm xdebug.ini;  fi
   - IS_HHVM=`echo $TRAVIS_PHP_VERSION | grep "hhvm" | wc -l`
   - sudo apt-get install parallel libpcre3-dev
-  - test $IS_HHVM == "1" || echo "" | pecl install apcu-beta
-  - test $IS_HHVM == "1" || phpenv config-add tests/travis.php.ini
+  - if [[ $IS_HHVM != '1' && $TRAVIS_PHP_VERSION != '7' ]]; then pecl install apcu-beta
+  - if [[ $IS_HHVM != '1' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-add tests/travis.php.ini
   - composer install --no-interaction --prefer-source
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "zendframework/zendxml": "~1.0-dev"
     },
     "require-dev": {
-        "doctrine/annotations": ">=1.0",
-        "ircmaxell/random-lib": ">=1.1",
-        "mikey179/vfsStream": "1.2.*",
-        "fabpot/php-cs-fixer": "1.*",
+        "doctrine/annotations": "^1.0",
+        "ircmaxell/random-lib": "^1.1",
+        "mikey179/vfsStream": "~1.2",
+        "fabpot/php-cs-fixer": "~1.0",
         "phpunit/PHPUnit": "~4.0",
         "satooshi/php-coveralls": "dev-master",
         "phpunit/phpcov": "~2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2038 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "ffc1017f896134261b0d06fb2487f6b0",
+    "packages": [
+        {
+            "name": "zendframework/zendxml",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/ZendXml.git",
+                "reference": "1c8d4b424824d605b203a33729bbb3a3f7c4616b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/ZendXml/zipball/1c8d4b424824d605b203a33729bbb3a3f7c4616b",
+                "reference": "1c8d4b424824d605b203a33729bbb3a3f7c4616b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ZendXml\\": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Utility library for XML usage, best practices, and security in PHP",
+            "homepage": "http://packages.zendframework.com/",
+            "keywords": [
+                "security",
+                "xml",
+                "zf2"
+            ],
+            "time": "2014-11-22 20:27:31"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "eeda578cbe24a170331a1cfdf78be723412df7a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/eeda578cbe24a170331a1cfdf78be723412df7a4",
+                "reference": "eeda578cbe24a170331a1cfdf78be723412df7a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Annotations\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2014-12-20 20:49:38"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Instantiator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2014-10-13 12:58:55"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "fabpot/php-cs-fixer",
+            "version": "v1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "1dff3bb23fef67d62e266249cd3203b0aa025a7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1dff3bb23fef67d62e266249cd3203b0aa025a7e",
+                "reference": "1dff3bb23fef67d62e266249cd3203b0aa025a7e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.1",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/filesystem": "~2.1",
+                "symfony/finder": "~2.1",
+                "symfony/process": "~2.3",
+                "symfony/stopwatch": "~2.5"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "0.7.*@dev"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A script to automatically fix Symfony Coding Standard",
+            "time": "2015-03-22 12:52:15"
+        },
+        {
+            "name": "guzzle/guzzle",
+            "version": "v3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
+                "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                }
+            ],
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2015-03-18 18:23:50"
+        },
+        {
+            "name": "ircmaxell/random-lib",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/RandomLib.git",
+                "reference": "13efa4368bb2ac88bb3b1459b487d907de4dbf7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/RandomLib/zipball/13efa4368bb2ac88bb3b1459b487d907de4dbf7c",
+                "reference": "13efa4368bb2ac88bb3b1459b487d907de4dbf7c",
+                "shasum": ""
+            },
+            "require": {
+                "ircmaxell/security-lib": "1.0.*@dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.1.*",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "RandomLib": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@ircmaxell.com",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A Library For Generating Secure Random Numbers",
+            "homepage": "https://github.com/ircmaxell/RandomLib",
+            "keywords": [
+                "cryptography",
+                "random",
+                "random-numbers",
+                "random-strings"
+            ],
+            "time": "2015-01-15 16:31:45"
+        },
+        {
+            "name": "ircmaxell/security-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/SecurityLib.git",
+                "reference": "80934de3c482dcafb46b5756e59ebece082b6dc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/SecurityLib/zipball/80934de3c482dcafb46b5756e59ebece082b6dc7",
+                "reference": "80934de3c482dcafb46b5756e59ebece082b6dc7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "SecurityLib": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@ircmaxell.com",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A Base Security Library",
+            "homepage": "https://github.com/ircmaxell/PHP-SecurityLib",
+            "time": "2013-04-30 18:00:34"
+        },
+        {
+            "name": "mikey179/vfsStream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikey179/vfsStream.git",
+                "reference": "61b12172292cf539685507aa65b076c1530e83c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/61b12172292cf539685507aa65b076c1530e83c1",
+                "reference": "61b12172292cf539685507aa65b076c1530e83c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2014-09-14 10:18:53"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "phpDocumentor": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2015-02-03 12:10:50"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "~1.0,>=1.0.2",
+                "phpdocumentor/reflection-docblock": "~2.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "http://phpspec.org",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2014-11-17 16:23:49"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "34cc484af1ca149188d0d9e91412191e398e0b67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/34cc484af1ca149188d0d9e91412191e398e0b67",
+                "reference": "34cc484af1ca149188d0d9e91412191e398e0b67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "~1.0",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-01-24 10:06:35"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10 15:34:57"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Text/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2014-01-30 17:20:04"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "1.0.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1.0.5",
+                "reference": "1.0.5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2013-08-02 07:42:54"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/db32c18eba00b121c145575fcbcd4d4d24e6db74",
+                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-01-17 09:51:32"
+        },
+        {
+            "name": "phpunit/phpcov",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcov.git",
+                "reference": "85d3c38f0b455aa7097512b8f3256f796e9b4db6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/85d3c38f0b455aa7097512b8f3256f796e9b4db6",
+                "reference": "85d3c38f0b455aa7097512b8f3256f796e9b4db6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~2.0",
+                "phpunit/phpunit": "~4.1",
+                "sebastian/diff": "~1.1",
+                "sebastian/finder-facade": "~1.1",
+                "sebastian/version": "~1.0.3",
+                "symfony/console": "~2.2"
+            },
+            "bin": [
+                "phpcov"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "CLI frontend for PHP_CodeCoverage",
+            "homepage": "https://github.com/sebastianbergmann/phpcov",
+            "time": "2014-06-25 14:46:28"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "5b578d3865a9128b9c209b011fda6539ec06e7a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5b578d3865a9128b9c209b011fda6539ec06e7a5",
+                "reference": "5b578d3865a9128b9c209b011fda6539ec06e7a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpspec/prophecy": "~1.3.1",
+                "phpunit/php-code-coverage": "~2.0",
+                "phpunit/php-file-iterator": "~1.3.2",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "~1.0.2",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.1",
+                "sebastian/environment": "~1.2",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-02-05 15:51:19"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "c63d2367247365f688544f0d500af90a11a44c65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/c63d2367247365f688544f0d500af90a11a44c65",
+                "reference": "c63d2367247365f688544f0d500af90a11a44c65",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "~1.0,>=1.0.1",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.3"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2014-10-03 05:12:11"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "satooshi/php-coveralls",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/satooshi/php-coveralls.git",
+                "reference": "2fbf803803d179ab1082807308a67bbd5a760c70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/satooshi/php-coveralls/zipball/2fbf803803d179ab1082807308a67bbd5a760c70",
+                "reference": "2fbf803803d179ab1082807308a67bbd5a760c70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzle/guzzle": ">=2.7",
+                "php": ">=5.3",
+                "psr/log": "1.0.0",
+                "symfony/config": ">=2.0",
+                "symfony/console": ">=2.0",
+                "symfony/stopwatch": ">=2.2",
+                "symfony/yaml": ">=2.0"
+            },
+            "require-dev": {
+                "apigen/apigen": "2.8.*@stable",
+                "pdepend/pdepend": "dev-master as 2.0.0",
+                "phpmd/phpmd": "dev-master",
+                "phpunit/php-invoker": ">=1.1.0,<1.2.0",
+                "phpunit/phpunit": "3.7.*@stable",
+                "sebastian/finder-facade": "dev-master",
+                "sebastian/phpcpd": "1.4.*@stable",
+                "squizlabs/php_codesniffer": "1.4.*@stable",
+                "theseer/fdomdocument": "dev-master"
+            },
+            "suggest": {
+                "symfony/http-kernel": "Allows Symfony integration"
+            },
+            "bin": [
+                "composer/bin/coveralls"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Satooshi\\Component": "src/",
+                    "Satooshi\\Bundle": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kitamura Satoshi",
+                    "email": "with.no.parachute@gmail.com",
+                    "homepage": "https://www.facebook.com/satooshi.jp"
+                }
+            ],
+            "description": "PHP client library for Coveralls API",
+            "homepage": "https://github.com/satooshi/php-coveralls",
+            "keywords": [
+                "ci",
+                "coverage",
+                "github",
+                "test"
+            ],
+            "time": "2014-11-11 15:35:34"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
+                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-01-29 16:28:08"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/5843509fed39dee4b356a306401e9dd1a931fec7",
+                "reference": "5843509fed39dee4b356a306401e9dd1a931fec7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2014-08-15 10:29:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6e6c71d918088c251b181ba8b3088af4ac336dd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e6c71d918088c251b181ba8b3088af4ac336dd7",
+                "reference": "6e6c71d918088c251b181ba8b3088af4ac336dd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2014-10-25 08:00:45"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "84839970d05254c73cde183a721c7af13aede943"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
+                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2015-01-27 07:23:06"
+        },
+        {
+            "name": "sebastian/finder-facade",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/finder-facade.git",
+                "reference": "1e396fda3449fce9df032749fa4fa2619e0347e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/finder-facade/zipball/1e396fda3449fce9df032749fa4fa2619e0347e0",
+                "reference": "1e396fda3449fce9df032749fa4fa2619e0347e0",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/finder": ">=2.2.0",
+                "theseer/fdomdocument": ">=1.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
+            "homepage": "https://github.com/sebastianbergmann/finder-facade",
+            "time": "2013-05-28 06:10:03"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2014-10-06 09:23:50"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
+                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-01-24 09:48:32"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/a77d9123f8e809db3fbdea15038c27a95da4058b",
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2014-12-15 14:25:24"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Config",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Config.git",
+                "reference": "7a47189c7667ca69bcaafd19ef8a8941db449a2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/7a47189c7667ca69bcaafd19ef8a8941db449a2c",
+                "reference": "7a47189c7667ca69bcaafd19ef8a8941db449a2c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/filesystem": "~2.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-12 10:28:44"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "53f86497ccd01677e22435cfb7262599450a90d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/53f86497ccd01677e22435cfb7262599450a90d1",
+                "reference": "53f86497ccd01677e22435cfb7262599450a90d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-13 17:37:22"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/EventDispatcher",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "70f7c8478739ad21e3deef0d977b38c77f1fb284"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/70f7c8478739ad21e3deef0d977b38c77f1fb284",
+                "reference": "70f7c8478739ad21e3deef0d977b38c77f1fb284",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-13 17:37:22"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Filesystem",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "fdc5f151bc2db066b51870d5bea3773d915ced0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/fdc5f151bc2db066b51870d5bea3773d915ced0b",
+                "reference": "fdc5f151bc2db066b51870d5bea3773d915ced0b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-12 10:28:44"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Finder",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Finder.git",
+                "reference": "bebc7479c566fa4f14b9bcef9e32e719eabec74e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/bebc7479c566fa4f14b9bcef9e32e719eabec74e",
+                "reference": "bebc7479c566fa4f14b9bcef9e32e719eabec74e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-12 10:28:44"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Process",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Process.git",
+                "reference": "4d717f34f3d1d6ab30fbe79f7132960a27f4a0dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/4d717f34f3d1d6ab30fbe79f7132960a27f4a0dc",
+                "reference": "4d717f34f3d1d6ab30fbe79f7132960a27f4a0dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Process\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-12 10:28:44"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Stopwatch",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Stopwatch.git",
+                "reference": "ba4e774f71e2ce3e3f65cabac4031b9029972af5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/ba4e774f71e2ce3e3f65cabac4031b9029972af5",
+                "reference": "ba4e774f71e2ce3e3f65cabac4031b9029972af5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-02-24 11:52:21"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.6.5",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "0cd8e72071e46e15fc072270ae39ea1b66b10a9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/0cd8e72071e46e15fc072270ae39ea1b66b10a9d",
+                "reference": "0cd8e72071e46e15fc072270ae39ea1b66b10a9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-12 10:28:44"
+        },
+        {
+            "name": "theseer/fdomdocument",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/fDOMDocument.git",
+                "reference": "d08cf070350f884c63fc9078d27893c2ab6c7cef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/fDOMDocument/zipball/d08cf070350f884c63fc9078d27893c2ab6c7cef",
+                "reference": "d08cf070350f884c63fc9078d27893c2ab6c7cef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "lib-libxml": "*",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
+            "homepage": "https://github.com/theseer/fDOMDocument",
+            "time": "2014-09-13 10:57:19"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "zendframework/zendxml": 20,
+        "satooshi/php-coveralls": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.23"
+    },
+    "platform-dev": []
+}

--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -243,8 +243,8 @@ class Image extends AbstractRenderer
             $this->resource,
             $this->leftOffset,
             $this->topOffset,
-            $this->leftOffset + $barcodeWidth - 1,
-            $this->topOffset + $barcodeHeight - 1,
+            (int) ($this->leftOffset + $barcodeWidth - 1),
+            (int) ($this->topOffset + $barcodeHeight - 1),
             $this->imageBackgroundColor
         );
     }

--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -204,6 +204,11 @@ class Image extends AbstractRenderer
                 $height = $this->userHeight;
             }
 
+            // Cast width and height to ensure they are correct type for image
+            // operations
+            $width  = (int) $width;
+            $height = (int) $height;
+
             $this->resource = imagecreatetruecolor($width, $height);
 
             $white = imagecolorallocate($this->resource, 255, 255, 255);

--- a/library/Zend/Cache/Pattern/CallbackCache.php
+++ b/library/Zend/Cache/Pattern/CallbackCache.php
@@ -59,7 +59,7 @@ class CallbackCache extends AbstractPattern
         $cacheOutput = $options->getCacheOutput();
         if ($cacheOutput) {
             ob_start();
-            ob_implicit_flush(false);
+            ob_implicit_flush(0);
         }
 
         // TODO: do not cache on errors using [set|restore]_error_handler
@@ -137,9 +137,11 @@ class CallbackCache extends AbstractPattern
         $callbackKey = strtolower($callbackKey);
 
         // generate a unique key of object callbacks
-        if (is_object($callback)) { // Closures & __invoke
+        if (is_object($callback)) {
+            // Closures & __invoke
             $object = $callback;
-        } elseif (isset($callback[0])) { // array($object, 'method')
+        } elseif (isset($callback[0])) {
+            // array($object, 'method')
             $object = $callback[0];
         }
         if (isset($object)) {

--- a/library/Zend/Cache/Pattern/CaptureCache.php
+++ b/library/Zend/Cache/Pattern/CaptureCache.php
@@ -35,7 +35,7 @@ class CaptureCache extends AbstractPattern
             return false;
         });
 
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
     }
 
     /**

--- a/library/Zend/Cache/Pattern/OutputCache.php
+++ b/library/Zend/Cache/Pattern/OutputCache.php
@@ -60,7 +60,7 @@ class OutputCache extends AbstractPattern
         }
 
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $this->keyStack[] = $key;
         return false;
     }

--- a/library/Zend/Cache/Storage/Adapter/Dba.php
+++ b/library/Zend/Cache/Storage/Adapter/Dba.php
@@ -264,7 +264,8 @@ class Dba extends AbstractAdapter implements
 
         $this->_open();
 
-        do { // Workaround for PHP-Bug #62491 & #62492
+        // Workaround for PHP-Bug #62491 & #62492
+        do {
             $recheck     = false;
             $internalKey = dba_firstkey($this->handle);
             while ($internalKey !== false && $internalKey !== null) {
@@ -377,8 +378,10 @@ class Dba extends AbstractAdapter implements
         $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
 
+        $cacheableValue = (string) $value; // dba_replace requires a string
+
         $this->_open();
-        if (!dba_replace($internalKey, $value, $this->handle)) {
+        if (!dba_replace($internalKey, $cacheableValue, $this->handle)) {
             throw new Exception\RuntimeException("dba_replace('{$internalKey}', ...) failed");
         }
 

--- a/library/Zend/Cache/Storage/Adapter/Filesystem.php
+++ b/library/Zend/Cache/Storage/Adapter/Filesystem.php
@@ -1498,6 +1498,11 @@ class Filesystem extends AbstractAdapter implements
      */
     protected function putFileContent($file, $data, $nonBlocking = false, & $wouldblock = null)
     {
+        if (! is_string($data)) {
+            // Ensure we have a string
+            $data = (string) $data;
+        }
+
         $options     = $this->getOptions();
         $locking     = $options->getFileLocking();
         $nonBlocking = $locking && $nonBlocking;

--- a/library/Zend/Config/Processor/Token.php
+++ b/library/Zend/Config/Processor/Token.php
@@ -259,7 +259,7 @@ class Token implements ProcessorInterface
 
         if (!is_string($value) && (is_bool($value) || is_numeric($value))) {
             $stringVal  = (string) $value;
-            $changedVal = strtr($value, $this->map);
+            $changedVal = strtr($stringVal, $this->map);
 
             // replace the value only if a string replacement occurred
             if ($changedVal !== $stringVal) {

--- a/library/Zend/Crypt/BlockCipher.php
+++ b/library/Zend/Crypt/BlockCipher.php
@@ -461,7 +461,7 @@ class BlockCipher
         }
         $hmacSize   = Hmac::getOutputSize($this->hash);
         $hmac       = substr($data, 0, $hmacSize);
-        $ciphertext = substr($data, $hmacSize);
+        $ciphertext = substr($data, $hmacSize) ?: '';
         if (!$this->binaryOutput) {
             $ciphertext = base64_decode($ciphertext);
         }

--- a/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pdo/Connection.php
@@ -42,7 +42,9 @@ class Connection extends AbstractConnection
         } elseif ($connectionParameters instanceof \PDO) {
             $this->setResource($connectionParameters);
         } elseif (null !== $connectionParameters) {
-            throw new Exception\InvalidArgumentException('$connection must be an array of parameters, a PDO object or null');
+            throw new Exception\InvalidArgumentException(
+                '$connection must be an array of parameters, a PDO object or null'
+            );
         }
     }
 
@@ -66,7 +68,9 @@ class Connection extends AbstractConnection
     {
         $this->connectionParameters = $connectionParameters;
         if (isset($connectionParameters['dsn'])) {
-            $this->driverName = substr($connectionParameters['dsn'], 0,
+            $this->driverName = substr(
+                $connectionParameters['dsn'],
+                0,
                 strpos($connectionParameters['dsn'], ':')
             );
         } elseif (isset($connectionParameters['pdodriver'])) {
@@ -87,7 +91,9 @@ class Connection extends AbstractConnection
     public function getDsn()
     {
         if (!$this->dsn) {
-            throw new Exception\RunTimeException("The DSN has not been set or constructed from parameters in connect() for this Connection");
+            throw new Exception\RunTimeException(
+                'The DSN has not been set or constructed from parameters in connect() for this Connection'
+            );
         }
 
         return $this->dsn;
@@ -161,9 +167,11 @@ class Connection extends AbstractConnection
                     $dsn = $value;
                     break;
                 case 'driver':
-                    $value = strtolower($value);
+                    $value = strtolower((string) $value);
                     if (strpos($value, 'pdo') === 0) {
-                        $pdoDriver = strtolower(substr(str_replace(array('-', '_', ' '), '', $value), 3));
+                        $pdoDriver = str_replace(array('-', '_', ' '), '', $value);
+                        $pdoDriver = substr($pdoDriver, 3) ?: '';
+                        $pdoDriver = strtolower($pdoDriver);
                     }
                     break;
                 case 'pdodriver':

--- a/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
+++ b/library/Zend/Db/Adapter/Platform/AbstractPlatform.php
@@ -108,7 +108,7 @@ abstract class AbstractPlatform implements PlatformInterface
             'Attempting to quote a value in ' . get_class($this) .
             ' without extension/driver support can introduce security vulnerabilities in a production environment'
         );
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return '\'' . addcslashes((string) $value, "\x00\n\r\\'\"\x1a") . '\'';
     }
 
     /**
@@ -116,7 +116,7 @@ abstract class AbstractPlatform implements PlatformInterface
      */
     public function quoteTrustedValue($value)
     {
-        return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
+        return '\'' . addcslashes((string) $value, "\x00\n\r\\'\"\x1a") . '\'';
     }
 
     /**

--- a/library/Zend/Db/Adapter/Platform/Sql92.php
+++ b/library/Zend/Db/Adapter/Platform/Sql92.php
@@ -25,7 +25,8 @@ class Sql92 extends AbstractPlatform
     public function quoteValue($value)
     {
         trigger_error(
-            'Attempting to quote a value without specific driver level support can introduce security vulnerabilities in a production environment.'
+            'Attempting to quote a value without specific driver level support'
+            . ' can introduce security vulnerabilities in a production environment.'
         );
         return '\'' . addcslashes($value, "\x00\n\r\\'\"\x1a") . '\'';
     }

--- a/library/Zend/Db/Sql/Ddl/Column/Float.php
+++ b/library/Zend/Db/Sql/Ddl/Column/Float.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Db\Sql\Ddl\Column;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "float" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "Floating", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Float extends Floating
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Raises a deprecation notice.
+     */
+    public function __construct(
+        $name,
+        $digits = null,
+        $decimal = null,
+        $nullable = false,
+        $default = null,
+        array $options = array()
+    ) {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\Floating',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+        
+        parent::__construct($name, $digits, $decimal, $nullable, $default, $options);
+    }
+}

--- a/library/Zend/Db/Sql/Ddl/Column/Float.php
+++ b/library/Zend/Db/Sql/Ddl/Column/Float.php
@@ -42,7 +42,7 @@ class Float extends Floating
             ),
             E_USER_DEPRECATED
         );
-        
+
         parent::__construct($name, $digits, $decimal, $nullable, $default, $options);
     }
 }

--- a/library/Zend/Db/Sql/Ddl/Column/Floating.php
+++ b/library/Zend/Db/Sql/Ddl/Column/Floating.php
@@ -9,7 +9,13 @@
 
 namespace Zend\Db\Sql\Ddl\Column;
 
-class Float extends AbstractPrecisionColumn
+/**
+ * Column representing a FLOAT type.
+ *
+ * Cannot name a class "float" starting in PHP 7, as it's a reserved keyword;
+ * hence, "floating", with a type of "FLOAT".
+ */
+class Floating extends AbstractPrecisionColumn
 {
     /**
      * @var string

--- a/library/Zend/Feed/Reader/Entry/AbstractEntry.php
+++ b/library/Zend/Feed/Reader/Entry/AbstractEntry.php
@@ -122,8 +122,9 @@ abstract class AbstractEntry
      */
     public function saveXml()
     {
-        $dom = new DOMDocument('1.0', $this->getEncoding());
-        $entry = $dom->importNode($this->getElement(), true);
+        $dom   = new DOMDocument('1.0', $this->getEncoding());
+        $deep  = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
+        $entry = $dom->importNode($this->getElement(), $deep);
         $dom->appendChild($entry);
         return $dom->saveXml();
     }
@@ -202,8 +203,10 @@ abstract class AbstractEntry
                 return call_user_func_array(array($extension, $method), $args);
             }
         }
-        throw new Exception\RuntimeException('Method: ' . $method
-            . ' does not exist and could not be located on a registered Extension');
+        throw new Exception\RuntimeException(sprintf(
+            'Method: %s does not exist and could not be located on a registered Extension',
+            $method
+        ));
     }
 
     /**

--- a/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -103,20 +103,21 @@ class Entry extends Extension\AbstractEntry
                 case 'html':
                 case 'text/html':
                     $content = $el->nodeValue;
-                break;
+                    break;
                 case 'xhtml':
                     $this->getXpath()->registerNamespace('xhtml', 'http://www.w3.org/1999/xhtml');
                     $xhtml = $this->getXpath()->query(
                         $this->getXpathPrefix() . '/atom:content/xhtml:div'
                     )->item(0);
                     $d = new DOMDocument('1.0', $this->getEncoding());
-                    $xhtmls = $d->importNode($xhtml, true);
+                    $deep = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
+                    $xhtmls = $d->importNode($xhtml, $deep);
                     $d->appendChild($xhtmls);
                     $content = $this->collectXhtml(
                         $d->saveXML(),
                         $d->lookupPrefix('http://www.w3.org/1999/xhtml')
                     );
-                break;
+                    break;
             }
         }
 
@@ -296,9 +297,12 @@ class Entry extends Extension\AbstractEntry
             return $this->data['baseUrl'];
         }
 
-        $baseUrl = $this->getXpath()->evaluate('string('
-            . $this->getXpathPrefix() . '/@xml:base[1]'
-        . ')');
+        $baseUrl = $this->getXpath()->evaluate(
+            'string('
+            . $this->getXpathPrefix()
+            . '/@xml:base[1]'
+            . ')'
+        );
 
         if (!$baseUrl) {
             $baseUrl = $this->getXpath()->evaluate('string(//@xml:base[1])');

--- a/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
+++ b/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
@@ -265,12 +265,14 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
 
         if (!$this->getDataContainer()->getId()) {
             $this->getDataContainer()->setId(
-                $this->getDataContainer()->getLink());
+                $this->getDataContainer()->getLink()
+            );
         }
         if (!Uri::factory($this->getDataContainer()->getId())->isValid()
             && !preg_match(
                 "#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#",
-                $this->getDataContainer()->getId())
+                $this->getDataContainer()->getId()
+            )
             && !$this->_validateTagUri($this->getDataContainer()->getId())
         ) {
             throw new Writer\Exception\InvalidArgumentException('Atom 1.0 IDs must be a valid URI/IRI');
@@ -289,7 +291,11 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
      */
     protected function _validateTagUri($id)
     {
-        if (preg_match('/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/', $id, $matches)) {
+        if (preg_match(
+            '/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/',
+            $id,
+            $matches
+        )) {
             $dvalid = false;
             $date = $matches['date'];
             $d6 = strtotime($date);
@@ -341,7 +347,8 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
         $element = $dom->createElement('content');
         $element->setAttribute('type', 'xhtml');
         $xhtmlElement = $this->_loadXhtml($content);
-        $xhtml = $dom->importNode($xhtmlElement, true);
+        $deep = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
+        $xhtml = $dom->importNode($xhtmlElement, $deep);
         $element->appendChild($xhtml);
         $root->appendChild($element);
     }
@@ -369,8 +376,11 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
             "/(<[\/]?)([a-zA-Z]+)/"
         ), '$1xhtml:$2', $xhtml);
         $dom = new DOMDocument('1.0', $this->getEncoding());
-        $dom->loadXML('<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">'
-            . $xhtml . '</xhtml:div>');
+        $dom->loadXML(
+            '<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+            . $xhtml
+            . '</xhtml:div>'
+        );
         return $dom->documentElement;
     }
 

--- a/library/Zend/Feed/Writer/Renderer/Feed/Atom.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Atom.php
@@ -40,7 +40,8 @@ class Atom extends AbstractAtom implements Renderer\RendererInterface
         $this->dom = new DOMDocument('1.0', $this->container->getEncoding());
         $this->dom->formatOutput = true;
         $root = $this->dom->createElementNS(
-            Writer\Writer::NAMESPACE_ATOM_10, 'feed'
+            Writer\Writer::NAMESPACE_ATOM_10,
+            'feed'
         );
         $this->setRootElement($root);
         $this->dom->appendChild($root);
@@ -76,7 +77,8 @@ class Atom extends AbstractAtom implements Renderer\RendererInterface
             } else {
                 if (!$this->dom->documentElement->hasAttribute('xmlns:at')) {
                     $this->dom->documentElement->setAttribute(
-                        'xmlns:at', 'http://purl.org/atompub/tombstones/1.0'
+                        'xmlns:at',
+                        'http://purl.org/atompub/tombstones/1.0'
                     );
                 }
                 $renderer = new Renderer\Entry\AtomDeleted($entry);
@@ -88,7 +90,8 @@ class Atom extends AbstractAtom implements Renderer\RendererInterface
             $renderer->setRootElement($this->dom->documentElement);
             $renderer->render();
             $element = $renderer->getElement();
-            $imported = $this->dom->importNode($element, true);
+            $deep = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
+            $imported = $this->dom->importNode($element, $deep);
             $root->appendChild($imported);
         }
         return $this;

--- a/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -85,7 +85,8 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             $renderer->setRootElement($this->dom->documentElement);
             $renderer->render();
             $element = $renderer->getElement();
-            $imported = $this->dom->importNode($element, true);
+            $deep = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
+            $imported = $this->dom->importNode($element, $deep);
             $channel->appendChild($imported);
         }
         return $this;
@@ -195,8 +196,11 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     protected function _setGenerator(DOMDocument $dom, DOMElement $root)
     {
         if (!$this->getDataContainer()->getGenerator()) {
-            $this->getDataContainer()->setGenerator('Zend_Feed_Writer',
-                Version::VERSION, 'http://framework.zend.com');
+            $this->getDataContainer()->setGenerator(
+                'Zend_Feed_Writer',
+                Version::VERSION,
+                'http://framework.zend.com'
+            );
         }
 
         $gdata = $this->getDataContainer()->getGenerator();

--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -21,7 +21,8 @@ use Zend\ServiceManager\AbstractPluginManager;
 class FilterPluginManager extends AbstractPluginManager
 {
     protected $aliases = array(
-        'Zend\I18n\Filter\Int'       => 'Zend\I18n\Filter\ToInt',
+        'Zend\Filter\Int'            => 'Zend\Filter\ToInt',
+        'Zend\Filter\Null'           => 'Zend\Filter\ToNull',
     );
 
     /**
@@ -74,7 +75,7 @@ class FilterPluginManager extends AbstractPluginManager
         'inflector'                  => 'Zend\Filter\Inflector',
         'int'                        => 'Zend\Filter\ToInt',
         'monthselect'                => 'Zend\Filter\MonthSelect',
-        'null'                       => 'Zend\Filter\Null',
+        'null'                       => 'Zend\Filter\ToNull',
         'numberformat'               => 'Zend\I18n\Filter\NumberFormat',
         'numberparse'                => 'Zend\I18n\Filter\NumberParse',
         'pregreplace'                => 'Zend\Filter\PregReplace',
@@ -85,6 +86,7 @@ class FilterPluginManager extends AbstractPluginManager
         'stripnewlines'              => 'Zend\Filter\StripNewlines',
         'striptags'                  => 'Zend\Filter\StripTags',
         'toint'                      => 'Zend\Filter\ToInt',
+        'tonull'                     => 'Zend\Filter\ToNull',
         'urinormalize'               => 'Zend\Filter\UriNormalize',
         'whitelist'                  => 'Zend\Filter\Whitelist',
         'wordcamelcasetodash'        => 'Zend\Filter\Word\CamelCaseToDash',

--- a/library/Zend/Filter/FilterPluginManager.php
+++ b/library/Zend/Filter/FilterPluginManager.php
@@ -20,6 +20,10 @@ use Zend\ServiceManager\AbstractPluginManager;
  */
 class FilterPluginManager extends AbstractPluginManager
 {
+    protected $aliases = array(
+        'Zend\I18n\Filter\Int'       => 'Zend\I18n\Filter\ToInt',
+    );
+
     /**
      * Default set of plugins factories
      *
@@ -68,7 +72,7 @@ class FilterPluginManager extends AbstractPluginManager
         'fileuppercase'              => 'Zend\Filter\File\UpperCase',
         'htmlentities'               => 'Zend\Filter\HtmlEntities',
         'inflector'                  => 'Zend\Filter\Inflector',
-        'int'                        => 'Zend\Filter\Int',
+        'int'                        => 'Zend\Filter\ToInt',
         'monthselect'                => 'Zend\Filter\MonthSelect',
         'null'                       => 'Zend\Filter\Null',
         'numberformat'               => 'Zend\I18n\Filter\NumberFormat',
@@ -80,6 +84,7 @@ class FilterPluginManager extends AbstractPluginManager
         'stringtrim'                 => 'Zend\Filter\StringTrim',
         'stripnewlines'              => 'Zend\Filter\StripNewlines',
         'striptags'                  => 'Zend\Filter\StripTags',
+        'toint'                      => 'Zend\Filter\ToInt',
         'urinormalize'               => 'Zend\Filter\UriNormalize',
         'whitelist'                  => 'Zend\Filter\Whitelist',
         'wordcamelcasetodash'        => 'Zend\Filter\Word\CamelCaseToDash',

--- a/library/Zend/Filter/Int.php
+++ b/library/Zend/Filter/Int.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "int" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "ToInt", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Int extends ToInt
+{
+    public function __construct()
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\ToInt',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+    }
+}

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -28,7 +28,7 @@ class Null extends ToNull
     {
         trigger_error(
             sprintf(
-                'The class %s has been deprecated; please use %s\\ToInt',
+                'The class %s has been deprecated; please use %s\\ToNull',
                 __CLASS__,
                 __NAMESPACE__
             ),

--- a/library/Zend/Filter/Null.php
+++ b/library/Zend/Filter/Null.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Filter;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "null" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "ToNull", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Null extends ToNull
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($typeOrOptions = null)
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\ToInt',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        parent::__construct($typeOrOptions);
+    }
+}

--- a/library/Zend/Filter/ToInt.php
+++ b/library/Zend/Filter/ToInt.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Filter;
 
-class Int extends AbstractFilter
+class ToInt extends AbstractFilter
 {
     /**
      * Defined by Zend\Filter\FilterInterface

--- a/library/Zend/Filter/ToNull.php
+++ b/library/Zend/Filter/ToNull.php
@@ -11,7 +11,7 @@ namespace Zend\Filter;
 
 use Traversable;
 
-class Null extends AbstractFilter
+class ToNull extends AbstractFilter
 {
     const TYPE_BOOLEAN      = 1;
     const TYPE_INTEGER      = 2;

--- a/library/Zend/Form/Annotation/AnnotationBuilder.php
+++ b/library/Zend/Form/Annotation/AnnotationBuilder.php
@@ -24,8 +24,8 @@ use Zend\Form\FormFactoryAwareInterface;
 use Zend\Stdlib\ArrayUtils;
 
 /**
- * Parses a class' properties for annotations in order to create a form and
- * input filter definition.
+ * Parses the properties of a class for annotations in order to create a form
+ * and input filter definition.
  */
 class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareInterface
 {
@@ -69,6 +69,7 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
         'Hydrator',
         'Input',
         'InputFilter',
+        'Instance',
         'Name',
         'Object',
         'Options',

--- a/library/Zend/Form/Annotation/ElementAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/ElementAnnotationsListener.php
@@ -25,7 +25,7 @@ use Zend\Stdlib\ArrayObject;
  * - Flags
  * - Input
  * - Hydrator
- * - Object
+ * - Object and Instance (the latter is preferred starting in 2.4)
  * - Required
  * - Type
  * - Validator
@@ -313,7 +313,7 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
     }
 
     /**
-     * Handle the Object annotation
+     * Handle the Object and Instance annotations
      *
      * Sets the object to bind to the form or fieldset
      *
@@ -323,7 +323,9 @@ class ElementAnnotationsListener extends AbstractAnnotationsListener
     public function handleObjectAnnotation($e)
     {
         $annotation = $e->getParam('annotation');
-        if (!$annotation instanceof Object) {
+
+        // Only need to typehint on Instance, as Object extends it
+        if (! $annotation instanceof Instance) {
             return;
         }
 

--- a/library/Zend/Form/Annotation/FormAnnotationsListener.php
+++ b/library/Zend/Form/Annotation/FormAnnotationsListener.php
@@ -20,7 +20,7 @@ use Zend\EventManager\EventManagerInterface;
  * - Attributes
  * - Flags
  * - Hydrator
- * - Object
+ * - Object and Instance (the latter is preferred starting in 2.4)
  * - InputFilter
  * - Type
  * - ValidationGroup
@@ -129,7 +129,7 @@ class FormAnnotationsListener extends AbstractAnnotationsListener
     }
 
     /**
-     * Handle the Object annotation
+     * Handle the Object and Instance annotations
      *
      * Sets the object to bind to the form or fieldset
      *
@@ -139,7 +139,9 @@ class FormAnnotationsListener extends AbstractAnnotationsListener
     public function handleObjectAnnotation($e)
     {
         $annotation = $e->getParam('annotation');
-        if (!$annotation instanceof Object) {
+
+        // Only need to typehint on Instance, as Object extends it
+        if (! $annotation instanceof Instance) {
             return;
         }
 

--- a/library/Zend/Form/Annotation/Instance.php
+++ b/library/Zend/Form/Annotation/Instance.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+namespace Zend\Form\Annotation;
+
+/**
+ * Instance (formerly "object") annotation
+ *
+ * Use this annotation to specify an object instance to use as the bound object
+ * of a form or fieldset
+ *
+ * @Annotation
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Instance extends AbstractStringAnnotation
+{
+    /**
+     * Retrieve the object
+     *
+     * @return null|string
+     */
+    public function getObject()
+    {
+        return $this->value;
+    }
+}

--- a/library/Zend/Form/Annotation/Object.php
+++ b/library/Zend/Form/Annotation/Object.php
@@ -10,23 +10,33 @@
 namespace Zend\Form\Annotation;
 
 /**
- * Object annotation
+ * Stub class for backwards compatibility.
  *
- * Use this annotation to specify an object to use as the bound object of a form or fieldset
+ * Since PHP 7 adds "object" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "Instance", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
  *
+ * @deprecated
  * @Annotation
- * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Object extends AbstractStringAnnotation
+class Object extends Instance
 {
     /**
-     * Retrieve the object
-     *
-     * @return null|string
+     * {@inheritdoc}
      */
-    public function getObject()
+    public function __construct(array $data)
     {
-        return $this->value;
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\Instance,'
+                . ' and the annotation @Instance or @Annotation\Instance',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        parent::__construct($data);
     }
 }

--- a/library/Zend/Form/Element/Range.php
+++ b/library/Zend/Form/Element/Range.php
@@ -10,7 +10,7 @@
 namespace Zend\Form\Element;
 
 use Zend\Form\Element\Number as NumberElement;
-use Zend\I18n\Validator\Float as NumberValidator;
+use Zend\I18n\Validator\IsFloat as NumberValidator;
 use Zend\Validator\GreaterThan as GreaterThanValidator;
 use Zend\Validator\LessThan as LessThanValidator;
 use Zend\Validator\Step as StepValidator;

--- a/library/Zend/Http/Cookies.php
+++ b/library/Zend/Http/Cookies.php
@@ -219,7 +219,8 @@ class Cookies extends Headers
 
         // Get correct cookie path
         $path = $uri->getPath();
-        $path = substr($path, 0, strrpos($path, '/'));
+        $lastSlashPos = strrpos($path, '/') ?: 0;
+        $path = substr($path, 0, $lastSlashPos);
         if (! $path) {
             $path = '/';
         }

--- a/library/Zend/Http/Header/Accept.php
+++ b/library/Zend/Http/Header/Accept.php
@@ -80,7 +80,7 @@ class Accept extends AbstractAccept
         if ($pos = strpos($fieldValuePart, '/')) {
             $type = trim(substr($fieldValuePart, 0, $pos));
         } else {
-            $type = trim(substr($fieldValuePart, 0));
+            $type = trim($fieldValuePart);
         }
 
         $params = $this->getParametersFromFieldValuePart($fieldValuePart);

--- a/library/Zend/Http/Header/CacheControl.php
+++ b/library/Zend/Http/Header/CacheControl.php
@@ -38,7 +38,10 @@ class CacheControl implements HeaderInterface
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'cache-control') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Cache-Control string: "' . $name . '"');
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid header line for Cache-Control string: ""',
+                $name
+            ));
         }
 
         $directives = static::parseValue($value);
@@ -179,6 +182,7 @@ class CacheControl implements HeaderInterface
             case 0:
                 $directive = $lastMatch;
                 goto state_value;
+                // intentional fall-through
 
             default:
                 throw new Exception\InvalidArgumentException('expected DIRECTIVE');
@@ -189,10 +193,12 @@ class CacheControl implements HeaderInterface
             case 0:
                 $directives[$directive] = substr($lastMatch, 2, -1);
                 goto state_separator;
+                // intentional fall-through
 
             case 1:
                 $directives[$directive] = rtrim(substr($lastMatch, 1));
                 goto state_separator;
+                // intentional fall-through
 
             default:
                 $directives[$directive] = true;
@@ -203,6 +209,7 @@ class CacheControl implements HeaderInterface
         switch (static::match(array('\s*,\s*', '$'), $value, $lastMatch)) {
             case 0:
                 goto state_directive;
+                // intentional fall-through
 
             case 1:
                 return $directives;
@@ -223,10 +230,13 @@ class CacheControl implements HeaderInterface
      */
     protected static function match($tokens, &$string, &$lastMatch)
     {
+        // Ensure we have a string
+        $value = (string) $string;
+
         foreach ($tokens as $i => $token) {
-            if (preg_match('/^' . $token . '/', $string, $matches)) {
+            if (preg_match('/^' . $token . '/', $value, $matches)) {
                 $lastMatch = $matches[0];
-                $string = substr($string, strlen($matches[0]));
+                $string = substr($value, strlen($matches[0]));
                 return $i;
             }
         }

--- a/library/Zend/Http/PhpEnvironment/Request.php
+++ b/library/Zend/Http/PhpEnvironment/Request.php
@@ -252,7 +252,8 @@ class Request extends HttpRequest
 
         // URI scheme
         if ((!empty($this->serverParams['HTTPS']) && strtolower($this->serverParams['HTTPS']) !== 'off')
-            || (!empty($this->serverParams['HTTP_X_FORWARDED_PROTO']) && $this->serverParams['HTTP_X_FORWARDED_PROTO'] == 'https')
+            || (!empty($this->serverParams['HTTP_X_FORWARDED_PROTO'])
+                 && $this->serverParams['HTTP_X_FORWARDED_PROTO'] == 'https')
         ) {
             $scheme = 'https';
         } else {
@@ -362,7 +363,7 @@ class Request extends HttpRequest
      * Return the parameter container responsible for env parameters or a single parameter value.
      *
      * @param string|null           $name            Parameter name to retrieve, or null to get the whole container.
-     * @param mixed|null            $default         Default value to use when the parameter is missing.     * @return \Zend\Stdlib\ParametersInterface
+     * @param mixed|null            $default         Default value to use when the parameter is missing.
      * @return \Zend\Stdlib\ParametersInterface|mixed
      */
     public function getEnv($name = null, $default = null)
@@ -507,7 +508,8 @@ class Request extends HttpRequest
             $basename = basename($filename);
             if ($basename) {
                 $path     = ($phpSelf ? trim($phpSelf, '/') : '');
-                $baseUrl .= substr($path, 0, strpos($path, $basename)) . $basename;
+                $basePos  = strpos($path, $basename) ?: 0;
+                $baseUrl .= substr($path, 0, $basePos) . $basename;
             }
         }
 

--- a/library/Zend/I18n/Validator/Float.php
+++ b/library/Zend/I18n/Validator/Float.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n\Validator;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "float" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "IsFloat", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Float extends IsFloat
+{
+    /**
+     * Constructor for the integer validator
+     *
+     * @param array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
+     */
+    public function __construct($options = array())
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\IsFloat',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        parent::__construct($options);
+    }
+}

--- a/library/Zend/I18n/Validator/Int.php
+++ b/library/Zend/I18n/Validator/Int.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\I18n\Validator;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "int" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "IsInt", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Int extends IsInt
+{
+    /**
+     * Constructor for the integer validator
+     *
+     * @param  array|Traversable $options
+     * @throws Exception\ExtensionNotLoadedException if ext/intl is not present
+     */
+    public function __construct($options = array())
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\IsInt',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        parent::__construct($options);
+    }
+}

--- a/library/Zend/I18n/Validator/IsFloat.php
+++ b/library/Zend/I18n/Validator/IsFloat.php
@@ -20,7 +20,7 @@ use Zend\Stdlib\StringWrapper\StringWrapperInterface;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
 
-class Float extends AbstractValidator
+class IsFloat extends AbstractValidator
 {
     const INVALID   = 'floatInvalid';
     const NOT_FLOAT = 'notFloat';
@@ -153,7 +153,8 @@ class Float extends AbstractValidator
         //NO-BREAK SPACE and ARABIC THOUSANDS SEPARATOR
         if ($groupSeparator == "\xC2\xA0") {
             $value = str_replace(' ', $groupSeparator, $value);
-        } elseif ($groupSeparator == "\xD9\xAC") {  //NumberFormatter doesn't have grouping at all for Arabic-Indic
+        } elseif ($groupSeparator == "\xD9\xAC") {
+            //NumberFormatter doesn't have grouping at all for Arabic-Indic
             $value = str_replace(array('\'', $groupSeparator), '', $value);
         }
 
@@ -217,7 +218,8 @@ class Float extends AbstractValidator
          */
 
         $lnum    = '[' . $numberRange . ']+';
-        $dnum    = '(([' . $numberRange . ']*' . $decimal . $lnum . ')|(' . $lnum . $decimal . '[' . $numberRange . ']*))';
+        $dnum    = '(([' . $numberRange . ']*' . $decimal . $lnum . ')|('
+            . $lnum . $decimal . '[' . $numberRange . ']*))';
         $expDnum = '((' . $prefix . '((' . $lnum . '|' . $dnum . ')' . $exp . $prefix . $lnum . ')' . $suffix . ')|'
             . '(' . $suffix . '(' . $lnum . $prefix . $exp . '(' . $dnum . '|' . $lnum . '))' . $prefix . '))';
 

--- a/library/Zend/I18n/Validator/IsInt.php
+++ b/library/Zend/I18n/Validator/IsInt.php
@@ -18,8 +18,7 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Validator\AbstractValidator;
 use Zend\Validator\Exception;
 
-
-class Int extends AbstractValidator
+class IsInt extends AbstractValidator
 {
     const INVALID = 'intInvalid';
     const NOT_INT = 'notInt';

--- a/library/Zend/Ldap/Converter/Converter.php
+++ b/library/Zend/Ldap/Converter/Converter.php
@@ -163,7 +163,7 @@ class Converter
         if (!is_scalar($value)) {
             return $return;
         }
-        if (true === $value || 'true' === strtolower($value) || 1 === $value) {
+        if (true === $value || (is_string($value) && 'true' === strtolower($value)) || 1 === $value) {
             $return = 'TRUE';
         }
         return $return;
@@ -321,7 +321,9 @@ class Converter
                 if (isset($off[3])) {
                     $offsetMinutes = substr($off[3], 0, 2);
                     if ($offsetMinutes < 0 || $offsetMinutes > 59) {
-                        throw new Exception\InvalidArgumentException('Invalid date format found (invalid offset minute)');
+                        throw new Exception\InvalidArgumentException(
+                            'Invalid date format found (invalid offset minute)'
+                        );
                     }
                     $time['offsetminutes'] = $offsetMinutes;
                 }

--- a/library/Zend/Log/Writer/Noop.php
+++ b/library/Zend/Log/Writer/Noop.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Log\Writer;
 
-class Null extends AbstractWriter
+class Noop extends AbstractWriter
 {
     /**
      * Write a message to the log.

--- a/library/Zend/Log/Writer/Null.php
+++ b/library/Zend/Log/Writer/Null.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Log\Writer;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "null" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "Noop", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Null extends Noop
+{
+    public function __construct()
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\Noop',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+    }
+}

--- a/library/Zend/Log/WriterPluginManager.php
+++ b/library/Zend/Log/WriterPluginManager.php
@@ -13,6 +13,11 @@ use Zend\ServiceManager\AbstractPluginManager;
 
 class WriterPluginManager extends AbstractPluginManager
 {
+    protected $aliases = array(
+        'null'                 => 'noop',
+        'Zend\Log\Writer\Null' => 'noop',
+    );
+    
     /**
      * Default set of writers
      *
@@ -25,7 +30,7 @@ class WriterPluginManager extends AbstractPluginManager
         'firephp'        => 'Zend\Log\Writer\FirePhp',
         'mail'           => 'Zend\Log\Writer\Mail',
         'mock'           => 'Zend\Log\Writer\Mock',
-        'null'           => 'Zend\Log\Writer\Null',
+        'noop'           => 'Zend\Log\Writer\Noop',
         'stream'         => 'Zend\Log\Writer\Stream',
         'syslog'         => 'Zend\Log\Writer\Syslog',
         'zendmonitor'    => 'Zend\Log\Writer\ZendMonitor',

--- a/library/Zend/Log/WriterPluginManager.php
+++ b/library/Zend/Log/WriterPluginManager.php
@@ -17,7 +17,7 @@ class WriterPluginManager extends AbstractPluginManager
         'null'                 => 'noop',
         'Zend\Log\Writer\Null' => 'noop',
     );
-    
+
     /**
      * Default set of writers
      *

--- a/library/Zend/Mail/Storage/Mbox.php
+++ b/library/Zend/Mail/Storage/Mbox.php
@@ -231,7 +231,7 @@ class Mbox extends AbstractStorage
 
         $result = false;
 
-        $line = fgets($file);
+        $line = fgets($file) ?: '';
         if (strpos($line, 'From ') === 0) {
             $result = true;
         }

--- a/library/Zend/Mail/Transport/Factory.php
+++ b/library/Zend/Mail/Transport/Factory.php
@@ -19,7 +19,9 @@ abstract class Factory
      */
     protected static $classMap = array(
         'file'      => 'Zend\Mail\Transport\File',
-        'null'      => 'Zend\Mail\Transport\Null',
+        'inmemory'  => 'Zend\Mail\Transport\InMemory',
+        'memory'    => 'Zend\Mail\Transport\InMemory',
+        'null'      => 'Zend\Mail\Transport\InMemory',
         'sendmail'  => 'Zend\Mail\Transport\Sendmail',
         'smtp'      => 'Zend\Mail\Transport\Smtp',
     );
@@ -64,7 +66,8 @@ abstract class Factory
 
         if (! $transport instanceof TransportInterface) {
             throw new Exception\DomainException(sprintf(
-                '%s expects the "type" attribute to resolve to a valid Zend\Mail\Transport\TransportInterface instance; received "%s"',
+                '%s expects the "type" attribute to resolve to a valid'
+                . ' Zend\Mail\Transport\TransportInterface instance; received "%s"',
                 __METHOD__,
                 $type
             ));

--- a/library/Zend/Mail/Transport/InMemory.php
+++ b/library/Zend/Mail/Transport/InMemory.php
@@ -12,12 +12,13 @@ namespace Zend\Mail\Transport;
 use Zend\Mail\Message;
 
 /**
- * File transport
+ * InMemory transport
  *
- * The null transport will just store the message in memory.  It is helpful
- * when unit testing.
+ * This transport will just store the message in memory.  It is helpful
+ * when unit testing, or to prevent sending email when in development or
+ * testing.
  */
-class Null implements TransportInterface
+class InMemory implements TransportInterface
 {
     /**
      * @var Message
@@ -25,7 +26,7 @@ class Null implements TransportInterface
     protected $lastMessage;
 
     /**
-     * Takes the last message and Saves it for testing
+     * Takes the last message and saves it for testing.
      *
      * @param Message $message
      */
@@ -35,7 +36,7 @@ class Null implements TransportInterface
     }
 
     /**
-     * Get the last message sent
+     * Get the last message sent.
      *
      * @return Message
      */

--- a/library/Zend/Mail/Transport/Null.php
+++ b/library/Zend/Mail/Transport/Null.php
@@ -9,8 +9,6 @@
 
 namespace Zend\Mail\Transport;
 
-use Zend\Mail\Message;
-
 /**
  * Stub class for backwards compatibility.
  *

--- a/library/Zend/Mail/Transport/Null.php
+++ b/library/Zend/Mail/Transport/Null.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail\Transport;
+
+use Zend\Mail\Message;
+
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "null" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "InMemory", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Null extends InMemory
+{
+    public function __construct()
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\InMemory',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+    }
+}

--- a/library/Zend/Mime/Mime.php
+++ b/library/Zend/Mime/Mime.php
@@ -188,7 +188,7 @@ class Mime
         while (strlen($str) > 0) {
             $currentLine = max(count($lines)-1, 0);
             $token       = static::getNextQuotedPrintableToken($str);
-            $str         = substr($str, strlen($token));
+            $str         = substr($str, strlen($token)) ?: '';
 
             $tmp .= $token;
             if ($token == '=20') {

--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -162,11 +162,12 @@ abstract class AbstractController implements
     {
         $className = get_class($this);
 
+        $nsPos = strpos($className, '\\') ?: 0;
         $events->setIdentifiers(array_merge(
             array(
                 __CLASS__,
                 $className,
-                substr($className, 0, strpos($className, '\\'))
+                substr($className, 0, $nsPos)
             ),
             array_values(class_implements($className)),
             (array) $this->eventIdentifier

--- a/library/Zend/Mvc/Router/Http/Wildcard.php
+++ b/library/Zend/Mvc/Router/Http/Wildcard.php
@@ -74,7 +74,10 @@ class Wildcard implements RouteInterface
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
         } elseif (!is_array($options)) {
-            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable set of options');
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects an array or Traversable set of options',
+                __METHOD__
+            ));
         }
 
         if (!isset($options['key_value_delimiter'])) {
@@ -107,14 +110,14 @@ class Wildcard implements RouteInterface
         }
 
         $uri  = $request->getUri();
-        $path = $uri->getPath();
+        $path = $uri->getPath() ?: '';
 
         if ($path === '/') {
             $path = '';
         }
 
         if ($pathOffset !== null) {
-            $path = substr($path, $pathOffset);
+            $path = substr($path, $pathOffset) ?: '';
         }
 
         $matches = array();

--- a/library/Zend/Mvc/View/Http/InjectTemplateListener.php
+++ b/library/Zend/Mvc/View/Http/InjectTemplateListener.php
@@ -131,6 +131,10 @@ class InjectTemplateListener extends AbstractListenerAggregate
      */
     public function mapController($controller)
     {
+        if (! is_string($controller)) {
+            return false;
+        }
+
         foreach ($this->controllerMap as $namespace => $replacement) {
             if (
                 // Allow disabling rule by setting value to false since config
@@ -146,7 +150,7 @@ class InjectTemplateListener extends AbstractListenerAggregate
             // Map namespace to $replacement if its value is string
             if (is_string($replacement)) {
                 $map = rtrim($replacement, '/') . '/';
-                $controller = substr($controller, strlen($namespace) + 1);
+                $controller = substr($controller, strlen($namespace) + 1) ?: '';
             }
 
             //strip Controller namespace(s) (but not classname)

--- a/library/Zend/Paginator/Adapter/Null.php
+++ b/library/Zend/Paginator/Adapter/Null.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Paginator\Adapter;
+
+class Null extends NullFill
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($count = 0)
+    {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\NullFill',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        parent::__construct($count);
+    }
+}

--- a/library/Zend/Paginator/Adapter/NullFill.php
+++ b/library/Zend/Paginator/Adapter/NullFill.php
@@ -9,7 +9,7 @@
 
 namespace Zend\Paginator\Adapter;
 
-class Null implements AdapterInterface
+class NullFill implements AdapterInterface
 {
     /**
      * Item count

--- a/library/Zend/Paginator/AdapterPluginManager.php
+++ b/library/Zend/Paginator/AdapterPluginManager.php
@@ -21,6 +21,19 @@ use Zend\ServiceManager\AbstractPluginManager;
 class AdapterPluginManager extends AbstractPluginManager
 {
     /**
+     * Default aliases
+     *
+     * Primarily for ensuring previously defined adapters select their
+     * current counterparts.
+     *
+     * @var array
+     */
+    protected $aliases = array(
+        'null'                        => 'nullfill',
+        'Zend\Paginator\Adapter\Null' => 'nullfill',
+    );
+
+    /**
      * Default set of adapters
      *
      * @var array
@@ -28,7 +41,7 @@ class AdapterPluginManager extends AbstractPluginManager
     protected $invokableClasses = array(
         'array'         => 'Zend\Paginator\Adapter\ArrayAdapter',
         'iterator'      => 'Zend\Paginator\Adapter\Iterator',
-        'null'          => 'Zend\Paginator\Adapter\Null',
+        'nullfill'      => 'Zend\Paginator\Adapter\NullFill',
     );
 
     /**

--- a/library/Zend/Server/Reflection.php
+++ b/library/Zend/Server/Reflection.php
@@ -38,7 +38,7 @@ class Reflection
     {
         if (is_object($class)) {
             $reflection = new \ReflectionObject($class);
-        } elseif (class_exists($class)) {
+        } elseif (is_string($class) && class_exists($class)) {
             $reflection = new \ReflectionClass($class);
         } else {
             throw new Reflection\Exception\InvalidArgumentException('Invalid class or object passed to attachClass()');
@@ -71,7 +71,10 @@ class Reflection
     public static function reflectFunction($function, $argv = false, $namespace = '')
     {
         if (!is_string($function) || !function_exists($function)) {
-            throw new Reflection\Exception\InvalidArgumentException('Invalid function "' . $function . '" passed to reflectFunction');
+            throw new Reflection\Exception\InvalidArgumentException(sprintf(
+                'Invalid function "%s" passed to reflectFunction',
+                $function
+            ));
         }
 
         if ($argv && !is_array($argv)) {

--- a/library/Zend/Session/Config/SessionConfig.php
+++ b/library/Zend/Session/Config/SessionConfig.php
@@ -85,7 +85,7 @@ class SessionConfig extends StandardConfig
                 break;
         }
 
-        $result = ini_set($key, $storageValue);
+        $result = ini_set($key, (string) $storageValue);
         if (false === $result) {
             throw new Exception\InvalidArgumentException(
                 "'{$key}' is not a valid sessions-related ini setting."

--- a/library/Zend/Session/SaveHandler/MongoDBOptions.php
+++ b/library/Zend/Session/SaveHandler/MongoDBOptions.php
@@ -76,7 +76,8 @@ class MongoDBOptions extends AbstractOptions
     {
         parent::__construct($options);
 
-        if ($this->saveOptions === array('w' => 1) && version_compare(phpversion('mongo'), '1.3.0', '<')) {
+        $mongoVersion = phpversion('mongo') ?: '0.0.0';
+        if ($this->saveOptions === array('w' => 1) && version_compare($mongoVersion, '1.3.0', '<')) {
             $this->saveOptions = array('safe' => true);
         }
     }
@@ -85,9 +86,9 @@ class MongoDBOptions extends AbstractOptions
      * Override AbstractOptions::__set
      *
      * Validates value if save options are being set.
-     * 
-     * @param string $key 
-     * @param mixed $value 
+     *
+     * @param string $key
+     * @param mixed $value
      */
     public function __set($key, $value)
     {

--- a/library/Zend/Session/SaveHandler/MongoDBOptions.php
+++ b/library/Zend/Session/SaveHandler/MongoDBOptions.php
@@ -82,6 +82,26 @@ class MongoDBOptions extends AbstractOptions
     }
 
     /**
+     * Override AbstractOptions::__set
+     *
+     * Validates value if save options are being set.
+     * 
+     * @param string $key 
+     * @param mixed $value 
+     */
+    public function __set($key, $value)
+    {
+        if (strtolower($key) !== 'saveoptions') {
+            return parent::__set($key, $value);
+        }
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException('Expected array for save options');
+        }
+        $this->setSaveOptions($value);
+    }
+
+    /**
      * Set database name
      *
      * @param string $database

--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -448,7 +448,10 @@ class Server implements ZendServerServer
 
         foreach ($typeMap as $type) {
             if (!is_callable($type['from_xml'])) {
-                throw new Exception\InvalidArgumentException('Invalid from_xml callback for type: ' . $type['type_name']);
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'Invalid from_xml callback for type: %s',
+                    $type['type_name']
+                ));
             }
             if (!is_callable($type['to_xml'])) {
                 throw new Exception\InvalidArgumentException('Invalid to_xml callback for type: ' . $type['type_name']);
@@ -590,7 +593,9 @@ class Server implements ZendServerServer
     public function setClass($class, $namespace = '', $argv = null)
     {
         if (isset($this->class)) {
-            throw new Exception\InvalidArgumentException('A class has already been registered with this soap server instance');
+            throw new Exception\InvalidArgumentException(
+                'A class has already been registered with this soap server instance'
+            );
         }
 
         if (is_object($class)) {
@@ -914,7 +919,7 @@ class Server implements ZendServerServer
 
         // Restore original error handler
         restore_error_handler();
-        ini_set('display_errors', $displayErrorsOriginalState);
+        ini_set('display_errors', (string) $displayErrorsOriginalState);
 
         // Send a fault, if we have one
         if ($fault instanceof SoapFault && !$this->returnResponse) {
@@ -947,7 +952,7 @@ class Server implements ZendServerServer
     protected function _initializeSoapErrorContext()
     {
         $displayErrorsOriginalState = ini_get('display_errors');
-        ini_set('display_errors', false);
+        ini_set('display_errors', '0');
         set_error_handler(array($this, 'handlePhpErrors'), E_USER_ERROR);
         return $displayErrorsOriginalState;
     }
@@ -976,14 +981,18 @@ class Server implements ZendServerServer
             foreach ($class as $row) {
                 $this->registerFaultException($row);
             }
-        } elseif (is_string($class) && class_exists($class) && (is_subclass_of($class, 'Exception') || 'Exception' === $class)) {
+        } elseif (is_string($class)
+            && class_exists($class)
+            && (is_subclass_of($class, 'Exception') || 'Exception' === $class)
+        ) {
             $ref = new ReflectionClass($class);
 
             $this->faultExceptions[] = $ref->getName();
             $this->faultExceptions = array_unique($this->faultExceptions);
         } else {
             throw new Exception\InvalidArgumentException(
-                'Argument for Zend\Soap\Server::registerFaultException should be string or array of strings with valid exception names'
+                'Argument for Zend\Soap\Server::registerFaultException should be'
+                . ' string or array of strings with valid exception names'
             );
         }
 
@@ -1075,7 +1084,14 @@ class Server implements ZendServerServer
             $message = 'Unknown error';
         }
 
-        $allowedFaultModes = array('VersionMismatch', 'MustUnderstand', 'DataEncodingUnknown', 'Sender', 'Receiver', 'Server');
+        $allowedFaultModes = array(
+            'VersionMismatch',
+            'MustUnderstand',
+            'DataEncodingUnknown',
+            'Sender',
+            'Receiver',
+            'Server'
+        );
         if (!in_array($code, $allowedFaultModes)) {
             $code = 'Receiver';
         }

--- a/library/Zend/Text/Figlet/Figlet.php
+++ b/library/Zend/Text/Figlet/Figlet.php
@@ -978,8 +978,9 @@ class Figlet
         $magic = $this->_readMagic($fp);
 
         // Get the header
+        $line = fgets($fp, 1000) ?: '';
         $numsRead = sscanf(
-            fgets($fp, 1000),
+            $line,
             '%*c%c %d %*d %d %d %d %d %d',
             $this->hardBlank,
             $this->charHeight,

--- a/library/Zend/Text/Figlet/Figlet.php
+++ b/library/Zend/Text/Figlet/Figlet.php
@@ -1057,7 +1057,13 @@ class Figlet
         // At the end fetch all extended characters
         while (!feof($fp)) {
             // Get the Unicode
-            list($uniCode) = explode(' ', fgets($fp, 2048));
+            $uniCode = fgets($fp, 2048);
+
+            if (false === $uniCode) {
+                continue;
+            }
+
+            list($uniCode) = explode(' ', $uniCode);
 
             if (empty($uniCode)) {
                 continue;

--- a/library/Zend/Uri/Uri.php
+++ b/library/Zend/Uri/Uri.php
@@ -284,7 +284,7 @@ class Uri implements UriInterface
         // Capture scheme
         if (($scheme = self::parseScheme($uri)) !== null) {
             $this->setScheme($scheme);
-            $uri = substr($uri, strlen($scheme) + 1);
+            $uri = substr($uri, strlen($scheme) + 1) ?: '';
         }
 
         // Capture authority part
@@ -1101,11 +1101,19 @@ class Uri implements UriInterface
                     break;
                 case ($path == '/..'):
                     $path   = '/';
-                    $output = substr($output, 0, strrpos($output, '/', -1));
+                    $lastSlashPos = strrpos($output, '/', -1);
+                    if (false === $lastSlashPos) {
+                        break;
+                    }
+                    $output = substr($output, 0, $lastSlashPos);
                     break;
                 case (substr($path, 0, 4) == '/../'):
                     $path   = '/' . substr($path, 4);
-                    $output = substr($output, 0, strrpos($output, '/', -1));
+                    $lastSlashPos = strrpos($output, '/', -1);
+                    if (false === $lastSlashPos) {
+                        break;
+                    }
+                    $output = substr($output, 0, $lastSlashPos);
                     break;
                 case (substr($path, 0, 3) == '/./'):
                     $path = substr($path, 2);

--- a/library/Zend/Validator/DateStep.php
+++ b/library/Zend/Validator/DateStep.php
@@ -219,7 +219,7 @@ class DateStep extends Date
         $absoluteValueDate = new DateTime($valueDate->format('Y-m-d H:i:s'), new DateTimeZone('UTC'));
         $absoluteBaseDate = new DateTime($baseDate->format('Y-m-d H:i:s'), new DateTimeZone('UTC'));
 
-        $timeDiff  = $absoluteValueDate->diff($absoluteBaseDate, true);
+        $timeDiff  = $absoluteValueDate->diff($absoluteBaseDate, 1);
         $diffParts = array_combine($unitKeys, explode('|', $timeDiff->format('%y|%m|%d|%h|%i|%s')));
 
         if (5 === $partCounts["0"]) {

--- a/library/Zend/Validator/EmailAddress.php
+++ b/library/Zend/Validator/EmailAddress.php
@@ -457,9 +457,12 @@ class EmailAddress extends AbstractValidator
      */
     protected function splitEmailParts($value)
     {
+        $value = is_string($value) ? $value : '';
+
         // Split email address up and disallow '..'
-        if ((strpos($value, '..') !== false) or
-            (!preg_match('/^(.+)@([^@]+)$/', $value, $matches))) {
+        if (strpos($value, '..') !== false
+            || ! preg_match('/^(.+)@([^@]+)$/', $value, $matches)
+        ) {
             return false;
         }
 
@@ -526,7 +529,7 @@ class EmailAddress extends AbstractValidator
     protected function idnToAscii($email)
     {
         if (extension_loaded('intl')) {
-            return idn_to_ascii($email);
+            return (idn_to_ascii($email) ?: $email);
         }
         return $email;
     }

--- a/library/Zend/Validator/Step.php
+++ b/library/Zend/Validator/Step.php
@@ -146,7 +146,9 @@ class Step extends AbstractValidator
         }
 
         //find the maximum precision from both input params to give accurate results
-        $precision = strlen(substr($x, strpos($x, '.')+1)) + strlen(substr($y, strpos($y, '.')+1));
+        $xFloatSegment = substr($x, strpos($x, '.') + 1) ?: '';
+        $yFloatSegment = substr($y, strpos($y, '.') + 1) ?: '';
+        $precision = strlen($xFloatSegment) + strlen($yFloatSegment);
 
         return round($x - $y * floor($x / $y), $precision);
     }

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -15,6 +15,15 @@ use Zend\ServiceManager\ConfigInterface;
 class ValidatorPluginManager extends AbstractPluginManager
 {
     /**
+     * Default aliases
+     *
+     * @var array
+     */
+    protected $aliases = array(
+        'Zend\I18n\Validator\Int'  => 'Zend\I18n\Validator\IsInt',
+    );
+
+    /**
      * Default set of validators
      *
      * @var array
@@ -89,10 +98,12 @@ class ValidatorPluginManager extends AbstractPluginManager
         'iban'                     => 'Zend\Validator\Iban',
         'identical'                => 'Zend\Validator\Identical',
         'inarray'                  => 'Zend\Validator\InArray',
-        'int'                      => 'Zend\I18n\Validator\Int',
+        'int'                      => 'Zend\I18n\Validator\IsInt',
         'ip'                       => 'Zend\Validator\Ip',
         'isbn'                     => 'Zend\Validator\Isbn',
         'isinstanceof'             => 'Zend\Validator\IsInstanceOf',
+        'isint'                    => 'Zend\I18n\Validator\IsInt',
+        'ip'                       => 'Zend\Validator\Ip',
         'lessthan'                 => 'Zend\Validator\LessThan',
         'notempty'                 => 'Zend\Validator\NotEmpty',
         'phonenumber'              => 'Zend\I18n\Validator\PhoneNumber',

--- a/library/Zend/Validator/ValidatorPluginManager.php
+++ b/library/Zend/Validator/ValidatorPluginManager.php
@@ -20,6 +20,7 @@ class ValidatorPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $aliases = array(
+        'Zend\I18n\Validator\Float'=> 'Zend\I18n\Validator\IsFloat',
         'Zend\I18n\Validator\Int'  => 'Zend\I18n\Validator\IsInt',
     );
 
@@ -91,7 +92,7 @@ class ValidatorPluginManager extends AbstractPluginManager
         'fileupload'               => 'Zend\Validator\File\Upload',
         'fileuploadfile'           => 'Zend\Validator\File\UploadFile',
         'filewordcount'            => 'Zend\Validator\File\WordCount',
-        'float'                    => 'Zend\I18n\Validator\Float',
+        'float'                    => 'Zend\I18n\Validator\IsFloat',
         'greaterthan'              => 'Zend\Validator\GreaterThan',
         'hex'                      => 'Zend\Validator\Hex',
         'hostname'                 => 'Zend\Validator\Hostname',
@@ -101,6 +102,7 @@ class ValidatorPluginManager extends AbstractPluginManager
         'int'                      => 'Zend\I18n\Validator\IsInt',
         'ip'                       => 'Zend\Validator\Ip',
         'isbn'                     => 'Zend\Validator\Isbn',
+        'isfloat'                  => 'Zend\I18n\Validator\IsFloat',
         'isinstanceof'             => 'Zend\Validator\IsInstanceOf',
         'isint'                    => 'Zend\I18n\Validator\IsInt',
         'ip'                       => 'Zend\Validator\Ip',

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -208,10 +208,12 @@ class Sitemap extends AbstractHelper
                     $lastmod = date('c', $lastmod);
                 }
 
-                if (!$this->getUseSitemapValidators() ||
-                    $lastmodValidator->isValid($lastmod)) {
+                if (!$this->getUseSitemapValidators()
+                    || $lastmodValidator->isValid($lastmod)
+                ) {
+                    // Cast $lastmod to string in case no validation was used
                     $urlNode->appendChild(
-                        $dom->createElementNS(self::SITEMAP_NS, 'lastmod', $lastmod)
+                        $dom->createElementNS(self::SITEMAP_NS, 'lastmod', (string) $lastmod)
                     );
                 }
             }

--- a/library/Zend/XmlRpc/AbstractValue.php
+++ b/library/Zend/XmlRpc/AbstractValue.php
@@ -201,7 +201,7 @@ abstract class AbstractValue
                 return new Value\Boolean($value);
 
             case self::XMLRPC_TYPE_STRING:
-                return new Value\String($value);
+                return new Value\Text($value);
 
             case self::XMLRPC_TYPE_BASE64:
                 return new Value\Base64($value);
@@ -306,7 +306,7 @@ abstract class AbstractValue
                 // Fall through to the next case
             default:
                 // If type isn't identified (or identified as string), it treated as string
-                return new Value\String($value);
+                return new Value\Text($value);
         }
     }
 
@@ -345,7 +345,7 @@ abstract class AbstractValue
                 $xmlrpcValue = new Value\Boolean($value);
                 break;
             case self::XMLRPC_TYPE_STRING:
-                $xmlrpcValue = new Value\String($value);
+                $xmlrpcValue = new Value\Text($value);
                 break;
             case self::XMLRPC_TYPE_DATETIME:  // The value should already be in an iso8601 format
                 $xmlrpcValue = new Value\DateTime($value);
@@ -394,7 +394,6 @@ abstract class AbstractValue
                     // Maybe we want to throw an exception here ?
                     if (!isset($member->value) or !isset($member->name)) {
                         continue;
-                        //throw new Value_Exception('Member of the '. self::XMLRPC_TYPE_STRUCT .' XML-RPC native type must contain a VALUE tag');
                     }
                     $values[(string) $member->name] = static::_xmlStringToNativeXmlRpc($member->value);
                 }

--- a/library/Zend/XmlRpc/Value/Text.php
+++ b/library/Zend/XmlRpc/Value/Text.php
@@ -9,7 +9,7 @@
 
 namespace Zend\XmlRpc\Value;
 
-class String extends AbstractScalar
+class Text extends AbstractScalar
 {
     /**
      * Set the value of a string native type

--- a/tests/ZendTest/Cache/Pattern/CallbackCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/CallbackCacheTest.php
@@ -148,7 +148,7 @@ class CallbackCacheTest extends CommonPatternTest
         $firstCounter = TestCallbackCache::$fooCounter + 1;
 
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $return = $this->_pattern->call($callback, $args);
         $data = ob_get_clean();
 
@@ -157,7 +157,7 @@ class CallbackCacheTest extends CommonPatternTest
 
         // second call - cached
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $return = $this->_pattern->call($callback, $args);
         $data = ob_get_clean();
 

--- a/tests/ZendTest/Cache/Pattern/ClassCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/ClassCacheTest.php
@@ -106,7 +106,7 @@ class ClassCacheTest extends CommonPatternTest
         $firstCounter = TestClassCache::$fooCounter + 1;
 
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $return = call_user_func_array(array($this->_pattern, $method), $args);
         $data = ob_get_clean();
 
@@ -115,7 +115,7 @@ class ClassCacheTest extends CommonPatternTest
 
         // second call - cached
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $return = call_user_func_array(array($this->_pattern, $method), $args);
         $data = ob_get_clean();
 

--- a/tests/ZendTest/Cache/Pattern/ObjectCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/ObjectCacheTest.php
@@ -159,7 +159,7 @@ class ObjectCacheTest extends CommonPatternTest
         $firstCounter = TestObjectCache::$fooCounter + 1;
 
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $return = call_user_func_array($callback, $args);
         $data = ob_get_contents();
         ob_end_clean();
@@ -169,7 +169,7 @@ class ObjectCacheTest extends CommonPatternTest
 
         // second call - cached
         ob_start();
-        ob_implicit_flush(false);
+        ob_implicit_flush(0);
         $return = call_user_func_array($callback, $args);
         $data = ob_get_contents();
         ob_end_clean();

--- a/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/CommonAdapterTest.php
@@ -1157,6 +1157,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
      */
     protected function waitForFullSecond()
     {
-        usleep((microtime(true)-time()) * 1000000);
+        $interval = (microtime(true)-time()) * 1000000;
+        usleep((int) $interval);
     }
 }

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -108,8 +108,8 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("return 'function11';", trim($body));
 
         $function = new FunctionReflection('ZendTest\Code\Reflection\TestAsset\function12');
-        $body = $function->getBody();
-        $this->assertEquals("", trim($body));
+        $body = $function->getBody() ?: '';
+        $this->assertEquals('', trim($body));
     }
 
     public function testFunctionClosureBodyReturn()
@@ -152,8 +152,8 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("return 'function 8';", trim($body));
 
         $function = new FunctionReflection($function9);
-        $body = $function->getBody();
-        $this->assertEquals("", trim($body));
+        $body = $function->getBody() ?: '';
+        $this->assertEquals('', trim($body));
 
         $function = new FunctionReflection($function10);
         $body = $function->getBody();

--- a/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FunctionReflectionTest.php
@@ -226,7 +226,7 @@ class FunctionReflectionTest extends \PHPUnit_Framework_TestCase
         $function = new FunctionReflection($function9);
         $content = $function->getContents(false);
         $this->assertEquals("function() {}", trim($content));
-        
+
         $function = new FunctionReflection($function10);
         $content = $function->getContents(false);
         $this->assertEquals("function() { return 'function10'; }", trim($content));

--- a/tests/ZendTest/Console/RequestTest.php
+++ b/tests/ZendTest/Console/RequestTest.php
@@ -35,7 +35,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($params->toArray(), array('foo' => 'baz', 'bar'));
         $this->assertEquals($request->getParam('foo'), 'baz');
         $this->assertEquals($request->getScriptName(), 'foo.php');
-        $this->assertEquals(1, count($request->env()));
+        $this->assertGreaterThanOrEqual(1, count($request->env()));
         $this->assertEquals($request->env()->get('FOO_VAR'), 'bar');
         $this->assertEquals($request->getEnv('FOO_VAR'), 'bar');
     }

--- a/tests/ZendTest/Console/RouteMatcher/DefaultRouteMatcherTest.php
+++ b/tests/ZendTest/Console/RouteMatcher/DefaultRouteMatcherTest.php
@@ -1323,7 +1323,7 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
             'filters-single' => array(
                 '<number>',
                 array(
-                    'number' => new \Zend\Filter\Int()
+                    'number' => new \Zend\Filter\ToInt()
                 ),
                 array('123four'),
                 array(
@@ -1333,7 +1333,7 @@ class DefaultRouteMatcherTest extends \PHPUnit_Framework_TestCase
             'filters-multiple' => array(
                 '<number> <strtolower>',
                 array(
-                    'number' => new \Zend\Filter\Int(),
+                    'number' => new \Zend\Filter\ToInt(),
                     'strtolower' => new \Zend\Filter\StringToLower(),
                 ),
                 array('nan', 'FOOBAR'),

--- a/tests/ZendTest/Console/TestAssets/ConsoleAdapter.php
+++ b/tests/ZendTest/Console/TestAssets/ConsoleAdapter.php
@@ -47,7 +47,7 @@ class ConsoleAdapter extends AbstractAdapter
         if ($this->autoRewind) {
             rewind($this->stream);
         }
-        $line = stream_get_line($this->stream, $maxLength, PHP_EOL);
+        $line = stream_get_line($this->stream, $maxLength, PHP_EOL) ?: '';
         return rtrim($line, PHP_EOL);
     }
 

--- a/tests/ZendTest/Crypt/Key/Derivation/ScryptTest.php
+++ b/tests/ZendTest/Crypt/Key/Derivation/ScryptTest.php
@@ -168,7 +168,7 @@ class ScryptTest extends \PHPUnit_Framework_TestCase
             if (extension_loaded('Scrypt') && ($size < 16)) {
                 $this->setExpectedException('Zend\Crypt\Key\Derivation\Exception\InvalidArgumentException');
             }
-            $result = Scrypt::calc('test', 'salt', 16, 1, 1, $size);
+            $result = Scrypt::calc('test', 'salt', 16, 1, 1, $size) ?: '';
             $this->assertEquals($size, strlen($result));
         }
     }

--- a/tests/ZendTest/Db/Sql/Ddl/Column/FloatTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/FloatTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Db\Sql\Ddl\Column;
+
+use Zend\Db\Sql\Ddl\Column\Float as FloatColumn;
+
+class FloatTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Float column under PHP 7; reserved keyword');
+        }
+    }
+
+    public function testRaisesDeprecationNoticeOnInstantiation()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new FloatColumn('foo', 10, 5);
+    }
+}

--- a/tests/ZendTest/Db/Sql/Ddl/Column/FloatingTest.php
+++ b/tests/ZendTest/Db/Sql/Ddl/Column/FloatingTest.php
@@ -9,18 +9,22 @@
 
 namespace ZendTest\Db\Sql\Ddl\Column;
 
-use Zend\Db\Sql\Ddl\Column\Float;
+use Zend\Db\Sql\Ddl\Column\Floating;
 
-class FloatTest extends \PHPUnit_Framework_TestCase
+class FloatingTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Zend\Db\Sql\Ddl\Column\Float::getExpressionData
+     * @covers Zend\Db\Sql\Ddl\Column\Floating::getExpressionData
      */
     public function testGetExpressionData()
     {
-        $column = new Float('foo', 10, 5);
+        $column = new Floating('foo', 10, 5);
         $this->assertEquals(
-            array(array('%s %s NOT NULL', array('foo', 'FLOAT(10,5)'), array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL))),
+            array(array(
+                '%s %s NOT NULL',
+                array('foo', 'FLOAT(10,5)'),
+                array($column::TYPE_IDENTIFIER, $column::TYPE_LITERAL)
+            )),
             $column->getExpressionData()
         );
     }

--- a/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/IbmDb2/SelectDecoratorTest.php
@@ -57,7 +57,7 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
      * @covers Zend\Db\Sql\Platform\IbmDb2\SelectDecorator::getSqlString
      * @dataProvider dataProvider
      */
-    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
+    public function testGetSqlString(Select $select, $ignored0, $ignored1, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');

--- a/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Mysql/SelectDecoratorTest.php
@@ -58,7 +58,7 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
      * @covers Zend\Db\Sql\Platform\Mysql\SelectDecorator::processOffset
      * @dataProvider dataProvider
      */
-    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
+    public function testGetSqlString(Select $select, $ignore, $alsoIgnore, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');

--- a/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/Oracle/SelectDecoratorTest.php
@@ -55,7 +55,7 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
      * @covers Zend\Db\Sql\Platform\Oracle\SelectDecorator::getSqlString
      * @dataProvider dataProvider
      */
-    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
+    public function testGetSqlString(Select $select, $ignored, $alsoIgnored, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');

--- a/tests/ZendTest/Db/Sql/Platform/SqlServer/SelectDecoratorTest.php
+++ b/tests/ZendTest/Db/Sql/Platform/SqlServer/SelectDecoratorTest.php
@@ -56,7 +56,7 @@ class SelectDecoratorTest extends \PHPUnit_Framework_TestCase
      * @covers Zend\Db\Sql\Platform\SqlServer\SelectDecorator::processLimitOffset
      * @dataProvider dataProvider
      */
-    public function testGetSqlString(Select $select, $notUsed, $notUsed, $expectedSql)
+    public function testGetSqlString(Select $select, $ignored, $alsoIgnored, $expectedSql)
     {
         $parameterContainer = new ParameterContainer;
         $statement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');

--- a/tests/ZendTest/Di/DiCompatibilityTest.php
+++ b/tests/ZendTest/Di/DiCompatibilityTest.php
@@ -44,7 +44,7 @@ class DiCompatibilityTest extends \PHPUnit_Framework_TestCase
         return array(
             array('Zend\Di\Di'),
             array('Zend\EventManager\EventManager'),
-            array('Zend\Filter\Null'),
+            array('Zend\Filter\ToNull'),
             array('Zend\Form\Form'),
             array('Zend\Log\Logger'),
             array('Zend\Stdlib\SplStack'),

--- a/tests/ZendTest/Di/DiCompatibilityTest.php
+++ b/tests/ZendTest/Di/DiCompatibilityTest.php
@@ -60,6 +60,10 @@ class DiCompatibilityTest extends \PHPUnit_Framework_TestCase
      */
     public function testRaiseErrorMissingConstructorRequiredParameter($class)
     {
+        if (version_compare(PHP_VERSION, '7', '>=')) {
+            $this->markTestSkipped('Errors have changed to E_FATAL, no longer allowing test to run');
+        }
+
         $phpunit = $this;
         $caught  = false;
         set_error_handler(function ($errno, $errstr) use ($phpunit, &$caught) {

--- a/tests/ZendTest/Filter/FilterPluginManagerTest.php
+++ b/tests/ZendTest/Filter/FilterPluginManagerTest.php
@@ -24,7 +24,7 @@ class FilterPluginManagerTest extends \PHPUnit_Framework_TestCase
     public function testFilterSuccessfullyRetrieved()
     {
         $filter = $this->filters->get('int');
-        $this->assertInstanceOf('Zend\Filter\Int', $filter);
+        $this->assertInstanceOf('Zend\Filter\ToInt', $filter);
     }
 
     public function testRegisteringInvalidFilterRaisesException()

--- a/tests/ZendTest/Filter/IntTest.php
+++ b/tests/ZendTest/Filter/IntTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Filter;
+
+use Zend\Filter\Int as IntFilter;
+
+/**
+ * @group      Zend_Filter
+ */
+class IntTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Int filter under PHP 7; reserved keyword');
+        }
+    }
+
+    public function testRaisesNoticeOnInstantiation()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new IntFilter();
+    }
+}

--- a/tests/ZendTest/Filter/NullTest.php
+++ b/tests/ZendTest/Filter/NullTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Filter;
+
+use Zend\Filter\Null as NullFilter;
+
+/**
+ * @group      Zend_Filter
+ */
+class NullTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Null filter under PHP 7; reserved keyword');
+        }
+    }
+
+    public function testRaisesNoticeOnInstantiation()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new NullFilter();
+    }
+}

--- a/tests/ZendTest/Filter/ToIntTest.php
+++ b/tests/ZendTest/Filter/ToIntTest.php
@@ -9,12 +9,12 @@
 
 namespace ZendTest\Filter;
 
-use Zend\Filter\Int as IntFilter;
+use Zend\Filter\ToInt as ToIntFilter;
 
 /**
  * @group      Zend_Filter
  */
-class IntTest extends \PHPUnit_Framework_TestCase
+class ToIntTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Ensures that the filter follows expected behavior
@@ -23,7 +23,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
      */
     public function testBasic()
     {
-        $filter = new IntFilter();
+        $filter = new ToIntFilter();
 
         $valuesExpected = array(
             'string' => 0,
@@ -57,7 +57,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
      */
     public function testReturnUnfiltered($input)
     {
-        $filter = new IntFilter();
+        $filter = new ToIntFilter();
 
         $this->assertEquals($input, $filter($input));
     }

--- a/tests/ZendTest/Filter/ToNullTest.php
+++ b/tests/ZendTest/Filter/ToNullTest.php
@@ -9,27 +9,27 @@
 
 namespace ZendTest\Filter;
 
-use Zend\Filter\Null as NullFilter;
+use Zend\Filter\ToNull as ToNullFilter;
 
 /**
  * @group      Zend_Filter
  */
-class NullTest extends \PHPUnit_Framework_TestCase
+class ToNullTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorOptions()
     {
-        $filter = new NullFilter(array(
-            'type' => NullFilter::TYPE_INTEGER,
+        $filter = new ToNullFilter(array(
+            'type' => ToNullFilter::TYPE_INTEGER,
         ));
 
-        $this->assertEquals(NullFilter::TYPE_INTEGER, $filter->getType());
+        $this->assertEquals(ToNullFilter::TYPE_INTEGER, $filter->getType());
     }
 
     public function testConstructorParams()
     {
-        $filter = new NullFilter(NullFilter::TYPE_INTEGER);
+        $filter = new ToNullFilter(ToNullFilter::TYPE_INTEGER);
 
-        $this->assertEquals(NullFilter::TYPE_INTEGER, $filter->getType());
+        $this->assertEquals(ToNullFilter::TYPE_INTEGER, $filter->getType());
     }
 
     /**
@@ -39,7 +39,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefault($value, $expected)
     {
-        $filter = new NullFilter();
+        $filter = new ToNullFilter();
         $this->assertSame($expected, $filter->filter($value));
     }
 
@@ -50,7 +50,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
      */
     public function testTypes($type, $testData)
     {
-        $filter = new NullFilter($type);
+        $filter = new ToNullFilter($type);
         foreach ($testData as $data) {
             list($value, $expected) = $data;
             $message = sprintf(
@@ -72,7 +72,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
     public function testCombinedTypes($typeData, $testData)
     {
         foreach ($typeData as $type) {
-            $filter = new NullFilter(array('type' => $type));
+            $filter = new ToNullFilter(array('type' => $type));
             foreach ($testData as $data) {
                 list($value, $expected) = $data;
                 $message = sprintf(
@@ -89,14 +89,14 @@ class NullTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingFalseType()
     {
-        $filter = new NullFilter();
+        $filter = new ToNullFilter();
         $this->setExpectedException('\Zend\Filter\Exception\InvalidArgumentException', 'Unknown type value');
         $filter->setType(true);
     }
 
     public function testGettingDefaultType()
     {
-        $filter = new NullFilter();
+        $filter = new ToNullFilter();
         $this->assertEquals(63, $filter->getType());
     }
 
@@ -123,7 +123,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                NullFilter::TYPE_BOOLEAN,
+                ToNullFilter::TYPE_BOOLEAN,
                 array(
                     array(null, null),
                     array(false, null),
@@ -141,7 +141,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                NullFilter::TYPE_INTEGER,
+                ToNullFilter::TYPE_INTEGER,
                 array(
                     array(null, null),
                     array(false, false),
@@ -159,7 +159,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                NullFilter::TYPE_EMPTY_ARRAY,
+                ToNullFilter::TYPE_EMPTY_ARRAY,
                 array(
                     array(null, null),
                     array(false, false),
@@ -177,7 +177,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                NullFilter::TYPE_STRING,
+                ToNullFilter::TYPE_STRING,
                 array(
                     array(null, null),
                     array(false, false),
@@ -195,7 +195,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                NullFilter::TYPE_ZERO_STRING,
+                ToNullFilter::TYPE_ZERO_STRING,
                 array(
                     array(null, null),
                     array(false, false),
@@ -213,7 +213,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                NullFilter::TYPE_FLOAT,
+                ToNullFilter::TYPE_FLOAT,
                 array(
                     array(null, null),
                     array(false, false),
@@ -231,7 +231,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                NullFilter::TYPE_ALL,
+                ToNullFilter::TYPE_ALL,
                 array(
                     array(null, null),
                     array(false, null),
@@ -257,17 +257,17 @@ class NullTest extends \PHPUnit_Framework_TestCase
             array(
                 array(
                     array(
-                        NullFilter::TYPE_ZERO_STRING,
-                        NullFilter::TYPE_STRING,
-                        NullFilter::TYPE_BOOLEAN,
+                        ToNullFilter::TYPE_ZERO_STRING,
+                        ToNullFilter::TYPE_STRING,
+                        ToNullFilter::TYPE_BOOLEAN,
                     ),
                     array(
                         'zero',
                         'string',
                         'boolean',
                     ),
-                    NullFilter::TYPE_ZERO_STRING | NullFilter::TYPE_STRING | NullFilter::TYPE_BOOLEAN,
-                    NullFilter::TYPE_ZERO_STRING + NullFilter::TYPE_STRING + NullFilter::TYPE_BOOLEAN,
+                    ToNullFilter::TYPE_ZERO_STRING | ToNullFilter::TYPE_STRING | ToNullFilter::TYPE_BOOLEAN,
+                    ToNullFilter::TYPE_ZERO_STRING + ToNullFilter::TYPE_STRING + ToNullFilter::TYPE_BOOLEAN,
                 ),
                 array(
                     array(null, null),

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -356,7 +356,9 @@ class CollectionTest extends TestCase
         $this->productFieldset->setUseAsBaseFieldset(true);
         $form->add($this->productFieldset);
 
-        $originalObjectHash = spl_object_hash($this->productFieldset->get("categories")->getTargetElement()->getObject());
+        $originalObjectHash = spl_object_hash(
+            $this->productFieldset->get("categories")->getTargetElement()->getObject()
+        );
 
         $product = new Product();
         $product->setName("foo");
@@ -383,7 +385,9 @@ class CollectionTest extends TestCase
             )
         );
 
-        $objectAfterExtractHash = spl_object_hash($this->productFieldset->get("categories")->getTargetElement()->getObject());
+        $objectAfterExtractHash = spl_object_hash(
+            $this->productFieldset->get("categories")->getTargetElement()->getObject()
+        );
 
         $this->assertSame($originalObjectHash, $objectAfterExtractHash);
     }
@@ -391,7 +395,7 @@ class CollectionTest extends TestCase
     public function testDoesNotCreateNewObjects()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -434,7 +438,7 @@ class CollectionTest extends TestCase
     public function testCreatesNewObjectsIfSpecified()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -574,7 +578,10 @@ class CollectionTest extends TestCase
         $form->setHydrator(new \Zend\Stdlib\Hydrator\ObjectProperty());
 
         $product = new Product();
-        $categories = array(new \ZendTest\Form\TestAsset\Entity\Category(), new \ZendTest\Form\TestAsset\Entity\Category());
+        $categories = array(
+            new \ZendTest\Form\TestAsset\Entity\Category(),
+            new \ZendTest\Form\TestAsset\Entity\Category(),
+        );
         $product->setCategories($categories);
 
         $market = new \StdClass();
@@ -784,8 +791,14 @@ class CollectionTest extends TestCase
             $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Product', $_productFieldset->getObject());
 
             // test for collection -> fieldset -> fieldset
-            $this->assertInstanceOf('ZendTest\Form\TestAsset\CountryFieldset', $_productFieldset->get('made_in_country'));
-            $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Country', $_productFieldset->get('made_in_country')->getObject());
+            $this->assertInstanceOf(
+                'ZendTest\Form\TestAsset\CountryFieldset',
+                $_productFieldset->get('made_in_country')
+            );
+            $this->assertInstanceOf(
+                'ZendTest\Form\TestAsset\Entity\Country',
+                $_productFieldset->get('made_in_country')->getObject()
+            );
 
             // test for collection -> fieldset -> collection
             $_productCategories = $_productFieldset->get('categories');
@@ -1059,7 +1072,10 @@ class CollectionTest extends TestCase
                         break;
                     case 'phones':
                         foreach ($_childFieldset->getFieldsets() as $_phoneFieldset) {
-                            $this->assertInstanceOf('ZendTest\Form\TestAsset\Entity\Phone', $_phoneFieldset->getObject());
+                            $this->assertInstanceOf(
+                                'ZendTest\Form\TestAsset\Entity\Phone',
+                                $_phoneFieldset->getObject()
+                            );
                         }
                         break;
                 }

--- a/tests/ZendTest/Form/Element/RangeTest.php
+++ b/tests/ZendTest/Form/Element/RangeTest.php
@@ -17,7 +17,7 @@ class RangeTest extends TestCase
     public function testProvidesInputSpecificationWithDefaultAttributes()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -28,7 +28,7 @@ class RangeTest extends TestCase
         $this->assertInternalType('array', $inputSpec['validators']);
 
         $expectedClasses = array(
-            'Zend\I18n\Validator\Float',
+            'Zend\I18n\Validator\IsFloat',
             'Zend\Validator\GreaterThan',
             'Zend\Validator\LessThan',
             'Zend\Validator\Step',
@@ -57,7 +57,7 @@ class RangeTest extends TestCase
     public function testProvidesInputSpecificationThatIncludesValidator()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -74,7 +74,7 @@ class RangeTest extends TestCase
         $this->assertInternalType('array', $inputSpec['validators']);
 
         $expectedClasses = array(
-            'Zend\I18n\Validator\Float',
+            'Zend\I18n\Validator\IsFloat',
             'Zend\Validator\GreaterThan',
             'Zend\Validator\LessThan',
             'Zend\Validator\Step',

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -209,7 +209,7 @@ class FormTest extends TestCase
     public function testHasValidatedFlag()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -253,7 +253,7 @@ class FormTest extends TestCase
     public function testSpecifyingValidationGroupForcesPartialValidation()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -275,7 +275,7 @@ class FormTest extends TestCase
     public function testSpecifyingValidationGroupForNestedFieldsetsForcesPartialValidation()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -954,8 +954,10 @@ class FormTest extends TestCase
         $this->assertEquals('basic_fieldset[field]', $basicFieldset->get('field')->getName());
 
         $nestedFieldset = $basicFieldset->get('nested_fieldset');
-        $this->assertEquals('basic_fieldset[nested_fieldset][anotherField]', $nestedFieldset->get('anotherField')
-            ->getName());
+        $this->assertEquals(
+            'basic_fieldset[nested_fieldset][anotherField]',
+            $nestedFieldset->get('anotherField')->getName()
+        );
     }
 
     public function testCanCorrectlyExtractDataFromComposedEntities()
@@ -1001,7 +1003,7 @@ class FormTest extends TestCase
     public function testCanCorrectlyExtractDataFromOneToManyRelationship()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -1493,7 +1495,7 @@ class FormTest extends TestCase
     public function testPreserveEntitiesBoundToCollectionAfterValidation()
     {
         if (!extension_loaded('intl')) {
-            // Required by \Zend\I18n\Validator\Float
+            // Required by \Zend\I18n\Validator\IsFloat
             $this->markTestSkipped('ext/intl not enabled');
         }
 
@@ -1662,8 +1664,9 @@ class FormTest extends TestCase
         $factory = new Factory();
         $this->form = $factory->createForm($spec);
         $this->form->setPreferFormInputFilter(true);
-        $this->assertFalse($this->form->getInputFilter()->get('element')
-            ->isRequired());
+        $this->assertFalse(
+            $this->form->getInputFilter()->get('element')->isRequired()
+        );
     }
 
     /**

--- a/tests/ZendTest/Form/TestAsset/Annotation/EntityUsingInstanceProperty.php
+++ b/tests/ZendTest/Form/TestAsset/Annotation/EntityUsingInstanceProperty.php
@@ -12,12 +12,12 @@ namespace ZendTest\Form\TestAsset\Annotation;
 use Zend\Form\Annotation;
 
 /**
- * @Annotation\Options({"use_as_base_fieldset":true})
- */
-class EntityUsingObjectProperty
+* @Annotation\Options({"use_as_base_fieldset":true})
+*/
+class EntityUsingInstanceProperty
 {
     /**
-     * @Annotation\Object("ZendTest\Form\TestAsset\Annotation\Entity")
+     * @Annotation\Instance("ZendTest\Form\TestAsset\Annotation\Entity")
      * @Annotation\Type("Zend\Form\Fieldset")
      * @Annotation\Hydrator({"type":"Zend\Stdlib\Hydrator\ClassMethods", "options": {"underscoreSeparatedKeys": false}})
      */

--- a/tests/ZendTest/Form/TestAsset/ProductFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/ProductFieldset.php
@@ -81,7 +81,7 @@ class ProductFieldset extends Fieldset implements InputFilterProviderInterface
                 'required' => true,
                 'validators' => array(
                     array(
-                        'name' => 'Float'
+                        'name' => 'IsFloat'
                     )
                 )
             ),

--- a/tests/ZendTest/Http/Client/CurlTest.php
+++ b/tests/ZendTest/Http/Client/CurlTest.php
@@ -116,6 +116,10 @@ class CurlTest extends CommonHttpTests
      */
     public function testSettingInvalidCurlOption()
     {
+        if (version_compare(PHP_VERSION, 7, 'gte')) {
+            $this->markTestSkipped('Test is invalid for PHP version 7');
+        }
+
         $config = array(
             'adapter'     => 'Zend\Http\Client\Adapter\Curl',
             'curloptions' => array(CURLOPT_CLOSEPOLICY => true),

--- a/tests/ZendTest/Http/Header/DateTest.php
+++ b/tests/ZendTest/Http/Header/DateTest.php
@@ -37,7 +37,7 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Http\Header\Date', $dateHeader);
 
         $date     = new \DateTime(null, new \DateTimeZone('GMT'));
-        $interval = $dateHeader->date()->diff($date, true);
+        $interval = $dateHeader->date()->diff($date, 1);
 
         $this->assertSame('+12 hours 00 minutes 00 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
     }
@@ -50,7 +50,7 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Zend\Http\Header\Date', $dateHeader);
 
         $date     = new \DateTime(null, new \DateTimeZone('GMT'));
-        $interval = $dateHeader->date()->diff($date, true);
+        $interval = $dateHeader->date()->diff($date, 1);
 
         $this->assertSame('+12 hours 00 minutes 00 seconds', $interval->format('%R%H hours %I minutes %S seconds'));
     }

--- a/tests/ZendTest/I18n/Validator/FloatTest.php
+++ b/tests/ZendTest/I18n/Validator/FloatTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\I18n\Validator;
+
+use Zend\I18n\Validator\Float as FloatValidator;
+use Locale;
+
+/**
+ * @group      Zend_Validator
+ */
+class FloatTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FloatValidator
+     */
+    protected $validator;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Float validator under PHP 7; reserved keyword');
+        }
+
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
+        $this->locale = Locale::getDefault();
+    }
+
+    public function tearDown()
+    {
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->locale);
+        }
+    }
+
+    public function testConstructorRaisesDeprecationNotice()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new FloatValidator();
+    }
+}

--- a/tests/ZendTest/I18n/Validator/IntTest.php
+++ b/tests/ZendTest/I18n/Validator/IntTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\I18n\Validator;
+
+use Zend\I18n\Validator\Int as IntValidator;
+use Locale;
+
+/**
+ * @group      Zend_Validator
+ */
+class IntTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Int
+     */
+    protected $validator;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Int validator under PHP 7; reserved keyword');
+        }
+
+        if (!extension_loaded('intl')) {
+            $this->markTestSkipped('ext/intl not enabled');
+        }
+
+        $this->locale = Locale::getDefault();
+    }
+
+    public function tearDown()
+    {
+        if (extension_loaded('intl')) {
+            Locale::setDefault($this->locale);
+        }
+    }
+
+    public function testConstructorRaisesDeprecationNotice()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new IntValidator();
+    }
+}

--- a/tests/ZendTest/I18n/Validator/IsFloatTest.php
+++ b/tests/ZendTest/I18n/Validator/IsFloatTest.php
@@ -9,17 +9,17 @@
 
 namespace ZendTest\I18n\Validator;
 
-use Zend\I18n\Validator\Float as FloatValidator;
+use Zend\I18n\Validator\IsFloat as IsFloatValidator;
 use Locale;
 use NumberFormatter;
 
 /**
  * @group      Zend_Validator
  */
-class FloatTest extends \PHPUnit_Framework_TestCase
+class IsFloatTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var FloatValidator
+     * @var IsFloatValidator
      */
     protected $validator;
 
@@ -35,7 +35,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->locale    = Locale::getDefault();
-        $this->validator = new FloatValidator(array('locale' => 'en'));
+        $this->validator = new IsFloatValidator(array('locale' => 'en'));
     }
 
     public function tearDown()
@@ -211,7 +211,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     public function testUsingApplicationLocale()
     {
         Locale::setDefault('de');
-        $valid = new FloatValidator();
+        $valid = new IsFloatValidator();
         $this->assertEquals('de', $valid->getLocale());
     }
 

--- a/tests/ZendTest/I18n/Validator/IsIntTest.php
+++ b/tests/ZendTest/I18n/Validator/IsIntTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\I18n\Validator;
 
-use Zend\I18n\Validator\Int as IntValidator;
+use Zend\I18n\Validator\IsInt as IsIntValidator;
 use Locale;
 
 /**
  * @group      Zend_Validator
  */
-class IntTest extends \PHPUnit_Framework_TestCase
+class IsIntTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Int
@@ -34,7 +34,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->locale    = Locale::getDefault();
-        $this->validator = new IntValidator();
+        $this->validator = new IsIntValidator();
     }
 
     public function tearDown()
@@ -107,7 +107,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
     public function testUsingApplicationLocale()
     {
         Locale::setDefault('de');
-        $valid = new IntValidator();
+        $valid = new IsIntValidator();
         $this->assertTrue($valid->isValid('10.000'));
     }
 
@@ -117,7 +117,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
     public function testLocaleDetectsNoEnglishLocaleOnOtherSetLocale()
     {
         Locale::setDefault('de');
-        $valid = new IntValidator();
+        $valid = new IsIntValidator();
         $this->assertTrue($valid->isValid(1200));
         $this->assertFalse($valid->isValid('1,200'));
     }
@@ -125,7 +125,10 @@ class IntTest extends \PHPUnit_Framework_TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'),
-                                     'messageTemplates', $validator);
+        $this->assertAttributeEquals(
+            $validator->getOption('messageTemplates'),
+            'messageTemplates',
+            $validator
+        );
     }
 }

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -182,7 +182,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadingScalarJSONResponseShouldThrowException($json)
     {
-        $this->setExpectedException('Zend\Json\Server\Exception\RuntimeException');
+        $this->setExpectedException('Zend\Json\Exception\RuntimeException');
         $this->response->loadJson($json);
     }
 

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -105,7 +105,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $writers = $this->logger->getWriters();
         $this->assertInstanceOf('Zend\Stdlib\SplPriorityQueue', $writers);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Null);
+        $this->assertTrue($writer instanceof \Zend\Log\Writer\Noop);
         $writer = $writers->extract();
         $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
     }
@@ -120,7 +120,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Zend\Stdlib\SplPriorityQueue', $writers);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Null);
+        $this->assertTrue($writer instanceof \Zend\Log\Writer\Noop);
         $writer = $writers->extract();
         $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
     }
@@ -137,7 +137,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $writer = $writers->extract();
         $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Null);
+        $this->assertTrue($writer instanceof \Zend\Log\Writer\Noop);
     }
 
     public function testLogging()

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Log;
 
 use Exception;
 use ErrorException;
-use PHPUnit_Framework_Exception;
 use Zend\Log\Logger;
 use Zend\Log\Processor\Backtrace;
 use Zend\Log\Writer\Mock as MockWriter;

--- a/tests/ZendTest/Log/Writer/NoopTest.php
+++ b/tests/ZendTest/Log/Writer/NoopTest.php
@@ -9,16 +9,16 @@
 
 namespace ZendTest\Log\Writer;
 
-use Zend\Log\Writer\Null as NullWriter;
+use Zend\Log\Writer\Noop as NoopWriter;
 
 /**
  * @group      Zend_Log
  */
-class NullTest extends \PHPUnit_Framework_TestCase
+class NoopTest extends \PHPUnit_Framework_TestCase
 {
     public function testWrite()
     {
-        $writer = new NullWriter();
+        $writer = new NoopWriter();
         $writer->write(array('message' => 'foo', 'priority' => 42));
     }
 }

--- a/tests/ZendTest/Log/Writer/NullTest.php
+++ b/tests/ZendTest/Log/Writer/NullTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Log\Writer;
+
+use Zend\Log\Writer\Null as NullWriter;
+
+/**
+ * @group      Zend_Log
+ */
+class NullTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Null log writer under PHP 7; reserved keyword');
+        }
+    }
+
+    public function testRaisesNoticeOnInstantiation()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new NullWriter();
+    }
+}

--- a/tests/ZendTest/Mail/Transport/FactoryTest.php
+++ b/tests/ZendTest/Mail/Transport/FactoryTest.php
@@ -56,12 +56,18 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
     public function typeProvider()
     {
-        return array(
+        $types = array(
             array('Zend\Mail\Transport\File'),
-            array('Zend\Mail\Transport\Null'),
+            array('Zend\Mail\Transport\InMemory'),
             array('Zend\Mail\Transport\Sendmail'),
             array('Zend\Mail\Transport\Smtp'),
         );
+
+        if (version_compare(PHP_VERSION, '7.0', '<')) {
+            $types[] = array('Zend\Mail\Transport\Null');
+        }
+
+        return $types;
     }
 
     /**
@@ -82,12 +88,15 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         return array(
             array('file', 'Zend\Mail\Transport\File'),
-            array('null', 'Zend\Mail\Transport\Null'),
+            array('null', 'Zend\Mail\Transport\InMemory'),
+            array('memory', 'Zend\Mail\Transport\InMemory'),
+            array('inmemory', 'Zend\Mail\Transport\InMemory'),
+            array('InMemory', 'Zend\Mail\Transport\InMemory'),
             array('sendmail', 'Zend\Mail\Transport\Sendmail'),
             array('smtp', 'Zend\Mail\Transport\Smtp'),
             array('File', 'Zend\Mail\Transport\File'),
-            array('Null', 'Zend\Mail\Transport\Null'),
-            array('NULL', 'Zend\Mail\Transport\Null'),
+            array('Null', 'Zend\Mail\Transport\InMemory'),
+            array('NULL', 'Zend\Mail\Transport\InMemory'),
             array('Sendmail', 'Zend\Mail\Transport\Sendmail'),
             array('SendMail', 'Zend\Mail\Transport\Sendmail'),
             array('Smtp', 'Zend\Mail\Transport\Smtp'),
@@ -106,7 +115,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
         $transport = Factory::create($spec);
 
-        $this->assertInstanceOf('Zend\Mail\Transport\Null', $transport);
+        $this->assertInstanceOf('Zend\Mail\Transport\InMemory', $transport);
     }
 
     /**

--- a/tests/ZendTest/Mail/Transport/FactoryTest.php
+++ b/tests/ZendTest/Mail/Transport/FactoryTest.php
@@ -47,9 +47,14 @@ class FactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testCanCreateClassUsingTypeKey($type)
     {
+        set_error_handler(function ($code, $message) {
+            // skip deprecation notices
+            return;
+        }, E_USER_DEPRECATED);
         $transport = Factory::create(array(
             'type' => $type,
         ));
+        restore_error_handler();
 
         $this->assertInstanceOf($type, $transport);
     }

--- a/tests/ZendTest/Mail/Transport/InMemoryTest.php
+++ b/tests/ZendTest/Mail/Transport/InMemoryTest.php
@@ -10,12 +10,12 @@
 namespace ZendTest\Mail\Transport;
 
 use Zend\Mail\Message;
-use Zend\Mail\Transport\Null;
+use Zend\Mail\Transport\InMemory;
 
 /**
  * @group      Zend_Mail
  */
-class NullTest extends \PHPUnit_Framework_TestCase
+class InMemoryTest extends \PHPUnit_Framework_TestCase
 {
     public function getMessage()
     {
@@ -39,7 +39,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
     public function testReceivesMailArtifacts()
     {
         $message = $this->getMessage();
-        $transport = new Null();
+        $transport = new InMemory();
 
         $transport->send($message);
 

--- a/tests/ZendTest/Mail/Transport/NullTest.php
+++ b/tests/ZendTest/Mail/Transport/NullTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mail\Transport;
+
+use Zend\Mail\Transport\Null as NullTransport;
+
+/**
+ * @group      Zend_Mail
+ */
+class NullTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Null transport under PHP 7; reserved keyword');
+        }
+    }
+
+    public function testRaisesNoticeOnInstantiation()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new NullTransport();
+    }
+}

--- a/tests/ZendTest/Paginator/Adapter/NullFillTest.php
+++ b/tests/ZendTest/Paginator/Adapter/NullFillTest.php
@@ -15,7 +15,7 @@ use Zend\Paginator;
 /**
  * @group      Zend_Paginator
  */
-class NullTest extends \PHPUnit_Framework_TestCase
+class NullFillTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Zend\Paginator\Adapter\Array
@@ -28,7 +28,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->adapter = new Adapter\Null(101);
+        $this->adapter = new Adapter\NullFill(101);
     }
     /**
      * Cleans up the environment after running a test.
@@ -55,7 +55,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterReturnsCorrectValues()
     {
-        $paginator = new Paginator\Paginator(new Adapter\Null(2));
+        $paginator = new Paginator\Paginator(new Adapter\NullFill(2));
         $paginator->setCurrentPageNumber(1);
         $paginator->setItemCountPerPage(5);
 
@@ -64,7 +64,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $pages->currentItemCount);
         $this->assertEquals(2, $pages->lastItemNumber);
 
-        $paginator = new Paginator\Paginator(new Adapter\Null(19));
+        $paginator = new Paginator\Paginator(new Adapter\NullFill(19));
         $paginator->setCurrentPageNumber(4);
         $paginator->setItemCountPerPage(5);
 
@@ -79,7 +79,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
      */
     public function testEmptySet()
     {
-        $this->adapter = new Adapter\Null(0);
+        $this->adapter = new Adapter\NullFill(0);
         $actual = $this->adapter->getItems(0, 10);
         $this->assertEquals(array(), $actual);
     }
@@ -89,7 +89,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetOfOne()
     {
-        $this->adapter = new Adapter\Null(1);
+        $this->adapter = new Adapter\NullFill(1);
         $actual = $this->adapter->getItems(0, 10);
         $this->assertEquals(array_fill(0, 1, null), $actual);
     }

--- a/tests/ZendTest/Paginator/Adapter/NullTest.php
+++ b/tests/ZendTest/Paginator/Adapter/NullTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Paginator\Adapter;
+
+use Zend\Paginator\Adapter;
+
+/**
+ * @group      Zend_Paginator
+ */
+class NullTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Cannot test Null adapter under PHP 7; reserved keyword');
+        }
+    }
+
+    public function testRaisesNoticeOnInstantiation()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        new Adapter\Null();
+    }
+}

--- a/tests/ZendTest/Paginator/AdapterPluginManagerTest.php
+++ b/tests/ZendTest/Paginator/AdapterPluginManagerTest.php
@@ -56,7 +56,7 @@ class AdapterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $plugin = $this->adapaterPluginManager->get('dbselect', array($this->mockSelect, $this->mockAdapter));
         $this->assertInstanceOf('Zend\Paginator\Adapter\DbSelect', $plugin);
         $plugin = $this->adapaterPluginManager->get('null', 101);
-        $this->assertInstanceOf('Zend\Paginator\Adapter\Null', $plugin);
+        $this->assertInstanceOf('Zend\Paginator\Adapter\NullFill', $plugin);
 
         //test dbtablegateway
         $mockStatement = $this->getMock('Zend\Db\Adapter\Driver\StatementInterface');
@@ -79,7 +79,10 @@ class AdapterPluginManagerTest extends \PHPUnit_Framework_TestCase
         $order  = "foo";
         $group  = "foo";
         $having = "count(foo)>0";
-        $plugin = $this->adapaterPluginManager->get('dbtablegateway', array($mockTableGateway, $where, $order, $group, $having));
+        $plugin = $this->adapaterPluginManager->get(
+            'dbtablegateway',
+            array($mockTableGateway, $where, $order, $group, $having)
+        );
         $this->assertInstanceOf('Zend\Paginator\Adapter\DbTableGateway', $plugin);
 
         //test callback

--- a/tests/ZendTest/Serializer/Adapter/MsgPackTest.php
+++ b/tests/ZendTest/Serializer/Adapter/MsgPackTest.php
@@ -139,7 +139,7 @@ class MsgPackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $data);
     }
 
-    public function testUnserialzeInvalid()
+    public function testUnserializeInvalid()
     {
         $value = "\0\1\r\n";
         $this->setExpectedException(

--- a/tests/ZendTest/Serializer/Adapter/PhpCodeTest.php
+++ b/tests/ZendTest/Serializer/Adapter/PhpCodeTest.php
@@ -126,6 +126,9 @@ class PhpCodeTest extends \PHPUnit_Framework_TestCase
 
     public function testUnserializeInvalid()
     {
+        if (version_compare(PHP_VERSION, '7', 'ge')) {
+            $this->markTestSkipped('Cannot catch parse errors in PHP 7+');
+        }
         $value = 'not a serialized string';
 
         $this->setExpectedException('Zend\Serializer\Exception\RuntimeException', 'syntax error');

--- a/tests/ZendTest/Session/SaveHandler/MongoDBOptionsTest.php
+++ b/tests/ZendTest/Session/SaveHandler/MongoDBOptionsTest.php
@@ -92,7 +92,7 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend\Session\Exception\InvalidArgumentException
      */
     public function testInvalidSaveOptions()
     {

--- a/tests/ZendTest/Session/SaveHandler/MongoDBOptionsTest.php
+++ b/tests/ZendTest/Session/SaveHandler/MongoDBOptionsTest.php
@@ -22,7 +22,8 @@ class MongoDBOptionsTest extends \PHPUnit_Framework_TestCase
         $options = new MongoDBOptions();
         $this->assertNull($options->getDatabase());
         $this->assertNull($options->getCollection());
-        $defaultSaveOptions = version_compare(phpversion('mongo'), '1.3.0', '<') ? array('safe' => true) : array('w' => 1);
+        $mongoVersion = phpversion('mongo') ?: '0.0.0';
+        $defaultSaveOptions = version_compare($mongoVersion, '1.3.0', '<') ? array('safe' => true) : array('w' => 1);
         $this->assertEquals($defaultSaveOptions, $options->getSaveOptions());
         $this->assertEquals('name', $options->getNameField());
         $this->assertEquals('data', $options->getDataField());

--- a/tests/ZendTest/Session/TestAsset/TestSaveHandlerWithValidator.php
+++ b/tests/ZendTest/Session/TestAsset/TestSaveHandlerWithValidator.php
@@ -19,7 +19,9 @@ class TestSaveHandlerWithValidator implements SaveHandler
     }
 
     public function close()
-    {}
+    {
+        return true;
+    }
 
     public function read($id)
     {
@@ -27,11 +29,17 @@ class TestSaveHandlerWithValidator implements SaveHandler
     }
 
     public function write($id, $data)
-    {}
+    {
+        return true;
+    }
 
     public function destroy($id)
-    {}
+    {
+        return true;
+    }
 
     public function gc($maxlifetime)
-    {}
+    {
+        return true;
+    }
 }

--- a/tests/ZendTest/Stdlib/FilterCompositeTest.php
+++ b/tests/ZendTest/Stdlib/FilterCompositeTest.php
@@ -23,7 +23,8 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
     public function testValidationAdd()
     {
         $this->assertTrue($this->filterComposite->filter("foo"));
-        $this->filterComposite->addFilter("has",
+        $this->filterComposite->addFilter(
+            'has',
             function ($property) {
                 return false;
             }
@@ -33,7 +34,8 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testValidationRemove()
     {
-        $this->filterComposite->addFilter("has",
+        $this->filterComposite->addFilter(
+            'has',
             function ($property) {
                 return false;
             }
@@ -45,7 +47,8 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testValidationHas()
     {
-        $this->filterComposite->addFilter("has",
+        $this->filterComposite->addFilter(
+            'has',
             function ($property) {
                 return false;
             }
@@ -60,16 +63,19 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
         $this->filterComposite->addFilter("get", new \Zend\Stdlib\Hydrator\Filter\GetFilter());
         $this->filterComposite->addFilter("is", new \Zend\Stdlib\Hydrator\Filter\IsFilter());
 
-        $this->filterComposite->addFilter("exclude",
+        $this->filterComposite->addFilter(
+            'exclude',
             function ($property) {
-                $method = substr($property, strpos($property, '::'));
+                $separatorPos = strpos($property, '::') ?: 0;
+                $method = substr($property, $separatorPos);
 
                 if ($method === 'getServiceLocator') {
                     return false;
                 }
 
                 return true;
-            }, FilterComposite::CONDITION_AND
+            },
+            FilterComposite::CONDITION_AND
         );
 
         $this->assertTrue($this->filterComposite->filter('getFooBar'));
@@ -109,11 +115,11 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FilterComposite();
         $filter->addFilter("foobarbaz", function ($property) {
-                return true;
-            }, FilterComposite::CONDITION_AND);
+            return true;
+        }, FilterComposite::CONDITION_AND);
         $filter->addFilter("foobar", function ($property) {
-                return true;
-            }, FilterComposite::CONDITION_AND);
+            return true;
+        }, FilterComposite::CONDITION_AND);
         $this->assertTrue($filter->filter("foo"));
     }
 
@@ -121,11 +127,11 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new FilterComposite();
         $filter->addFilter("foobarbaz", function ($property) {
-                return true;
-            });
+            return true;
+        });
         $filter->addFilter("foobar", function ($property) {
-                return false;
-            });
+            return false;
+        });
         $this->assertTrue($filter->filter("foo"));
     }
 
@@ -133,24 +139,26 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $filter1 = new FilterComposite();
         $filter1->addFilter("foobarbaz", function ($property) {
-                return true;
-            });
+            return true;
+        });
         $filter1->addFilter("foobar", function ($property) {
-                return false;
-            });
+            return false;
+        });
         $filter2 = new FilterComposite();
         $filter2->addFilter("bar", function ($property) {
-                return true;
-            }, FilterComposite::CONDITION_AND);
+            return true;
+        }, FilterComposite::CONDITION_AND);
         $filter2->addFilter("barblubb", function ($property) {
-                return true;
-            }, FilterComposite::CONDITION_AND);
+            return true;
+        }, FilterComposite::CONDITION_AND);
         $this->assertTrue($filter1->filter("foo"));
         $this->assertTrue($filter2->filter("foo"));
         $filter1->addFilter("bar", $filter2);
         $this->assertTrue($filter1->filter("blubb"));
 
-        $filter1->addFilter("blubb", function ($property) { return false; }, FilterComposite::CONDITION_AND);
+        $filter1->addFilter("blubb", function ($property) {
+            return false;
+        }, FilterComposite::CONDITION_AND);
         $this->assertFalse($filter1->filter("test"));
     }
 

--- a/tests/ZendTest/Validator/File/IsCompressedTest.php
+++ b/tests/ZendTest/Validator/File/IsCompressedTest.php
@@ -20,6 +20,12 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
 {
     protected function getMagicMime()
     {
+        // PHP 7 uses yet another version of libmagic, and thus a new magic
+        // database format.
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            return __DIR__ . '/_files/magic.7.mime';
+        }
+
         // As of PHP >= 5.3.11 and >= 5.4.1 the magic database format has changed.
         // http://doc.php.net/downloads/pdf/split/de/File-Information.pdf (page 11)
         if (version_compare(PHP_VERSION, '5.4', '>=')

--- a/tests/ZendTest/Validator/File/IsImageTest.php
+++ b/tests/ZendTest/Validator/File/IsImageTest.php
@@ -20,6 +20,12 @@ class IsImageTest extends \PHPUnit_Framework_TestCase
 {
     protected function getMagicMime()
     {
+        // PHP 7 uses yet another version of libmagic, and thus a new magic
+        // database format.
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            return __DIR__ . '/_files/magic.7.mime';
+        }
+
         // As of PHP >= 5.3.11 and >= 5.4.1 the magic database format has changed.
         // http://doc.php.net/downloads/pdf/split/de/File-Information.pdf (page 11)
         if (version_compare(PHP_VERSION, '5.4', '>=')

--- a/tests/ZendTest/Validator/File/_files/magic.7.mime
+++ b/tests/ZendTest/Validator/File/_files/magic.7.mime
@@ -1,0 +1,21766 @@
+# Magic data for file(1) command.
+# Format is described in magic(files), where:
+# files is 5 on V7 and BSD, 4 on SV, and ?? on SVID.
+# Don't edit this file, edit /etc/magic or send your magic improvements
+# to the maintainers, at file@mx.gw.com
+
+#------------------------------------------------------------------------------
+# Localstuff:  file(1) magic for locally observed files
+#
+# $File: Localstuff,v 1.4 2003/03/23 04:17:27 christos Exp $
+# Add any locally observed files here.  Remember:
+# text if readable, executable if runnable binary, data if unreadable.
+
+#------------------------------------------------------------------------------
+# $File$
+# acorn:  file(1) magic for files found on Acorn systems
+#
+
+# RISC OS Chunk File Format
+# From RISC OS Programmer's Reference Manual, Appendix D
+# We guess the file type from the type of the first chunk.
+0	lelong		0xc3cbc6c5	RISC OS Chunk data
+>12	string		OBJ_		\b, AOF object
+>12	string		LIB_		\b, ALF library
+
+# RISC OS AIF, contains "SWI OS_Exit" at offset 16.
+16	lelong		0xef000011	RISC OS AIF executable
+
+# RISC OS Draw files
+# From RISC OS Programmer's Reference Manual, Appendix E
+0	string 		Draw		RISC OS Draw file data
+
+# RISC OS new format font files
+# From RISC OS Programmer's Reference Manual, Appendix E
+0	string		FONT\0		RISC OS outline font data,
+>5	byte		x		version %d
+0	string		FONT\1		RISC OS 1bpp font data,
+>5	byte		x		version %d
+0	string		FONT\4		RISC OS 4bpp font data
+>5	byte		x		version %d
+
+# RISC OS Music files
+# From RISC OS Programmer's Reference Manual, Appendix E
+0	string		Maestro\r	RISC OS music file
+>8	byte		x		version %d
+
+>8	byte		x		type %d
+
+# Digital Symphony data files
+# From: Bernard Jungen (bern8817@euphonynet.be)
+0		string	\x02\x01\x13\x13\x13\x01\x0d\x10	Digital Symphony sound sample (RISC OS),
+>8		byte	x	version %d,
+>9		pstring	x	named "%s",
+>(9.b+19)	byte	=0	8-bit logarithmic
+>(9.b+19)	byte	=1	LZW-compressed linear
+>(9.b+19)	byte	=2	8-bit linear signed
+>(9.b+19)	byte	=3	16-bit linear signed
+>(9.b+19)	byte	=4	SigmaDelta-compressed linear
+>(9.b+19)	byte	=5	SigmaDelta-compressed logarithmic
+>(9.b+19)	byte	>5	unknown format
+
+0	string	\x02\x01\x13\x13\x14\x12\x01\x0b	Digital Symphony song (RISC OS),
+>8	byte	x	version %d,
+>9	byte	=1	1 voice,
+>9	byte	!1	%d voices,
+>10	leshort	=1	1 track,
+>10	leshort	!1	%d tracks,
+>12	leshort	=1	1 pattern
+>12	leshort	!1	%d patterns
+
+0	string	\x02\x01\x13\x13\x10\x14\x12\x0e
+>9	byte	=0	Digital Symphony sequence (RISC OS),
+>>8	byte	x	version %d,
+>>10	byte	=1	1 line,
+>>10	byte	!1	%d lines,
+>>11	leshort	=1	1 position
+>>11	leshort	!1	%d positions
+>9	byte	=1	Digital Symphony pattern data (RISC OS),
+>>8	byte	x	version %d,
+>>10	leshort	=1	1 pattern
+>>10	leshort	!1	%d patterns
+
+#------------------------------------------------------------------------------
+# $File$
+# adi: file(1) magic for ADi's objects
+# From Gregory McGarry <g.mcgarry@ieee.org>
+#
+0	leshort		0x521c		COFF DSP21k
+>18	lelong		&02		executable,
+>18	lelong		^02
+>>18	lelong		&01		static object,
+>>18	lelong		^01		relocatable object,
+>18	lelong		&010		stripped
+>18	lelong		^010		not stripped
+
+#------------------------------------------------------------------------------
+# $File: adventure,v 1.13 2010/12/31 16:32:54 christos Exp $
+# adventure: file(1) magic for Adventure game files
+#
+# from Allen Garvin <earendil@faeryland.tamu-commerce.edu>
+# Edited by Dave Chapeskie <dchapes@ddm.on.ca> Jun 28, 1998
+# Edited by Chris Chittleborough <cchittleborough@yahoo.com.au>, March 2002
+#
+# ALAN
+# I assume there are other, lower versions, but these are the only ones I
+# saw in the archive.
+0	beshort	0x0206	ALAN game data
+>2	byte	<10	version 2.6%d
+
+
+# Infocom (see z-machine)
+#------------------------------------------------------------------------------
+# Z-machine:  file(1) magic for Z-machine binaries.
+# Updated by Adam Buchbinder <adam.buchbinder@gmail.com>
+#
+#http://www.gnelson.demon.co.uk/zspec/sect11.html
+#http://www.jczorkmid.net/~jpenney/ZSpec11-latest.txt
+#http://en.wikipedia.org/wiki/Z-machine
+# The first byte is the Z-machine revision; it is always between 1 and 8. We
+# had false matches (for instance, inbig5.ocp from the Omega TeX extension as
+# well as an occasional MP3 file), so we sanity-check the version number.
+#
+# It might be possible to sanity-check the release number as well, as it seems
+# (at least in classic Infocom games) to always be a relatively small number,
+# always under 150 or so, but as this isn't rigorous, we'll wait on that until
+# it becomes clear that it's needed.
+#
+0	ubyte			>0
+>0	ubyte			<9
+>>16	belong&0xfe00f0f0	0x3030
+>>>0	ubyte			< 10
+>>>>2	ubeshort		< 10
+>>>>>18	regex			[0-9][0-9][0-9][0-9][0-9][0-9]
+>>>>>>0	ubyte			< 10	Infocom (Z-machine %d,
+>>>>>>>2	ubeshort	< 10 	Release %d /
+>>>>>>>>18	string		>\0	Serial %.6s)
+!:strength + 40
+
+#------------------------------------------------------------------------------
+# Glulx:  file(1) magic for Glulx binaries.
+#
+# I haven't checked for false matches yet.
+#
+0	string			Glul	Glulx game data
+>4	beshort			x	(Version %d
+>>6	byte			x	\b.%d
+>>8	byte			x	\b.%d)
+>36	string			Info	Compiled by Inform
+
+
+
+# For Quetzal and blorb magic see iff
+
+
+# TADS (Text Adventure Development System) version 2
+#  All files are machine-independent (games compile to byte-code) and are tagged
+#  with a version string of the form "V2.<digit>.<digit>\0".
+#  Game files start with "TADS2 bin\n\r\032\0" then the compiler version.
+0	string	TADS2\ bin	TADS
+>9	belong  !0x0A0D1A00	game data, CORRUPTED
+>9	belong	 0x0A0D1A00
+>>13	string	>\0		%s game data
+#  Resource files start with "TADS2 rsc\n\r\032\0" then the compiler version.
+0	string	TADS2\ rsc	TADS
+>9	belong  !0x0A0D1A00	resource data, CORRUPTED
+>9	belong	 0x0A0D1A00
+>>13	string	>\0		%s resource data
+#  Some saved game files start with "TADS2 save/g\n\r\032\0", a little-endian
+#  2-byte length N, the N-char name of the game file *without* a NUL (darn!),
+# "TADS2 save\n\r\032\0" and the interpreter version. 
+0	string	TADS2\ save/g	TADS
+>12	belong	!0x0A0D1A00	saved game data, CORRUPTED
+>12	belong	 0x0A0D1A00
+>>(16.s+32) string >\0		%s saved game data
+#  Other saved game files start with "TADS2 save\n\r\032\0" and the interpreter
+#  version.
+0	string	TADS2\ save	TADS
+>10	belong	!0x0A0D1A00	saved game data, CORRUPTED
+>10	belong	 0x0A0D1A00
+>>14	string	>\0		%s saved game data
+
+# TADS (Text Adventure Development System) version 3
+#  Game files start with "T3-image\015\012\032"
+0	string	T3-image\015\012\032
+>11	leshort	x		TADS 3 game data (format version %d)
+#  Saved game files start with "T3-state-v####\015\012\032"
+#  where #### is a format version number
+0	string	T3-state-v
+>14	string	\015\012\032	TADS 3 saved game data (format version
+>>10	byte	x		%c
+>>11	byte	x		\b%c
+>>12	byte	x		\b%c
+>>13	byte	x		\b%c)
+
+# Danny Milosavljevic <danny.milo@gmx.net>
+# this are adrift (adventure game standard) game files, extension .taf
+# depending on version magic continues with 0x93453E6139FA (V 4.0)
+# 0x9445376139FA (V 3.90)
+# 0x9445366139FA (V 3.80)
+# this is from source (http://www.adrift.org.uk/) and I have some taf
+# files, and checked them.
+#0	belong	0x3C423FC9
+#>4	belong	0x6A87C2CF	Adrift game file
+#!:mime	application/x-adrift
+
+#------------------------------------------------------------------------------
+# $File$
+# allegro:  file(1) magic for Allegro datafiles
+# Toby Deshane <hac@shoelace.digivill.net>
+#
+0 belong 0x736C6821   Allegro datafile (packed)
+0 belong 0x736C682E   Allegro datafile (not packed/autodetect)
+0 belong 0x736C682B   Allegro datafile (appended exe data)
+
+#------------------------------------------------------------------------------
+# $File$
+# alliant:  file(1) magic for Alliant FX series a.out files
+#
+# If the FX series is the one that had a processor with a 68K-derived
+# instruction set, the "short" should probably become "beshort" and the
+# "long" should probably become "belong".
+# If it's the i860-based one, they should probably become either the
+# big-endian or little-endian versions, depending on the mode they ran
+# the 860 in....
+#
+0	short		0420		0420 Alliant virtual executable
+>2	short		&0x0020		common library
+>16	long		>0		not stripped
+0	short		0421		0421 Alliant compact executable
+>2	short		&0x0020		common library
+>16	long		>0		not stripped
+
+#------------------------------------------------------------------------------
+# $File$
+# alpha architecture description
+#
+
+0	leshort		0603		COFF format alpha
+>22	leshort&030000	!020000		executable
+>24	leshort		0410		pure
+>24	leshort		0413		paged
+>22	leshort&020000	!0		dynamically linked
+>16	lelong		!0		not stripped
+>16	lelong		0		stripped
+>22	leshort&030000	020000		shared library
+>24	leshort		0407		object
+>27	byte		x		- version %d
+>26	byte		x		.%d
+>28	byte		x		-%d
+
+# Basic recognition of Digital UNIX core dumps - Mike Bremford <mike@opac.bl.uk>
+#
+# The actual magic number is just "Core", followed by a 2-byte version
+# number; however, treating any file that begins with "Core" as a Digital
+# UNIX core dump file may produce too many false hits, so we include one
+# byte of the version number as well; DU 5.0 appears only to be up to
+# version 2.
+#
+0	string		Core\001	Alpha COFF format core dump (Digital UNIX)
+>24	string		>\0		\b, from '%s'
+0	string		Core\002	Alpha COFF format core dump (Digital UNIX)
+>24	string		>\0		\b, from '%s'
+
+
+#------------------------------------------------------------------------------
+# $File$
+# amanda:  file(1) magic for amanda file format
+#
+0	string	AMANDA:\ 		AMANDA 
+>8	string	TAPESTART\ DATE		tape header file,
+>>23	string	X
+>>>25	string	>\ 			Unused %s
+>>23	string	>\ 			DATE %s
+>8	string	FILE\ 			dump file,
+>>13	string	>\ 			DATE %s
+
+#------------------------------------------------------------------------------
+# $File: amigaos,v 1.14 2009/09/19 16:28:07 christos Exp $
+# amigaos:  file(1) magic for AmigaOS binary formats:
+
+#
+# From ignatios@cs.uni-bonn.de (Ignatios Souvatzis)
+#
+0	belong		0x000003fa	AmigaOS shared library
+0	belong		0x000003f3	AmigaOS loadseg()ble executable/binary
+0	belong		0x000003e7	AmigaOS object/library data
+#
+0	beshort		0xe310		Amiga Workbench
+>2	beshort		1		
+>>48	byte		1		disk icon
+>>48	byte		2		drawer icon
+>>48	byte		3		tool icon
+>>48	byte		4		project icon
+>>48	byte		5		garbage icon
+>>48	byte		6		device icon
+>>48	byte		7		kickstart icon
+>>48	byte		8		workbench application icon
+>2	beshort		>1		icon, vers. %d
+#
+# various sound formats from the Amiga
+# G=F6tz Waschk <waschk@informatik.uni-rostock.de>
+#
+0	string		FC14		Future Composer 1.4 Module sound file
+0	string		SMOD		Future Composer 1.3 Module sound file
+0	string		AON4artofnoise	Art Of Noise Module sound file
+1	string		MUGICIAN/SOFTEYES Mugician Module sound file
+58	string		SIDMON\ II\ -\ THE	Sidmon 2.0 Module sound file
+0	string		Synth4.0	Synthesis Module sound file
+0	string		ARP.		The Holy Noise Module sound file
+0	string		BeEp\0		JamCracker Module sound file
+0	string		COSO\0		Hippel-COSO Module sound file
+# Too simple (short, pure ASCII, deep), MPi
+#26	string		V.3		Brian Postma's Soundmon Module sound file v3
+#26	string		BPSM		Brian Postma's Soundmon Module sound file v3
+#26	string		V.2		Brian Postma's Soundmon Module sound file v2
+
+# The following are from: "Stefan A. Haubenthal" <polluks@web.de>
+0	beshort		0x0f00		AmigaOS bitmap font
+0	beshort		0x0f03		AmigaOS outline font
+0	belong		0x80001001	AmigaOS outline tag
+0	string		##\ version	catalog translation
+0	string		EMOD\0		Amiga E module
+8	string		ECXM\0		ECX module
+0	string/c	@database	AmigaGuide file
+
+# Amiga disk types
+# 
+0	string		RDSK		Rigid Disk Block
+>160	string		x		on %.24s
+0	string		DOS\0		Amiga DOS disk
+0	string		DOS\1		Amiga FFS disk
+0	string		DOS\2		Amiga Inter DOS disk
+0	string		DOS\3		Amiga Inter FFS disk
+0	string		DOS\4		Amiga Fastdir DOS disk
+0	string		DOS\5		Amiga Fastdir FFS disk
+0	string		KICK		Kickstart disk
+
+# From: Alex Beregszaszi <alex@fsn.hu>
+0	string		LZX		LZX compressed archive (Amiga)
+
+# From: Przemek Kramarczyk <pkramarczyk@gmail.com>
+0	string 		.KEY		AmigaDOS script
+0	string 		.key		AmigaDOS script
+
+#------------------------------------------------------------
+# $File: android,v 1.6 2014/08/04 06:00:36 christos Exp $
+# Various android related magic entries
+#------------------------------------------------------------
+
+# Dalvik .dex format. http://retrodev.com/android/dexformat.html
+# From <mkf@google.com> "Mike Fleming"
+# Fixed to avoid regexec 17 errors on some dex files
+# From <diff@lookout.com> "Tim Strazzere"
+0	string	dex\n
+>0	regex	dex\n[0-9]{2}\0	Dalvik dex file
+>4	string	>000			version %s
+0	string	dey\n
+>0	regex	dey\n[0-9]{2}\0	Dalvik dex file (optimized for host)
+>4	string	>000			version %s
+
+# Android bootimg format
+# From https://android.googlesource.com/\
+# platform/system/core/+/master/mkbootimg/bootimg.h
+0		string	ANDROID!	Android bootimg
+>1024	string	LOKI\01		\b, LOKI'd
+>8		lelong	>0			\b, kernel
+>>12	lelong	>0			\b (0x%x)
+>16		lelong	>0			\b, ramdisk
+>>20	lelong	>0			\b (0x%x)
+>24		lelong	>0			\b, second stage
+>>28	lelong	>0			\b (0x%x)
+>36		lelong	>0			\b, page size: %d
+>38		string	>0			\b, name: %s
+>64		string	>0		 	\b, cmdline (%s)
+
+# Android Backup archive
+# From: Ariel Shkedi
+# File extension: .ab
+# No mime-type defined
+# URL: https://github.com/android/platform_frameworks_base/blob/\
+# 0bacfd2ba68d21a68a3df345b830bc2a1e515b5a/services/java/com/\
+# android/server/BackupManagerService.java#L2367
+# After the header comes a tar file
+# If compressed, the entire tar file is compressed with JAVA deflate
+#
+# Include the version number hardcoded with the magic string to avoid
+# false positives
+0	string/b	ANDROID\ BACKUP\n1\n	Android Backup
+>17	string		0\n			\b, Not-Compressed
+>17	string		1\n			\b, Compressed
+# any string as long as it's not the word none (which is matched below)
+>>19    regex/1l	\^([^n\n]|n[^o]|no[^n]|non[^e]|none.+).*	\b, Encrypted (%s)
+>>19	string		none\n			\b, Not-Encrypted
+# Commented out because they don't seem useful to print
+# (but they are part of the header - the tar file comes after them):
+#>>>&1		regex/1l .*	\b, Password salt: %s
+#>>>>&1		regex/1l .*	\b, Master salt: %s
+#>>>>>&1	regex/1l .*	\b, PBKDF2 rounds: %s
+#>>>>>>&1	regex/1l .*	\b, IV: %s
+#>>>>>>>&1	regex/1l .*	\b, Key: %s
+
+# *.pit files by Joerg Jenderek
+# http://forum.xda-developers.com/showthread.php?p=9122369
+# http://forum.xda-developers.com/showthread.php?t=816449
+# Partition Information Table for Samsung's smartphone with Android
+# used by flash software Odin
+0		ulelong			0x12349876	
+# 1st pit entry marker
+>0x01C	ulequad&0xFFFFFFFCFFFFFFFC	=0x0000000000000000	
+# minimal 13 and maximal 18 PIT entries found
+>>4		ulelong			<128	Partition Information Table for Samsung smartphone
+>>>4		ulelong			x	\b, %d entries
+# 1. pit entry
+>>>4		ulelong			>0	\b; #1
+>>>0x01C	use				PIT-entry
+>>>4		ulelong			>1	\b; #2
+>>>0x0A0	use				PIT-entry
+>>>4		ulelong			>2	\b; #3
+>>>0x124	use				PIT-entry
+>>>4		ulelong			>3	\b; #4
+>>>0x1A8	use				PIT-entry
+>>>4		ulelong			>4	\b; #5
+>>>0x22C	use				PIT-entry
+>>>4		ulelong			>5	\b; #6
+>>>0x2B0	use				PIT-entry
+>>>4		ulelong			>6	\b; #7
+>>>0x334	use				PIT-entry
+>>>4		ulelong			>7 	\b; #8
+>>>0x3B8	use				PIT-entry
+>>>4		ulelong			>8 	\b; #9
+>>>0x43C	use				PIT-entry
+>>>4		ulelong			>9	\b; #10
+>>>0x4C0	use				PIT-entry
+>>>4		ulelong			>10	\b; #11
+>>>0x544	use				PIT-entry
+>>>4		ulelong			>11	\b; #12
+>>>0x5C8	use				PIT-entry
+>>>4		ulelong			>12	\b; #13
+>>>>0x64C	use				PIT-entry
+# 14. pit entry
+>>>4		ulelong			>13	\b; #14
+>>>>0x6D0	use				PIT-entry
+>>>4		ulelong			>14	\b; #15
+>>>0x754	use				PIT-entry
+>>>4		ulelong			>15	\b; #16
+>>>0x7D8	use				PIT-entry
+>>>4		ulelong			>16	\b; #17
+>>>0x85C	use				PIT-entry
+# 18. pit entry
+>>>4		ulelong			>17	\b; #18
+>>>0x8E0	use				PIT-entry
+
+0	name			PIT-entry
+# garbage value implies end of pit entries
+>0x00		ulequad&0xFFFFFFFCFFFFFFFC	=0x0000000000000000	
+# skip empty partition name
+>>0x24		ubyte				!0			
+# partition name
+>>>0x24		string				>\0			%-.32s
+# flags
+>>>0x0C		ulelong&0x00000002		2			\b+RW
+# partition ID:
+# 0~IPL,MOVINAND,GANG;1~PIT,GPT;2~HIDDEN;3~SBL,HIDDEN;4~SBL2,HIDDEN;5~BOOT;6~KENREl,RECOVER,misc;7~RECOVER
+# ;11~MODEM;20~efs;21~PARAM;22~FACTORY,SYSTEM;23~DBDATAFS,USERDATA;24~CACHE;80~BOOTLOADER;81~TZSW
+>>>0x08	ulelong		x			(0x%x)
+# filename
+>>>0x44		string				>\0			"%-.64s"
+#>>>0x18	ulelong				>0			
+# blocksize in 512 byte units ?
+#>>>>0x18	ulelong				x			\b, %db
+# partition size in blocks ?
+#>>>>0x22	ulelong				x			\b*%d
+
+# Android bootimg format
+# From https://android.googlesource.com/\
+# platform/system/core/+/master/libsparse/sparse_format.h
+0		lelong	0xed26ff3a		Android sparse image
+>4		leshort	x			\b, version: %d
+>6		leshort	x			\b.%d
+>16		lelong	x			\b, Total of %d
+>12		lelong	x			\b %d-byte output blocks in
+>20		lelong	x			\b %d input chunks.
+
+#------------------------------------------------------------------------------
+# $File: animation,v 1.55 2014/09/13 14:29:51 christos Exp $
+# animation:  file(1) magic for animation/movie formats
+#
+# animation formats
+# MPEG, FLI, DL originally from vax@ccwf.cc.utexas.edu (VaX#n8)
+# FLC, SGI, Apple originally from Daniel Quinlan (quinlan@yggdrasil.com)
+
+# SGI and Apple formats
+0	string		MOVI		Silicon Graphics movie file
+!:mime	video/x-sgi-movie
+4       string          moov            Apple QuickTime
+!:mime	video/quicktime
+>12     string          mvhd            \b movie (fast start)
+>12     string          mdra            \b URL
+>12     string          cmov            \b movie (fast start, compressed header)
+>12     string          rmra            \b multiple URLs
+4       string          mdat            Apple QuickTime movie (unoptimized)
+!:mime	video/quicktime
+#4       string          wide            Apple QuickTime movie (unoptimized)
+#!:mime	video/quicktime
+#4       string          skip            Apple QuickTime movie (modified)
+#!:mime	video/quicktime
+#4       string          free            Apple QuickTime movie (modified)
+#!:mime	video/quicktime
+4       string          idsc            Apple QuickTime image (fast start)
+!:mime	image/x-quicktime
+#4       string          idat            Apple QuickTime image (unoptimized)
+#!:mime	image/x-quicktime
+4       string          pckg            Apple QuickTime compressed archive
+!:mime	application/x-quicktime-player
+4	string/W	jP		JPEG 2000 image
+!:mime	image/jp2
+# http://www.ftyps.com/ with local additions
+4	string		ftyp		ISO Media
+>8	string		3g2		\b, MPEG v4 system, 3GPP2
+!:mime	video/3gpp2
+>>11	byte		4		\b v4 (H.263/AMR GSM 6.10)
+>>11	byte		5		\b v5 (H.263/AMR GSM 6.10)
+>>11	byte		6		\b v6 (ITU H.264/AMR GSM 6.10)
+>>11	byte		a		\b C.S0050-0 V1.0
+>>11	byte		b		\b C.S0050-0-A V1.0.0
+>>11	byte		c		\b C.S0050-0-B V1.0
+>8	string		3ge		\b, MPEG v4 system, 3GPP
+!:mime	video/3gpp
+>>11	byte		6		\b, Release 6 MBMS Extended Presentations
+>>11	byte		7		\b, Release 7 MBMS Extended Presentations
+>8	string		3gg		\b, MPEG v4 system, 3GPP
+>11	byte		6		\b, Release 6 General Profile
+!:mime	video/3gpp
+>8	string		3gp		\b, MPEG v4 system, 3GPP
+>11	byte		1		\b, Release %d (non existent)
+>11	byte		2		\b, Release %d (non existent)
+>11	byte		3		\b, Release %d (non existent)
+>11	byte		4		\b, Release %d
+>11	byte		5		\b, Release %d
+>11	byte		6		\b, Release %d
+>11	byte		7		\b, Release %d Streaming Servers
+!:mime	video/3gpp
+>8	string		3gs		\b, MPEG v4 system, 3GPP
+>11	byte		7		\b, Release %d Streaming Servers
+!:mime	video/3gpp
+>8	string		avc1		\b, MPEG v4 system, 3GPP JVT AVC [ISO 14496-12:2005]
+!:mime	video/mp4
+>8	string/W	qt		\b, Apple QuickTime movie
+!:mime	video/quicktime
+>8	string		CAEP		\b, Canon Digital Camera
+>8	string		caqv		\b, Casio Digital Camera
+>8	string		CDes		\b, Convergent Design
+>8	string		da0a		\b, DMB MAF w/ MPEG Layer II aud, MOT slides, DLS, JPG/PNG/MNG
+>8	string		da0b		\b, DMB MAF, ext DA0A, with 3GPP timed text, DID, TVA, REL, IPMP
+>8	string		da1a		\b, DMB MAF audio with ER-BSAC audio, JPG/PNG/MNG images
+>8	string		da1b		\b, DMB MAF, ext da1a, with 3GPP timed text, DID, TVA, REL, IPMP
+>8	string		da2a		\b, DMB MAF aud w/ HE-AAC v2 aud, MOT slides, DLS, JPG/PNG/MNG
+>8	string		da2b		\b, DMB MAF, ext da2a, with 3GPP timed text, DID, TVA, REL, IPMP
+>8	string		da3a		\b, DMB MAF aud with HE-AAC aud, JPG/PNG/MNG images
+>8	string		da3b		\b, DMB MAF, ext da3a w/ BIFS, 3GPP, DID, TVA, REL, IPMP
+>8	string		dmb1		\b, DMB MAF supporting all the components defined in the spec
+>8	string		dmpf		\b, Digital Media Project
+>8	string		drc1		\b, Dirac (wavelet compression), encap in ISO base media (MP4)
+>8	string		dv1a		\b, DMB MAF vid w/ AVC vid, ER-BSAC aud, BIFS, JPG/PNG/MNG, TS
+>8	string		dv1b		\b, DMB MAF, ext dv1a, with 3GPP timed text, DID, TVA, REL, IPMP
+>8	string		dv2a		\b, DMB MAF vid w/ AVC vid, HE-AAC v2 aud, BIFS, JPG/PNG/MNG, TS
+>8	string		dv2b		\b, DMB MAF, ext dv2a, with 3GPP timed text, DID, TVA, REL, IPMP
+>8	string		dv3a		\b, DMB MAF vid w/ AVC vid, HE-AAC aud, BIFS, JPG/PNG/MNG, TS
+>8	string		dv3b		\b, DMB MAF, ext dv3a, with 3GPP timed text, DID, TVA, REL, IPMP
+>8	string		dvr1		\b, DVB (.DVB) over RTP
+!:mime	video/vnd.dvb.file
+>8	string		dvt1		\b, DVB (.DVB) over MPEG-2 Transport Stream
+!:mime	video/vnd.dvb.file
+>8	string		F4V		\b, Video for Adobe Flash Player 9+ (.F4V)
+!:mime	video/mp4
+>8	string		F4P		\b, Protected Video for Adobe Flash Player 9+ (.F4P)
+!:mime	video/mp4
+>8	string		F4A		\b, Audio for Adobe Flash Player 9+ (.F4A)
+!:mime	audio/mp4
+>8	string		F4B		\b, Audio Book for Adobe Flash Player 9+ (.F4B)
+!:mime	audio/mp4
+>8	string		isc2		\b, ISMACryp 2.0 Encrypted File
+#	?/enc-isoff-generic
+>8	string		iso2		\b, MP4 Base Media v2 [ISO 14496-12:2005]
+!:mime	video/mp4
+>8	string		isom		\b, MP4 Base Media v1 [IS0 14496-12:2003]
+!:mime	video/mp4
+>8	string/W	jp2		\b, JPEG 2000
+!:mime	image/jp2
+>8	string		JP2		\b, JPEG 2000 Image (.JP2) [ISO 15444-1 ?]
+!:mime	image/jp2
+>8	string		JP20		\b, Unknown, from GPAC samples (prob non-existent)
+>8	string		jpm		\b, JPEG 2000 Compound Image (.JPM) [ISO 15444-6]
+!:mime	image/jpm
+>8	string		jpx		\b, JPEG 2000 w/ extensions (.JPX) [ISO 15444-2]
+!:mime	image/jpx
+>8	string		KDDI		\b, 3GPP2 EZmovie for KDDI 3G cellphones
+!:mime	video/3gpp2
+>8	string		M4A 		\b, Apple iTunes ALAC/AAC-LC (.M4A) Audio
+!:mime	audio/x-m4a
+>8	string		M4B 		\b, Apple iTunes ALAC/AAC-LC (.M4B) Audio Book
+!:mime	audio/mp4
+>8	string		M4P 		\b, Apple iTunes ALAC/AAC-LC (.M4P) AES Protected Audio
+!:mime	video/mp4
+>8	string		M4V 		\b, Apple iTunes Video (.M4V) Video
+!:mime	video/x-m4v
+>8	string		M4VH		\b, Apple TV (.M4V)
+!:mime	video/x-m4v
+>8	string		M4VP		\b, Apple iPhone (.M4V)
+!:mime	video/x-m4v
+>8	string		mj2s		\b, Motion JPEG 2000 [ISO 15444-3] Simple Profile
+!:mime	video/mj2
+>8	string		mjp2		\b, Motion JPEG 2000 [ISO 15444-3] General Profile
+!:mime	video/mj2
+>8	string		mmp4		\b, MPEG-4/3GPP Mobile Profile (.MP4 / .3GP) (for NTT)
+!:mime	video/mp4
+>8	string		mobi		\b, MPEG-4, MOBI format
+!:mime	video/mp4
+>8	string		mp21		\b, MPEG-21 [ISO/IEC 21000-9]
+>8	string		mp41		\b, MP4 v1 [ISO 14496-1:ch13]
+!:mime	video/mp4
+>8	string		mp42		\b, MP4 v2 [ISO 14496-14]
+!:mime	video/mp4
+>8	string		mp71		\b, MP4 w/ MPEG-7 Metadata [per ISO 14496-12]
+>8	string		mp7t		\b, MPEG v4 system, MPEG v7 XML
+>8	string		mp7b		\b, MPEG v4 system, MPEG v7 binary XML
+>8	string		mmp4		\b, MPEG v4 system, 3GPP Mobile
+!:mime	video/mp4
+>8	string		MPPI		\b, Photo Player, MAF [ISO/IEC 23000-3]
+>8	string		mqt		\b, Sony / Mobile QuickTime (.MQV) US Pat 7,477,830
+!:mime	video/quicktime
+>8	string		MSNV		\b, MPEG-4 (.MP4) for SonyPSP
+!:mime	audio/mp4
+>8	string		NDAS		\b, MP4 v2 [ISO 14496-14] Nero Digital AAC Audio
+!:mime	audio/mp4
+>8	string		NDSC		\b, MPEG-4 (.MP4) Nero Cinema Profile
+!:mime	video/mp4
+>8	string		NDSH		\b, MPEG-4 (.MP4) Nero HDTV Profile
+!:mime	video/mp4
+>8	string		NDSM		\b, MPEG-4 (.MP4) Nero Mobile Profile
+!:mime	video/mp4
+>8	string		NDSP		\b, MPEG-4 (.MP4) Nero Portable Profile
+!:mime	video/mp4
+>8	string		NDSS		\b, MPEG-4 (.MP4) Nero Standard Profile
+!:mime	video/mp4
+>8	string		NDXC		\b, H.264/MPEG-4 AVC (.MP4) Nero Cinema Profile
+!:mime	video/mp4
+>8	string		NDXH		\b, H.264/MPEG-4 AVC (.MP4) Nero HDTV Profile
+!:mime	video/mp4
+>8	string		NDXM		\b, H.264/MPEG-4 AVC (.MP4) Nero Mobile Profile
+!:mime	video/mp4
+>8	string		NDXP		\b, H.264/MPEG-4 AVC (.MP4) Nero Portable Profile
+!:mime	video/mp4
+>8	string		NDXS		\b, H.264/MPEG-4 AVC (.MP4) Nero Standard Profile
+!:mime	video/mp4
+>8	string		odcf  		\b, OMA DCF DRM Format 2.0 (OMA-TS-DRM-DCF-V2_0-20060303-A)
+>8	string		opf2 		\b, OMA PDCF DRM Format 2.1 (OMA-TS-DRM-DCF-V2_1-20070724-C)
+>8	string		opx2  		\b, OMA PDCF DRM + XBS ext (OMA-TS-DRM_XBS-V1_0-20070529-C)
+>8	string		pana		\b, Panasonic Digital Camera
+>8	string		qt  		\b, Apple QuickTime (.MOV/QT)
+!:mime	video/quicktime
+>8	string		ROSS		\b, Ross Video
+>8	string		sdv		\b, SD Memory Card Video
+>8	string		ssc1		\b, Samsung stereo, single stream (patent pending)
+>8	string		ssc2		\b, Samsung stereo, dual stream (patent pending)
+
+# MPEG sequences
+# Scans for all common MPEG header start codes
+0	 belong		    0x00000001     
+>4	 byte&0x1F	    0x07	   JVT NAL sequence, H.264 video
+>>5      byte               66             \b, baseline
+>>5      byte               77             \b, main
+>>5      byte               88             \b, extended
+>>7      byte               x              \b @ L %u
+0        belong&0xFFFFFF00  0x00000100     
+>3       byte               0xBA           MPEG sequence
+!:mime  video/mpeg
+>>4      byte               &0x40          \b, v2, program multiplex
+>>4      byte               ^0x40          \b, v1, system multiplex
+>3       byte               0xBB           MPEG sequence, v1/2, multiplex (missing pack header)
+>3       byte&0x1F          0x07           MPEG sequence, H.264 video
+>>4      byte               66             \b, baseline
+>>4      byte               77             \b, main
+>>4      byte               88             \b, extended
+>>6      byte               x              \b @ L %u
+# GRR too general as it catches also FoxPro Memo example NG.FPT
+>3       byte               0xB0           MPEG sequence, v4
+# TODO: maybe this extra line exclude FoxPro Memo example NG.FPT starting with 000001b0 00000100 00000000
+#>>4      byte               !0             MPEG sequence, v4
+!:mime  video/mpeg4-generic
+>>5      belong             0x000001B5
+>>>9     byte               &0x80
+>>>>10   byte&0xF0          16             \b, video
+>>>>10   byte&0xF0          32             \b, still texture
+>>>>10   byte&0xF0          48             \b, mesh
+>>>>10   byte&0xF0          64             \b, face
+>>>9     byte&0xF8          8              \b, video
+>>>9     byte&0xF8          16             \b, still texture
+>>>9     byte&0xF8          24             \b, mesh
+>>>9     byte&0xF8          32             \b, face
+>>4      byte               1              \b, simple @ L1
+>>4      byte               2              \b, simple @ L2
+>>4      byte               3              \b, simple @ L3
+>>4      byte               4              \b, simple @ L0
+>>4      byte               17             \b, simple scalable @ L1
+>>4      byte               18             \b, simple scalable @ L2
+>>4      byte               33             \b, core @ L1
+>>4      byte               34             \b, core @ L2
+>>4      byte               50             \b, main @ L2
+>>4      byte               51             \b, main @ L3
+>>4      byte               53             \b, main @ L4
+>>4      byte               66             \b, n-bit @ L2
+>>4      byte               81             \b, scalable texture @ L1
+>>4      byte               97             \b, simple face animation @ L1
+>>4      byte               98             \b, simple face animation @ L2
+>>4      byte               99             \b, simple face basic animation @ L1
+>>4      byte               100            \b, simple face basic animation @ L2
+>>4      byte               113            \b, basic animation text @ L1
+>>4      byte               114            \b, basic animation text @ L2
+>>4      byte               129            \b, hybrid @ L1
+>>4      byte               130            \b, hybrid @ L2
+>>4      byte               145            \b, advanced RT simple @ L!
+>>4      byte               146            \b, advanced RT simple @ L2
+>>4      byte               147            \b, advanced RT simple @ L3
+>>4      byte               148            \b, advanced RT simple @ L4
+>>4      byte               161            \b, core scalable @ L1
+>>4      byte               162            \b, core scalable @ L2
+>>4      byte               163            \b, core scalable @ L3
+>>4      byte               177            \b, advanced coding efficiency @ L1
+>>4      byte               178            \b, advanced coding efficiency @ L2
+>>4      byte               179            \b, advanced coding efficiency @ L3
+>>4      byte               180            \b, advanced coding efficiency @ L4
+>>4      byte               193            \b, advanced core @ L1
+>>4      byte               194            \b, advanced core @ L2
+>>4      byte               209            \b, advanced scalable texture @ L1
+>>4      byte               210            \b, advanced scalable texture @ L2
+>>4      byte               211            \b, advanced scalable texture @ L3
+>>4      byte               225            \b, simple studio @ L1
+>>4      byte               226            \b, simple studio @ L2
+>>4      byte               227            \b, simple studio @ L3
+>>4      byte               228            \b, simple studio @ L4
+>>4      byte               229            \b, core studio @ L1
+>>4      byte               230            \b, core studio @ L2
+>>4      byte               231            \b, core studio @ L3
+>>4      byte               232            \b, core studio @ L4
+>>4      byte               240            \b, advanced simple @ L0
+>>4      byte               241            \b, advanced simple @ L1
+>>4      byte               242            \b, advanced simple @ L2
+>>4      byte               243            \b, advanced simple @ L3
+>>4      byte               244            \b, advanced simple @ L4
+>>4      byte               245            \b, advanced simple @ L5
+>>4      byte               247            \b, advanced simple @ L3b
+>>4      byte               248            \b, FGS @ L0
+>>4      byte               249            \b, FGS @ L1
+>>4      byte               250            \b, FGS @ L2
+>>4      byte               251            \b, FGS @ L3
+>>4      byte               252            \b, FGS @ L4
+>>4      byte               253            \b, FGS @ L5
+>3       byte               0xB5           MPEG sequence, v4
+!:mime  video/mpeg4-generic
+>>4      byte               &0x80
+>>>5     byte&0xF0          16             \b, video (missing profile header)
+>>>5     byte&0xF0          32             \b, still texture (missing profile header)
+>>>5     byte&0xF0          48             \b, mesh (missing profile header)
+>>>5     byte&0xF0          64             \b, face (missing profile header)
+>>4      byte&0xF8          8              \b, video (missing profile header)
+>>4      byte&0xF8          16             \b, still texture (missing profile header)
+>>4      byte&0xF8          24             \b, mesh (missing profile header)
+>>4      byte&0xF8          32             \b, face (missing profile header)
+>3       byte               0xB3           MPEG sequence
+!:mime  video/mpeg
+>>12     belong             0x000001B8     \b, v1, progressive Y'CbCr 4:2:0 video
+>>12     belong             0x000001B2     \b, v1, progressive Y'CbCr 4:2:0 video
+>>12     belong             0x000001B5     \b, v2,
+>>>16    byte&0x0F          1              \b HP
+>>>16    byte&0x0F          2              \b Spt
+>>>16    byte&0x0F          3              \b SNR
+>>>16    byte&0x0F          4              \b MP
+>>>16    byte&0x0F          5              \b SP
+>>>17    byte&0xF0          64             \b@HL
+>>>17    byte&0xF0          96             \b@H-14
+>>>17    byte&0xF0          128            \b@ML
+>>>17    byte&0xF0          160            \b@LL
+>>>17    byte               &0x08          \b progressive
+>>>17    byte               ^0x08          \b interlaced
+>>>17    byte&0x06          2              \b Y'CbCr 4:2:0 video
+>>>17    byte&0x06          4              \b Y'CbCr 4:2:2 video
+>>>17    byte&0x06          6              \b Y'CbCr 4:4:4 video
+>>11     byte               &0x02
+>>>75    byte               &0x01
+>>>>140  belong             0x000001B8     \b, v1, progressive Y'CbCr 4:2:0 video
+>>>>140  belong             0x000001B2     \b, v1, progressive Y'CbCr 4:2:0 video
+>>>>140  belong             0x000001B5     \b, v2,
+>>>>>144 byte&0x0F          1              \b HP
+>>>>>144 byte&0x0F          2              \b Spt
+>>>>>144 byte&0x0F          3              \b SNR
+>>>>>144 byte&0x0F          4              \b MP
+>>>>>144 byte&0x0F          5              \b SP
+>>>>>145 byte&0xF0          64             \b@HL
+>>>>>145 byte&0xF0          96             \b@H-14
+>>>>>145 byte&0xF0          128            \b@ML
+>>>>>145 byte&0xF0          160            \b@LL
+>>>>>145 byte               &0x08          \b progressive
+>>>>>145 byte               ^0x08          \b interlaced
+>>>>>145 byte&0x06          2              \b Y'CbCr 4:2:0 video
+>>>>>145 byte&0x06          4              \b Y'CbCr 4:2:2 video
+>>>>>145 byte&0x06          6              \b Y'CbCr 4:4:4 video
+>>76    belong             0x000001B8     \b, v1, progressive Y'CbCr 4:2:0 video
+>>76    belong             0x000001B2     \b, v1, progressive Y'CbCr 4:2:0 video
+>>76    belong             0x000001B5     \b, v2,
+>>>80   byte&0x0F          1              \b HP
+>>>80   byte&0x0F          2              \b Spt
+>>>80   byte&0x0F          3              \b SNR
+>>>80   byte&0x0F          4              \b MP
+>>>80   byte&0x0F          5              \b SP
+>>>81   byte&0xF0          64             \b@HL
+>>>81   byte&0xF0          96             \b@H-14
+>>>81   byte&0xF0          128            \b@ML
+>>>81   byte&0xF0          160            \b@LL
+>>>81   byte               &0x08          \b progressive
+>>>81   byte               ^0x08          \b interlaced
+>>>81   byte&0x06          2              \b Y'CbCr 4:2:0 video
+>>>81   byte&0x06          4              \b Y'CbCr 4:2:2 video
+>>>81   byte&0x06          6              \b Y'CbCr 4:4:4 video
+>>4      belong&0xFFFFFF00  0x78043800     \b, HD-TV 1920P
+>>>7     byte&0xF0          0x10           \b, 16:9
+>>4      belong&0xFFFFFF00  0x50002D00     \b, SD-TV 1280I
+>>>7     byte&0xF0          0x10           \b, 16:9
+>>4      belong&0xFFFFFF00  0x30024000     \b, PAL Capture
+>>>7     byte&0xF0          0x10           \b, 4:3
+>>4      beshort&0xFFF0     0x2C00         \b, 4CIF
+>>>5     beshort&0x0FFF     0x01E0         \b NTSC
+>>>5     beshort&0x0FFF     0x0240         \b PAL
+>>>7     byte&0xF0          0x20           \b, 4:3
+>>>7     byte&0xF0          0x30           \b, 16:9
+>>>7     byte&0xF0          0x40           \b, 11:5
+>>>7     byte&0xF0          0x80           \b, PAL 4:3
+>>>7     byte&0xF0          0xC0           \b, NTSC 4:3
+>>4      belong&0xFFFFFF00  0x2801E000     \b, LD-TV 640P
+>>>7     byte&0xF0          0x10           \b, 4:3
+>>4      belong&0xFFFFFF00  0x1400F000     \b, 320x240
+>>>7     byte&0xF0          0x10           \b, 4:3
+>>4      belong&0xFFFFFF00  0x0F00A000     \b, 240x160
+>>>7     byte&0xF0          0x10           \b, 4:3
+>>4      belong&0xFFFFFF00  0x0A007800     \b, 160x120
+>>>7     byte&0xF0          0x10           \b, 4:3
+>>4      beshort&0xFFF0     0x1600         \b, CIF
+>>>5     beshort&0x0FFF     0x00F0         \b NTSC
+>>>5     beshort&0x0FFF     0x0120         \b PAL
+>>>7     byte&0xF0          0x20           \b, 4:3
+>>>7     byte&0xF0          0x30           \b, 16:9
+>>>7     byte&0xF0          0x40           \b, 11:5
+>>>7     byte&0xF0          0x80           \b, PAL 4:3
+>>>7     byte&0xF0          0xC0           \b, NTSC 4:3
+>>>5     beshort&0x0FFF     0x0240         \b PAL 625
+>>>>7    byte&0xF0          0x20           \b, 4:3
+>>>>7    byte&0xF0          0x30           \b, 16:9
+>>>>7    byte&0xF0          0x40           \b, 11:5
+>>4      beshort&0xFFF0     0x2D00         \b, CCIR/ITU
+>>>5     beshort&0x0FFF     0x01E0         \b NTSC 525
+>>>5     beshort&0x0FFF     0x0240         \b PAL 625
+>>>7     byte&0xF0          0x20           \b, 4:3
+>>>7     byte&0xF0          0x30           \b, 16:9
+>>>7     byte&0xF0          0x40           \b, 11:5
+>>4      beshort&0xFFF0     0x1E00         \b, SVCD
+>>>5     beshort&0x0FFF     0x01E0         \b NTSC 525
+>>>5     beshort&0x0FFF     0x0240         \b PAL 625
+>>>7     byte&0xF0          0x20           \b, 4:3
+>>>7     byte&0xF0          0x30           \b, 16:9
+>>>7     byte&0xF0          0x40           \b, 11:5
+>>7      byte&0x0F          1              \b, 23.976 fps
+>>7      byte&0x0F          2              \b, 24 fps
+>>7      byte&0x0F          3              \b, 25 fps
+>>7      byte&0x0F          4              \b, 29.97 fps
+>>7      byte&0x0F          5              \b, 30 fps
+>>7      byte&0x0F          6              \b, 50 fps
+>>7      byte&0x0F          7              \b, 59.94 fps
+>>7      byte&0x0F          8              \b, 60 fps
+>>11     byte               &0x04          \b, Constrained
+
+# MPEG ADTS Audio (*.mpx/mxa/aac)
+# from dreesen@math.fu-berlin.de
+# modified to fully support MPEG ADTS
+
+# MP3, M1A
+# modified by Joerg Jenderek
+# GRR the original test are too common for many DOS files
+# so don't accept as MP3 until we've tested the rate
+0       beshort&0xFFFE  0xFFFA
+# rates
+>2      byte&0xF0       0x10           MPEG ADTS, layer III, v1,  32 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x20           MPEG ADTS, layer III, v1,  40 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x30           MPEG ADTS, layer III, v1,  48 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x40           MPEG ADTS, layer III, v1,  56 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x50           MPEG ADTS, layer III, v1,  64 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x60           MPEG ADTS, layer III, v1,  80 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x70           MPEG ADTS, layer III, v1,  96 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x80           MPEG ADTS, layer III, v1, 112 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0x90           MPEG ADTS, layer III, v1, 128 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0xA0           MPEG ADTS, layer III, v1, 160 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0xB0           MPEG ADTS, layer III, v1, 192 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0xC0           MPEG ADTS, layer III, v1, 224 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0xD0           MPEG ADTS, layer III, v1, 256 kbps
+!:mime	audio/mpeg
+>2      byte&0xF0       0xE0           MPEG ADTS, layer III, v1, 320 kbps
+!:mime	audio/mpeg
+# timing
+>2      byte&0x0C       0x00           \b, 44.1 kHz
+>2      byte&0x0C       0x04           \b, 48 kHz
+>2      byte&0x0C       0x08           \b, 32 kHz
+# channels/options
+>3      byte&0xC0       0x00           \b, Stereo
+>3      byte&0xC0       0x40           \b, JntStereo
+>3      byte&0xC0       0x80           \b, 2x Monaural
+>3      byte&0xC0       0xC0           \b, Monaural
+#>1     byte            ^0x01          \b, Data Verify
+#>2     byte            &0x02          \b, Packet Pad
+#>2     byte            &0x01          \b, Custom Flag
+#>3     byte            &0x08          \b, Copyrighted
+#>3     byte            &0x04          \b, Original Source
+#>3     byte&0x03       1              \b, NR: 50/15 ms
+#>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# MP2, M1A
+0       beshort&0xFFFE  0xFFFC         MPEG ADTS, layer II, v1
+!:mime	audio/mpeg
+# rates
+>2      byte&0xF0       0x10           \b,  32 kbps
+>2      byte&0xF0       0x20           \b,  48 kbps
+>2      byte&0xF0       0x30           \b,  56 kbps
+>2      byte&0xF0       0x40           \b,  64 kbps
+>2      byte&0xF0       0x50           \b,  80 kbps
+>2      byte&0xF0       0x60           \b,  96 kbps
+>2      byte&0xF0       0x70           \b, 112 kbps
+>2      byte&0xF0       0x80           \b, 128 kbps
+>2      byte&0xF0       0x90           \b, 160 kbps
+>2      byte&0xF0       0xA0           \b, 192 kbps
+>2      byte&0xF0       0xB0           \b, 224 kbps
+>2      byte&0xF0       0xC0           \b, 256 kbps
+>2      byte&0xF0       0xD0           \b, 320 kbps
+>2      byte&0xF0       0xE0           \b, 384 kbps
+# timing
+>2      byte&0x0C       0x00           \b, 44.1 kHz
+>2      byte&0x0C       0x04           \b, 48 kHz
+>2      byte&0x0C       0x08           \b, 32 kHz
+# channels/options
+>3      byte&0xC0       0x00           \b, Stereo
+>3      byte&0xC0       0x40           \b, JntStereo
+>3      byte&0xC0       0x80           \b, 2x Monaural
+>3      byte&0xC0       0xC0           \b, Monaural
+#>1     byte            ^0x01          \b, Data Verify
+#>2     byte            &0x02          \b, Packet Pad
+#>2     byte            &0x01          \b, Custom Flag
+#>3     byte            &0x08          \b, Copyrighted
+#>3     byte            &0x04          \b, Original Source
+#>3     byte&0x03       1              \b, NR: 50/15 ms
+#>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# MPA, M1A
+# updated by Joerg Jenderek
+# GRR the original test are too common for many DOS files, so test 32 <= kbits <= 448
+# GRR this test is still too general as it catches a BOM of UTF-16 files (0xFFFE)
+# FIXME: Almost all little endian UTF-16 text with BOM are clobbered by these entries
+#0	beshort&0xFFFE		0xFFFE	
+#>2	ubyte&0xF0	>0x0F		
+#>>2	ubyte&0xF0	<0xE1		MPEG ADTS, layer I, v1
+## rate
+#>>>2      byte&0xF0       0x10           \b,  32 kbps
+#>>>2      byte&0xF0       0x20           \b,  64 kbps
+#>>>2      byte&0xF0       0x30           \b,  96 kbps
+#>>>2      byte&0xF0       0x40           \b, 128 kbps
+#>>>2      byte&0xF0       0x50           \b, 160 kbps
+#>>>2      byte&0xF0       0x60           \b, 192 kbps
+#>>>2      byte&0xF0       0x70           \b, 224 kbps
+#>>>2      byte&0xF0       0x80           \b, 256 kbps
+#>>>2      byte&0xF0       0x90           \b, 288 kbps
+#>>>2      byte&0xF0       0xA0           \b, 320 kbps
+#>>>2      byte&0xF0       0xB0           \b, 352 kbps
+#>>>2      byte&0xF0       0xC0           \b, 384 kbps
+#>>>2      byte&0xF0       0xD0           \b, 416 kbps
+#>>>2      byte&0xF0       0xE0           \b, 448 kbps
+## timing
+#>>>2      byte&0x0C       0x00           \b, 44.1 kHz
+#>>>2      byte&0x0C       0x04           \b, 48 kHz
+#>>>2      byte&0x0C       0x08           \b, 32 kHz
+## channels/options
+#>>>3      byte&0xC0       0x00           \b, Stereo
+#>>>3      byte&0xC0       0x40           \b, JntStereo
+#>>>3      byte&0xC0       0x80           \b, 2x Monaural
+#>>>3      byte&0xC0       0xC0           \b, Monaural
+##>1     byte            ^0x01          \b, Data Verify
+##>2     byte            &0x02          \b, Packet Pad
+##>2     byte            &0x01          \b, Custom Flag
+##>3     byte            &0x08          \b, Copyrighted
+##>3     byte            &0x04          \b, Original Source
+##>3     byte&0x03       1              \b, NR: 50/15 ms
+##>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# MP3, M2A
+0       beshort&0xFFFE  0xFFF2         MPEG ADTS, layer III, v2
+!:mime	audio/mpeg
+# rate
+>2      byte&0xF0       0x10           \b,   8 kbps
+>2      byte&0xF0       0x20           \b,  16 kbps
+>2      byte&0xF0       0x30           \b,  24 kbps
+>2      byte&0xF0       0x40           \b,  32 kbps
+>2      byte&0xF0       0x50           \b,  40 kbps
+>2      byte&0xF0       0x60           \b,  48 kbps
+>2      byte&0xF0       0x70           \b,  56 kbps
+>2      byte&0xF0       0x80           \b,  64 kbps
+>2      byte&0xF0       0x90           \b,  80 kbps
+>2      byte&0xF0       0xA0           \b,  96 kbps
+>2      byte&0xF0       0xB0           \b, 112 kbps
+>2      byte&0xF0       0xC0           \b, 128 kbps
+>2      byte&0xF0       0xD0           \b, 144 kbps
+>2      byte&0xF0       0xE0           \b, 160 kbps
+# timing
+>2      byte&0x0C       0x00           \b, 22.05 kHz
+>2      byte&0x0C       0x04           \b, 24 kHz
+>2      byte&0x0C       0x08           \b, 16 kHz
+# channels/options
+>3      byte&0xC0       0x00           \b, Stereo
+>3      byte&0xC0       0x40           \b, JntStereo
+>3      byte&0xC0       0x80           \b, 2x Monaural
+>3      byte&0xC0       0xC0           \b, Monaural
+#>1     byte            ^0x01          \b, Data Verify
+#>2     byte            &0x02          \b, Packet Pad
+#>2     byte            &0x01          \b, Custom Flag
+#>3     byte            &0x08          \b, Copyrighted
+#>3     byte            &0x04          \b, Original Source
+#>3     byte&0x03       1              \b, NR: 50/15 ms
+#>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# MP2, M2A
+0       beshort&0xFFFE  0xFFF4         MPEG ADTS, layer II, v2
+!:mime	audio/mpeg
+# rate 
+>2      byte&0xF0       0x10           \b,   8 kbps
+>2      byte&0xF0       0x20           \b,  16 kbps 
+>2      byte&0xF0       0x30           \b,  24 kbps
+>2      byte&0xF0       0x40           \b,  32 kbps
+>2      byte&0xF0       0x50           \b,  40 kbps
+>2      byte&0xF0       0x60           \b,  48 kbps
+>2      byte&0xF0       0x70           \b,  56 kbps
+>2      byte&0xF0       0x80           \b,  64 kbps
+>2      byte&0xF0       0x90           \b,  80 kbps
+>2      byte&0xF0       0xA0           \b,  96 kbps
+>2      byte&0xF0       0xB0           \b, 112 kbps
+>2      byte&0xF0       0xC0           \b, 128 kbps
+>2      byte&0xF0       0xD0           \b, 144 kbps
+>2      byte&0xF0       0xE0           \b, 160 kbps
+# timing
+>2      byte&0x0C       0x00           \b, 22.05 kHz
+>2      byte&0x0C       0x04           \b, 24 kHz
+>2      byte&0x0C       0x08           \b, 16 kHz
+# channels/options
+>3      byte&0xC0       0x00           \b, Stereo
+>3      byte&0xC0       0x40           \b, JntStereo
+>3      byte&0xC0       0x80           \b, 2x Monaural
+>3      byte&0xC0       0xC0           \b, Monaural
+#>1     byte            ^0x01          \b, Data Verify
+#>2     byte            &0x02          \b, Packet Pad
+#>2     byte            &0x01          \b, Custom Flag
+#>3     byte            &0x08          \b, Copyrighted
+#>3     byte            &0x04          \b, Original Source
+#>3     byte&0x03       1              \b, NR: 50/15 ms
+#>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# MPA, M2A
+0       beshort&0xFFFE  0xFFF6         MPEG ADTS, layer I, v2
+!:mime	audio/mpeg
+# rate
+>2      byte&0xF0       0x10           \b,  32 kbps
+>2      byte&0xF0       0x20           \b,  48 kbps
+>2      byte&0xF0       0x30           \b,  56 kbps
+>2      byte&0xF0       0x40           \b,  64 kbps
+>2      byte&0xF0       0x50           \b,  80 kbps
+>2      byte&0xF0       0x60           \b,  96 kbps
+>2      byte&0xF0       0x70           \b, 112 kbps
+>2      byte&0xF0       0x80           \b, 128 kbps
+>2      byte&0xF0       0x90           \b, 144 kbps
+>2      byte&0xF0       0xA0           \b, 160 kbps
+>2      byte&0xF0       0xB0           \b, 176 kbps
+>2      byte&0xF0       0xC0           \b, 192 kbps
+>2      byte&0xF0       0xD0           \b, 224 kbps
+>2      byte&0xF0       0xE0           \b, 256 kbps
+# timing
+>2      byte&0x0C       0x00           \b, 22.05 kHz
+>2      byte&0x0C       0x04           \b, 24 kHz
+>2      byte&0x0C       0x08           \b, 16 kHz
+# channels/options
+>3      byte&0xC0       0x00           \b, Stereo
+>3      byte&0xC0       0x40           \b, JntStereo
+>3      byte&0xC0       0x80           \b, 2x Monaural
+>3      byte&0xC0       0xC0           \b, Monaural
+#>1     byte            ^0x01          \b, Data Verify
+#>2     byte            &0x02          \b, Packet Pad
+#>2     byte            &0x01          \b, Custom Flag
+#>3     byte            &0x08          \b, Copyrighted
+#>3     byte            &0x04          \b, Original Source
+#>3     byte&0x03       1              \b, NR: 50/15 ms
+#>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# MP3, M25A
+0       beshort&0xFFFE  0xFFE2         MPEG ADTS, layer III,  v2.5
+!:mime	audio/mpeg
+# rate  
+>2      byte&0xF0       0x10           \b,   8 kbps
+>2      byte&0xF0       0x20           \b,  16 kbps
+>2      byte&0xF0       0x30           \b,  24 kbps
+>2      byte&0xF0       0x40           \b,  32 kbps
+>2      byte&0xF0       0x50           \b,  40 kbps
+>2      byte&0xF0       0x60           \b,  48 kbps
+>2      byte&0xF0       0x70           \b,  56 kbps
+>2      byte&0xF0       0x80           \b,  64 kbps
+>2      byte&0xF0       0x90           \b,  80 kbps
+>2      byte&0xF0       0xA0           \b,  96 kbps
+>2      byte&0xF0       0xB0           \b, 112 kbps
+>2      byte&0xF0       0xC0           \b, 128 kbps
+>2      byte&0xF0       0xD0           \b, 144 kbps
+>2      byte&0xF0       0xE0           \b, 160 kbps
+# timing
+>2      byte&0x0C       0x00           \b, 11.025 kHz
+>2      byte&0x0C       0x04           \b, 12 kHz
+>2      byte&0x0C       0x08           \b, 8 kHz
+# channels/options
+>3      byte&0xC0       0x00           \b, Stereo
+>3      byte&0xC0       0x40           \b, JntStereo
+>3      byte&0xC0       0x80           \b, 2x Monaural
+>3      byte&0xC0       0xC0           \b, Monaural
+#>1     byte            ^0x01          \b, Data Verify
+#>2     byte            &0x02          \b, Packet Pad
+#>2     byte            &0x01          \b, Custom Flag
+#>3     byte            &0x08          \b, Copyrighted
+#>3     byte            &0x04          \b, Original Source
+#>3     byte&0x03       1              \b, NR: 50/15 ms
+#>3     byte&0x03       3              \b, NR: CCIT J.17
+
+# AAC (aka MPEG-2 NBC audio) and MPEG-4 audio
+
+# Stored AAC streams (instead of the MP4 format)
+0       string          ADIF           MPEG ADIF, AAC
+!:mime	audio/x-hx-aac-adif
+>4      byte            &0x80
+>>13    byte            &0x10          \b, VBR
+>>13    byte            ^0x10          \b, CBR
+>>16    byte&0x1E       0x02           \b, single stream
+>>16    byte&0x1E       0x04           \b, 2 streams
+>>16    byte&0x1E       0x06           \b, 3 streams
+>>16    byte            &0x08          \b, 4 or more streams
+>>16    byte            &0x10          \b, 8 or more streams
+>>4    byte            &0x80          \b, Copyrighted
+>>13   byte            &0x40          \b, Original Source
+>>13   byte            &0x20          \b, Home Flag
+>4      byte            ^0x80
+>>4     byte            &0x10          \b, VBR
+>>4     byte            ^0x10          \b, CBR
+>>7     byte&0x1E       0x02           \b, single stream
+>>7     byte&0x1E       0x04           \b, 2 streams
+>>7     byte&0x1E       0x06           \b, 3 streams
+>>7     byte            &0x08          \b, 4 or more streams
+>>7     byte            &0x10          \b, 8 or more streams
+>>4    byte            &0x40          \b, Original Stream(s)
+>>4    byte            &0x20          \b, Home Source
+
+# Live or stored single AAC stream (used with MPEG-2 systems)
+0       beshort&0xFFF6  0xFFF0         MPEG ADTS, AAC
+!:mime	audio/x-hx-aac-adts
+>1      byte            &0x08          \b, v2
+>1      byte            ^0x08          \b, v4
+# profile
+>>2     byte            &0xC0          \b LTP
+>2      byte&0xc0       0x00           \b Main
+>2      byte&0xc0       0x40           \b LC
+>2      byte&0xc0       0x80           \b SSR
+# timing
+>2      byte&0x3c       0x00           \b, 96 kHz
+>2      byte&0x3c       0x04           \b, 88.2 kHz
+>2      byte&0x3c       0x08           \b, 64 kHz
+>2      byte&0x3c       0x0c           \b, 48 kHz
+>2      byte&0x3c       0x10           \b, 44.1 kHz
+>2      byte&0x3c       0x14           \b, 32 kHz
+>2      byte&0x3c       0x18           \b, 24 kHz
+>2      byte&0x3c       0x1c           \b, 22.05 kHz
+>2      byte&0x3c       0x20           \b, 16 kHz
+>2      byte&0x3c       0x24           \b, 12 kHz
+>2      byte&0x3c       0x28           \b, 11.025 kHz
+>2      byte&0x3c       0x2c           \b, 8 kHz
+# channels
+>2      beshort&0x01c0  0x0040         \b, monaural
+>2      beshort&0x01c0  0x0080         \b, stereo
+>2      beshort&0x01c0  0x00c0         \b, stereo + center
+>2      beshort&0x01c0  0x0100         \b, stereo+center+LFE
+>2      beshort&0x01c0  0x0140         \b, surround
+>2      beshort&0x01c0  0x0180         \b, surround + LFE
+>2      beshort         &0x01C0        \b, surround + side
+#>1     byte            ^0x01           \b, Data Verify
+#>2     byte            &0x02           \b, Custom Flag
+#>3     byte            &0x20           \b, Original Stream
+#>3     byte            &0x10           \b, Home Source
+#>3     byte            &0x08           \b, Copyrighted
+
+# Live MPEG-4 audio streams (instead of RTP FlexMux)
+0       beshort&0xFFE0  0x56E0         MPEG-4 LOAS
+!:mime	audio/x-mp4a-latm
+#>1     beshort&0x1FFF  x              \b, %hu byte packet
+>3      byte&0xE0       0x40
+>>4     byte&0x3C       0x04           \b, single stream
+>>4     byte&0x3C       0x08           \b, 2 streams
+>>4     byte&0x3C       0x0C           \b, 3 streams
+>>4     byte            &0x08          \b, 4 or more streams
+>>4     byte            &0x20          \b, 8 or more streams
+>3      byte&0xC0       0
+>>4     byte&0x78       0x08           \b, single stream
+>>4     byte&0x78       0x10           \b, 2 streams
+>>4     byte&0x78       0x18           \b, 3 streams
+>>4     byte            &0x20          \b, 4 or more streams
+>>4     byte            &0x40          \b, 8 or more streams
+# This magic isn't strong enough (matches plausible ISO-8859-1 text)
+#0       beshort         0x4DE1         MPEG-4 LO-EP audio stream
+#!:mime	audio/x-mp4a-latm
+
+# Summary: FLI animation format
+# Created by: Daniel Quinlan <quinlan@yggdrasil.com>
+# Modified by (1): Abel Cheung <abelcheung@gmail.com> (avoid over-generic detection)
+4	leshort		0xAF11
+# standard FLI always has 320x200 resolution and 8 bit color
+>8	leshort		320
+>>10	leshort		200
+>>>12	leshort		8			FLI animation, 320x200x8
+!:mime	video/x-fli
+>>>>6	leshort		x			\b, %d frames
+# frame speed is multiple of 1/70s
+>>>>16	leshort		x			\b, %d/70s per frame
+
+# Summary: FLC animation format
+# Created by: Daniel Quinlan <quinlan@yggdrasil.com>
+# Modified by (1): Abel Cheung <abelcheung@gmail.com> (avoid over-generic detection)
+4	leshort		0xAF12
+# standard FLC always use 8 bit color
+>12	leshort		8			FLC animation
+!:mime	video/x-flc
+>>8	leshort		x			\b, %d
+>>10	leshort		x			\bx%dx8
+>>6	uleshort	x			\b, %d frames
+>>16	uleshort	x			\b, %dms per frame
+
+# DL animation format
+# XXX - collision with most `mips' magic
+#
+# I couldn't find a real magic number for these, however, this
+# -appears- to work.  Note that it might catch other files, too, so be
+# careful!
+#
+# Note that title and author appear in the two 20-byte chunks
+# at decimal offsets 2 and 22, respectively, but they are XOR'ed with
+# 255 (hex FF)!  The DL format is really bad.
+#
+#0	byte	1	DL version 1, medium format (160x100, 4 images/screen)
+#!:mime	video/x-unknown
+#>42	byte	x	- %d screens,
+#>43	byte	x	%d commands
+#0	byte	2	DL version 2
+#!:mime	video/x-unknown
+#>1	byte	1	- large format (320x200,1 image/screen),
+#>1	byte	2	- medium format (160x100,4 images/screen),
+#>1	byte	>2	- unknown format,
+#>42	byte	x	%d screens,
+#>43	byte	x	%d commands
+# Based on empirical evidence, DL version 3 have several nulls following the
+# \003.  Most of them start with non-null values at hex offset 0x34 or so.
+#0	string	\3\0\0\0\0\0\0\0\0\0\0\0	DL version 3
+
+# iso 13818 transport stream
+#
+# from Oskar Schirmer <schirmer@scara.com> Feb 3, 2001 (ISO 13818.1)
+# syncbyte      8 bit	0x47
+# error_ind     1 bit	-
+# payload_start 1 bit	1
+# priority      1 bit	-
+# PID          13 bit	0x0000
+# scrambling    2 bit	-
+# adaptfld_ctrl 2 bit	1 or 3
+# conti_count   4 bit	-
+0	belong&0xFF5FFF10	0x47400010
+>188	byte			0x47		MPEG transport stream data
+
+# DIF digital video file format <mpruett@sgi.com>
+0	belong&0xffffff00	0x1f070000      DIF
+>4	byte			&0x01		(DVCPRO) movie file
+>4	byte			^0x01		(DV) movie file
+>3	byte			&0x80		(PAL)
+>3	byte			^0x80		(NTSC)
+
+# Microsoft Advanced Streaming Format (ASF) <mpruett@sgi.com>
+0	belong			0x3026b275	Microsoft ASF
+!:mime  video/x-ms-asf
+
+# MNG Video Format, <URL:http://www.libpng.org/pub/mng/spec/>
+0	string			\x8aMNG		MNG video data,
+!:mime	video/x-mng
+>4	belong			!0x0d0a1a0a	CORRUPTED,
+>4	belong			0x0d0a1a0a
+>>16    belong	x				%d x
+>>20    belong	x				%d
+
+# JNG Video Format, <URL:http://www.libpng.org/pub/mng/spec/>
+0	string			\x8bJNG		JNG video data,
+!:mime	video/x-jng
+>4	belong			!0x0d0a1a0a	CORRUPTED,
+>4	belong			0x0d0a1a0a
+>>16    belong	x				%d x
+>>20    belong	x				%d
+
+# Vivo video (Wolfram Kleff)
+3	string		\x0D\x0AVersion:Vivo	Vivo video data
+
+# VRML (Virtual Reality Modelling Language)
+0       string/w        #VRML\ V1.0\ ascii	VRML 1 file
+!:mime	model/vrml
+0	string/w	#VRML\ V2.0\ utf8	ISO/IEC 14772 VRML 97 file
+!:mime	model/vrml
+
+# X3D (Extensible 3D) [http://www.web3d.org/specifications/x3d-3.0.dtd]
+# From Michel Briand <michelbriand@free.fr>
+0	string/t		\<?xml\ version="
+!:strength +1
+>20	search/1000/cw  \<!DOCTYPE\ X3D		X3D (Extensible 3D) model xml text
+!:mime model/x3d
+
+#---------------------------------------------------------------------------
+# HVQM4: compressed movie format designed by Hudson for Nintendo GameCube
+# From Mark Sheppard <msheppard@climax.co.uk>, 2002-10-03
+#
+0	string		HVQM4		%s
+>6	string		>\0		v%s
+>0	byte		x		GameCube movie,
+>0x34	ubeshort	x		%d x
+>0x36	ubeshort	x		%d,
+>0x26	ubeshort	x		%dus,
+>0x42	ubeshort	0		no audio
+>0x42	ubeshort	>0		%dHz audio
+
+# From: "Stefan A. Haubenthal" <polluks@web.de>
+0	string		DVDVIDEO-VTS	Video title set,
+>0x21	byte		x		v%x
+0	string		DVDVIDEO-VMG	Video manager,
+>0x21	byte		x		v%x
+
+# From: Behan Webster <behanw@websterwood.com>
+# NuppelVideo used by Mythtv (*.nuv)
+# Note: there are two identical stanzas here differing only in the
+# initial string matched. It used to be done with a regex, but we're
+# trying to get rid of those.
+0	string		NuppelVideo	MythTV NuppelVideo
+>12	string		x		v%s
+>20	lelong		x		(%d
+>24	lelong		x		\bx%d),
+>36	string		P		\bprogressive,
+>36	string		I		\binterlaced,
+>40	ledouble	x		\baspect:%.2f,
+>48	ledouble	x		\bfps:%.2f
+0	string		MythTV		MythTV NuppelVideo
+>12	string		x		v%s
+>20	lelong		x		(%d
+>24	lelong		x		\bx%d),
+>36	string		P		\bprogressive,
+>36	string		I		\binterlaced,
+>40	ledouble	x		\baspect:%.2f,
+>48	ledouble	x		\bfps:%.2f
+
+#						MPEG file
+# MPEG sequences
+# FIXME: This section is from the old magic.mime file and needs
+# integrating with the rest
+#0       belong             0x000001BA
+#>4      byte               &0x40
+#!:mime	video/mp2p
+#>4      byte               ^0x40
+#!:mime	video/mpeg
+#0       belong             0x000001BB
+#!:mime	video/mpeg
+#0       belong             0x000001B0
+#!:mime	video/mp4v-es
+#0       belong             0x000001B5
+#!:mime	video/mp4v-es
+#0       belong             0x000001B3
+#!:mime	video/mpv
+#0       belong&0xFF5FFF10  0x47400010
+#!:mime	video/mp2t
+#0       belong             0x00000001
+#>4      byte&0x1F	   0x07
+#!:mime	video/h264
+
+# Type: Bink Video
+# Extension: .bik
+# URL:  http://wiki.multimedia.cx/index.php?title=Bink_Container
+# From: <hoehle@users.sourceforge.net>  2008-07-18
+0	string		BIK	Bink Video
+>3	regex		=[a-z]	rev.%s
+#>4	ulelong		x	size %d
+>20	ulelong		x	\b, %d
+>24	ulelong		x	\bx%d
+>8	ulelong		x	\b, %d frames
+>32	ulelong		x	at rate %d/
+>28	ulelong		>1	\b%d
+>40	ulelong		=0	\b, no audio
+>40	ulelong		!0	\b, %d audio track
+>>40	ulelong		!1	\bs
+# follow properties of the first audio track only
+>>48	uleshort	x	%dHz
+>>51	byte&0x20	0	mono
+>>51	byte&0x20	!0	stereo
+#>>51	byte&0x10	0	FFT
+#>>51	byte&0x10	!0	DCT
+
+# Type:	NUT Container
+# URL:	http://wiki.multimedia.cx/index.php?title=NUT
+# From:	Adam Buchbinder <adam.buchbinder@gmail.com>
+0	string	nut/multimedia\ container\0	NUT multimedia container
+
+# Type: Nullsoft Video (NSV)
+# URL:  http://wiki.multimedia.cx/index.php?title=Nullsoft_Video
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	NSVf	Nullsoft Video
+
+# Type: REDCode Video
+# URL:  http://www.red.com/ ; http://wiki.multimedia.cx/index.php?title=REDCode
+# From: Mike Melanson <mike@multimedia.cx>
+4	string	RED1	REDCode Video
+
+# Type: MTV Multimedia File
+# URL:  http://wiki.multimedia.cx/index.php?title=MTV
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	AMVS	MTV Multimedia File
+
+# Type: ARMovie
+# URL:  http://wiki.multimedia.cx/index.php?title=ARMovie
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	ARMovie\012	ARMovie
+
+# Type: Interplay MVE Movie
+# URL:  http://wiki.multimedia.cx/index.php?title=Interplay_MVE
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	Interplay\040MVE\040File\032	Interplay MVE Movie
+
+# Type: Windows Television DVR File
+# URL:  http://wiki.multimedia.cx/index.php?title=WTV
+# From: Mike Melanson <mike@mutlimedia.cx>
+# This takes the form of a Windows-style GUID
+0	bequad	0xB7D800203749DA11
+>8	bequad	0xA64E0007E95EAD8D	Windows Television DVR Media
+
+# Type: Sega FILM/CPK Multimedia
+# URL:  http://wiki.multimedia.cx/index.php?title=Sega_FILM
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	FILM	Sega FILM/CPK Multimedia,
+>32	belong	x	%d x
+>28	belong	x	%d
+
+# Type: Nintendo THP Multimedia
+# URL:  http://wiki.multimedia.cx/index.php?title=THP
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	THP\0	Nintendo THP Multimedia
+
+# Type: BBC Dirac Video
+# URL:  http://wiki.multimedia.cx/index.php?title=Dirac
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	BBCD	BBC Dirac Video
+
+# Type: RAD Game Tools Smacker Multimedia
+# URL:  http://wiki.multimedia.cx/index.php?title=Smacker
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	SMK	RAD Game Tools Smacker Multimedia
+>3	byte	x	version %c,
+>4	lelong	x	%d x
+>8	lelong	x	%d,
+>12	lelong	x	%d frames
+
+#------------------------------------------------------------------------------
+# $File$
+# aout:  file(1) magic for a.out executable/object/etc entries that
+# handle executables on multiple platforms.
+#
+
+#
+# Little-endian 32-bit-int a.out, merged from bsdi (for BSD/OS, from
+# BSDI), netbsd, and vax (for UNIX/32V and BSD)
+#
+# XXX - is there anything we can look at to distinguish BSD/OS 386 from
+# NetBSD 386 from various VAX binaries?  The BSD/OS shared library flag
+# works only for binaries using shared libraries.  Grabbing the entry
+# point from the a.out header, using it to find the first code executed
+# in the program, and looking at that might help.
+#
+0	lelong		0407		a.out little-endian 32-bit executable
+>16	lelong		>0		not stripped
+>32	byte		0x6a		(uses BSD/OS shared libs)
+
+0	lelong		0410		a.out little-endian 32-bit pure executable
+>16	lelong		>0		not stripped
+>32	byte		0x6a		(uses BSD/OS shared libs)
+
+0	lelong		0413		a.out little-endian 32-bit demand paged pure executable
+>16	lelong		>0		not stripped
+>32	byte		0x6a		(uses BSD/OS shared libs)
+
+#
+# Big-endian 32-bit-int a.out, merged from sun (for old 68010 SunOS a.out),
+# mips (for old 68020(!) SGI a.out), and netbsd (for old big-endian a.out).
+#
+# XXX - is there anything we can look at to distinguish old SunOS 68010
+# from old 68020 IRIX from old NetBSD?  Again, I guess we could look at
+# the first instruction or instructions in the program.
+#
+0	belong		0407		a.out big-endian 32-bit executable
+>16	belong		>0		not stripped
+
+0	belong		0410		a.out big-endian 32-bit pure executable
+>16	belong		>0		not stripped
+
+0	belong		0413		a.out big-endian 32-bit demand paged executable
+>16	belong		>0		not stripped
+
+
+#------------------------------------------------------------------------------
+# $File$
+# apl:  file(1) magic for APL (see also "pdp" and "vax" for other APL
+#       workspaces)
+#
+0	long		0100554		APL workspace (Ken's original?)
+
+#------------------------------------------------------------------------------
+# $File: apple,v 1.28 2014/04/28 12:04:50 christos Exp $
+# apple:  file(1) magic for Apple file formats
+#
+0	search/1/t	FiLeStArTfIlEsTaRt	binscii (apple ][) text
+0	string		\x0aGL			Binary II (apple ][) data
+0	string		\x76\xff		Squeezed (apple ][) data
+0	string		NuFile			NuFile archive (apple ][) data
+0	string		N\xf5F\xe9l\xe5		NuFile archive (apple ][) data
+0	belong		0x00051600		AppleSingle encoded Macintosh file
+0	belong		0x00051607		AppleDouble encoded Macintosh file
+
+# Type: Apple Emulator 2IMG format
+# From: Radek Vokal <rvokal@redhat.com>
+0	string		2IMG	Apple ][ 2IMG Disk Image
+>4	string		XGS!	\b, XGS
+>4	string		CTKG	\b, Catakig
+>4	string		ShIm	\b, Sheppy's ImageMaker
+>4	string		WOOF	\b, Sweet 16
+>4	string		B2TR	\b, Bernie ][ the Rescue
+>4	string		!nfc	\b, ASIMOV2
+>4	string		x	\b, Unknown Format
+>0xc	byte		00	\b, DOS 3.3 sector order
+>>0x10	byte		00	\b, Volume 254
+>>0x10	byte&0x7f	x	\b, Volume %u
+>0xc	byte		01	\b, ProDOS sector order
+>>0x14	short		x	\b, %u Blocks
+>0xc	byte		02	\b, NIB data
+
+# magic for Newton PDA package formats
+# from Ruda Moura <ruda@helllabs.org>
+0	string	package0	Newton package, NOS 1.x,
+>12	belong	&0x80000000	AutoRemove,
+>12	belong	&0x40000000	CopyProtect,
+>12	belong	&0x10000000	NoCompression,
+>12	belong	&0x04000000	Relocation,
+>12	belong	&0x02000000	UseFasterCompression,
+>16	belong	x		version %d
+
+0	string	package1	Newton package, NOS 2.x,
+>12	belong	&0x80000000	AutoRemove,
+>12	belong	&0x40000000	CopyProtect,
+>12	belong	&0x10000000	NoCompression,
+>12	belong	&0x04000000	Relocation,
+>12	belong	&0x02000000	UseFasterCompression,
+>16	belong	x		version %d
+
+0	string	package4	Newton package,
+>8	byte	8		NOS 1.x,
+>8	byte	9		NOS 2.x,
+>12	belong	&0x80000000	AutoRemove,
+>12	belong	&0x40000000	CopyProtect,
+>12	belong	&0x10000000	NoCompression,
+
+# The following entries for the Apple II are for files that have
+# been transferred as raw binary data from an Apple, without having
+# been encapsulated by any of the above archivers.
+#
+# In general, Apple II formats are hard to identify because Apple DOS
+# and especially Apple ProDOS have strong typing in the file system and
+# therefore programmers never felt much need to include type information
+# in the files themselves.
+#
+# Eric Fischer <enf@pobox.com>
+
+# AppleWorks word processor:
+#
+# This matches the standard tab stops for an AppleWorks file, but if
+# a file has a tab stop set in the first four columns this will fail.
+#
+# The "O" is really the magic number, but that's so common that it's
+# necessary to check the tab stops that follow it to avoid false positives.
+
+4       string          O====   AppleWorks word processor data
+>85     byte&0x01       >0      \b, zoomed
+>90     byte&0x01       >0      \b, paginated
+>92     byte&0x01       >0      \b, with mail merge
+#>91    byte            x       \b, left margin %d
+
+# AppleWorks database:
+#
+# This isn't really a magic number, but it's the closest thing to one
+# that I could find.  The 1 and 2 really mean "order in which you defined
+# categories" and "left to right, top to bottom," respectively; the D and R
+# mean that the cursor should move either down or right when you press Return.
+
+#30	string		\x01D	AppleWorks database data
+#30	string		\x02D	AppleWorks database data
+#30	string		\x01R	AppleWorks database data
+#30	string		\x02R	AppleWorks database data
+
+# AppleWorks spreadsheet:
+#
+# Likewise, this isn't really meant as a magic number.  The R or C means
+# row- or column-order recalculation; the A or M means automatic or manual
+# recalculation.
+
+#131	string		RA	AppleWorks spreadsheet data
+#131	string		RM	AppleWorks spreadsheet data
+#131	string		CA	AppleWorks spreadsheet data
+#131	string		CM	AppleWorks spreadsheet data
+
+# Applesoft BASIC:
+#
+# This is incredibly sloppy, but will be true if the program was
+# written at its usual memory location of 2048 and its first line
+# number is less than 256.  Yuck.
+# update by Joerg Jenderek at Feb 2013
+
+# GRR: this test is still too general as it catches also Gujin BOOT144.SYS (0xfa080000)
+#0       belong&0xff00ff 0x80000 Applesoft BASIC program data
+0	belong&0x00ff00ff	0x00080000	
+# assuming that line number must be positive
+>2	leshort			>0		Applesoft BASIC program data, first line number %d
+#>2     leshort         x       \b, first line number %d
+
+# ORCA/EZ assembler:
+# 
+# This will not identify ORCA/M source files, since those have
+# some sort of date code instead of the two zero bytes at 6 and 7
+# XXX Conflicts with ELF
+#4       belong&0xff00ffff       0x01000000      ORCA/EZ assembler source data
+#>5      byte                    x               \b, build number %d
+
+# Broderbund Fantavision
+#
+# I don't know what these values really mean, but they seem to recur.
+# Will they cause too many conflicts?
+
+# Probably :-)
+#2	belong&0xFF00FF		0x040008	Fantavision movie data
+
+# Some attempts at images.
+#
+# These are actually just bit-for-bit dumps of the frame buffer, so
+# there's really no reasonably way to distinguish them except for their
+# address (if preserved) -- 8192 or 16384 -- and their length -- 8192
+# or, occasionally, 8184.
+#
+# Nevertheless this will manage to catch a lot of images that happen
+# to have a solid-colored line at the bottom of the screen.
+
+# GRR: Magic too weak
+#8144	string	\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F	Apple II image with white background
+#8144	string	\x55\x2A\x55\x2A\x55\x2A\x55\x2A	Apple II image with purple background
+#8144	string	\x2A\x55\x2A\x55\x2A\x55\x2A\x55	Apple II image with green background
+#8144	string	\xD5\xAA\xD5\xAA\xD5\xAA\xD5\xAA	Apple II image with blue background
+#8144	string	\xAA\xD5\xAA\xD5\xAA\xD5\xAA\xD5	Apple II image with orange background
+
+# Beagle Bros. Apple Mechanic fonts
+
+0	belong&0xFF00FFFF	0x6400D000	Apple Mechanic font
+
+# Apple Universal Disk Image Format (UDIF) - dmg files.
+# From Johan Gade.
+# These entries are disabled for now until we fix the following issues.
+#
+# Note there might be some problems with the "VAX COFF executable" 
+# entry. Note this entry should be placed before the mac filesystem section, 
+# particularly the "Apple Partition data" entry.
+#
+# The intended meaning of these tests is, that the file is only of the 
+# specified type if both of the lines are correct - i.e. if the first
+# line matches and the second doesn't then it is not of that type.
+#
+#0	long	0x7801730d
+#>4	long	0x62626060	UDIF read-only zlib-compressed image (UDZO)
+#
+# Note that this entry is recognized correctly by the "Apple Partition 
+# data" entry - however since this entry is more specific - this
+# information seems to be more useful.
+#0	long	0x45520200
+#>0x410	string	disk\ image	UDIF read/write image (UDRW)
+
+# From: Toby Peterson <toby@apple.com>
+0	string	bplist00	Apple binary property list
+
+# Apple binary property list (bplist)
+#  Assumes version bytes are hex.
+#  Provides content hints for version 0 files. Assumes that the root
+#  object is the first object (true for CoreFoundation implementation).
+# From: David Remahl <dremahl@apple.com>
+0		string	bplist
+>6		byte	x	\bCoreFoundation binary property list data, version 0x%c
+>>7		byte	x	\b%c
+>6		string		00		\b
+>>8		byte&0xF0	0x00	\b
+>>>8	byte&0x0F	0x00	\b, root type: null
+>>>8	byte&0x0F	0x08	\b, root type: false boolean
+>>>8	byte&0x0F	0x09	\b, root type: true boolean
+>>8		byte&0xF0	0x10	\b, root type: integer
+>>8		byte&0xF0	0x20	\b, root type: real
+>>8		byte&0xF0	0x30	\b, root type: date
+>>8		byte&0xF0	0x40    \b, root type: data
+>>8		byte&0xF0	0x50	\b, root type: ascii string
+>>8		byte&0xF0	0x60	\b, root type: unicode string
+>>8		byte&0xF0	0x80	\b, root type: uid (CORRUPT)
+>>8		byte&0xF0	0xa0	\b, root type: array
+>>8		byte&0xF0	0xd0	\b, root type: dictionary
+
+# Apple/NeXT typedstream data
+#  Serialization format used by NeXT and Apple for various
+#  purposes in YellowStep/Cocoa, including some nib files.
+# From: David Remahl <dremahl@apple.com>
+2		string		typedstream	NeXT/Apple typedstream data, big endian
+>0		byte		x		\b, version %d
+>0		byte		<5		\b
+>>13	byte		0x81	\b
+>>>14	ubeshort	x		\b, system %d
+2		string		streamtyped NeXT/Apple typedstream data, little endian
+>0		byte		x		\b, version %d
+>0		byte		<5		\b
+>>13	byte		0x81	\b
+>>>14	uleshort	x		\b, system %d
+
+#------------------------------------------------------------------------------
+# CAF: Apple CoreAudio File Format
+#
+# Container format for high-end audio purposes.
+# From: David Remahl <dremahl@apple.com>
+#
+0	string		caff		CoreAudio Format audio file
+>4	beshort		<10		version %d
+>6	beshort		x
+
+
+#------------------------------------------------------------------------------
+# Keychain database files
+0	string		kych		Mac OS X Keychain File
+
+#------------------------------------------------------------------------------
+# Code Signing related file types
+0	belong		0xfade0c00	Mac OS X Code Requirement
+>8	belong		1			(opExpr)
+>4	belong		x			- %d bytes
+
+0	belong		0xfade0c01	Mac OS X Code Requirement Set
+>8	belong		>1			containing %d items
+>4	belong		x			- %d bytes
+
+0	belong		0xfade0c02	Mac OS X Code Directory
+>8	belong		x			version %x
+>12	belong		>0			flags 0x%x
+>4	belong		x			- %d bytes
+
+0	belong		0xfade0cc0	Mac OS X Detached Code Signature (non-executable)
+>4	belong		x			- %d bytes
+
+0	belong		0xfade0cc1	Mac OS X Detached Code Signature
+>8	belong		>1			(%d elements)
+>4	belong		x			- %d bytes
+
+# From: "Nelson A. de Oliveira" <naoliv@gmail.com>
+# .vdi
+4	string innotek\ VirtualBox\ Disk\ Image %s
+
+# Apple disk partition stuff, strengthen the magic using byte 4
+0	beshort	0x4552
+>4	byte	0			Apple Driver Map
+>>2	beshort	x			\b, blocksize %d
+>>4	belong	x			\b, blockcount %d
+>>10	beshort	x			\b, devtype %d
+>>12	beshort	x			\b, devid %d
+>>20	beshort x			\b, descriptors %d
+# Assume 	8 partitions each at a multiple of the sector size.
+# We could glean this from the partition descriptors, but they are empty!?!?
+>>(2.S*1)	indirect		\b, contains[@0x%x]: 
+>>(2.S*2)	indirect		\b, contains[@0x%x]: 
+>>(2.S*3)	indirect		\b, contains[@0x%x]: 
+>>(2.S*4)	indirect		\b, contains[@0x%x]: 
+>>(2.S*5)	indirect		\b, contains[@0x%x]: 
+>>(2.S*6)	indirect		\b, contains[@0x%x]: 
+>>(2.S*7)	indirect		\b, contains[@0x%x]: 
+>>(2.S*8)	indirect		\b, contains[@0x%x]: 
+
+# Yes, the 3rd and 4th bytes are reserved, but we use them to make the
+# magic stronger.
+0	belong	0x504d0000		Apple Partition Map
+>4	belong	x			\b, map block count %d
+>8	belong	x			\b, start block %d
+>12	belong	x			\b, block count %d
+>16	string >0			\b, name %s
+>48	string >0			\b, type %s
+>124	string >0			\b, processor %s
+>140	string >0			\b, boot arguments %s
+>92	belong	& 1			\b, valid
+>92	belong	& 2			\b, allocated
+>92	belong	& 4			\b, in use
+>92	belong	& 8			\b, has boot info
+>92	belong	& 16			\b, readable
+>92	belong	& 32			\b, writable
+>92	belong	& 64			\b, pic boot code
+>92	belong	& 128			\b, chain compatible driver
+>92	belong	& 256			\b, real driver
+>92	belong	& 512			\b, chain driver
+>92	belong	& 1024			\b, mount at startup
+>92	belong	& 2048			\b, is the startup partition
+
+#http://wiki.mozilla.org/DS_Store_File_Format`
+#http://en.wikipedia.org/wiki/.DS_Store
+0	string	\0\0\0\1Bud1\0		Apple Desktop Services Store
+
+#------------------------------------------------------------------------------
+# $File$
+# applix:  file(1) magic for Applixware
+# From: Peter Soos <sp@osb.hu>
+#
+0	string		*BEGIN		Applixware
+>7	string		WORDS			Words Document
+>7	string		GRAPHICS		Graphic
+>7	string		RASTER			Bitmap
+>7	string		SPREADSHEETS		Spreadsheet
+>7	string		MACRO			Macro
+>7	string		BUILDER			Builder Object
+#------------------------------------------------------------------------------
+# $File: archive,v 1.87 2014/06/03 19:15:58 christos Exp $
+# archive:  file(1) magic for archive formats (see also "msdos" for self-
+#           extracting compressed archives)
+#
+# cpio, ar, arc, arj, hpack, lha/lharc, rar, squish, uc2, zip, zoo, etc.
+# pre-POSIX "tar" archives are handled in the C code.
+
+# POSIX tar archives
+257	string		ustar\0		POSIX tar archive
+!:mime	application/x-tar # encoding: posix
+257	string		ustar\040\040\0	GNU tar archive
+!:mime	application/x-tar # encoding: gnu
+
+# Incremental snapshot gnu-tar format from:
+# http://www.gnu.org/software/tar/manual/html_node/Snapshot-Files.html
+0	string		GNU\ tar-	GNU tar incremental snapshot data
+>&0	regex		[0-9]\.[0-9]+-[0-9]+	version %s
+
+# cpio archives
+#
+# Yes, the top two "cpio archive" formats *are* supposed to just be "short".
+# The idea is to indicate archives produced on machines with the same
+# byte order as the machine running "file" with "cpio archive", and
+# to indicate archives produced on machines with the opposite byte order
+# from the machine running "file" with "byte-swapped cpio archive".
+#
+# The SVR4 "cpio(4)" hints that there are additional formats, but they
+# are defined as "short"s; I think all the new formats are
+# character-header formats and thus are strings, not numbers.
+0	short		070707		cpio archive
+!:mime	application/x-cpio
+0	short		0143561		byte-swapped cpio archive
+!:mime	application/x-cpio # encoding: swapped
+0	string		070707		ASCII cpio archive (pre-SVR4 or odc)
+0	string		070701		ASCII cpio archive (SVR4 with no CRC)
+0	string		070702		ASCII cpio archive (SVR4 with CRC)
+
+#
+# Various archive formats used by various versions of the "ar"
+# command.
+#
+
+#
+# Original UNIX archive formats.
+# They were written with binary values in host byte order, and
+# the magic number was a host "int", which might have been 16 bits
+# or 32 bits.  We don't say "PDP-11" or "VAX", as there might have
+# been ports to little-endian 16-bit-int or 32-bit-int platforms
+# (x86?) using some of those formats; if none existed, feel free
+# to use "PDP-11" for little-endian 16-bit and "VAX" for little-endian
+# 32-bit.  There might have been big-endian ports of that sort as
+# well.
+#
+0	leshort		0177555		very old 16-bit-int little-endian archive
+0	beshort		0177555		very old 16-bit-int big-endian archive
+0	lelong		0177555		very old 32-bit-int little-endian archive
+0	belong		0177555		very old 32-bit-int big-endian archive
+
+0	leshort		0177545		old 16-bit-int little-endian archive
+>2	string		__.SYMDEF	random library
+0	beshort		0177545		old 16-bit-int big-endian archive
+>2	string		__.SYMDEF	random library
+0	lelong		0177545		old 32-bit-int little-endian archive
+>4	string		__.SYMDEF	random library
+0	belong		0177545		old 32-bit-int big-endian archive
+>4	string		__.SYMDEF	random library
+
+#
+# From "pdp" (but why a 4-byte quantity?)
+#
+0	lelong		0x39bed		PDP-11 old archive
+0	lelong		0x39bee		PDP-11 4.0 archive
+
+#
+# XXX - what flavor of APL used this, and was it a variant of
+# some ar archive format?  It's similar to, but not the same
+# as, the APL workspace magic numbers in pdp.
+#
+0	long		0100554		apl workspace
+
+#
+# System V Release 1 portable(?) archive format.
+#
+0	string		=<ar>		System V Release 1 ar archive
+!:mime	application/x-archive
+
+#
+# Debian package; it's in the portable archive format, and needs to go
+# before the entry for regular portable archives, as it's recognized as
+# a portable archive whose first member has a name beginning with
+# "debian".
+#
+0	string		=!<arch>\ndebian
+>8	string		debian-split	part of multipart Debian package
+!:mime	application/vnd.debian.binary-package
+>8	string		debian-binary	Debian binary package
+!:mime	application/vnd.debian.binary-package
+>8	string		!debian
+>68	string		>\0		(format %s)
+# These next two lines do not work, because a bzip2 Debian archive
+# still uses gzip for the control.tar (first in the archive).  Only
+# data.tar varies, and the location of its filename varies too.
+# file/libmagic does not current have support for ascii-string based
+# (offsets) as of 2005-09-15.
+#>81	string		bz2		\b, uses bzip2 compression
+#>84	string		gz		\b, uses gzip compression
+#>136	ledate		x		created: %s
+
+#
+# MIPS archive; they're in the portable archive format, and need to go
+# before the entry for regular portable archives, as it's recognized as
+# a portable archive whose first member has a name beginning with
+# "__________E".
+#
+0	string	=!<arch>\n__________E	MIPS archive
+!:mime	application/x-archive
+>20	string	U			with MIPS Ucode members
+>21	string	L			with MIPSEL members
+>21	string	B			with MIPSEB members
+>19	string	L			and an EL hash table
+>19	string	B			and an EB hash table
+>22	string	X			-- out of date
+
+0	search/1	-h-		Software Tools format archive text
+
+#
+# BSD/SVR2-and-later portable archive formats.
+#
+0	string		=!<arch>		current ar archive
+!:mime	application/x-archive
+>8	string		__.SYMDEF	random library
+>68	string		__.SYMDEF\ SORTED	random library
+
+#
+# "Thin" archive, as can be produced by GNU ar.
+#
+0	string		=!<thin>\n	thin archive with
+>68	belong		0		no symbol entries
+>68	belong		1		%d symbol entry
+>68	belong		>1		%d symbol entries
+
+# ARC archiver, from Daniel Quinlan (quinlan@yggdrasil.com)
+#
+# The first byte is the magic (0x1a), byte 2 is the compression type for
+# the first file (0x01 through 0x09), and bytes 3 to 15 are the MS-DOS
+# filename of the first file (null terminated).  Since some types collide
+# we only test some types on basis of frequency: 0x08 (83%), 0x09 (5%),
+# 0x02 (5%), 0x03 (3%), 0x04 (2%), 0x06 (2%).  0x01 collides with terminfo.
+0	lelong&0x8080ffff	0x0000081a	ARC archive data, dynamic LZW
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000091a	ARC archive data, squashed
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000021a	ARC archive data, uncompressed
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000031a	ARC archive data, packed
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000041a	ARC archive data, squeezed
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000061a	ARC archive data, crunched
+!:mime	application/x-arc
+# [JW] stuff taken from idarc, obviously ARC successors:
+0	lelong&0x8080ffff	0x00000a1a	PAK archive data
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000141a	ARC+ archive data
+!:mime	application/x-arc
+0	lelong&0x8080ffff	0x0000481a	HYP archive data
+!:mime	application/x-arc
+
+# Acorn archive formats (Disaster prone simpleton, m91dps@ecs.ox.ac.uk)
+# I can't create either SPARK or ArcFS archives so I have not tested this stuff
+# [GRR:  the original entries collide with ARC, above; replaced with combined
+#  version (not tested)]
+#0	byte		0x1a		RISC OS archive (spark format)
+0	string		\032archive	RISC OS archive (ArcFS format)
+0       string          Archive\000     RISC OS archive (ArcFS format)
+
+# All these were taken from idarc, many could not be verified. Unfortunately,
+# there were many low-quality sigs, i.e. easy to trigger false positives.
+# Please notify me of any real-world fishy/ambiguous signatures and I'll try
+# to get my hands on the actual archiver and see if I find something better. [JW]
+# probably many can be enhanced by finding some 0-byte or control char near the start
+
+# idarc calls this Crush/Uncompressed... *shrug*
+0	string	CRUSH Crush archive data
+# Squeeze It (.sqz)
+0	string	HLSQZ Squeeze It archive data
+# SQWEZ
+0	string	SQWEZ SQWEZ archive data
+# HPack (.hpk)
+0	string	HPAK HPack archive data
+# HAP
+0	string	\x91\x33HF HAP archive data
+# MD/MDCD
+0	string	MDmd MDCD archive data
+# LIM
+0	string	LIM\x1a LIM archive data
+# SAR
+3	string	LH5 SAR archive data
+# BSArc/BS2
+0	string	\212\3SB\020\0	BSArc/BS2 archive data
+# Bethesda Softworks Archive (Oblivion)
+0	string	BSA\0 		BSArc archive data
+>4	lelong	x		version %d
+# MAR
+2	string	=-ah MAR archive data
+# ACB
+#0	belong&0x00f800ff	0x00800000 ACB archive data
+# CPZ
+# TODO, this is what idarc says: 0	string	\0\0\0 CPZ archive data
+# JRC
+0	string	JRchive JRC archive data
+# Quantum
+0	string	DS\0 Quantum archive data
+# ReSOF
+0	string	PK\3\6 ReSOF archive data
+# QuArk
+0	string	7\4 QuArk archive data
+# YAC
+14	string	YC YAC archive data
+# X1
+0	string	X1 X1 archive data
+0	string	XhDr X1 archive data
+# CDC Codec (.dqt)
+0	belong&0xffffe000	0x76ff2000 CDC Codec archive data
+# AMGC
+0	string	\xad6" AMGC archive data
+# NuLIB
+0	string	N\xc3\xb5F\xc3\xa9lx\xc3\xa5 NuLIB archive data
+# PakLeo
+0	string	LEOLZW PAKLeo archive data
+# ChArc
+0	string	SChF ChArc archive data
+# PSA
+0	string	PSA PSA archive data
+# CrossePAC
+0	string	DSIGDCC CrossePAC archive data
+# Freeze
+0	string	\x1f\x9f\x4a\x10\x0a Freeze archive data
+# KBoom
+0	string	\xc2\xa8MP\xc2\xa8 KBoom archive data
+# NSQ, must go after CDC Codec
+0	string	\x76\xff NSQ archive data
+# DPA
+0	string	Dirk\ Paehl DPA archive data
+# BA
+# TODO: idarc says "bytes 0-2 == bytes 3-5"
+# TTComp
+0	string	\0\6 TTComp archive data
+# ESP, could this conflict with Easy Software Products' (e.g.ESP ghostscript) documentation?
+0	string	ESP ESP archive data
+# ZPack
+0	string	\1ZPK\1 ZPack archive data
+# Sky
+0	string	\xbc\x40 Sky archive data
+# UFA
+0	string	UFA UFA archive data
+# Dry
+0	string	=-H2O DRY archive data
+# FoxSQZ
+0	string	FOXSQZ FoxSQZ archive data
+# AR7
+0	string	,AR7 AR7 archive data
+# PPMZ
+0	string	PPMZ PPMZ archive data
+# MS Compress
+4	string	\x88\xf0\x27 MS Compress archive data
+# updated by Joerg Jenderek
+>9	string	\0
+>>0	string	KWAJ
+>>>7	string	\321\003	MS Compress archive data
+>>>>14	ulong	>0		\b, original size: %d bytes
+>>>>18		ubyte	>0x65
+>>>>>18		string	x       \b, was %.8s
+>>>>>(10.b-4)	string	x       \b.%.3s
+# MP3 (archiver, not lossy audio compression)
+0	string	MP3\x1a MP3-Archiver archive data
+# ZET
+0	string	OZ\xc3\x9d ZET archive data
+# TSComp
+0	string	\x65\x5d\x13\x8c\x08\x01\x03\x00 TSComp archive data
+# ARQ
+0	string	gW\4\1 ARQ archive data
+# Squash
+3	string	OctSqu Squash archive data
+# Terse
+0	string	\5\1\1\0 Terse archive data
+# PUCrunch
+0	string	\x01\x08\x0b\x08\xef\x00\x9e\x32\x30\x36\x31 PUCrunch archive data
+# UHarc
+0	string	UHA UHarc archive data
+# ABComp
+0	string	\2AB ABComp archive data
+0	string	\3AB2 ABComp archive data
+# CMP
+0	string	CO\0 CMP archive data
+# Splint
+0	string	\x93\xb9\x06 Splint archive data
+# InstallShield
+0	string	\x13\x5d\x65\x8c InstallShield Z archive Data
+# Gather
+1	string	GTH Gather archive data
+# BOA
+0	string	BOA BOA archive data
+# RAX
+0	string	ULEB\xa RAX archive data
+# Xtreme
+0	string	ULEB\0 Xtreme archive data
+# Pack Magic
+0	string	@\xc3\xa2\1\0 Pack Magic archive data
+# BTS
+0	belong&0xfeffffff	0x1a034465 BTS archive data
+# ELI 5750
+0	string	Ora\  ELI 5750 archive data
+# QFC
+0	string	\x1aFC\x1a QFC archive data
+0	string	\x1aQF\x1a QFC archive data
+# PRO-PACK
+0	string	RNC PRO-PACK archive data
+# 777
+0	string	777 777 archive data
+# LZS221
+0	string	sTaC LZS221 archive data
+# HPA
+0	string	HPA HPA archive data
+# Arhangel
+0	string	LG Arhangel archive data
+# EXP1, uses bzip2
+0	string	0123456789012345BZh EXP1 archive data
+# IMP
+0	string	IMP\xa IMP archive data
+# NRV
+0	string	\x00\x9E\x6E\x72\x76\xFF NRV archive data
+# Squish
+0	string	\x73\xb2\x90\xf4 Squish archive data
+# Par
+0	string	PHILIPP Par archive data
+0	string	PAR Par archive data
+# HIT
+0	string	UB HIT archive data
+# SBX
+0	belong&0xfffff000	0x53423000 SBX archive data
+# NaShrink
+0	string	NSK NaShrink archive data
+# SAPCAR
+0	string	#\ CAR\ archive\ header SAPCAR archive data
+0	string	CAR\ 2.00RG SAPCAR archive data
+# Disintegrator
+0	string	DST Disintegrator archive data
+# ASD
+0	string	ASD ASD archive data
+# InstallShield CAB
+0	string	ISc( InstallShield CAB
+# TOP4
+0	string	T4\x1a TOP4 archive data
+# BatComp left out: sig looks like COM executable
+# so TODO: get real 4dos batcomp file and find sig
+# BlakHole
+0	string	BH\5\7 BlakHole archive data
+# BIX
+0	string	BIX0 BIX archive data
+# ChiefLZA
+0	string	ChfLZ ChiefLZA archive data
+# Blink
+0	string	Blink Blink archive data
+# Logitech Compress
+0	string	\xda\xfa Logitech Compress archive data
+# ARS-Sfx (FIXME: really a SFX? then goto COM/EXE)
+1	string	(C)\ STEPANYUK ARS-Sfx archive data
+# AKT/AKT32
+0	string	AKT32 AKT32 archive data
+0	string	AKT AKT archive data
+# NPack
+0	string	MSTSM NPack archive data
+# PFT
+0	string	\0\x50\0\x14 PFT archive data
+# SemOne
+0	string	SEM SemOne archive data
+# PPMD
+0	string	\x8f\xaf\xac\x84 PPMD archive data
+# FIZ
+0	string	FIZ FIZ archive data
+# MSXiE
+0	belong&0xfffff0f0	0x4d530000 MSXiE archive data
+# DeepFreezer
+0	belong&0xfffffff0	0x797a3030 DeepFreezer archive data
+# DC
+0	string	=<DC- DC archive data
+# TPac
+0	string	\4TPAC\3 TPac archive data
+# Ai
+0	string	Ai\1\1\0 Ai archive data
+0	string	Ai\1\0\0 Ai archive data
+# Ai32
+0	string	Ai\2\0 Ai32 archive data
+0	string	Ai\2\1 Ai32 archive data
+# SBC
+0	string	SBC SBC archive data
+# Ybs
+0	string	YBS Ybs archive data
+# DitPack
+0	string	\x9e\0\0 DitPack archive data
+# DMS
+0	string	DMS! DMS archive data
+# EPC
+0	string	\x8f\xaf\xac\x8c EPC archive data
+# VSARC
+0	string	VS\x1a VSARC archive data
+# PDZ
+0	string	PDZ PDZ archive data
+# ReDuq
+0	string	rdqx ReDuq archive data
+# GCA
+0	string	GCAX GCA archive data
+# PPMN
+0	string	pN PPMN archive data
+# WinImage
+3	string	WINIMAGE WinImage archive data
+# Compressia
+0	string	CMP0CMP Compressia archive data
+# UHBC
+0	string	UHB UHBC archive data
+# WinHKI
+0	string	\x61\x5C\x04\x05 WinHKI archive data
+# WWPack data file
+0	string	WWP WWPack archive data
+# BSN (BSA, PTS-DOS)
+0	string	\xffBSG BSN archive data
+1	string	\xffBSG BSN archive data
+3	string	\xffBSG BSN archive data
+1	string	\0\xae\2 BSN archive data
+1	string	\0\xae\3 BSN archive data
+1	string	\0\xae\7 BSN archive data
+# AIN
+0	string	\x33\x18 AIN archive data
+0	string	\x33\x17 AIN archive data
+# XPA32
+0	string	xpa\0\1 XPA32 archive data
+# SZip (TODO: doesn't catch all versions)
+0	string	SZ\x0a\4 SZip archive data
+# XPack DiskImage
+0	string	jm XPack DiskImage archive data
+# XPack Data
+0	string	xpa XPack archive data
+# XPack Single Data
+0	string	\xc3\x8d\ jm XPack single archive data
+
+# TODO: missing due to unknown magic/magic at end of file:
+#DWC
+#ARG
+#ZAR
+#PC/3270
+#InstallIt
+#RKive
+#RK
+#XPack Diskimage
+
+# These were inspired by idarc, but actually verified
+# Dzip archiver (.dz)
+0	string	DZ Dzip archive data
+>2	byte	x \b, version %i
+>3	byte	x \b.%i
+# ZZip archiver (.zz)
+0	string	ZZ\ \0\0 ZZip archive data
+0	string	ZZ0 ZZip archive data
+# PAQ archiver (.paq)
+0	string	\xaa\x40\x5f\x77\x1f\xe5\x82\x0d PAQ archive data
+0	string	PAQ PAQ archive data
+>3	byte&0xf0	0x30
+>>3	byte	x (v%c)
+# JAR archiver (.j), this is the successor to ARJ, not Java's JAR (which is essentially ZIP)
+0xe	string	\x1aJar\x1b JAR (ARJ Software, Inc.) archive data
+0	string	JARCS JAR (ARJ Software, Inc.) archive data
+
+# ARJ archiver (jason@jarthur.Claremont.EDU)
+0	leshort		0xea60		ARJ archive data
+!:mime	application/x-arj
+>5	byte		x		\b, v%d,
+>8	byte		&0x04		multi-volume,
+>8	byte		&0x10		slash-switched,
+>8	byte		&0x20		backup,
+>34	string		x		original name: %s,
+>7	byte		0		os: MS-DOS
+>7	byte		1		os: PRIMOS
+>7	byte		2		os: Unix
+>7	byte		3		os: Amiga
+>7	byte		4		os: Macintosh
+>7	byte		5		os: OS/2
+>7	byte		6		os: Apple ][ GS
+>7	byte		7		os: Atari ST
+>7	byte		8		os: NeXT
+>7	byte		9		os: VAX/VMS
+>3	byte		>0		%d]
+# [JW] idarc says this is also possible
+2	leshort		0xea60		ARJ archive data
+
+# HA archiver (Greg Roelofs, newt@uchicago.edu)
+# This is a really bad format. A file containing HAWAII will match this...
+#0	string		HA		HA archive data,
+#>2	leshort		=1		1 file,
+#>2	leshort		>1		%hu files,
+#>4	byte&0x0f	=0		first is type CPY
+#>4	byte&0x0f	=1		first is type ASC
+#>4	byte&0x0f	=2		first is type HSC
+#>4	byte&0x0f	=0x0e		first is type DIR
+#>4	byte&0x0f	=0x0f		first is type SPECIAL
+# suggestion: at least identify small archives (<1024 files)
+0  belong&0xffff00fc 0x48410000 HA archive data
+>2	leshort		=1		1 file,
+>2	leshort		>1		%u files,
+>4	byte&0x0f	=0		first is type CPY
+>4	byte&0x0f	=1		first is type ASC
+>4	byte&0x0f	=2		first is type HSC
+>4	byte&0x0f	=0x0e		first is type DIR
+>4	byte&0x0f	=0x0f		first is type SPECIAL
+
+# HPACK archiver (Peter Gutmann, pgut1@cs.aukuni.ac.nz)
+0	string		HPAK		HPACK archive data
+
+# JAM Archive volume format, by Dmitry.Kohmanyuk@UA.net
+0	string		\351,\001JAM\ 		JAM archive,
+>7	string		>\0			version %.4s
+>0x26	byte		=0x27			-
+>>0x2b	string          >\0			label %.11s,
+>>0x27	lelong		x			serial %08x,
+>>0x36	string		>\0			fstype %.8s
+
+# LHARC/LHA archiver (Greg Roelofs, newt@uchicago.edu)
+2	string		-lh0-		LHarc 1.x/ARX archive data [lh0]
+!:mime	application/x-lharc
+2	string		-lh1-		LHarc 1.x/ARX archive data [lh1]
+!:mime	application/x-lharc
+2	string		-lz4-		LHarc 1.x archive data [lz4]
+!:mime	application/x-lharc
+2	string		-lz5-		LHarc 1.x archive data [lz5]
+!:mime	application/x-lharc
+#	[never seen any but the last; -lh4- reported in comp.compression:]
+2	string		-lzs-		LHa/LZS archive data [lzs]
+!:mime	application/x-lha
+2	string		-lh\40-		LHa 2.x? archive data [lh ]
+!:mime	application/x-lha
+2	string		-lhd-		LHa 2.x? archive data [lhd]
+!:mime	application/x-lha
+2	string		-lh2-		LHa 2.x? archive data [lh2]
+!:mime	application/x-lha
+2	string		-lh3-		LHa 2.x? archive data [lh3]
+!:mime	application/x-lha
+2	string		-lh4-		LHa (2.x) archive data [lh4]
+!:mime	application/x-lha
+2	string		-lh5-		LHa (2.x) archive data [lh5]
+!:mime	application/x-lha
+2	string		-lh6-		LHa (2.x) archive data [lh6]
+!:mime	application/x-lha
+2	string		-lh7-		LHa (2.x)/LHark archive data [lh7]
+!:mime	application/x-lha
+>20	byte		x		- header level %d
+# taken from idarc [JW]
+2   string      -lZ         PUT archive data
+2   string      -lz         LZS archive data
+2   string      -sw1-       Swag archive data
+
+# RAR archiver (Greg Roelofs, newt@uchicago.edu)
+0	string		Rar!		RAR archive data,
+!:mime	application/x-rar
+>44	byte		x		v%0x,
+>10	byte		>0		flags:
+>>10	byte		&0x01		Archive volume,
+>>10	byte		&0x02		Commented,
+>>10	byte		&0x04		Locked,
+>>10	byte		&0x08		Solid,
+>>10	byte		&0x20		Authenticated,
+>35	byte		0		os: MS-DOS
+>35	byte		1		os: OS/2
+>35	byte		2		os: Win32
+>35	byte		3		os: Unix
+# some old version? idarc says:
+0   string      RE\x7e\x5e  RAR archive data
+
+# SQUISH archiver (Greg Roelofs, newt@uchicago.edu)
+0	string		SQSH		squished archive data (Acorn RISCOS)
+
+# UC2 archiver (Greg Roelofs, newt@uchicago.edu)
+# [JW] see exe section for self-extracting version
+0	string		UC2\x1a		UC2 archive data
+
+# PKZIP multi-volume archive
+0	string		PK\x07\x08PK\x03\x04	Zip multi-volume archive data, at least PKZIP v2.50 to extract
+!:mime	application/zip
+
+# Zip archives (Greg Roelofs, c/o zip-bugs@wkuvx1.wku.edu)
+0	string		PK\005\006	Zip archive data (empty)
+0	string		PK\003\004
+
+# Specialised zip formats which start with a member named 'mimetype'
+# (stored uncompressed, with no 'extra field') containing the file's MIME type.
+# Check for have 8-byte name, 0-byte extra field, name "mimetype", and
+#  contents starting with "application/":
+>26	string		\x8\0\0\0mimetypeapplication/
+
+#  KOffice / OpenOffice & StarOffice / OpenDocument formats
+#    From: Abel Cheung <abel@oaka.org>
+
+#   KOffice (1.2 or above) formats
+#    (mimetype contains "application/vnd.kde.<SUBTYPE>")
+>>50	string	vnd.kde.		KOffice (>=1.2)
+>>>58	string	karbon			Karbon document
+>>>58	string	kchart			KChart document
+>>>58	string	kformula		KFormula document
+>>>58	string	kivio			Kivio document
+>>>58	string	kontour			Kontour document
+>>>58	string	kpresenter		KPresenter document
+>>>58	string	kspread			KSpread document
+>>>58	string	kword			KWord document
+
+#   OpenOffice formats (for OpenOffice 1.x / StarOffice 6/7)
+#    (mimetype contains "application/vnd.sun.xml.<SUBTYPE>")
+>>50	string	vnd.sun.xml.		OpenOffice.org 1.x
+>>>62	string	writer			Writer
+>>>>68	byte	!0x2e			document
+>>>>68	string	.template		template
+>>>>68	string	.global			global document
+>>>62	string	calc			Calc
+>>>>66	byte	!0x2e			spreadsheet
+>>>>66	string	.template		template
+>>>62	string	draw			Draw
+>>>>66	byte	!0x2e			document
+>>>>66	string	.template		template
+>>>62	string	impress			Impress
+>>>>69	byte	!0x2e			presentation
+>>>>69	string	.template		template
+>>>62	string	math			Math document
+>>>62	string	base			Database file
+
+#   OpenDocument formats (for OpenOffice 2.x / StarOffice >= 8)
+#    http://lists.oasis-open.org/archives/office/200505/msg00006.html
+#    (mimetype contains "application/vnd.oasis.opendocument.<SUBTYPE>")
+>>50	string	vnd.oasis.opendocument.	OpenDocument
+>>>73	string	text
+>>>>77	byte	!0x2d			Text
+!:mime	application/vnd.oasis.opendocument.text
+>>>>77	string	-template		Text Template
+!:mime	application/vnd.oasis.opendocument.text-template
+>>>>77	string	-web			HTML Document Template
+!:mime	application/vnd.oasis.opendocument.text-web
+>>>>77	string	-master			Master Document
+!:mime	application/vnd.oasis.opendocument.text-master
+>>>73	string	graphics
+>>>>81	byte	!0x2d			Drawing
+!:mime	application/vnd.oasis.opendocument.graphics
+>>>>81	string	-template		Template
+!:mime	application/vnd.oasis.opendocument.graphics-template
+>>>73	string	presentation
+>>>>85	byte	!0x2d			Presentation
+!:mime	application/vnd.oasis.opendocument.presentation
+>>>>85	string	-template		Template
+!:mime	application/vnd.oasis.opendocument.presentation-template
+>>>73	string	spreadsheet
+>>>>84	byte	!0x2d			Spreadsheet
+!:mime	application/vnd.oasis.opendocument.spreadsheet
+>>>>84	string	-template		Template
+!:mime	application/vnd.oasis.opendocument.spreadsheet-template
+>>>73	string	chart
+>>>>78	byte	!0x2d			Chart
+!:mime	application/vnd.oasis.opendocument.chart
+>>>>78	string	-template		Template
+!:mime	application/vnd.oasis.opendocument.chart-template
+>>>73	string	formula
+>>>>80	byte	!0x2d			Formula
+!:mime	application/vnd.oasis.opendocument.formula
+>>>>80	string	-template		Template
+!:mime	application/vnd.oasis.opendocument.formula-template
+>>>73	string	database		Database
+!:mime	application/vnd.oasis.opendocument.database
+>>>73	string	image
+>>>>78	byte	!0x2d			Image
+!:mime	application/vnd.oasis.opendocument.image
+>>>>78	string	-template		Template
+!:mime	application/vnd.oasis.opendocument.image-template
+
+#  EPUB (OEBPS) books using OCF (OEBPS Container Format)
+#    http://www.idpf.org/ocf/ocf1.0/download/ocf10.htm, section 4.
+#    From: Ralf Brown <ralf.brown@gmail.com>
+>>50	string	epub+zip	EPUB document
+!:mime application/epub+zip
+
+#  Catch other ZIP-with-mimetype formats
+#	In a ZIP file, the bytes immediately after a member's contents are
+#	always "PK". The 2 regex rules here print the "mimetype" member's
+#	contents up to the first 'P'. Luckily, most MIME types don't contain
+#	any capital 'P's. This is a kludge.
+#    (mimetype contains "application/<OTHER>")
+>>50		string	!epub+zip
+>>>50		string	!vnd.oasis.opendocument.
+>>>>50		string	!vnd.sun.xml.
+>>>>>50		string	!vnd.kde.
+>>>>>>38	regex	[!-OQ-~]+		Zip data (MIME type "%s"?)
+!:mime	application/zip
+#    (mimetype contents other than "application/*")
+>26		string	\x8\0\0\0mimetype
+>>38		string	!application/
+>>>38		regex	[!-OQ-~]+		Zip data (MIME type "%s"?)
+!:mime	application/zip
+
+# Java Jar files
+>(26.s+30)	leshort	0xcafe		Java archive data (JAR)
+!:mime	application/java-archive
+
+# Generic zip archives (Greg Roelofs, c/o zip-bugs@wkuvx1.wku.edu)
+#   Next line excludes specialized formats:
+>(26.s+30)	leshort	!0xcafe
+>>26    string          !\x8\0\0\0mimetype	Zip archive data
+!:mime	application/zip
+>>>4	byte		0x09		\b, at least v0.9 to extract
+>>>4	byte		0x0a		\b, at least v1.0 to extract
+>>>4	byte		0x0b		\b, at least v1.1 to extract
+>>>4	byte		0x14		\b, at least v2.0 to extract
+>>>4	byte		0x2d		\b, at least v3.0 to extract
+>>>0x161	string		WINZIP		\b, WinZIP self-extracting
+
+# StarView Metafile
+# From Pierre Ducroquet <pinaraf@pinaraf.info>
+0	string	VCLMTF	StarView MetaFile
+>6	beshort	x	\b, version %d
+>8	belong	x	\b, size %d
+
+# Zoo archiver
+20	lelong		0xfdc4a7dc	Zoo archive data
+!:mime	application/x-zoo
+>4	byte		>48		\b, v%c.
+>>6	byte		>47		\b%c
+>>>7	byte		>47		\b%c
+>32	byte		>0		\b, modify: v%d
+>>33	byte		x		\b.%d+
+>42	lelong		0xfdc4a7dc	\b,
+>>70	byte		>0		extract: v%d
+>>>71	byte		x		\b.%d+
+
+# Shell archives
+10	string		#\ This\ is\ a\ shell\ archive	shell archive text
+!:mime	application/octet-stream
+
+#
+# LBR. NB: May conflict with the questionable
+#          "binary Computer Graphics Metafile" format.
+#
+0       string  \0\ \ \ \ \ \ \ \ \ \ \ \0\0    LBR archive data
+#
+# PMA (CP/M derivative of LHA)
+#
+2       string          -pm0-           PMarc archive data [pm0]
+2       string          -pm1-           PMarc archive data [pm1]
+2       string          -pm2-           PMarc archive data [pm2]
+2       string          -pms-           PMarc SFX archive (CP/M, DOS)
+5       string          -pc1-           PopCom compressed executable (CP/M)
+
+# From Rafael Laboissiere <rafael@laboissiere.net>
+# The Project Revision Control System (see
+# http://prcs.sourceforge.net) generates a packaged project
+# file which is recognized by the following entry:
+0	leshort		0xeb81	PRCS packaged project
+
+# Microsoft cabinets
+# by David Necas (Yeti) <yeti@physics.muni.cz>
+#0	string	MSCF\0\0\0\0	Microsoft cabinet file data,
+#>25	byte	x		v%d
+#>24	byte	x		\b.%d
+# MPi: All CABs have version 1.3, so this is pointless.
+# Better magic in debian-additions.
+
+# GTKtalog catalogs
+# by David Necas (Yeti) <yeti@physics.muni.cz>
+4	string	gtktalog\ 	GTKtalog catalog data,
+>13	string	3		version 3
+>>14	beshort	0x677a		(gzipped)
+>>14	beshort	!0x677a		(not gzipped)
+>13	string	>3		version %s
+
+############################################################################
+# Parity archive reconstruction file, the 'par' file format now used on Usenet.
+0       string          PAR\0	PARity archive data
+>48	leshort		=0	- Index file
+>48	leshort		>0	- file number %d
+
+# Felix von Leitner <felix-file@fefe.de>
+0	string	d8:announce	BitTorrent file
+!:mime	application/x-bittorrent
+
+# Atari MSA archive - Teemu Hukkanen <tjhukkan@iki.fi>
+0	beshort 0x0e0f		Atari MSA archive data
+>2	beshort x		\b, %d sectors per track
+>4	beshort 0		\b, 1 sided
+>4	beshort 1		\b, 2 sided
+>6	beshort x		\b, starting track: %d
+>8	beshort x		\b, ending track: %d
+
+# Alternate ZIP string (amc@arwen.cs.berkeley.edu)
+0	string	PK00PK\003\004	Zip archive data
+
+# ACE archive (from http://www.wotsit.org/download.asp?f=ace)
+# by Stefan `Sec` Zehl <sec@42.org>
+7	string		**ACE**		ACE archive data
+>15	byte	>0		version %d
+>16	byte	=0x00		\b, from MS-DOS
+>16	byte	=0x01		\b, from OS/2
+>16	byte	=0x02		\b, from Win/32
+>16	byte	=0x03		\b, from Unix
+>16	byte	=0x04		\b, from MacOS
+>16	byte	=0x05		\b, from WinNT
+>16	byte	=0x06		\b, from Primos
+>16	byte	=0x07		\b, from AppleGS
+>16	byte	=0x08		\b, from Atari
+>16	byte	=0x09		\b, from Vax/VMS
+>16	byte	=0x0A		\b, from Amiga
+>16	byte	=0x0B		\b, from Next
+>14	byte	x		\b, version %d to extract
+>5	leshort &0x0080		\b, multiple volumes,
+>>17	byte	x		\b (part %d),
+>5	leshort &0x0002		\b, contains comment
+>5	leshort	&0x0200		\b, sfx
+>5	leshort	&0x0400		\b, small dictionary
+>5	leshort	&0x0800		\b, multi-volume
+>5	leshort	&0x1000		\b, contains AV-String
+>>30	string	\x16*UNREGISTERED\x20VERSION*	(unregistered)
+>5	leshort &0x2000		\b, with recovery record
+>5	leshort &0x4000		\b, locked
+>5	leshort &0x8000		\b, solid
+# Date in MS-DOS format (whatever that is)
+#>18	lelong	x		Created on
+
+# sfArk : compression program for Soundfonts (sf2) by Dirk Jagdmann
+# <doj@cubic.org>
+0x1A	string	sfArk		sfArk compressed Soundfont
+>0x15	string	2
+>>0x1	string	>\0		Version %s
+>>0x2A	string	>\0		: %s
+
+# DR-DOS 7.03 Packed File *.??_
+0	string	Packed\ File\ 	Personal NetWare Packed File
+>12	string	x		\b, was "%.12s"
+
+# EET archive
+# From: Tilman Sauerbeck <tilman@code-monkey.de>
+0	belong	0x1ee7ff00	EET archive
+!:mime	application/x-eet
+
+# rzip archives
+0	string	RZIP		rzip compressed data
+>4	byte	x		- version %d
+>5	byte	x		\b.%d
+>6	belong	x		(%d bytes)
+
+# From: "Robert Dale" <robdale@gmail.com>
+0	belong	123		dar archive,
+>4	belong	x		label "%.8x
+>>8	belong	x		%.8x
+>>>12	beshort	x		%.4x"
+>14	byte	0x54		end slice
+>14	beshort	0x4e4e		multi-part
+>14	beshort	0x4e53		multi-part, with -S
+
+# Symbian installation files
+#  http://www.thouky.co.uk/software/psifs/sis.html
+#  http://developer.symbian.com/main/downloads/papers/SymbianOSv91/softwareinstallsis.pdf
+8	lelong	0x10000419	Symbian installation file
+!:mime	application/vnd.symbian.install
+>4	lelong	0x1000006D	(EPOC release 3/4/5)
+>4	lelong	0x10003A12	(EPOC release 6)
+0	lelong	0x10201A7A	Symbian installation file (Symbian OS 9.x)
+!:mime	x-epoc/x-sisx-app
+
+# From "Nelson A. de Oliveira" <naoliv@gmail.com>
+0	string	MPQ\032		MoPaQ (MPQ) archive
+
+# From: Dirk Jagdmann <doj@cubic.org>
+# xar archive format: http://code.google.com/p/xar/
+0	string	xar!		xar archive
+>6	beshort	x		- version %d
+
+# From: "Nelson A. de Oliveira" <naoliv@gmail.com>
+# .kgb
+0	string KGB_arch		KGB Archiver file
+>10	string x		with compression level %.1s
+
+# xar (eXtensible ARchiver) archive
+# From: "David Remahl" <dremahl@apple.com>
+0	string	xar!		xar archive
+#>4	beshort	x		header size %d
+>6	beshort	x		version %d,
+#>8	quad	x		compressed TOC: %d,
+#>16	quad	x		uncompressed TOC: %d,
+>24	belong	0		no checksum
+>24	belong	1		SHA-1 checksum
+>24	belong	2		MD5 checksum
+
+# Type: Parity Archive
+# From: Daniel van Eeden <daniel_e@dds.nl>
+0	string	PAR2		Parity Archive Volume Set
+
+# Bacula volume format. (Volumes always start with a block header.)
+# URL: http://bacula.org/3.0.x-manuals/en/developers/developers/Block_Header.html
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+12	string	BB02		Bacula volume
+>20	bedate	x		\b, started %s
+
+# ePub is XHTML + XML inside a ZIP archive.  The first member of the
+#   archive must be an uncompressed file called 'mimetype' with contents
+#   'application/epub+zip'
+
+
+# From: "Michael Gorny" <mgorny@gentoo.org>
+# ZPAQ: http://mattmahoney.net/dc/zpaq.html
+0	string	zPQ	ZPAQ stream
+>3	byte	x	\b, level %d
+
+# BBeB ebook, unencrypted (LRF format)
+# URL: http://www.sven.de/librie/Librie/LrfFormat
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+0	string	L\0R\0F\0\0\0	BBeB ebook data, unencrypted
+>8	beshort	x		\b, version %d
+>36	byte	1		\b, front-to-back
+>36	byte	16		\b, back-to-front
+>42	beshort	x		\b, (%dx,
+>44	beshort	x		%d)
+
+# Symantec GHOST image by Joerg Jenderek at May 2014
+# http://us.norton.com/ghost/
+# http://www.garykessler.net/library/file_sigs.html
+0		ubelong&0xFFFFf7f0	0xFEEF0100	Norton GHost image
+# *.GHO
+>2		ubyte&0x08		0x00		\b, first file
+# *.GHS or *.[0-9] with cns program option
+>2		ubyte&0x08		0x08		\b, split file
+# part of split index interesting for *.ghs
+>>4		ubyte			x		id=0x%x
+# compression tag minus one equals numeric compression command line switch z[1-9]
+>3		ubyte			0		\b, no compression
+>3		ubyte			2		\b, fast compression (Z1)
+>3		ubyte			3		\b, medium compression (Z2)
+>3		ubyte			>3		
+>>3		ubyte			<11		\b, compression (Z%d-1)
+>2		ubyte&0x08		0x00		
+# ~ 30 byte password field only for *.gho
+>>12		ubequad			!0		\b, password protected
+>>44		ubyte			!1		
+# 1~Image All, sector-by-sector only for *.gho
+>>>10		ubyte			1		\b, sector copy
+# 1~Image Boot track only for *.gho
+>>>43		ubyte			1		\b, boot track
+# 1~Image Disc only for *.gho implies Image Boot track and sector copy
+>>44		ubyte			1		\b, disc sector copy
+# optional image description only *.gho
+>>0xff		string			>\0		"%-.254s"
+# look for DOS sector end sequence
+>0xE08	search/7776		\x55\xAA	
+>>&-512	indirect		x		\b; contains 
+
+#------------------------------------------------------------------------------
+# $File: assembler,v 1.5 2013/09/17 17:33:36 christos Exp $
+# make:  file(1) magic for assembler source
+#
+0	regex	\^[\040\t]{0,50}\\.asciiz		assembler source text
+!:mime	text/x-asm
+0	regex	\^[\040\t]{0,50}\\.byte		assembler source text
+!:mime	text/x-asm
+0	regex	\^[\040\t]{0,50}\\.even		assembler source text
+!:mime	text/x-asm
+0	regex	\^[\040\t]{0,50}\\.globl		assembler source text
+!:mime	text/x-asm
+0	regex	\^[\040\t]{0,50}\\.text		assembler source text
+!:mime	text/x-asm
+0	regex	\^[\040\t]{0,50}\\.file		assembler source text
+!:mime	text/x-asm
+0	regex	\^[\040\t]{0,50}\\.type		assembler source text
+!:mime	text/x-asm
+
+#------------------------------------------------------------------------------
+# $File$
+# asterix:  file(1) magic for Aster*x; SunOS 5.5.1 gave the 4-character
+# strings as "long" - we assume they're just strings:
+# From: guy@netapp.com (Guy Harris)
+#
+0	string		*STA		Aster*x
+>7	string		WORD			Words Document
+>7	string		GRAP			Graphic
+>7	string		SPRE			Spreadsheet
+>7	string		MACR			Macro
+0	string		2278		Aster*x Version 2
+>29	byte		0x36			Words Document
+>29	byte		0x35			Graphic
+>29	byte		0x32			Spreadsheet
+>29	byte		0x38			Macro
+
+
+#------------------------------------------------------------------------------
+# $File: att3b,v 1.8 2009/09/19 16:28:08 christos Exp $
+# att3b:  file(1) magic for AT&T 3B machines
+#
+# The `versions' should be un-commented if they work for you.
+# (Was the problem just one of endianness?)
+#
+# 3B20
+#
+# The 3B20 conflicts with SCCS.
+#0	beshort		0550		3b20 COFF executable
+#>12	belong		>0		not stripped
+#>22	beshort		>0		- version %d
+#0	beshort		0551		3b20 COFF executable (TV)
+#>12	belong		>0		not stripped
+#>22	beshort		>0		- version %d
+#
+# WE32K
+#
+0	beshort		0560		WE32000 COFF
+>18	beshort		^00000020	object
+>18	beshort		&00000020	executable
+>12	belong		>0		not stripped
+>18	beshort		^00010000	N/A on 3b2/300 w/paging
+>18	beshort		&00020000	32100 required
+>18	beshort		&00040000	and MAU hardware required
+>20	beshort		0407		(impure)
+>20	beshort		0410		(pure)
+>20	beshort		0413		(demand paged)
+>20	beshort		0443		(target shared library)
+>22	beshort		>0		- version %d
+0	beshort		0561		WE32000 COFF executable (TV)
+>12	belong		>0		not stripped
+#>18	beshort		&00020000	- 32100 required
+#>18	beshort		&00040000	and MAU hardware required
+#>22	beshort		>0		- version %d
+#
+# core file for 3b2 
+0	string		\000\004\036\212\200	3b2 core file
+>364	string		>\0		of '%s'
+
+#------------------------------------------------------------------------------
+# $File: audio,v 1.71 2014/05/14 23:30:28 christos Exp $
+# audio:  file(1) magic for sound formats (see also "iff")
+#
+# Jan Nicolai Langfeldt (janl@ifi.uio.no), Dan Quinlan (quinlan@yggdrasil.com),
+# and others
+#
+
+# Sun/NeXT audio data
+0	string		.snd		Sun/NeXT audio data:
+>12	belong		1		8-bit ISDN mu-law,
+!:mime	audio/basic
+>12	belong		2		8-bit linear PCM [REF-PCM],
+!:mime	audio/basic
+>12	belong		3		16-bit linear PCM,
+!:mime	audio/basic
+>12	belong		4		24-bit linear PCM,
+!:mime	audio/basic
+>12	belong		5		32-bit linear PCM,
+!:mime	audio/basic
+>12	belong		6		32-bit IEEE floating point,
+!:mime	audio/basic
+>12	belong		7		64-bit IEEE floating point,
+!:mime	audio/basic
+>12	belong		8		Fragmented sample data,
+>12	belong		10		DSP program,
+>12	belong		11		8-bit fixed point,
+>12	belong		12		16-bit fixed point,
+>12	belong		13		24-bit fixed point,
+>12	belong		14		32-bit fixed point,
+>12	belong		18		16-bit linear with emphasis,
+>12	belong		19		16-bit linear compressed,
+>12	belong		20		16-bit linear with emphasis and compression,
+>12	belong		21		Music kit DSP commands,
+>12	belong		23		8-bit ISDN mu-law compressed (CCITT G.721 ADPCM voice enc.),
+!:mime  audio/x-adpcm
+>12	belong		24		compressed (8-bit CCITT G.722 ADPCM)
+>12	belong		25		compressed (3-bit CCITT G.723.3 ADPCM),
+>12	belong		26		compressed (5-bit CCITT G.723.5 ADPCM),
+>12	belong		27		8-bit A-law (CCITT G.711),
+>20	belong		1		mono,
+>20	belong		2		stereo,
+>20	belong		4		quad,
+>16	belong		>0		%d Hz
+
+# DEC systems (e.g. DECstation 5000) use a variant of the Sun/NeXT format
+# that uses little-endian encoding and has a different magic number
+0	lelong		0x0064732E	DEC audio data:
+>12	lelong		1		8-bit ISDN mu-law,
+!:mime	audio/x-dec-basic
+>12	lelong		2		8-bit linear PCM [REF-PCM],
+!:mime	audio/x-dec-basic
+>12	lelong		3		16-bit linear PCM,
+!:mime	audio/x-dec-basic
+>12	lelong		4		24-bit linear PCM,
+!:mime	audio/x-dec-basic
+>12	lelong		5		32-bit linear PCM,
+!:mime	audio/x-dec-basic
+>12	lelong		6		32-bit IEEE floating point,
+!:mime	audio/x-dec-basic
+>12	lelong		7		64-bit IEEE floating point,
+!:mime	audio/x-dec-basic
+>12	belong		8		Fragmented sample data,
+>12	belong		10		DSP program,
+>12	belong		11		8-bit fixed point,
+>12	belong		12		16-bit fixed point,
+>12	belong		13		24-bit fixed point,
+>12	belong		14		32-bit fixed point,
+>12	belong		18		16-bit linear with emphasis,
+>12	belong		19		16-bit linear compressed,
+>12	belong		20		16-bit linear with emphasis and compression,
+>12	belong		21		Music kit DSP commands,
+>12	lelong		23		8-bit ISDN mu-law compressed (CCITT G.721 ADPCM voice enc.),
+!:mime	audio/x-dec-basic
+>12	belong		24		compressed (8-bit CCITT G.722 ADPCM)
+>12	belong		25		compressed (3-bit CCITT G.723.3 ADPCM),
+>12	belong		26		compressed (5-bit CCITT G.723.5 ADPCM),
+>12	belong		27		8-bit A-law (CCITT G.711),
+>20	lelong		1		mono,
+>20	lelong		2		stereo,
+>20	lelong		4		quad,
+>16	lelong		>0		%d Hz
+
+# Creative Labs AUDIO stuff
+0	string	MThd			Standard MIDI data
+!:mime	audio/midi
+>8 	beshort	x			(format %d)
+>10	beshort	x			using %d track
+>10	beshort		>1		\bs
+>12	beshort&0x7fff	x		at 1/%d
+>12	beshort&0x8000	>0		SMPTE
+
+0	string	CTMF			Creative Music (CMF) data
+!:mime	audio/x-unknown
+0	string	SBI			SoundBlaster instrument data
+!:mime	audio/x-unknown
+0	string	Creative\ Voice\ File	Creative Labs voice data
+!:mime	audio/x-unknown
+# is this next line right?  it came this way...
+>19	byte	0x1A
+>23	byte	>0			- version %d
+>22	byte	>0			\b.%d
+
+# first entry is also the string "NTRK"
+0	belong		0x4e54524b	MultiTrack sound data
+>4	belong		x		- version %d
+
+# Extended MOD format (*.emd) (Greg Roelofs, newt@uchicago.edu); NOT TESTED
+# [based on posting 940824 by "Dirk/Elastik", husberg@lehtori.cc.tut.fi]
+0	string		EMOD		Extended MOD sound data,
+>4	byte&0xf0	x		version %d
+>4	byte&0x0f	x		\b.%d,
+>45	byte		x		%d instruments
+>83	byte		0		(module)
+>83	byte		1		(song)
+
+# Real Audio (Magic .ra\0375)
+0	belong		0x2e7261fd	RealAudio sound file
+!:mime	audio/x-pn-realaudio
+0	string		.RMF\0\0\0	RealMedia file
+!:mime	application/vnd.rn-realmedia
+#video/x-pn-realvideo
+#video/vnd.rn-realvideo
+#application/vnd.rn-realmedia
+#	sigh, there are many mimes for that but the above are the most common.
+
+# MTM/669/FAR/S3M/ULT/XM format checking [Aaron Eppert, aeppert@dialin.ind.net]
+# Oct 31, 1995
+# fixed by <doj@cubic.org> 2003-06-24
+# Too short...
+#0	string		MTM		MultiTracker Module sound file
+#0	string		if		Composer 669 Module sound data
+#0	string		JN		Composer 669 Module sound data (extended format)
+0	string		MAS_U		ULT(imate) Module sound data
+
+#0	string		FAR		Module sound data
+#>4	string		>\15		Title: "%s"
+
+0x2c	string		SCRM		ScreamTracker III Module sound data
+>0	string		>\0		Title: "%s"
+
+# Gravis UltraSound patches
+# From <ache@nagual.ru>
+
+0	string		GF1PATCH110\0ID#000002\0	GUS patch
+0	string		GF1PATCH100\0ID#000002\0	Old GUS	patch
+
+# mime types according to http://www.geocities.com/nevilo/mod.htm:
+#	audio/it	.it
+#	audio/x-zipped-it	.itz
+#	audio/xm	fasttracker modules
+#	audio/x-s3m	screamtracker modules
+#	audio/s3m	screamtracker modules
+#	audio/x-zipped-mod	mdz
+#	audio/mod	mod
+#	audio/x-mod	All modules (mod, s3m, 669, mtm, med, xm, it, mdz, stm, itz, xmz, s3z)
+
+#
+# Taken from loader code from mikmod version 2.14
+# by Steve McIntyre (stevem@chiark.greenend.org.uk)
+# <doj@cubic.org> added title printing on 2003-06-24
+0	string	MAS_UTrack_V00
+>14	string	>/0		ultratracker V1.%.1s module sound data
+!:mime	audio/x-mod
+#audio/x-tracker-module
+
+0	string	UN05		MikMod UNI format module sound data
+
+0	string	Extended\ Module: Fasttracker II module sound data
+!:mime	audio/x-mod
+#audio/x-tracker-module
+>17	string	>\0		Title: "%s"
+
+21	string/c	=!SCREAM!	Screamtracker 2 module sound data
+!:mime	audio/x-mod
+#audio/x-screamtracker-module
+21	string	BMOD2STM	Screamtracker 2 module sound data
+!:mime	audio/x-mod
+#audio/x-screamtracker-module
+1080	string	M.K.		4-channel Protracker module sound data
+!:mime	audio/x-mod
+#audio/x-protracker-module
+>0	string	>\0		Title: "%s"
+1080	string	M!K!		4-channel Protracker module sound data
+!:mime	audio/x-mod
+#audio/x-protracker-module
+>0	string	>\0		Title: "%s"
+1080	string	FLT4		4-channel Startracker module sound data
+!:mime	audio/x-mod
+#audio/x-startracker-module
+>0	string	>\0		Title: "%s"
+1080	string	FLT8		8-channel Startracker module sound data
+!:mime	audio/x-mod
+#audio/x-startracker-module
+>0	string	>\0		Title: "%s"
+1080	string	4CHN		4-channel Fasttracker module sound data
+!:mime	audio/x-mod
+#audio/x-fasttracker-module
+>0	string	>\0		Title: "%s"
+1080	string	6CHN		6-channel Fasttracker module sound data
+!:mime	audio/x-mod
+#audio/x-fasttracker-module
+>0	string	>\0		Title: "%s"
+1080	string	8CHN		8-channel Fasttracker module sound data
+!:mime	audio/x-mod
+#audio/x-fasttracker-module
+>0	string	>\0		Title: "%s"
+1080	string	CD81		8-channel Octalyser module sound data
+!:mime	audio/x-mod
+#audio/x-octalysertracker-module
+>0	string	>\0		Title: "%s"
+1080	string	OKTA		8-channel Octalyzer module sound data
+!:mime	audio/x-mod
+#audio/x-octalysertracker-module
+>0	string	>\0		Title: "%s"
+# Not good enough.
+#1082	string	CH
+#>1080	string	>/0		%.2s-channel Fasttracker "oktalyzer" module sound data
+1080	string	16CN		16-channel Taketracker module sound data
+!:mime	audio/x-mod
+#audio/x-taketracker-module
+>0	string	>\0		Title: "%s"
+1080	string	32CN		32-channel Taketracker module sound data
+!:mime	audio/x-mod
+#audio/x-taketracker-module
+>0	string	>\0		Title: "%s"
+
+# TOC sound files -Trevor Johnson <trevor@jpj.net>
+#
+0       string          TOC             TOC sound file
+
+# sidfiles <pooka@iki.fi>
+# added name,author,(c) and new RSID type by <doj@cubic.org> 2003-06-24
+0	string		SIDPLAY\ INFOFILE	Sidplay info file
+
+0	string		PSID			PlaySID v2.2+ (AMIGA) sidtune
+>4	beshort		>0			w/ header v%d,
+>14	beshort		=1			single song,
+>14	beshort		>1			%d songs,
+>16	beshort		>0			default song: %d
+>0x16	string		>\0			name: "%s"
+>0x36	string		>\0			author: "%s"
+>0x56	string		>\0			copyright: "%s"
+
+0	string		RSID			RSID sidtune PlaySID compatible
+>4	beshort		>0			w/ header v%d,
+>14	beshort		=1			single song,
+>14	beshort		>1			%d songs,
+>16	beshort		>0			default song: %d
+>0x16	string		>\0			name: "%s"
+>0x36	string		>\0			author: "%s"
+>0x56	string		>\0			copyright: "%s"
+
+# IRCAM sound files - Michael Pruett <michael@68k.org>
+# http://www-mmsp.ece.mcgill.ca/documents/AudioFormats/IRCAM/IRCAM.html
+0	belong		0x64a30100		IRCAM file (VAX little-endian)
+0	belong		0x0001a364		IRCAM file (VAX big-endian)
+0	belong		0x64a30200		IRCAM file (Sun big-endian)
+0	belong		0x0002a364		IRCAM file (Sun little-endian)
+0	belong		0x64a30300		IRCAM file (MIPS little-endian)
+0	belong		0x0003a364		IRCAM file (MIPS big-endian)
+0	belong		0x64a30400		IRCAM file (NeXT big-endian)
+0	belong		0x64a30400		IRCAM file (NeXT big-endian)
+0	belong		0x0004a364		IRCAM file (NeXT little-endian)
+
+# NIST SPHERE <mpruett@sgi.com>
+0	string		NIST_1A\n\ \ \ 1024\n	NIST SPHERE file
+
+# Sample Vision <mpruett@sgi.com>
+0	string		SOUND\ SAMPLE\ DATA\ 	Sample Vision file
+
+# Audio Visual Research <tonigonenstein@users.sourceforge.net>
+0	string		2BIT			Audio Visual Research file,
+>12	beshort		=0			mono,
+>12	beshort		=-1			stereo,
+>14	beshort		x			%d bits
+>16	beshort		=0			unsigned,
+>16	beshort		=-1			signed,
+>22	belong&0x00ffffff	x		%d Hz,
+>18	beshort		=0			no loop,
+>18	beshort		=-1			loop,
+>21	ubyte		<128			note %d,
+>22	byte		=0			replay 5.485 KHz
+>22	byte		=1			replay 8.084 KHz
+>22	byte		=2			replay 10.971 KHz
+>22	byte		=3			replay 16.168 KHz
+>22	byte		=4			replay 21.942 KHz
+>22	byte		=5			replay 32.336 KHz
+>22	byte		=6			replay 43.885 KHz
+>22	byte		=7			replay 47.261 KHz
+
+# SGI SoundTrack <mpruett@sgi.com>
+0	string		_SGI_SoundTrack		SGI SoundTrack project file
+# ID3 version 2 tags <waschk@informatik.uni-rostock.de>
+0	string		ID3	Audio file with ID3 version 2
+>3	byte		x	\b.%d
+>4	byte		x	\b.%d
+>>5	byte		&0x80	\b, unsynchronized frames
+>>5	byte		&0x40	\b, extended header
+>>5	byte		&0x20	\b, experimental
+>>5	byte		&0x10	\b, footer present
+>(6.I+10)	indirect	x	\b, contains: 
+
+# NSF (NES sound file) magic
+0	string		NESM\x1a	NES Sound File
+>14	string		>\0		("%s" by
+>46	string		>\0		%s, copyright
+>78	string		>\0		%s),
+>5	byte		x		version %d,
+>6	byte		x		%d tracks,
+>122	byte&0x2	=1		dual PAL/NTSC
+>122	byte&0x1	=1		PAL
+>122	byte&0x1	=0		NTSC
+
+# Type: SNES SPC700 sound files
+# From: Josh Triplett <josh@freedesktop.org>
+0	string	SNES-SPC700\ Sound\ File\ Data\ v	SNES SPC700 sound file
+>&0	string	0.30					\b, version %s
+>>0x23	byte	0x1B					\b, without ID666 tag
+>>0x23	byte	0x1A					\b, with ID666 tag
+>>>0x2E	string	>\0					\b, song "%.32s"
+>>>0x4E	string	>\0					\b, game "%.32s"
+
+# Impulse tracker module (audio/x-it)
+0	string		IMPM		Impulse Tracker module sound data -
+!:mime	audio/x-mod
+>4	string		>\0		"%s"
+>40	leshort		!0		compatible w/ITv%x
+>42	leshort		!0		created w/ITv%x
+
+# Imago Orpheus module (audio/x-imf)
+60	string		IM10		Imago Orpheus module sound data -
+>0	string		>\0		"%s"
+
+# From <collver1@attbi.com>
+# These are the /etc/magic entries to decode modules, instruments, and
+# samples in Impulse Tracker's native format.
+
+0	string		IMPS		Impulse Tracker Sample
+>18	byte		&2		16 bit
+>18	byte		^2		8 bit
+>18	byte		&4		stereo
+>18	byte		^4		mono
+0	string		IMPI		Impulse Tracker Instrument
+>28	leshort		!0		ITv%x
+>30	byte		!0		%d samples
+
+# Yamaha TX Wave:  file(1) magic for Yamaha TX Wave audio files
+# From <collver1@attbi.com>
+0	string		LM8953		Yamaha TX Wave
+>22	byte		0x49		looped
+>22	byte		0xC9		non-looped
+>23	byte		1		33kHz
+>23	byte		2		50kHz
+>23	byte		3		16kHz
+
+# scream tracker:  file(1) magic for Scream Tracker sample files
+#
+# From <collver1@attbi.com>
+76	string		SCRS		Scream Tracker Sample
+>0	byte		1		sample
+>0	byte		2		adlib melody
+>0	byte		>2		adlib drum
+>31	byte		&2		stereo
+>31	byte		^2		mono
+>31	byte		&4		16bit little endian
+>31	byte		^4		8bit
+>30	byte		0		unpacked
+>30	byte		1		packed
+
+# audio
+# From: Cory Dikkers <cdikkers@swbell.net>
+0	string		MMD0		MED music file, version 0
+0	string		MMD1		OctaMED Pro music file, version 1
+0	string		MMD3		OctaMED Soundstudio music file, version 3
+0	string		OctaMEDCmpr	OctaMED Soundstudio compressed file
+0	string		MED		MED_Song
+0	string		SymM		Symphonie SymMOD music file
+#
+0	string		THX		AHX version
+>3	byte		=0		1 module data
+>3	byte		=1		2 module data
+#
+0	string		OKTASONG	Oktalyzer module data
+#
+0	string		DIGI\ Booster\ module\0	%s
+>20	byte		>0		%c
+>>21	byte		>0		\b%c
+>>>22	byte		>0		\b%c
+>>>>23	byte		>0		\b%c
+>610	string		>\0		\b, "%s"
+#
+0	string		DBM0	   	DIGI Booster Pro Module
+>4	byte		>0		V%X.
+>>5	byte		x		\b%02X
+>16	string		>\0		\b, "%s"
+#
+0	string		FTMN		FaceTheMusic module
+>16	string		>\0d		\b, "%s"
+
+# From: <doj@cubic.org> 2003-06-24
+0	string		AMShdr\32	Velvet Studio AMS Module v2.2
+0	string		Extreme		Extreme Tracker AMS Module v1.3
+0	string		DDMF		Xtracker DMF Module
+>4	byte		x		v%i
+>0xD	string		>\0		Title: "%s"
+>0x2B	string		>\0		Composer: "%s"
+0	string		DSM\32		Dynamic Studio Module DSM
+0	string		SONG		DigiTrekker DTM Module
+0	string		DMDL		DigiTrakker MDL Module
+0	string		PSM\32		Protracker Studio PSM Module
+44	string		PTMF		Poly Tracker PTM Module
+>0	string		>\32		Title: "%s"
+0	string		MT20		MadTracker 2.0 Module MT2
+0	string		RAD\40by\40REALiTY!! RAD Adlib Tracker Module RAD
+0	string		RTMM		RTM Module
+0x426	string		MaDoKaN96	XMS Adlib Module
+>0	string		>\0		Composer: "%s"
+0	string		AMF		AMF Module
+>4	string		>\0		Title: "%s"
+0	string		MODINFO1	Open Cubic Player Module Inforation MDZ
+0	string		Extended\40Instrument: Fast Tracker II Instrument
+
+# From: Takeshi Hamasaki <hma@syd.odn.ne.jp>
+# NOA Nancy Codec file
+0	string		\210NOA\015\012\032	NOA Nancy Codec Movie file
+# Yamaha SMAF format
+0	string		MMMD		Yamaha SMAF file
+# Sharp Jisaku Melody format for PDC
+0	string		\001Sharp\040JisakuMelody	SHARP Cell-Phone ringing Melody
+>20	string		Ver01.00	Ver. 1.00
+>>32	byte		x		, %d tracks
+
+# Free lossless audio codec <http://flac.sourceforge.net>
+# From: Przemyslaw Augustyniak <silvathraec@rpg.pl>
+0	string			fLaC		FLAC audio bitstream data
+!:mime	audio/x-flac
+>4	byte&0x7f		>0		\b, unknown version
+>4	byte&0x7f		0		\b
+# some common bits/sample values
+>>20	beshort&0x1f0		0x030		\b, 4 bit
+>>20	beshort&0x1f0		0x050		\b, 6 bit
+>>20	beshort&0x1f0		0x070		\b, 8 bit
+>>20	beshort&0x1f0		0x0b0		\b, 12 bit
+>>20	beshort&0x1f0		0x0f0		\b, 16 bit
+>>20	beshort&0x1f0		0x170		\b, 24 bit
+>>20	byte&0xe		0x0		\b, mono
+>>20	byte&0xe		0x2		\b, stereo
+>>20	byte&0xe		0x4		\b, 3 channels
+>>20	byte&0xe		0x6		\b, 4 channels
+>>20	byte&0xe		0x8		\b, 5 channels
+>>20	byte&0xe		0xa		\b, 6 channels
+>>20	byte&0xe		0xc		\b, 7 channels
+>>20	byte&0xe		0xe		\b, 8 channels
+# some common sample rates
+>>17	belong&0xfffff0		0x0ac440	\b, 44.1 kHz
+>>17	belong&0xfffff0		0x0bb800	\b, 48 kHz
+>>17	belong&0xfffff0		0x07d000	\b, 32 kHz
+>>17	belong&0xfffff0		0x056220	\b, 22.05 kHz
+>>17	belong&0xfffff0		0x05dc00	\b, 24 kHz
+>>17	belong&0xfffff0		0x03e800	\b, 16 kHz
+>>17	belong&0xfffff0		0x02b110	\b, 11.025 kHz
+>>17	belong&0xfffff0		0x02ee00	\b, 12 kHz
+>>17	belong&0xfffff0		0x01f400	\b, 8 kHz
+>>17	belong&0xfffff0		0x177000	\b, 96 kHz
+>>17	belong&0xfffff0		0x0fa000	\b, 64 kHz
+>>21	byte&0xf		>0		\b, >4G samples
+>>21	byte&0xf		0		\b
+>>>22	belong			>0		\b, %u samples
+>>>22	belong			0		\b, length unknown
+
+# (ISDN) VBOX voice message file (Wolfram Kleff)
+0       string          VBOX            VBOX voice message data
+
+# ReBorn Song Files (.rbs)
+# David J. Singer <doc@deadvirgins.org.uk>
+8       string          RB40             RBS Song file
+>29     string          ReBorn           created by ReBorn
+>37     string          Propellerhead    created by ReBirth
+
+# Synthesizer Generator and Kimwitu share their file format
+0	string		A#S#C#S#S#L#V#3	    Synthesizer Generator or Kimwitu data
+# Kimwitu++ uses a slightly different magic
+0	string		A#S#C#S#S#L#HUB	    Kimwitu++ data
+
+# From "Simon Hosie
+0       string  TFMX-SONG       TFMX module sound data
+
+# Monkey's Audio compressed audio format (.ape)
+# From danny.milo@gmx.net (Danny Milosavljevic)
+# New version from Abel Cheung <abel (@) oaka.org>
+0		string		MAC\040		Monkey's Audio compressed format
+!:mime audio/x-ape
+>4		uleshort	>0x0F8B		version %d
+>>(0x08.l)	uleshort	=1000		with fast compression
+>>(0x08.l)	uleshort	=2000		with normal compression
+>>(0x08.l)	uleshort	=3000		with high compression
+>>(0x08.l)	uleshort	=4000		with extra high compression
+>>(0x08.l)	uleshort	=5000		with insane compression
+>>(0x08.l+18)	uleshort	=1		\b, mono
+>>(0x08.l+18)	uleshort	=2		\b, stereo
+>>(0x08.l+20)	ulelong		x		\b, sample rate %d
+>4		uleshort	<0x0F8C		version %d
+>>6		uleshort	=1000		with fast compression
+>>6		uleshort	=2000		with normal compression
+>>6		uleshort	=3000		with high compression
+>>6		uleshort	=4000		with extra high compression
+>>6		uleshort	=5000		with insane compression
+>>10		uleshort	=1		\b, mono
+>>10		uleshort	=2		\b, stereo
+>>12		ulelong		x		\b, sample rate %d
+
+# adlib sound files
+# From Gurkan Sengun <gurkan@linuks.mine.nu>, http://www.linuks.mine.nu
+0    	string		RAWADATA	RdosPlay RAW
+
+1068	string		RoR		AMUSIC Adlib Tracker
+
+0	string		JCH		EdLib
+
+0	string		mpu401tr	MPU-401 Trakker
+
+0	string		SAdT		Surprise! Adlib Tracker
+>4	byte		x		Version %d
+
+0	string		XAD!		eXotic ADlib
+
+0	string		ofTAZ!		eXtra Simple Music
+
+# Spectrum 128 tunes (.ay files).
+# From: Emanuel Haupt <ehaupt@critical.ch>
+0	string		ZXAYEMUL	Spectrum 128 tune
+
+0	string		\0BONK		BONK,
+#>5	byte		x		version %d
+>14	byte		x		%d channel(s),
+>15	byte		=1		lossless,
+>15	byte		=0		lossy,
+>16	byte		x		mid-side
+
+384	string		LockStream	LockStream Embedded file (mostly MP3 on old Nokia phones)
+
+# format VQF (proprietary codec for sound)
+# some infos on the header file available at :
+# http://www.twinvq.org/english/technology_format.html
+0	string		TWIN97012000	VQF data
+>27	short		0		\b, Mono
+>27	short		1		\b, Stereo
+>31	short 		>0		\b, %d kbit/s
+>35	short 		>0		\b, %d kHz
+
+# Nelson A. de Oliveira (naoliv@gmail.com)
+# .eqf
+0	string	Winamp\ EQ\ library\ file	%s
+# it will match only versions like v<digit>.<digit>
+# Since I saw only eqf files with version v1.1 I think that it's OK
+>23	string	x	\b%.4s
+# .preset
+0	string	[Equalizer\ preset]	XMMS equalizer preset
+# .m3u
+0	search/1	#EXTM3U 	M3U playlist text
+# .pls
+0	search/1	[playlist]	PLS playlist text
+# licq.conf
+1	string	[licq]			LICQ configuration file
+
+# Atari ST audio files by Dirk Jagdmann <doj@cubic.org>
+0	string		ICE!		SNDH Atari ST music
+0	string		SC68\ Music-file\ /\ (c)\ (BeN)jami	sc68 Atari ST music
+
+# musepak support From: "Jiri Pejchal" <jiri.pejchal@gmail.com>
+0       string          MP+     Musepack audio
+!:mime	audio/x-musepack
+>3      byte            255     \b, SV pre8
+>3      byte&0xF        0x6     \b, SV 6
+>3      byte&0xF        0x8     \b, SV 8
+>3      byte&0xF        0x7     \b, SV 7
+>>3     byte&0xF0       0x0     \b.0
+>>3     byte&0xF0       0x10    \b.1
+>>3     byte&0xF0       240     \b.15
+>>10    byte&0xF0       0x0     \b, no profile
+>>10    byte&0xF0       0x10    \b, profile 'Unstable/Experimental'
+>>10    byte&0xF0       0x50    \b, quality 0
+>>10    byte&0xF0       0x60    \b, quality 1
+>>10    byte&0xF0       0x70    \b, quality 2 (Telephone)
+>>10    byte&0xF0       0x80    \b, quality 3 (Thumb)
+>>10    byte&0xF0       0x90    \b, quality 4 (Radio)
+>>10    byte&0xF0       0xA0    \b, quality 5 (Standard)
+>>10    byte&0xF0       0xB0    \b, quality 6 (Xtreme)
+>>10    byte&0xF0       0xC0    \b, quality 7 (Insane)
+>>10    byte&0xF0       0xD0    \b, quality 8 (BrainDead)
+>>10    byte&0xF0       0xE0    \b, quality 9
+>>10    byte&0xF0       0xF0    \b, quality 10
+>>27    byte            0x0     \b, Buschmann 1.7.0-9, Klemm 0.90-1.05
+>>27    byte            102     \b, Beta 1.02
+>>27    byte            104     \b, Beta 1.04
+>>27    byte            105     \b, Alpha 1.05
+>>27    byte            106     \b, Beta 1.06
+>>27    byte            110     \b, Release 1.1
+>>27    byte            111     \b, Alpha 1.11
+>>27    byte            112     \b, Beta 1.12
+>>27    byte            113     \b, Alpha 1.13
+>>27    byte            114     \b, Beta 1.14
+>>27    byte            115     \b, Alpha 1.15
+
+# IMY
+# from http://filext.com/detaillist.php?extdetail=IMY
+# http://cellphones.about.com/od/cellularfaqs/f/rf_imelody.htm
+# http://download.ncl.ie/doc/api/ie/ncl/media/music/IMelody.html
+# http://www.wx800.com/msg/download/irda/iMelody.pdf
+0	string	BEGIN:IMELODY	iMelody Ringtone Format
+
+# From: "Mateus Caruccio" <mateus@caruccio.com>
+# guitar pro v3,4,5 from http://filext.com/file-extension/gp3
+0	string	\030FICHIER\ GUITAR\ PRO\ v3.	Guitar Pro Ver. 3 Tablature
+
+# From: "Leslie P. Polzer" <leslie.polzer@gmx.net>
+60	string	SONG		SoundFX Module sound file
+
+# Type: Adaptive Multi-Rate Codec
+# URL:  http://filext.com/detaillist.php?extdetail=AMR
+# From: Russell Coker <russell@coker.com.au>
+0	string	#!AMR		Adaptive Multi-Rate Codec (GSM telephony)
+
+# Type: SuperCollider 3 Synth Definition File Format
+# From: Mario Lang <mlang@debian.org>
+0	string	SCgf	SuperCollider3 Synth Definition file,
+>4	belong	x	version %d
+
+# Type: True Audio Lossless Audio
+# URL:  http://wiki.multimedia.cx/index.php?title=True_Audio
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	TTA1	True Audio Lossless Audio
+
+# Type: WavPack Lossless Audio
+# URL:  http://wiki.multimedia.cx/index.php?title=WavPack
+# From: Mike Melanson <mike@multimedia.cx>
+0	string	wvpk	WavPack Lossless Audio
+
+# From Fabio R. Schmidlin <frs@pop.com.br>
+# VGM music file
+0	string		Vgm\ 
+>9	ubyte		>0	VGM Video Game Music dump v
+>>9	ubyte/16	>0	\b%d
+>>9	ubyte&0x0F	x	\b%d
+>>8	ubyte/16	x	\b.%d
+>>8	ubyte&0x0F	>0	\b%d
+#Get soundchips
+>>8	ubyte		x	\b, soundchip(s)=
+>>0x0C	ulelong		>0	SN76489,
+>>0x10	ulelong		>0	YM2413,
+>>0x2C	ulelong		>0	YM2612,
+>>0x30	ulelong		>0	YM2151,
+>>0x38	ulelong		>0	Sega PCM,
+>>0x34	ulelong		>0xC
+>>>0x40	ulelong		>0	RF5C68,
+>>0x34	ulelong		>0x10
+>>>0x44	ulelong		>0	YM2203,
+>>0x34	ulelong		>0x14
+>>>0x48	ulelong		>0	YM2608,
+>>0x34	ulelong		>0x18
+>>>0x4C	lelong		>0	YM2610,
+>>>0x4C	lelong		<0	YM2610B,
+>>0x34	ulelong		>0x1C
+>>>0x50	ulelong		>0	YM3812,
+>>0x34	ulelong		>0x20
+>>>0x54	ulelong		>0	YM3526,
+>>0x34	ulelong		>0x24
+>>>0x58	ulelong		>0	Y8950,
+>>0x34	ulelong		>0x28
+>>>0x5C	ulelong		>0	YMF262,
+>>0x34	ulelong		>0x2C
+>>>0x60	ulelong		>0	YMF278B,
+>>0x34	ulelong		>0x30
+>>>0x64	ulelong		>0	YMF271,
+>>0x34	ulelong		>0x34
+>>>0x68	ulelong		>0	YMZ280B,
+>>0x34	ulelong		>0x38
+>>>0x6C	ulelong		>0	RF5C164,
+>>0x34	ulelong		>0x3C
+>>>0x70	ulelong		>0	PWM,
+>>0x34	ulelong		>0x40
+>>>0x74	ulelong		>0
+>>>>0x78 ubyte		0x00	AY-3-8910,
+>>>>0x78 ubyte		0x01	AY-3-8912,
+>>>>0x78 ubyte		0x02	AY-3-8913,
+>>>>0x78 ubyte		0x03	AY-3-8930,
+>>>>0x78 ubyte		0x10	YM2149,
+>>>>0x78 ubyte		0x11	YM3439,
+
+# GVOX Encore file format
+# Since this is a proprietary file format and there is no publicly available
+# format specification, this is just based on induction
+#
+0	string	SCOW
+>4	byte	0xc4	GVOX Encore music, version 5.0 or above
+>4	byte	0xc2	GVOX Encore music, version < 5.0
+
+0	string	ZBOT
+>4	byte	0xc5	GVOX Encore music, version < 5.0
+
+
+#----------------------------------------------------------------
+# $File$
+# basis: file(1) magic for BBx/Pro5-files
+#      Oliver Dammer <dammer@olida.de>	 2005/11/07
+# http://www.basis.com business-basic-files.
+#
+0	string		\074\074bbx\076\076	BBx
+>7	string		\000			indexed file
+>7	string		\001			serial file
+>7	string		\002			keyed file
+>>13	short		0			(sort)
+>7	string		\004			program
+>>18	byte		x			(LEVEL %d)
+>>>23	string		>\000			psaved
+>7	string		\006			mkeyed file
+>>13	short		0			(sort)
+>>8	string		\000			(mkey)
+
+#------------------------------------------------------------------------------
+# $File: bflt,v 1.4 2009/09/19 16:28:08 christos Exp $
+# bFLT: file(1) magic for BFLT uclinux binary files
+#
+# From Philippe De Muyter <phdm@macqel.be>
+#
+0	string		bFLT		BFLT executable
+>4	belong		x		- version %d
+>4	belong		4
+>>36	belong&0x1	0x1		ram
+>>36	belong&0x2	0x2		gotpic
+>>36	belong&0x4	0x4		gzip
+>>36	belong&0x8	0x8		gzdata
+
+#------------------------------------------------------------------------------
+# $File: apple,v 1.27 2013/03/09 22:36:00 christos Exp $
+# blackberry:  file(1) magic for BlackBerry file formats
+#
+5	belong	0		
+>8	belong  010010010	BlackBerry RIM ETP file
+>>22	string	x		\b for %s
+# Berkeley Lab Checkpoint Restart (BLCR) checkpoint context files
+# http://ftg.lbl.gov/checkpoint
+0	string	C\0\0\0R\0\0\0	BLCR
+>16	lelong	1	x86
+>16	lelong	3	alpha
+>16	lelong	5	x86-64
+>16	lelong	7	ARM
+>8	lelong	x	context data (little endian, version %d)
+# Uncomment the following only of your "file" program supports "search"
+#>0	search/1024	VMA\06	for kernel
+#>>&1	byte	x	%d.
+#>>&2	byte	x	%d.
+#>>&3	byte	x	%d
+0	string	\0\0\0C\0\0\0R	BLCR
+>16	belong	2	SPARC
+>16	belong	4	ppc
+>16	belong	6	ppc64
+>16	belong	7	ARMEB
+>16	belong	8	SPARC64
+>8	belong	x	context data (big endian, version %d)
+# Uncomment the following only of your "file" program supports "search"
+#>0	search/1024	VMA\06	for kernel
+#>>&1	byte	x	%d.
+#>>&2	byte	x	\b%d.
+#>>&3	byte	x	\b%d
+
+#------------------------------------------------------------------------------
+# $File: blender,v 1.5 2009/09/19 16:28:08 christos Exp $
+# blender: file(1) magic for Blender 3D related files
+#
+# Native format rule v1.2. For questions use the developers list 
+# http://lists.blender.org/mailman/listinfo/bf-committers
+# GLOB chunk was moved near start and provides subversion info since 2.42 
+
+0		string	=BLENDER	Blender3D,
+>7		string	=_		saved as 32-bits
+>>8		string	=v		little endian
+>>>9		byte	x		with version %c.
+>>>10		byte	x		\b%c
+>>>11		byte	x		\b%c
+>>>0x40		string	=GLOB		\b.
+>>>>0x58	leshort	x		\b%.4d
+>>8		string	=V		big endian
+>>>9		byte	x		with version %c.
+>>>10		byte	x		\b%c
+>>>11		byte	x		\b%c
+>>>0x40		string	=GLOB		\b.
+>>>>0x58	beshort	x		\b%.4d
+>7		string	=-		saved as 64-bits
+>>8		string	=v		little endian
+>>9		byte	x		with version %c.
+>>10		byte	x		\b%c
+>>11		byte	x		\b%c
+>>0x44		string	=GLOB		\b.
+>>>0x60		leshort	x		\b%.4d
+>>8		string	=V		big endian
+>>>9		byte	x		with version %c.
+>>>10		byte	x		\b%c
+>>>11		byte	x		\b%c
+>>>0x44		string	=GLOB		\b.
+>>>>0x60	beshort	x		\b%.4d
+
+# Scripts that run in the embedded Python interpreter
+0		string	#!BPY		Blender3D BPython script
+
+#------------------------------------------------------------------------------
+# $File$
+# blit:  file(1) magic for 68K Blit stuff as seen from 680x0 machine
+#
+# Note that this 0407 conflicts with several other a.out formats...
+#
+# XXX - should this be redone with "be" and "le", so that it works on
+# little-endian machines as well?  If so, what's the deal with
+# "VAX-order" and "VAX-order2"?
+#
+#0	long		0407		68K Blit (standalone) executable
+#0	short		0407		VAX-order2 68K Blit (standalone) executable
+0	short		03401		VAX-order 68K Blit (standalone) executable
+0	long		0406		68k Blit mpx/mux executable
+0	short		0406		VAX-order2 68k Blit mpx/mux executable
+0	short		03001		VAX-order 68k Blit mpx/mux executable
+# Need more values for WE32 DMD executables.
+# Note that 0520 is the same as COFF
+#0	short		0520		tty630 layers executable
+
+#------------------------------------------------------------------------------
+# $File$
+# i80960 b.out objects and archives
+#
+0	long		0x10d		i960 b.out relocatable object
+>16	long		>0		not stripped
+#
+# b.out archive (hp-rt on i960)
+0	string		=!<bout>	b.out archive
+>8	string		__.SYMDEF	random library
+
+#------------------------------------------------------------------------------
+# $File: bsdi,v 1.6 2013/01/09 22:37:24 christos Exp $
+# bsdi:  file(1) magic for BSD/OS (from BSDI) objects
+# Some object/executable formats use the same magic numbers as are used
+# in other OSes; those are handled by entries in aout.
+#
+
+0	lelong		0314		386 compact demand paged pure executable
+>16	lelong		>0		not stripped
+>32	byte		0x6a		(uses shared libs)
+
+# same as in SunOS 4.x, except for static shared libraries
+0	belong&077777777	0600413		SPARC demand paged
+>0	byte		&0x80
+>>20	belong		<4096		shared library
+>>20	belong		=4096		dynamically linked executable
+>>20	belong		>4096		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+>36	belong		0xb4100001	(uses shared libs)
+
+0	belong&077777777	0600410		SPARC pure
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+>36	belong		0xb4100001	(uses shared libs)
+
+0	belong&077777777	0600407		SPARC
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+>36	belong		0xb4100001	(uses shared libs)
+# Chiasmus is a encryption standard developed by the German Federal
+# Office for Information Security (Bundesamt fuer Sicherheit in der
+# Informationstechnik).
+
+# Extension: .xia
+0	string	XIA1	Chiasmus encrypted data
+
+# Extension: .xis
+0	string	XIS	Chiasmus key
+
+#------------------------------------------------------------------------------
+# $File$
+# BTSnoop:  file(1) magic for BTSnoop files
+#
+# From <marcel@holtmann.org>
+0	string		btsnoop\0		BTSnoop
+>8	belong		x			version %d,
+>12	belong		1001			Unencapsulated HCI
+>12	belong		1002			HCI UART (H4)
+>12	belong		1003			HCI BCSP
+>12	belong		1004			HCI Serial (H5)
+>>12	belong		x			type %d
+
+#------------------------------------------------------------------------------
+# $File$
+# c64:  file(1) magic for various commodore 64 related files
+#
+# From: Dirk Jagdmann <doj@cubic.org>
+
+0x16500	belong		0x12014100	D64 Image
+0x16500	belong		0x12014180	D71 Image
+0x61800 belong		0x28034400	D81 Image
+0	string		C64\40CARTRIDGE	CCS C64 Emultar Cartridge Image
+0	belong		0x43154164	X64 Image
+
+0	string		GCR-1541	GCR Image
+>8	byte		x		version: %i
+>9	byte		x		tracks: %i
+
+9	string		PSUR		ARC archive (c64)
+2	string		-LH1-		LHA archive (c64)
+
+0	string		C64File		PC64 Emulator file
+>8	string		>\0		"%s"
+0	string		C64Image	PC64 Freezer Image
+
+0	beshort		0x38CD		C64 PCLink Image
+0	string		CBM\144\0\0	Power 64 C64 Emulator Snapshot
+
+0	belong		0xFF424CFF	WRAptor packer (c64)
+
+0	string		C64S\x20tape\x20file	T64 tape Image
+>32	leshort		x		Version:0x%x
+>36	leshort		!0		Entries:%i
+>40	string		x		Name:%.24s
+
+0	string		C64\x20tape\x20image\x20file\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0	T64 tape Image
+>32	leshort		x		Version:0x%x
+>36	leshort		!0		Entries:%i
+>40	string		x		Name:%.24s
+
+0	string		C64S\x20tape\x20image\x20file\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0	T64 tape Image
+>32	leshort		x		Version:0x%x
+>36	leshort		!0		Entries:%i
+>40	string		x		Name:%.24s
+
+#------------------------------------------------------------------------------
+# $File: cad,v 1.12 2013/07/04 15:24:37 christos Exp $
+# autocad:  file(1) magic for cad files
+#
+
+# Microstation DGN/CIT Files (www.bentley.com)
+# Last updated July 29, 2005 by Lester Hightower
+# DGN is the default file extension of Microstation/Intergraph CAD files.
+# CIT is the proprietary raster format (similar to TIFF) used to attach
+# raster underlays to Microstation DGN (vector) drawings.
+# 
+# http://www.wotsit.org/search.asp
+# http://filext.com/detaillist.php?extdetail=DGN
+# http://filext.com/detaillist.php?extdetail=CIT
+#
+# http://www.bentley.com/products/default.cfm?objectid=97F351F5-9C35-4E5E-89C2
+# 3F86C928&method=display&p_objectid=97F351F5-9C35-4E5E-89C280A93F86C928
+# http://www.bentley.com/products/default.cfm?objectid=A5C2FD43-3AC9-4C71-B682
+# 721C479F&method=display&p_objectid=A5C2FD43-3AC9-4C71-B682C7BE721C479F
+0	string	\010\011\376			Microstation
+>3	string	\002
+>>30	string	\026\105			DGNFile
+>>30	string	\034\105			DGNFile
+>>30	string	\073\107			DGNFile
+>>30	string	\073\110			DGNFile
+>>30	string	\106\107			DGNFile
+>>30	string	\110\103			DGNFile
+>>30	string	\120\104			DGNFile
+>>30	string	\172\104			DGNFile
+>>30	string	\172\105			DGNFile
+>>30	string	\172\106			DGNFile
+>>30	string	\234\106			DGNFile
+>>30	string	\273\105			DGNFile
+>>30	string	\306\106			DGNFile
+>>30	string	\310\104			DGNFile
+>>30	string	\341\104			DGNFile
+>>30	string	\372\103			DGNFile
+>>30	string	\372\104			DGNFile
+>>30	string	\372\106			DGNFile
+>>30	string	\376\103			DGNFile
+>4	string	\030\000\000			CITFile
+>4	string	\030\000\003			CITFile
+
+# AutoCAD 
+# Merge of the different contributions and updates from http://en.wikipedia.org/wiki/Dwg
+# and http://www.iana.org/assignments/media-types/image/vnd.dwg
+0	string	MC0.0	DWG AutoDesk AutoCAD Release 1.0
+!:mime image/vnd.dwg
+0	string	AC1.2	DWG AutoDesk AutoCAD Release 1.2
+!:mime image/vnd.dwg
+0	string	AC1.3	DWG AutoDesk AutoCAD Release 1.3
+!:mime image/vnd.dwg
+0	string	AC1.40	DWG AutoDesk AutoCAD Release 1.40
+!:mime image/vnd.dwg
+0	string	AC1.50	DWG AutoDesk AutoCAD Release 2.05
+!:mime image/vnd.dwg
+0	string	AC2.10	DWG AutoDesk AutoCAD Release 2.10
+!:mime image/vnd.dwg
+0	string	AC2.21	DWG AutoDesk AutoCAD Release 2.21
+!:mime image/vnd.dwg
+0	string	AC2.22	DWG AutoDesk AutoCAD Release 2.22
+!:mime image/vnd.dwg
+0	string	AC1001	DWG AutoDesk AutoCAD Release 2.22
+!:mime image/vnd.dwg
+0	string	AC1002	DWG AutoDesk AutoCAD Release 2.50
+!:mime image/vnd.dwg
+0	string	AC1003	DWG AutoDesk AutoCAD Release 2.60
+!:mime image/vnd.dwg
+0	string	AC1004	DWG AutoDesk AutoCAD Release 9
+!:mime image/vnd.dwg
+0	string	AC1006	DWG AutoDesk AutoCAD Release 10
+!:mime image/vnd.dwg
+0	string	AC1009	DWG AutoDesk AutoCAD Release 11/12
+!:mime image/vnd.dwg
+# AutoCAD DWG versions R13/R14 (www.autodesk.com)
+# Written December 01, 2003 by Lester Hightower
+# Based on the DWG File Format Specifications at http://www.opendwg.org/
+# AutoCad, from Nahuel Greco
+# AutoCAD DWG versions R12/R13/R14 (www.autodesk.com)
+0	string	AC1012	DWG AutoDesk AutoCAD Release 13
+!:mime image/vnd.dwg
+0	string	AC1014	DWG AutoDesk AutoCAD Release 14
+!:mime image/vnd.dwg
+0	string	AC1015	DWG AutoDesk AutoCAD 2000/2002
+!:mime image/vnd.dwg
+
+# A new version of AutoCAD DWG
+# Sergey Zaykov (mail_of_sergey@mail.ru, sergey_zaikov@rambler.ru,
+# ICQ 358572321)
+# From various sources like:
+# http://autodesk.blogs.com/between_the_lines/autocad-release-history.html
+0	string	AC1018	DWG AutoDesk AutoCAD 2004/2005/2006
+!:mime image/vnd.dwg
+0	string	AC1021	DWG AutoDesk AutoCAD 2007/2008/2009
+!:mime image/vnd.dwg
+0	string	AC1024	DWG AutoDesk AutoCAD 2010/2011/2012
+!:mime image/vnd.dwg
+0	string	AC1027	DWG AutoDesk AutoCAD 2013/2014
+!:mime image/vnd.dwg
+
+# KOMPAS 2D drawing from ASCON 
+# This is KOMPAS 2D drawing or fragment of drawing but is not detailed nor
+# gathered nor specification
+# ASCON http://ascon.net/main/ in English,
+#	http://ascon.ru/ main site in Russian
+# Extension is CDW for drawing and FRW for fragment of drawing 
+# Sergey Zaykov (mail_of_sergey@mail.ru, sergey_zaikov@rambler.ru,
+# ICQ 358572321, http://vkontakte.ru/id16076543)
+# From:
+# http://sd.ascon.ru/otrs/customer.pl?Action=CustomerFAQ&CategoryID=4&ItemID=292
+# (in russian) and my experiments
+0	string	KF
+>2	belong	0x4E00000C	Kompas drawing 12.0 SP1 
+>2	belong	0x4D00000C	Kompas drawing 12.0 
+>2	belong	0x3200000B	Kompas drawing 11.0 SP1 
+>2	belong	0x3100000B	Kompas drawing 11.0 
+>2	belong	0x2310000A	Kompas drawing 10.0 SP1 
+>2	belong	0x2110000A	Kompas drawing 10.0 
+>2	belong	0x08000009	Kompas drawing 9.0 SP1 
+>2	belong	0x05000009	Kompas drawing 9.0 
+>2	belong	0x33010008	Kompas drawing 8+ 
+>2	belong	0x1A000008	Kompas drawing 8.0 
+>2	belong	0x2C010107	Kompas drawing 7+ 
+>2	belong	0x05000007	Kompas drawing 7.0 
+>2	belong	0x32000006	Kompas drawing 6+ 
+>2	belong	0x09000006	Kompas drawing 6.0 
+>2	belong	0x5C009005	Kompas drawing 5.11R03 
+>2	belong	0x54009005	Kompas drawing 5.11R02 
+>2	belong	0x51009005	Kompas drawing 5.11R01 
+>2	belong	0x22009005	Kompas drawing 5.10R03 
+>2	belong	0x22009005	Kompas drawing 5.10R02 mar 
+>2	belong	0x21009005	Kompas drawing 5.10R02 febr 
+>2	belong	0x19009005	Kompas drawing 5.10R01 
+>2	belong	0xF4008005	Kompas drawing 5.9R01.003 
+>2	belong	0x1C008005	Kompas drawing 5.9R01.002 
+>2	belong	0x11008005	Kompas drawing 5.8R01.003 
+
+# CAD: file(1) magic for computer aided design files
+# Phillip Griffith <phillip dot griffith at gmail dot com>
+# AutoCAD magic taken from the Open Design Alliance's OpenDWG specifications.
+#
+0	belong	0x08051700	Bentley/Intergraph MicroStation DGN cell library
+0	belong	0x0809fe02	Bentley/Intergraph MicroStation DGN vector CAD
+0	belong	0xc809fe02	Bentley/Intergraph MicroStation DGN vector CAD
+0	beshort	0x0809		Bentley/Intergraph MicroStation
+>0x02	byte	0xfe
+>>0x04	beshort	0x1800		CIT raster CAD
+
+# 3DS (3d Studio files) Conflicts with diff output 0x3d '='
+#16	beshort		0x3d3d		image/x-3ds
+
+# MegaCAD 2D/3D drawing (.prt)
+# http://megacad.de/
+# From: Markus Heidelberg <markus.heidelberg@web.de>
+0	string	MegaCad23\0	MegaCAD 2D/3D drawing
+
+#------------------------------------------------------------------------------
+# $File: cafebabe,v 1.17 2015/01/01 17:07:00 christos Exp $
+# Cafe Babes unite!
+#
+# Since Java bytecode and Mach-O universal binaries have the same magic number,
+# the test must be performed in the same "magic" sequence to get both right.
+# The long at offset 4 in a Mach-O universal binary tells the number of
+# architectures; the short at offset 4 in a Java bytecode file is the JVM minor
+# version and the short at offset 6 is the JVM major version.  Since there are only 
+# only 18 labeled Mach-O architectures at current, and the first released 
+# Java class format was version 43.0, we can safely choose any number
+# between 18 and 39 to test the number of architectures against
+# (and use as a hack). Let's not use 18, because the Mach-O people
+# might add another one or two as time goes by...
+#
+### JAVA START ###
+0	belong		0xcafebabe
+>4	belong		>30		compiled Java class data,
+!:mime	application/x-java-applet
+>>6	beshort		x	        version %d.
+>>4	beshort		x       	\b%d
+# Which is which?
+#>>4	belong		0x032d		(Java 1.0)
+#>>4	belong		0x032d		(Java 1.1)
+>>4	belong		0x002e		(Java 1.2)
+>>4	belong		0x002f		(Java 1.3)
+>>4	belong		0x0030		(Java 1.4)
+>>4	belong		0x0031		(Java 1.5)
+>>4	belong		0x0032		(Java 1.6)
+>>4	belong		0x0033		(Java 1.7)
+>>4	belong		0x0034		(Java 1.8)
+
+0	belong		0xcafed00d	JAR compressed with pack200,
+>5	byte		x		version %d.
+>4	byte		x		\b%d
+!:mime	application/x-java-pack200
+
+
+0	belong		0xcafed00d	JAR compressed with pack200,
+>5	byte		x		version %d.
+>4	byte		x		\b%d
+!:mime	application/x-java-pack200
+
+### JAVA END ###
+### MACH-O START ###
+
+0	name		mach-o		\b [
+>0	use		mach-o-cpu	\b
+>(8.L)	indirect			\b: 
+>0	belong		x		\b]
+
+0	belong		0xcafebabe
+>4	belong		1		Mach-O universal binary with 1 architecture:
+>>8	use		mach-o		\b
+>4	belong		>1
+>>4	belong		<20		Mach-O universal binary with %d architectures:
+>>>8	use		mach-o		\b
+>>>28	use		mach-o		\b
+>>4	belong		>2
+>>>48	use		mach-o		\b
+>>4	belong		>3
+>>>68	use		mach-o		\b
+
+### MACH-O END ###
+
+#------------------------------------------------------------------------------
+# $File: elf,v 1.68 2014/09/19 19:05:57 christos Exp $
+# cbor:  file(1) magic for CBOR files as defined in RFC 7049
+
+0	string	\xd9\xd9\xf7 Concise Binary Object Representation (CBOR) container
+!:mime	application/cbor
+>3	ubyte	<0x20	(positive integer)
+>3	ubyte	<0x40
+>>3	ubyte	>0x1f	(negative integer)
+>3	ubyte	<0x60
+>>3	ubyte	>0x3f	(byte string)
+>3	ubyte	<0x80
+>>3	ubyte	>0x5f	(text string)
+>3	ubyte	<0xa0
+>3	ubyte	>0x7f	(array)
+>3	ubyte	<0xc0
+>>3	ubyte	>0x9f	(map)
+>3	ubyte	<0xe0
+>>3	ubyte	>0xbf	(tagged)
+>3	ubyte	>0xdf	(other)
+
+#------------------------------------------------------------------------------
+# $File$
+# CDDB: file(1) magic for CDDB(tm) format CD text data files
+#
+# From <steve@gracenote.com>
+#
+# This is the /etc/magic entry to decode datafiles as used by
+# CDDB-enabled CD player applications.
+#
+
+0	search/1/w	#\040xmcd	CDDB(tm) format CD text data
+
+#------------------------------------------------------------------------------
+# $File: chord,v 1.4 2009/09/19 16:28:08 christos Exp $
+# chord: file(1) magic for Chord music sheet typesetting utility input files
+#
+# From Philippe De Muyter <phdm@macqel.be>
+# File format is actually free, but many distributed files begin with `{title'
+#
+0	string		{title		Chord text file
+
+# Type:	PowerTab file format
+# URL:	http://www.power-tab.net/
+# From:	Jelmer Vernooij <jelmer@samba.org>
+0	string		ptab\003\000	Power-Tab v3 Tablature File
+0	string		ptab\004\000	Power-Tab v4 Tablature File
+
+#------------------------------------------------------------------------------
+# $File$
+# cisco:  file(1) magic for cisco Systems routers
+#
+# Most cisco file-formats are covered by the generic elf code
+#
+# Microcode files are non-ELF, 0x8501 conflicts with NetBSD/alpha.
+0	belong&0xffffff00	0x85011400  cisco IOS microcode
+>7	string		>\0		    for '%s'
+0	belong&0xffffff00	0x8501cb00  cisco IOS experimental microcode
+>7	string		>\0		    for '%s'
+
+#------------------------------------------------------------------------------
+# $File$
+# citrus locale declaration
+#
+
+0	string		RuneCT		Citrus locale declaration for LC_CTYPE
+
+#------------------------------------------------------------------------------
+# $File: c-lang,v 1.18 2013/08/14 13:06:43 christos Exp $
+# c-lang:  file(1) magic for C and related languages programs
+#
+
+# BCPL
+0	search/8192	"libhdr"	BCPL source text
+!:mime	text/x-bcpl
+0	search/8192	"LIBHDR"	BCPL source text
+!:mime	text/x-bcpl
+
+# C
+0	regex	\^#include	C source text
+!:mime	text/x-c
+0	regex	\^char[\ \t\n]+	C source text
+!:mime	text/x-c
+0	regex	\^double[\ \t\n]+		C source text
+!:mime	text/x-c
+0	regex	\^extern[\ \t\n]+		C source text
+!:mime	text/x-c
+0	regex	\^float[\ \t\n]+		C source text
+!:mime	text/x-c
+0	regex	\^struct[\ \t\n]+		C source text
+!:mime	text/x-c
+0	regex	\^union[\ \t\n]+		C source text
+!:mime	text/x-c
+0	search/8192	main(		C source text
+!:mime	text/x-c
+
+# C++
+# The strength of these rules is increased so they beat the C rules above
+0	regex	\^template[\ \t\n]+	C++ source text
+!:strength + 5
+!:mime	text/x-c++
+0	regex	\^virtual[\ \t\n]+		C++ source text
+!:strength + 5
+!:mime	text/x-c++
+0	regex	\^class[\ \t\n]+		C++ source text
+!:strength + 5
+!:mime	text/x-c++
+0	regex	\^public:		C++ source text
+!:strength + 5
+!:mime	text/x-c++
+0	regex	\^private:		C++ source text
+!:strength + 5
+!:mime	text/x-c++
+
+# From: Mikhail Teterin <mi@aldan.algebra.com> 
+0	string		cscope		cscope reference data
+>7	string		x		version %.2s
+# We skip the path here, because it is often long (so file will
+# truncate it) and mostly redundant.
+# The inverted index functionality was added some time between
+# versions 11 and 15, so look for -q if version is above 14:
+>7	string		>14
+>>10	search/100	\ -q\ 		with inverted index
+>10	search/100	\ -c\ 		text (non-compressed)
+
+#------------------------------------------------------------------------------
+# $File: clarion,v 1.4 2009/09/19 16:28:08 christos Exp $
+# clarion:  file(1) magic for # Clarion Personal/Professional Developer
+# (v2 and above)
+# From: Julien Blache <jb@jblache.org>
+
+# Database files
+# signature
+0	leshort	0x3343	Clarion Developer (v2 and above) data file
+# attributes
+>2	leshort	&0x0001	\b, locked
+>2	leshort	&0x0004	\b, encrypted
+>2	leshort	&0x0008	\b, memo file exists
+>2	leshort	&0x0010	\b, compressed
+>2	leshort	&0x0040	\b, read only
+# number of records
+>5	lelong	x	\b, %d records
+
+# Memo files
+0	leshort	0x334d	Clarion Developer (v2 and above) memo data
+
+# Key/Index files
+# No magic? :(
+
+# Help files
+0	leshort	0x49e0	Clarion Developer (v2 and above) help data
+
+#------------------------------------------------------------------------------
+# $File: claris,v 1.6 2012/06/20 21:19:05 christos Exp $
+# claris:  file(1) magic for claris
+# "H. Nanosecond" <aldomel@ix.netcom.com>
+# Claris Works a word processor, etc.
+# Version 3.0
+
+# .pct claris works clip art files
+#0000000 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000
+#*
+#0001000 #010 250 377 377 377 377 000 213 000 230 000 021 002 377 014 000
+#null to byte 1000 octal
+514	string	\377\377\377\377\000
+>0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0	Claris clip art
+514	string	\377\377\377\377\001
+>0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0	Claris clip art
+
+# Claris works files
+# .cwk
+0	string	\002\000\210\003\102\117\102\117\000\001\206 Claris works document
+# .plt
+0	string	\020\341\000\000\010\010	Claris Works palette files .plt
+
+# .msp a dictionary file I am not sure about this I have only one .msp file
+0	string	\002\271\262\000\040\002\000\164	Claris works dictionary
+
+# .usp are user dictionary bits
+# I am not sure about a magic header:
+#0000000 001 123 160 146 070 125 104 040 136 123 015 012 160 157 144 151
+#        soh   S   p   f   8   U   D  sp   ^   S  cr  nl   p   o   d   i
+#0000020 141 164 162 151 163 164 040 136 123 015 012 144 151 166 040 043
+#          a   t   r   i   s   t  sp   ^   S  cr  nl   d   i   v  sp   #
+
+# .mth Thesaurus
+# starts with \0 but no magic header
+
+# .chy Hyphenation file
+# I am not sure: 000 210 034 000 000
+
+# other claris files
+#./windows/claris/useng.ndx: data
+#./windows/claris/xtndtran.l32: data
+#./windows/claris/xtndtran.lst: data
+#./windows/claris/clworks.lbl: data
+#./windows/claris/clworks.prf: data
+#./windows/claris/userd.spl: data
+
+#------------------------------------------------------------------------------
+# $File: clipper,v 1.6 2009/09/19 16:28:08 christos Exp $
+# clipper:  file(1) magic for Intergraph (formerly Fairchild) Clipper.
+#
+# XXX - what byte order does the Clipper use?
+#
+# XXX - what's the "!" stuff:
+#
+# >18	short		!074000,000000	C1 R1 
+# >18	short		!074000,004000	C2 R1
+# >18	short		!074000,010000	C3 R1
+# >18	short		!074000,074000	TEST
+#
+# I shall assume it's ANDing the field with the first value and
+# comparing it with the second, and rewrite it as:
+#
+# >18	short&074000	000000		C1 R1 
+# >18	short&074000	004000		C2 R1
+# >18	short&074000	010000		C3 R1
+# >18	short&074000	074000		TEST
+#
+# as SVR3.1's "file" doesn't support anything of the "!074000,000000"
+# sort, nor does SunOS 4.x, so either it's something Intergraph added
+# in CLIX, or something AT&T added in SVR3.2 or later, or something
+# somebody else thought was a good idea; it's not documented in the
+# man page for this version of "magic", nor does it appear to be
+# implemented (at least not after I blew off the bogus code to turn
+# old-style "&"s into new-style "&"s, which just didn't work at all).
+#
+0	short		0575		CLIPPER COFF executable (VAX #)
+>20	short		0407		(impure)
+>20	short		0410		(5.2 compatible)
+>20	short		0411		(pure)
+>20	short		0413		(demand paged)
+>20	short		0443		(target shared library)
+>12	long		>0		not stripped
+>22	short		>0		- version %d
+0	short		0577		CLIPPER COFF executable
+>18	short&074000	000000		C1 R1 
+>18	short&074000	004000		C2 R1
+>18	short&074000	010000		C3 R1
+>18	short&074000	074000		TEST
+>20	short		0407		(impure)
+>20	short		0410		(pure)
+>20	short		0411		(separate I&D)
+>20	short		0413		(paged)
+>20	short		0443		(target shared library)
+>12	long		>0		not stripped
+>22	short		>0		- version %d
+>48	long&01		01		alignment trap enabled
+>52	byte		1		-Ctnc
+>52	byte		2		-Ctsw
+>52	byte		3		-Ctpw
+>52	byte		4		-Ctcb
+>53	byte		1		-Cdnc
+>53	byte		2		-Cdsw
+>53	byte		3		-Cdpw
+>53	byte		4		-Cdcb
+>54	byte		1		-Csnc
+>54	byte		2		-Cssw
+>54	byte		3		-Cspw
+>54	byte		4		-Cscb
+4	string		pipe		CLIPPER instruction trace
+4	string		prof		CLIPPER instruction profile
+
+#------------------------------------------------------------------------------
+# $File: commands,v 1.50 2014/05/30 16:48:44 christos Exp $
+# commands:  file(1) magic for various shells and interpreters
+#
+#0	string/w	:			shell archive or script for antique kernel text
+0	string/wt	#!\ /bin/sh		POSIX shell script text executable
+!:mime	text/x-shellscript
+0	string/wb	#!\ /bin/sh		POSIX shell script executable (binary data)
+!:mime	text/x-shellscript
+
+0	string/wt	#!\ /bin/csh		C shell script text executable
+!:mime	text/x-shellscript
+
+# korn shell magic, sent by George Wu, gwu@clyde.att.com
+0	string/wt	#!\ /bin/ksh		Korn shell script text executable
+!:mime	text/x-shellscript
+0	string/wb	#!\ /bin/ksh		Korn shell script executable (binary data)
+!:mime	text/x-shellscript
+
+0	string/wt 	#!\ /bin/tcsh		Tenex C shell script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/bin/tcsh	Tenex C shell script text executable
+!:mime	text/x-shellscript
+0	string/wt 	#!\ /usr/local/tcsh	Tenex C shell script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/local/bin/tcsh	Tenex C shell script text executable
+!:mime	text/x-shellscript
+
+#
+# zsh/ash/ae/nawk/gawk magic from cameron@cs.unsw.oz.au (Cameron Simpson)
+0	string/wt	#!\ /bin/zsh		Paul Falstad's zsh script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/bin/zsh	Paul Falstad's zsh script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/local/bin/zsh	Paul Falstad's zsh script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/local/bin/ash	Neil Brown's ash script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/local/bin/ae	Neil Brown's ae script text executable
+!:mime	text/x-shellscript
+0	string/wt	#!\ /bin/nawk		new awk script text executable
+!:mime	text/x-nawk
+0	string/wt	#!\ /usr/bin/nawk	new awk script text executable
+!:mime	text/x-nawk
+0	string/wt	#!\ /usr/local/bin/nawk	new awk script text executable
+!:mime	text/x-nawk
+0	string/wt	#!\ /bin/gawk		GNU awk script text executable
+!:mime	text/x-gawk
+0	string/wt	#!\ /usr/bin/gawk	GNU awk script text executable
+!:mime	text/x-gawk
+0	string/wt	#!\ /usr/local/bin/gawk	GNU awk script text executable
+!:mime	text/x-gawk
+#
+0	string/wt	#!\ /bin/awk		awk script text executable
+!:mime	text/x-awk
+0	string/wt	#!\ /usr/bin/awk	awk script text executable
+!:mime	text/x-awk
+0	regex/4096	=^\\s{0,100}BEGIN\\s{0,100}[{]	awk or perl script text
+
+# AT&T Bell Labs' Plan 9 shell
+0	string/wt	#!\ /bin/rc	Plan 9 rc shell script text executable
+
+# bash shell magic, from Peter Tobias (tobias@server.et-inf.fho-emden.de)
+0	string/wt	#!\ /bin/bash	Bourne-Again shell script text executable
+!:mime	text/x-shellscript
+0	string/wb	#!\ /bin/bash	Bourne-Again shell script executable (binary data)
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/bin/bash	Bourne-Again shell script text executable
+!:mime	text/x-shellscript
+0	string/wb	#!\ /usr/bin/bash	Bourne-Again shell script executable (binary data)
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/local/bash	Bourne-Again shell script text executable
+!:mime	text/x-shellscript
+0	string/wb	#!\ /usr/local/bash	Bourne-Again shell script executable (binary data)
+!:mime	text/x-shellscript
+0	string/wt	#!\ /usr/local/bin/bash	Bourne-Again shell script text executable
+!:mime	text/x-shellscript
+0	string/wb	#!\ /usr/local/bin/bash	Bourne-Again shell script executable (binary data)
+!:mime	text/x-shellscript
+
+# PHP scripts
+# Ulf Harnhammar <ulfh@update.uu.se>
+0	search/1/c	=<?php			PHP script text
+!:strength + 10
+!:mime	text/x-php
+0	search/1	=<?\n			PHP script text
+!:mime	text/x-php
+0	search/1	=<?\r			PHP script text
+!:mime	text/x-php
+0	search/1/w	#!\ /usr/local/bin/php	PHP script text executable
+!:strength + 10
+!:mime	text/x-php
+0	search/1/w	#!\ /usr/bin/php	PHP script text executable
+!:strength + 10
+!:mime	text/x-php
+# Smarty compiled template, http://www.smarty.net/
+# Elan Ruusamae <glen@delfi.ee>
+0	string	=<?php\ /*\ Smarty\ version	Smarty compiled template
+>24	regex	[0-9.]+				\b, version %s
+!:mime	text/x-php
+
+0	string		Zend\x00		PHP script Zend Optimizer data
+
+0	string/t	$!			DCL command file
+
+# Type: Pdmenu
+# URL:  http://packages.debian.org/pdmenu
+# From: Edward Betts <edward@debian.org>
+0	string		#!/usr/bin/pdmenu	Pdmenu configuration file text
+
+#----------------------------------------------------------------------------
+# $File$
+# communication
+
+# TTCN is the Tree and Tabular Combined Notation described in ISO 9646-3.
+# It is used for conformance testing of communication protocols.
+# Added by W. Borgert <debacle@debian.org>.
+0	string		$Suite			TTCN Abstract Test Suite
+>&1	string		$SuiteId
+>>&1	string		>\n			%s
+>&2	string		$SuiteId
+>>&1	string		>\n			%s
+>&3	string		$SuiteId
+>>&1	string		>\n			%s
+
+# MSC (message sequence charts) are a formal description technique,
+# described in ITU-T Z.120, mainly used for communication protocols.
+# Added by W. Borgert <debacle@debian.org>.
+0	string		mscdocument	Message Sequence Chart (document)
+0	string		msc		Message Sequence Chart (chart)
+0	string		submsc		Message Sequence Chart (subchart)
+#------------------------------------------------------------------------------
+# $File: compress,v 1.61 2014/09/12 20:57:45 christos Exp $
+# compress:  file(1) magic for pure-compression formats (no archives)
+#
+# compress, gzip, pack, compact, huf, squeeze, crunch, freeze, yabba, etc.
+#
+# Formats for various forms of compressed data
+# Formats for "compress" proper have been moved into "compress.c",
+# because it tries to uncompress it to figure out what's inside.
+
+# standard unix compress
+0	string		\037\235	compress'd data
+!:mime	application/x-compress
+!:apple	LZIVZIVU
+>2	byte&0x80	>0		block compressed
+>2	byte&0x1f	x		%d bits
+
+# gzip (GNU zip, not to be confused with Info-ZIP or PKWARE zip archiver)
+#   Edited by Chris Chittleborough <cchittleborough@yahoo.com.au>, March 2002
+#	* Original filename is only at offset 10 if "extra field" absent
+#	* Produce shorter output - notably, only report compression methods
+#         other than 8 ("deflate", the only method defined in RFC 1952).
+0       string          \037\213        gzip compressed data
+!:mime	application/x-gzip
+!:strength * 2
+>2	byte		<8		\b, reserved method
+>2	byte		>8		\b, unknown method
+>3	byte		&0x01		\b, ASCII
+>3	byte		&0x02		\b, has CRC
+>3	byte		&0x04		\b, extra field
+>3	byte&0xC	=0x08
+>>10	string		x		\b, was "%s"
+>3	byte		&0x10		\b, has comment
+>3	byte		&0x20		\b, encrypted
+>4	ledate		>0		\b, last modified: %s
+>8	byte		2		\b, max compression
+>8	byte		4		\b, max speed
+>9	byte		=0x00		\b, from FAT filesystem (MS-DOS, OS/2, NT)
+>9	byte		=0x01		\b, from Amiga
+>9	byte		=0x02		\b, from VMS
+>9	byte		=0x03		\b, from Unix
+>9	byte		=0x04		\b, from VM/CMS
+>9	byte		=0x05		\b, from Atari
+>9	byte		=0x06		\b, from HPFS filesystem (OS/2, NT)
+>9	byte		=0x07		\b, from MacOS
+>9	byte		=0x08		\b, from Z-System
+>9	byte		=0x09		\b, from CP/M
+>9	byte		=0x0A		\b, from TOPS/20
+>9	byte		=0x0B		\b, from NTFS filesystem (NT)
+>9	byte		=0x0C		\b, from QDOS
+>9	byte		=0x0D		\b, from Acorn RISCOS
+
+# packed data, Huffman (minimum redundancy) codes on a byte-by-byte basis
+0	string		\037\036	packed data
+!:mime	application/octet-stream
+>2	belong		>1		\b, %d characters originally
+>2	belong		=1		\b, %d character originally
+#
+# This magic number is byte-order-independent.
+0	short		0x1f1f		old packed data
+!:mime	application/octet-stream
+
+# XXX - why *two* entries for "compacted data", one of which is
+# byte-order independent, and one of which is byte-order dependent?
+#
+0	short		0x1fff		compacted data
+!:mime	application/octet-stream
+# This string is valid for SunOS (BE) and a matching "short" is listed
+# in the Ultrix (LE) magic file.
+0	string		\377\037	compacted data
+!:mime	application/octet-stream
+0	short		0145405		huf output
+!:mime	application/octet-stream
+
+# bzip2
+0	string		BZh		bzip2 compressed data
+!:mime	application/x-bzip2
+>3	byte		>47		\b, block size = %c00k
+
+# lzip
+0	string		LZIP		lzip compressed data
+!:mime application/x-lzip
+>4	byte		x		\b, version: %d
+
+# squeeze and crunch
+# Michael Haardt <michael@cantor.informatik.rwth-aachen.de>
+0	beshort		0x76FF		squeezed data,
+>4	string		x		original name %s
+0	beshort		0x76FE		crunched data,
+>2	string		x		original name %s
+0	beshort		0x76FD		LZH compressed data,
+>2	string		x		original name %s
+
+# Freeze
+0	string		\037\237	frozen file 2.1
+0	string		\037\236	frozen file 1.0 (or gzip 0.5)
+
+# SCO compress -H (LZH)
+0	string		\037\240	SCO compress -H (LZH) data
+
+# European GSM 06.10 is a provisional standard for full-rate speech
+# transcoding, prI-ETS 300 036, which uses RPE/LTP (residual pulse
+# excitation/long term prediction) coding at 13 kbit/s.
+#
+# There's only a magic nibble (4 bits); that nibble repeats every 33
+# bytes.  This isn't suited for use, but maybe we can use it someday.
+#
+# This will cause very short GSM files to be declared as data and
+# mismatches to be declared as data too!
+#0	byte&0xF0	0xd0		data
+#>33	byte&0xF0	0xd0
+#>66	byte&0xF0	0xd0
+#>99	byte&0xF0	0xd0
+#>132	byte&0xF0	0xd0		GSM 06.10 compressed audio
+
+# bzip	a block-sorting file compressor
+#	by Julian Seward <sewardj@cs.man.ac.uk> and others
+#
+#0	string		BZ		bzip compressed data
+#>2	byte		x		\b, version: %c
+#>3	string		=1		\b, compression block size 100k
+#>3	string		=2		\b, compression block size 200k
+#>3	string		=3		\b, compression block size 300k
+#>3	string		=4		\b, compression block size 400k
+#>3	string		=5		\b, compression block size 500k
+#>3	string		=6		\b, compression block size 600k
+#>3	string		=7		\b, compression block size 700k
+#>3	string		=8		\b, compression block size 800k
+#>3	string		=9		\b, compression block size 900k
+
+# lzop from <markus.oberhumer@jk.uni-linz.ac.at>
+0	string		\x89\x4c\x5a\x4f\x00\x0d\x0a\x1a\x0a	lzop compressed data
+>9	beshort		<0x0940
+>>9	byte&0xf0	=0x00		- version 0.
+>>9	beshort&0x0fff	x		\b%03x,
+>>13	byte		1		LZO1X-1,
+>>13	byte		2		LZO1X-1(15),
+>>13	byte		3		LZO1X-999,
+## >>22	bedate		>0		last modified: %s,
+>>14	byte		=0x00		os: MS-DOS
+>>14	byte		=0x01		os: Amiga
+>>14	byte		=0x02		os: VMS
+>>14	byte		=0x03		os: Unix
+>>14	byte		=0x05		os: Atari
+>>14	byte		=0x06		os: OS/2
+>>14	byte		=0x07		os: MacOS
+>>14	byte		=0x0A		os: Tops/20
+>>14	byte		=0x0B		os: WinNT
+>>14	byte		=0x0E		os: Win32
+>9	beshort		>0x0939
+>>9	byte&0xf0	=0x00		- version 0.
+>>9	byte&0xf0	=0x10		- version 1.
+>>9	byte&0xf0	=0x20		- version 2.
+>>9	beshort&0x0fff	x		\b%03x,
+>>15	byte		1		LZO1X-1,
+>>15	byte		2		LZO1X-1(15),
+>>15	byte		3		LZO1X-999,
+## >>25	bedate		>0		last modified: %s,
+>>17	byte		=0x00		os: MS-DOS
+>>17	byte		=0x01		os: Amiga
+>>17	byte		=0x02		os: VMS
+>>17	byte		=0x03		os: Unix
+>>17	byte		=0x05		os: Atari
+>>17	byte		=0x06		os: OS/2
+>>17	byte		=0x07		os: MacOS
+>>17	byte		=0x0A		os: Tops/20
+>>17	byte		=0x0B		os: WinNT
+>>17	byte		=0x0E		os: Win32
+
+# 4.3BSD-Quasijarus Strong Compression
+# http://minnie.tuhs.org/Quasijarus/compress.html
+0	string		\037\241	Quasijarus strong compressed data
+
+# From: Cory Dikkers <cdikkers@swbell.net>
+0	string		XPKF		Amiga xpkf.library compressed data
+0	string		PP11		Power Packer 1.1 compressed data
+0	string		PP20		Power Packer 2.0 compressed data,
+>4	belong		0x09090909	fast compression
+>4	belong		0x090A0A0A	mediocre compression
+>4	belong		0x090A0B0B	good compression
+>4	belong		0x090A0C0C	very good compression
+>4	belong		0x090A0C0D	best compression
+
+# 7-zip archiver, from Thomas Klausner (wiz@danbala.tuwien.ac.at)
+# http://www.7-zip.org or DOC/7zFormat.txt
+#
+0	string		7z\274\257\047\034	7-zip archive data,
+>6	byte		x			version %d
+>7	byte		x			\b.%d
+!:mime	application/x-7z-compressed
+
+# Type: LZMA
+0	lelong&0xffffff	=0x5d
+>12	leshort		0xff			LZMA compressed data,
+!:mime	application/x-lzma
+>>5	lequad		=0xffffffffffffffff	streamed
+>>5	lequad		!0xffffffffffffffff	non-streamed, size %lld
+>12	leshort		0			LZMA compressed data,
+>>5	lequad		=0xffffffffffffffff	streamed
+>>5	lequad		!0xffffffffffffffff	non-streamed, size %lld
+
+# http://tukaani.org/xz/xz-file-format.txt
+0	ustring		\xFD7zXZ\x00		XZ compressed data
+!:mime	application/x-xz
+
+# https://github.com/ckolivas/lrzip/blob/master/doc/magic.header.txt
+0	string		LRZI			LRZIP compressed data
+>4	byte		x			- version %d
+>5	byte		x			\b.%d
+!:mime	application/x-lrzip
+
+# http://fastcompression.blogspot.fi/2013/04/lz4-streaming-format-final.html
+0	lelong		0x184d2204	LZ4 compressed data (v1.4+)
+!:mime	application/x-lz4
+# Added by osm0sis@xda-developers.com
+0 	lelong		0x184c2103	LZ4 compressed data (v1.0-v1.3)
+!:mime	application/x-lz4
+0	lelong		0x184c2102	LZ4 compressed data (v0.1-v0.9)
+!:mime	application/x-lz4
+
+# AFX compressed files (Wolfram Kleff)
+2	string		-afx-		AFX compressed file data
+
+# Supplementary magic data for the file(1) command to support
+# rzip(1).  The format is described in magic(5).
+#
+# Copyright (C) 2003 by Andrew Tridgell.  You may do whatever you want with
+# this file.
+#
+0	string		RZIP		rzip compressed data
+>4	byte		x		- version %d
+>5	byte		x		\b.%d
+>6	belong		x		(%d bytes)
+
+0	string		ArC\x01		FreeArc archive <http://freearc.org>
+
+# Type:	DACT compressed files
+0	long	0x444354C3	DACT compressed data
+>4	byte	>-1		(version %i.
+>5	byte	>-1		%i.
+>6	byte	>-1		%i)
+>7	long	>0		, original size: %i bytes
+>15	long	>30		, block size: %i bytes
+
+# Valve Pack (VPK) files
+0	lelong	0x55aa1234	Valve Pak file
+>0x4	lelong	x		\b, version %u
+>0x8	lelong	x		\b, %u entries
+
+# Snappy framing format
+# http://code.google.com/p/snappy/source/browse/trunk/framing_format.txt
+0	string	\377\006\0\0sNaPpY	snappy framed data
+!:mime	application/x-snappy-framed
+
+# qpress, http://www.quicklz.com/
+0	string	qpress10	qpress compressed data
+!:mime	application/x-qpress
+
+# Zlib https://www.ietf.org/rfc/rfc6713.txt
+0	beshort%31	=0	
+>0	byte&0xf	=8
+>>0	byte&0x80 	=0	zlib compressed data
+!:mime	application/zlib
+
+#------------------------------------------------------------------------------
+# $File: console,v 1.18 2010/09/20 19:19:17 rrt Exp $
+# Console game magic
+# Toby Deshane <hac@shoelace.digivill.net>
+#    ines:  file(1) magic for Marat's iNES Nintendo Entertainment System
+#           ROM dump format
+
+0 string NES\032 iNES ROM dump,
+>4 byte  x     %dx16k PRG
+>5 byte  x     \b, %dx8k CHR
+>6 byte&0x01  =0x1  \b, [Vert.]
+>6 byte&0x01  =0x0  \b, [Horiz.]
+>6 byte&0x02  =0x2  \b, [SRAM]
+>6 byte&0x04  =0x4  \b, [Trainer]
+>6 byte&0x04  =0x8  \b, [4-Scr]
+
+#------------------------------------------------------------------------------
+# gameboy:  file(1) magic for the Nintendo (Color) Gameboy raw ROM format
+#
+0x104 belong 0xCEED6666 Gameboy ROM:
+>0x134 string >\0 "%.16s"
+>0x146 byte 0x03  \b,[SGB]
+>0x147 byte 0x00  \b, [ROM ONLY]
+>0x147 byte 0x01  \b, [ROM+MBC1]
+>0x147 byte 0x02  \b, [ROM+MBC1+RAM]
+>0x147 byte 0x03  \b, [ROM+MBC1+RAM+BATT]
+>0x147 byte 0x05  \b, [ROM+MBC2]
+>0x147 byte 0x06  \b, [ROM+MBC2+BATTERY]
+>0x147 byte 0x08  \b, [ROM+RAM]
+>0x147 byte 0x09  \b, [ROM+RAM+BATTERY]
+>0x147 byte 0x0B  \b, [ROM+MMM01]
+>0x147 byte 0x0C  \b, [ROM+MMM01+SRAM]
+>0x147 byte 0x0D  \b, [ROM+MMM01+SRAM+BATT]
+>0x147 byte 0x0F  \b, [ROM+MBC3+TIMER+BATT]
+>0x147 byte 0x10  \b, [ROM+MBC3+TIMER+RAM+BATT]
+>0x147 byte 0x11  \b, [ROM+MBC3]
+>0x147 byte 0x12  \b, [ROM+MBC3+RAM]
+>0x147 byte 0x13  \b, [ROM+MBC3+RAM+BATT]
+>0x147 byte 0x19  \b, [ROM+MBC5]
+>0x147 byte 0x1A  \b, [ROM+MBC5+RAM]
+>0x147 byte 0x1B  \b, [ROM+MBC5+RAM+BATT]
+>0x147 byte 0x1C  \b, [ROM+MBC5+RUMBLE]
+>0x147 byte 0x1D  \b, [ROM+MBC5+RUMBLE+SRAM]
+>0x147 byte 0x1E  \b, [ROM+MBC5+RUMBLE+SRAM+BATT]
+>0x147 byte 0x1F  \b, [Pocket Camera]
+>0x147 byte 0xFD  \b, [Bandai TAMA5]
+>0x147 byte 0xFE  \b, [Hudson HuC-3]
+>0x147 byte 0xFF  \b, [Hudson HuC-1]
+
+>0x148 byte 0     \b, ROM: 256Kbit
+>0x148 byte 1     \b, ROM: 512Kbit
+>0x148 byte 2     \b, ROM: 1Mbit
+>0x148 byte 3     \b, ROM: 2Mbit
+>0x148 byte 4     \b, ROM: 4Mbit
+>0x148 byte 5     \b, ROM: 8Mbit
+>0x148 byte 6     \b, ROM: 16Mbit
+>0x148 byte 0x52  \b, ROM: 9Mbit
+>0x148 byte 0x53  \b, ROM: 10Mbit
+>0x148 byte 0x54  \b, ROM: 12Mbit
+
+>0x149 byte 1     \b, RAM: 16Kbit
+>0x149 byte 2     \b, RAM: 64Kbit
+>0x149 byte 3     \b, RAM: 128Kbit
+>0x149 byte 4     \b, RAM: 1Mbit
+
+#>0x14e long  x     \b, CRC: %x
+
+#------------------------------------------------------------------------------
+# genesis:  file(1) magic for the Sega MegaDrive/Genesis raw ROM format
+#
+0x100 string SEGA  Sega MegaDrive/Genesis raw ROM dump
+>0x120 string >\0 Name: "%.16s"
+>0x110 string >\0 %.16s
+>0x1B0 string RA with SRAM
+
+#------------------------------------------------------------------------------
+# genesis:  file(1) magic for the Super MegaDrive ROM dump format
+#
+0x280 string EAGN  Super MagicDrive ROM dump
+>0 byte x %dx16k blocks
+>2 byte 0 \b, last in series or standalone
+>2 byte >0 \b, split ROM
+>8 byte 0xAA
+>9 byte 0xBB
+
+#------------------------------------------------------------------------------
+# genesis:  file(1) alternate magic for the Super MegaDrive ROM dump format
+#
+0x280 string EAMG  Super MagicDrive ROM dump
+>0 byte x %dx16k blocks
+>2 byte x \b, last in series or standalone
+>8 byte 0xAA
+>9 byte 0xBB
+
+#------------------------------------------------------------------------------
+# smsgg:  file(1) magic for Sega Master System and Game Gear ROM dumps
+#
+# Does not detect all images.  Very preliminary guesswork.  Need more data
+# on format.
+#
+# FIXME: need a little more info...;P
+#
+#0 byte 0xF3
+#>1 byte 0xED  Sega Master System/Game Gear ROM dump
+#>1 byte 0x31  Sega Master System/Game Gear ROM dump
+#>1 byte 0xDB  Sega Master System/Game Gear ROM dump
+#>1 byte 0xAF  Sega Master System/Game Gear ROM dump
+#>1 byte 0xC3  Sega Master System/Game Gear ROM dump
+
+#------------------------------------------------------------------------------
+# dreamcast:  file(1) uncertain magic for the Sega Dreamcast VMU image format
+#
+0 belong 0x21068028   Sega Dreamcast VMU game image
+0 string LCDi         Dream Animator file
+
+#------------------------------------------------------------------------------
+# v64: file(1) uncertain magic for the V64 format N64 ROM dumps
+#
+0 belong 0x37804012    V64 Nintendo 64 ROM dump
+
+# From: "Nelson A. de Oliveira" <naoliv@gmail.com>
+# Nintendo .nds
+192	string	\044\377\256Qi\232	Nintendo DS Game ROM Image
+# Nintendo .gba
+0	string	\056\000\000\352$\377\256Qi	Nintendo Game Boy Advance ROM Image
+
+#------------------------------------------------------------------------------
+# msx: file(1) magic for MSX game cartridge dumps
+# Too simple - MPi
+#0 beshort 0x4142 MSX game cartridge dump 
+
+#------------------------------------------------------------------------------
+# Sony Playstation executables (Adam Sjoegren <asjo@diku.dk>) :
+0	string	PS-X\ EXE	Sony Playstation executable
+#  Area:
+>113	string	x		(%s)
+
+#------------------------------------------------------------------------------
+# Microsoft Xbox executables .xbe (Esa Hyytia <ehyytia@cc.hut.fi>)
+0       string          XBEH            XBE, Microsoft Xbox executable
+# probabilistic checks whether signed or not
+>0x0004 ulelong =0x0
+>>&2    ulelong =0x0
+>>>&2   ulelong =0x0  \b, not signed
+>0x0004 ulelong >0
+>>&2    ulelong >0
+>>>&2   ulelong >0    \b, signed
+# expect base address of 0x10000
+>0x0104               ulelong =0x10000
+>>(0x0118-0x0FF60)    ulelong&0x80000007  0x80000007 \b, all regions
+>>(0x0118-0x0FF60)    ulelong&0x80000007  !0x80000007
+>>>(0x0118-0x0FF60)   ulelong >0           (regions:
+>>>>(0x0118-0x0FF60)  ulelong &0x00000001  NA
+>>>>(0x0118-0x0FF60)  ulelong &0x00000002  Japan
+>>>>(0x0118-0x0FF60)  ulelong &0x00000004  Rest_of_World
+>>>>(0x0118-0x0FF60)  ulelong &0x80000000  Manufacturer
+>>>(0x0118-0x0FF60)   ulelong >0           \b)
+
+# --------------------------------
+# Microsoft Xbox data file formats
+0       string          XIP0            XIP, Microsoft Xbox data
+0       string          XTF0            XTF, Microsoft Xbox data
+
+# Atari Lynx cartridge dump (EXE/BLL header)
+# From: "Stefan A. Haubenthal" <polluks@web.de>
+
+# Double-check that the image type matches too, 0x8008 conflicts with
+# 8 character OMF-86 object file headers.
+0	beshort		0x8008		
+>6	string		BS93		Lynx homebrew cartridge
+>>2	beshort		x		\b, RAM start $%04x
+>6	string		LYNX		Lynx cartridge
+>>2	beshort		x		\b, RAM start $%04x
+
+# Opera file system that is used on the 3DO console
+# From: Serge van den Boom <svdb@stack.nl>
+0	string		\x01ZZZZZ\x01	3DO "Opera" file system
+
+# From Gurkan Sengun <gurkan@linuks.mine.nu>, www.linuks.mine.nu
+0	string		GBS		Nintendo Gameboy Music/Audio Data
+12	string		GameBoy\ Music\ Module	Nintendo Gameboy Music Module
+
+# Playstations Patch Files from: From: Thomas Klausner <tk@giga.or.at>
+0	string	PPF30			Playstation Patch File version 3.0
+>5	byte	0			\b, PPF 1.0 patch
+>5	byte	1			\b, PPF 2.0 patch
+>5	byte	2			\b, PPF 3.0 patch
+>>56	byte	0			\b, Imagetype BIN (any)
+>>56	byte	1			\b, Imagetype GI (PrimoDVD)
+>>57	byte	0			\b, Blockcheck disabled
+>>57	byte	1			\b, Blockcheck enabled
+>>58	byte	0			\b, Undo data not available
+>>58	byte	1			\b, Undo data available
+>6	string	x			\b, description: %s
+
+0	string	PPF20			Playstation Patch File version 2.0
+>5	byte	0			\b, PPF 1.0 patch
+>5	byte	1			\b, PPF 2.0 patch
+>>56	lelong	>0			\b, size of file to patch %d
+>6	string	x			\b, description: %s
+
+0	string	PPF10			Playstation Patch File version 1.0
+>5	byte	0			\b, Simple Encoding
+>6	string	x			\b, description: %s
+
+# From: Daniel Dawson <ddawson@icehouse.net>
+# SNES9x .smv "movie" file format.
+0		string		SMV\x1A	SNES9x input recording
+>0x4		lelong		x	\b, version %d
+# version 4 is latest so far 
+>0x4		lelong		<5
+>>0x8		ledate		x	\b, recorded at %s
+>>0xc		lelong		>0	\b, rerecorded %d times
+>>0x10		lelong		x	\b, %d frames long
+>>0x14		byte		>0	\b, data for controller(s):
+>>>0x14		byte		&0x1	#1
+>>>0x14		byte		&0x2	#2
+>>>0x14		byte		&0x4	#3
+>>>0x14		byte		&0x8	#4
+>>>0x14		byte		&0x10	#5
+>>0x15		byte		^0x1	\b, begins from snapshot
+>>0x15		byte		&0x1	\b, begins from reset
+>>0x15		byte		^0x2	\b, NTSC standard
+>>0x15		byte		&0x2	\b, PAL standard
+>>0x17		byte		&0x1    \b, settings:
+# WIP1Timing not used as of version 4
+>>>0x4		lelong		<4
+>>>>0x17	byte		&0x2	WIP1Timing
+>>>0x17		byte		&0x4	Left+Right
+>>>0x17		byte		&0x8	VolumeEnvX
+>>>0x17		byte		&0x10	FakeMute
+>>>0x17		byte		&0x20	SyncSound
+# New flag as of version 4
+>>>0x4		lelong		>3
+>>>>0x17	byte		&0x80	NoCPUShutdown
+>>0x4		lelong		<4
+>>>0x18		lelong		>0x23
+>>>>0x20	leshort		!0
+>>>>>0x20	lestring16	x	\b, metadata: "%s"
+>>0x4		lelong		>3
+>>>0x24		byte		>0	\b, port 1:
+>>>>0x24	byte		1	joypad
+>>>>0x24	byte		2	mouse
+>>>>0x24	byte		3	SuperScope
+>>>>0x24	byte		4	Justifier
+>>>>0x24	byte		5	multitap
+>>>0x24		byte		>0	\b, port 2:
+>>>>0x25	byte		1	joypad
+>>>>0x25	byte		2	mouse
+>>>>0x25	byte		3	SuperScope
+>>>>0x25	byte		4	Justifier
+>>>>0x25	byte		5	multitap
+>>>0x18		lelong		>0x43
+>>>>0x40	leshort		!0
+>>>>>0x40	lestring16	x	\b, metadata: "%s"
+>>0x17		byte		&0x40   \b, ROM:
+>>>(0x18.l-26)	lelong		x	CRC32 0x%08x
+>>>(0x18.l-23)	string		x	"%s"
+
+# Type: scummVM savegame files
+# From: Sven Hartge <debian@ds9.argh.org>
+0	string	SCVM	ScummVM savegame
+>12	string	>\0	"%s"
+
+#------------------------------------------------------------------------------
+# $File: convex,v 1.7 2009/09/19 16:28:08 christos Exp $
+# convex:  file(1) magic for Convex boxes
+#
+# Convexes are big-endian.
+#
+# /*\
+#  * Below are the magic numbers and tests added for Convex.
+#  * Added at beginning, because they are expected to be used most.
+# \*/
+0	belong	0507	Convex old-style object
+>16	belong	>0	not stripped
+0	belong	0513	Convex old-style demand paged executable
+>16	belong	>0	not stripped
+0	belong	0515	Convex old-style pre-paged executable
+>16	belong	>0	not stripped
+0	belong	0517	Convex old-style pre-paged, non-swapped executable
+>16	belong	>0	not stripped
+0	belong	0x011257	Core file
+#
+# The following are a series of dump format magic numbers.  Each one
+# corresponds to a drastically different dump format.  The first on is
+# the original dump format on a 4.1 BSD or earlier file system.  The
+# second marks the change between the 4.1 file system and the 4.2 file
+# system.  The Third marks the changing of the block size from 1K
+# to 2K to be compatible with an IDC file system.  The fourth indicates
+# a dump that is dependent on Convex Storage Manager, because data in
+# secondary storage is not physically contained within the dump.
+# The restore program uses these number to determine how the data is
+# to be extracted.
+#
+24	belong	=60013	dump format, 4.2 or 4.3 BSD (IDC compatible)
+24	belong	=60014	dump format, Convex Storage Manager by-reference dump
+#
+# what follows is a bunch of bit-mask checks on the flags field of the opthdr.
+# If there is no `=' sign, assume just checking for whether the bit is set?
+#
+0	belong	0601		Convex SOFF
+>88	belong&0x000f0000	=0x00000000	c1
+>88	belong			&0x00010000	c2
+>88	belong			&0x00020000	c2mp
+>88	belong			&0x00040000	parallel
+>88	belong			&0x00080000	intrinsic
+>88	belong			&0x00000001	demand paged
+>88	belong			&0x00000002	pre-paged
+>88	belong			&0x00000004	non-swapped
+>88	belong			&0x00000008	POSIX
+#
+>84	belong			&0x80000000	executable
+>84	belong			&0x40000000	object
+>84	belong&0x20000000	=0		not stripped
+>84	belong&0x18000000	=0x00000000	native fpmode
+>84	belong&0x18000000	=0x10000000	ieee fpmode
+>84	belong&0x18000000	=0x18000000	undefined fpmode
+#
+0	belong			0605		Convex SOFF core
+#
+0	belong			0607		Convex SOFF checkpoint
+>88	belong&0x000f0000	=0x00000000	c1
+>88	belong			&0x00010000	c2
+>88	belong			&0x00020000	c2mp
+>88	belong			&0x00040000	parallel
+>88	belong			&0x00080000	intrinsic
+>88	belong			&0x00000008	POSIX
+#
+>84	belong&0x18000000	=0x00000000	native fpmode
+>84	belong&0x18000000	=0x10000000	ieee fpmode
+>84	belong&0x18000000	=0x18000000	undefined fpmode
+
+#------------------------------------------------------------------------------
+# $File$
+# cracklib:  file (1) magic for cracklib v2.7
+
+0	lelong	0x70775631	Cracklib password index, little endian
+>4	long	>0		(%i words)
+>4	long	0		("64-bit")
+>>8	long	>-1		(%i words)
+0	belong	0x70775631	Cracklib password index, big endian
+>4	belong	>-1		(%i words)
+# really bellong 0x0000000070775631
+0	search/1	\0\0\0\0pwV1	Cracklib password index, big endian ("64-bit")
+>12	belong	>0		(%i words)
+
+# ----------------------------------------------------------------------------
+# $File$
+# ctags:  file (1) magic for Exuberant Ctags files
+# From: Alexander Mai <mai@migdal.ikp.physik.tu-darmstadt.de>
+0	search/1	=!_TAG	Exuberant Ctags tag file text
+
+#--------------------------------------------------------------
+# ctf:  file(1) magic for CTF (Common Trace Format) trace files
+#
+# Specs. available here: <http://www.efficios.com/ctf>
+#--------------------------------------------------------------
+
+# CTF trace data
+0	lelong	0xc1fc1fc1	Common Trace Format (CTF) trace data (LE)
+0	belong	0xc1fc1fc1	Common Trace Format (CTF) trace data (BE)
+
+# CTF metadata (packetized)
+0	lelong	0x75d11d57	Common Trace Format (CTF) packetized metadata (LE)
+>35	byte	x		\b, v%d
+>36	byte	x		\b.%d
+0	belong	0x75d11d57	Common Trace Format (CTF) packetized metadata (BE)
+>35	byte	x		\b, v%d
+>36	byte	x		\b.%d
+
+# CTF metadata (plain text)
+0	string	/*\x20CTF\x20   Common Trace Format (CTF) plain text metadata
+!:strength + 5			# this is to make sure we beat C
+>&0	regex	[0-9]+\.[0-9]+	\b, v%s
+
+#------------------------------------------------------------------------------
+# $File: cubemaps,v 1.0 2011/12/22 09:01:05 christos Exp $
+# file(1) magic(5) data for cubemaps  Martin Erik Werner <martinerikwerner@gmail.com>
+#
+0	string	ACMP	Map file for the AssaultCube FPS game
+0	string	CUBE	Map file for cube and cube2 engine games
+0	string	MAPZ)	Map file for the Blood Frontier/Red Eclipse FPS games
+
+#------------------------------------------------------------------------------
+# $File: cups,v 1.2 2012/11/02 21:50:29 christos Exp $
+# Cups: file(1) magic for the cups raster file format
+# From: Laurent Martelli <martellilaurent@gmail.com>
+# http://www.cups.org/documentation.php/spec-raster.html
+#
+
+0	name		cups-le
+>280	lelong		x		\b, %d
+>284	lelong		x		\bx%d dpi
+>376	lelong		x		\b, %dx
+>380	lelong		x		\b%d pixels
+>388	lelong		x		%d bits/color
+>392	lelong		x		%d bits/pixel
+>400	lelong		0		ColorOrder=Chunky
+>400	lelong		1		ColorOrder=Banded
+>400	lelong		2		ColorOrder=Planar
+>404	lelong		0		ColorSpace=gray
+>404	lelong		1		ColorSpace=RGB
+>404	lelong		2		ColorSpace=RGBA
+>404	lelong		3		ColorSpace=black
+>404	lelong		4		ColorSpace=CMY
+>404	lelong		5		ColorSpace=YMC
+>404	lelong		6		ColorSpace=CMYK
+>404	lelong		7		ColorSpace=YMCK
+>404	lelong		8		ColorSpace=KCMY
+>404	lelong		9		ColorSpace=KCMYcm
+>404	lelong		10		ColorSpace=GMCK
+>404	lelong		11		ColorSpace=GMCS
+>404	lelong		12		ColorSpace=WHITE
+>404	lelong		13		ColorSpace=GOLD
+>404	lelong		14		ColorSpace=SILVER
+>404	lelong		15		ColorSpace=CIE XYZ
+>404	lelong		16		ColorSpace=CIE Lab
+>404	lelong		17		ColorSpace=RGBW
+>404	lelong		18		ColorSpace=sGray
+>404	lelong		19		ColorSpace=sRGB
+>404	lelong		20		ColorSpace=AdobeRGB
+
+# Cups Raster image format, Big Endian
+0	string		RaS		
+>3	string		t		Cups Raster version 1, Big Endian
+>3	string		2		Cups Raster version 2, Big Endian
+>3	string		3		Cups Raster version 3, Big Endian
+!:mime	application/vnd.cups-raster
+>0	use		^cups-le
+
+
+# Cups Raster image format, Little Endian
+1	string		SaR		
+>0	string		t		Cups Raster version 1, Little Endian
+>0	string		2		Cups Raster version 2, Little Endian
+>0	string		3		Cups Raster version 3, Little Endian
+!:mime	application/vnd.cups-raster
+>0	use		cups-le
+
+#------------------------------------------------------------------------------
+# $File$
+# dact:  file(1) magic for DACT compressed files
+#
+0	long		0x444354C3	DACT compressed data
+>4	byte		>-1		(version %i.
+>5	byte		>-1		$BS%i.
+>6	byte		>-1		$BS%i)
+>7	long		>0		$BS, original size: %i bytes
+>15	long		>30		$BS, block size: %i bytes
+
+#------------------------------------------------------------------------------
+# $File: database,v 1.42 2014/08/19 14:18:04 christos Exp $
+# database:  file(1) magic for various databases
+#
+# extracted from header/code files by Graeme Wilford (eep2gw@ee.surrey.ac.uk)
+#
+#
+# GDBM magic numbers
+#  Will be maintained as part of the GDBM distribution in the future.
+#  <downsj@teeny.org>
+0	belong	0x13579acd	GNU dbm 1.x or ndbm database, big endian, 32-bit
+!:mime	application/x-gdbm
+0	belong	0x13579ace	GNU dbm 1.x or ndbm database, big endian, old
+!:mime	application/x-gdbm
+0	belong	0x13579acf	GNU dbm 1.x or ndbm database, big endian, 64-bit
+!:mime	application/x-gdbm
+0	lelong	0x13579acd	GNU dbm 1.x or ndbm database, little endian, 32-bit
+!:mime	application/x-gdbm
+0	lelong	0x13579ace	GNU dbm 1.x or ndbm database, little endian, old
+!:mime	application/x-gdbm
+0	lelong	0x13579acf	GNU dbm 1.x or ndbm database, little endian, 64-bit
+!:mime	application/x-gdbm
+0	string	GDBM		GNU dbm 2.x database
+!:mime	application/x-gdbm
+#
+# Berkeley DB
+#
+# Ian Darwin's file /etc/magic files: big/little-endian version.
+#
+# Hash 1.85/1.86 databases store metadata in network byte order.
+# Btree 1.85/1.86 databases store the metadata in host byte order.
+# Hash and Btree 2.X and later databases store the metadata in host byte order.
+
+0	long	0x00061561	Berkeley DB
+!:mime	application/x-dbm
+>8	belong	4321
+>>4	belong	>2		1.86
+>>4	belong	<3		1.85
+>>4	belong	>0		(Hash, version %d, native byte-order)
+>8	belong	1234
+>>4	belong	>2		1.86
+>>4	belong	<3		1.85
+>>4	belong	>0		(Hash, version %d, little-endian)
+
+0	belong	0x00061561	Berkeley DB
+>8	belong	4321
+>>4	belong	>2		1.86
+>>4	belong	<3		1.85
+>>4	belong	>0		(Hash, version %d, big-endian)
+>8	belong	1234
+>>4	belong	>2		1.86
+>>4	belong	<3		1.85
+>>4	belong	>0		(Hash, version %d, native byte-order)
+
+0	long	0x00053162	Berkeley DB 1.85/1.86
+>4	long	>0		(Btree, version %d, native byte-order)
+0	belong	0x00053162	Berkeley DB 1.85/1.86
+>4	belong	>0		(Btree, version %d, big-endian)
+0	lelong	0x00053162	Berkeley DB 1.85/1.86
+>4	lelong	>0		(Btree, version %d, little-endian)
+
+12	long	0x00061561	Berkeley DB
+>16	long	>0		(Hash, version %d, native byte-order)
+12	belong	0x00061561	Berkeley DB
+>16	belong	>0		(Hash, version %d, big-endian)
+12	lelong	0x00061561	Berkeley DB
+>16	lelong	>0		(Hash, version %d, little-endian)
+
+12	long	0x00053162	Berkeley DB
+>16	long	>0		(Btree, version %d, native byte-order)
+12	belong	0x00053162	Berkeley DB
+>16	belong	>0		(Btree, version %d, big-endian)
+12	lelong	0x00053162	Berkeley DB
+>16	lelong	>0		(Btree, version %d, little-endian)
+
+12	long	0x00042253	Berkeley DB
+>16	long	>0		(Queue, version %d, native byte-order)
+12	belong	0x00042253	Berkeley DB
+>16	belong	>0		(Queue, version %d, big-endian)
+12	lelong	0x00042253	Berkeley DB
+>16	lelong	>0		(Queue, version %d, little-endian)
+
+# From Max Bowsher.
+12	long	0x00040988	Berkeley DB
+>16	long	>0		(Log, version %d, native byte-order)
+12	belong	0x00040988	Berkeley DB 
+>16	belong	>0		(Log, version %d, big-endian)
+12	lelong	0x00040988	Berkeley DB
+>16	lelong	>0		(Log, version %d, little-endian)
+
+#
+#
+# Round Robin Database Tool by Tobias Oetiker <oetiker@ee.ethz.ch>
+0	string/b	RRD\0		RRDTool DB
+>4	string/b	x		version %s
+
+>>10	short		!0		16bit aligned
+>>>10	bedouble	8.642135e+130	big-endian
+>>>>18	short		x		32bit long (m68k)
+
+>>10	short		0
+>>>12	long		!0		32bit aligned
+>>>>12	bedouble	8.642135e+130	big-endian
+>>>>>20 long		0		64bit long
+>>>>>20 long		!0		32bit long  
+>>>>12	ledouble	8.642135e+130	little-endian
+>>>>>24 long		0		64bit long
+>>>>>24 long		!0		32bit long (i386)
+>>>>12	string		\x43\x2b\x1f\x5b\x2f\x25\xc0\xc7	middle-endian
+>>>>>24 short		!0		32bit long (arm)
+
+>>8	quad		0		64bit aligned
+>>>16	bedouble	8.642135e+130	big-endian
+>>>>24	long		0		64bit long (s390x)
+>>>>24	long		!0		32bit long (hppa/mips/ppc/s390/SPARC)
+>>>16	ledouble	8.642135e+130	little-endian
+>>>>28	long		0		64bit long (alpha/amd64/ia64)
+>>>>28	long		!0		32bit long (armel/mipsel)
+
+#----------------------------------------------------------------------
+# ROOT: file(1) magic for ROOT databases
+#
+0       string  root\0  ROOT file
+>4      belong  x       Version %d
+>33     belong  x       (Compression: %d)
+
+# XXX: Weak magic.
+# Alex Ott <ott@jet.msk.su>
+## Paradox file formats
+#2	  leshort	0x0800	Paradox 
+#>0x39	  byte		3	v. 3.0 
+#>0x39	  byte		4	v. 3.5 
+#>0x39	  byte		9	v. 4.x 
+#>0x39	  byte		10	v. 5.x 
+#>0x39	  byte		11	v. 5.x 
+#>0x39	  byte		12	v. 7.x 
+#>>0x04	  byte		0	indexed .DB data file 
+#>>0x04	  byte		1	primary index .PX file 
+#>>0x04	  byte		2	non-indexed .DB data file 
+#>>0x04	  byte		3	non-incrementing secondary index .Xnn file 
+#>>0x04	  byte		4	secondary index .Ynn file 
+#>>0x04	  byte		5	incrementing secondary index .Xnn file 
+#>>0x04	  byte		6	non-incrementing secondary index .XGn file 
+#>>0x04	  byte		7	secondary index .YGn file 
+#>>>0x04	  byte		8	incrementing secondary index .XGn file 
+
+## XBase database files
+# updated by Joerg Jenderek at Feb 2013
+# http://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm
+# http://www.clicketyclick.dk/databases/xbase/format/dbf.html
+# http://home.f1.htw-berlin.de/scheibl/db/intern/dBase.htm
+# inspect VVYYMMDD , where 1<= MM <= 12 and 1<= DD <= 31
+0	ubelong&0x0000FFFF		<0x00000C20	
+# skip Infocom game Z-machine
+>2		ubyte			>0		
+# skip Androids *.xml
+>>3		ubyte			>0		
+>>>3		ubyte			<32		
+# 1 < version VV
+>>>>0		ubyte			>1		
+# skip HELP.CA3 by test for reserved byte ( NULL )
+>>>>>27		ubyte			0		
+# reserved bytes not always 0 ; also found 0x3901 (T4.DBF) ,0x7101 (T5.DBF,T6.DBF)
+#>>>>>30		ubeshort     		x		30NULL?%x
+# possible production flag,tag numbers(<=0x30),tag length(<=0x20), reserved (NULL) 
+>>>>>>24	ubelong&0xffFFFFff	>0x01302000	
+# .DBF or .MDX
+>>>>>>24	ubelong&0xffFFFFff	<0x01302001	
+# for Xbase Database file (*.DBF) reserved (NULL) for multi-user
+>>>>>>>24	ubelong&0xffFFFFff	=0		
+# test for 2 reserved NULL bytes,transaction and encryption byte flag
+>>>>>>>>12	ubelong&0xFFFFfEfE	0		
+# test for MDX flag
+>>>>>>>>>28	ubyte			x		
+>>>>>>>>>28	ubyte&0xf8		0		
+# header size >= 32
+>>>>>>>>>>8	uleshort		>31		
+# skip PIC15736.PCX by test for language driver name or field name
+>>>>>>>>>>>32	ubyte			>0		
+#!:mime	application/x-dbf; charset=unknown-8bit ??
+#!:mime	application/x-dbase
+>>>>>>>>>>>>0	use			xbase-type
+# database file
+>>>>>>>>>>>>0	ubyte			x		\b DBF
+>>>>>>>>>>>>4	lelong			0		\b, no records
+>>>>>>>>>>>>4	lelong			>0		\b, %d record
+# plural s appended
+>>>>>>>>>>>>>4	lelong			>1		\bs
+# http://www.clicketyclick.dk/databases/xbase/format/dbf_check.html#CHECK_DBF
+# 1 <= record size <= 4000 (dBase 3,4) or 32 * KB (=0x8000)
+>>>>>>>>>>>>10	uleshort		x		* %d
+# file size = records * record size + header size
+>>>>>>>>>>>>1	ubyte			x		\b, update-date
+>>>>>>>>>>>>1	use			xbase-date
+# http://msdn.microsoft.com/de-de/library/cc483186(v=vs.71).aspx
+#>>>>>>>>>>>>29	ubyte			=0		\b, codepage ID=0x%x
+# 2~cp850 , 3~cp1252 , 0x1b~?? ; what code page is 0x1b ?
+>>>>>>>>>>>>29	ubyte			>0		\b, codepage ID=0x%x
+#>>>>>>>>>>>>28	ubyte&0x01		0		\b, no index file
+>>>>>>>>>>>>28	ubyte&0x01		1		\b, with index file .MDX
+>>>>>>>>>>>>28	ubyte&0x02		2		\b, with memo .FPT
+>>>>>>>>>>>>28	ubyte&0x04		4		\b, DataBaseContainer
+# 1st record offset + 1 = header size
+>>>>>>>>>>>>8	uleshort		>0		
+>>>>>>>>>>>>(8.s+1)	ubyte		>0		
+>>>>>>>>>>>>>8		uleshort	>0		\b, at offset %d
+>>>>>>>>>>>>>(8.s+1)	ubyte		>0		
+>>>>>>>>>>>>>>&-1	string		>\0		1st record "%s"
+# for multiple index files (*.MDX) Production flag,tag numbers(<=0x30),tag length(<=0x20), reserverd (NULL) 
+>>>>>>>24	ubelong&0x0133f7ff	>0		
+# test for reserved NULL byte
+>>>>>>>>47	ubyte			0		
+# test for valid TAG key format (0x10 or 0)
+>>>>>>>>>559	ubyte&0xeF		0		
+# test MM <= 12
+>>>>>>>>>>45	ubeshort		<0x0C20		
+>>>>>>>>>>>45	ubyte			>0		
+>>>>>>>>>>>>46	ubyte			<32		
+>>>>>>>>>>>>>46	ubyte			>0		
+#!:mime	application/x-mdx
+>>>>>>>>>>>>>>0		use		xbase-type
+>>>>>>>>>>>>>>0		ubyte		x		\b MDX
+>>>>>>>>>>>>>>1		ubyte		x		\b, creation-date
+>>>>>>>>>>>>>>1		use		xbase-date
+>>>>>>>>>>>>>>44	ubyte		x		\b, update-date
+>>>>>>>>>>>>>>44	use		xbase-date
+# No.of tags in use (1,2,5,12)
+>>>>>>>>>>>>>>28	uleshort	x		\b, %d
+# No. of entries in tag (0x30)
+>>>>>>>>>>>>>>25	ubyte		x		\b/%d tags
+#  Length of tag
+>>>>>>>>>>>>>>26	ubyte		x		* %d
+# 1st tag name_
+>>>>>>>>>>>>>548	string		x		\b, 1st tag "%.11s"
+# 2nd tag name
+#>>>>>>>>>>>>(26.b+548)	string		x		\b, 2nd tag "%.11s"
+#
+#		Print the xBase names of different version variants 
+0	name				xbase-type
+>0	ubyte		<2		
+# 1 < version
+>0	ubyte		>1		
+>>0	ubyte		0x02		FoxBase
+# FoxBase+/dBaseIII+, no memo
+>>0	ubyte		0x03		FoxBase+/dBase III
+!:mime	application/x-dbf
+# dBASE IV no memo file
+>>0	ubyte		0x04		dBase IV
+!:mime	application/x-dbf
+# dBASE V no memo file
+>>0	ubyte		0x05		dBase V
+!:mime	application/x-dbf
+>>0	ubyte		0x30		Visual FoxPro
+!:mime	application/x-dbf
+>>0	ubyte		0x31		Visual FoxPro, autoincrement
+!:mime	application/x-dbf
+# Visual FoxPro, with field type Varchar or Varbinary
+>>0	ubyte		0x32		Visual FoxPro, with field type Varchar
+!:mime	application/x-dbf
+# dBASE IV SQL, no memo;dbv memo var size (Flagship)
+>>0	ubyte		0x43		dBase IV, with SQL table
+!:mime	application/x-dbf
+# http://msdn.microsoft.com/en-US/library/st4a0s68(v=vs.80).aspx
+#>>0	ubyte		0x62		dBase IV, with SQL table
+#!:mime	application/x-dbf
+# dBASE IV, with memo!!
+>>0	ubyte		0x7b		dBase IV, with memo
+!:mime	application/x-dbf
+# http://msdn.microsoft.com/en-US/library/st4a0s68(v=vs.80).aspx
+#>>0	ubyte		0x82		dBase IV, with SQL system
+#!:mime	application/x-dbf
+# FoxBase+/dBaseIII+ with memo .DBT!
+>>0	ubyte		0x83		FoxBase+/dBase III, with memo .DBT
+!:mime	application/x-dbf
+# VISUAL OBJECTS (first 1.0 versions) for the Dbase III files (NTX clipper driver); memo file
+>>0	ubyte		0x87		VISUAL OBJECTS, with memo file
+!:mime	application/x-dbf
+# http://msdn.microsoft.com/en-US/library/st4a0s68(v=vs.80).aspx
+#>>0	ubyte		0x8A		FoxBase+/dBase III, with memo .DBT
+#!:mime	application/x-dbf
+# dBASE IV with memo!
+>>0	ubyte		0x8B		dBase IV, with memo .DBT
+!:mime	application/x-dbf
+# dBase IV with SQL Table,no memo?
+>>0	ubyte		0x8E		dBase IV, with SQL table
+!:mime	application/x-dbf
+# .dbv and .dbt memo (Flagship)?
+>>0	ubyte		0xB3		Flagship
+# http://msdn.microsoft.com/en-US/library/st4a0s68(v=vs.80).aspx
+#>>0	ubyte		0xCA		dBase IV with memo .DBT
+#!:mime	application/x-dbf
+# dBASE IV with SQL table, with memo .DBT
+>>0	ubyte		0xCB		dBase IV with SQL table, with memo .DBT
+!:mime	application/x-dbf
+# HiPer-Six format;Clipper SIX, with SMT memo file		
+>>0	ubyte		0xE5		Clipper SIX with memo
+!:mime	application/x-dbf
+# http://msdn.microsoft.com/en-US/library/st4a0s68(v=vs.80).aspx
+#>>0	ubyte		0xF4		dBase IV, with SQL table, with memo
+#!:mime	application/x-dbf
+>>0	ubyte		0xF5		FoxPro with memo
+!:mime	application/x-dbf
+# http://msdn.microsoft.com/en-US/library/st4a0s68(v=vs.80).aspx
+#>>0	ubyte		0xFA		FoxPro 2.x, with memo
+#!:mime	application/x-dbf
+# unknown version (should not happen)
+>>0	default		x		xBase
+!:mime	application/x-dbf
+>>>0	ubyte		x		(0x%x)
+# flags in version byte
+# DBT flag (with dBASE III memo .DBT)!!
+# >>0	ubyte&0x80	>0		DBT_FLAG=%x
+# memo flag ??
+# >>0	ubyte&0x08	>0		MEMO_FLAG=%x
+# SQL flag ??
+# >>0	ubyte&0x70	>0		SQL_FLAG=%x
+#		test and print the date of xBase .DBF .MDX
+0	name				xbase-date
+# inspect YYMMDD , where 1<= MM <= 12 and 1<= DD <= 31
+>0	ubelong		x		
+>1	ubyte		<13		
+>>1	ubyte		>0		
+>>>2	ubyte		>0		
+>>>>2	ubyte		<32		
+>>>>>0	ubyte		x		
+# YY is interpreted as 20YY or 19YY
+>>>>>>0	ubyte		<100		\b %.2d
+# YY is interpreted 1900+YY; TODO: display yy or 20yy instead 1YY
+>>>>>>0	ubyte		>99		\b %d
+>>>>>1	ubyte		x		\b-%d
+>>>>>2	ubyte		x		\b-%d
+
+#	dBase memo files .DBT or .FPT
+# http://msdn.microsoft.com/en-us/library/8599s21w(v=vs.80).aspx
+16		ubyte		<4		
+>16		ubyte		!2		
+>>16		ubyte		!1		
+# next free block index is positive
+>>>0		ulelong		>0		
+# skip many JPG. ZIP, BZ2 by test for reserved bytes NULL , 0|2 , 0|1 , low byte of block size
+>>>>17		ubelong&0xFFfdFE00	0x00000000	
+# skip many RAR by test for low byte 0 ,high byte 0|2|even of block size, 0|a|e|d7 , 0|64h
+>>>>>20		ubelong&0xFF01209B	0x00000000	
+# dBASE III
+>>>>>>16	ubyte		3		
+# dBASE III DBT
+>>>>>>>0	use		dbase3-memo-print
+# dBASE III DBT without version, dBASE IV DBT , FoxPro FPT , or many ZIP , DBF garbage
+>>>>>>16	ubyte		0		
+# unusual dBASE III DBT like angest.dbt, dBASE IV DBT with block size 0 , FoxPro FPT ,  or garbage PCX DBF
+>>>>>>>20	uleshort	0		
+# FoxPro FPT , unusual dBASE III DBT like biblio.dbt or garbage
+>>>>>>>>8	ulong		=0		
+>>>>>>>>>6	ubeshort	>0		
+# skip emacs.PIF
+>>>>>>>>>>4	ushort		0		
+>>>>>>>>>>>0	use		foxpro-memo-print
+# dBASE III DBT , garbage
+>>>>>>>>>6	ubeshort	0		
+# skip MM*DD*.bin by test for for reserved NULL byte
+>>>>>>>>>>510	ubeshort	0		
+# skip TK-DOS11.img image by looking for memo text
+>>>>>>>>>>>512	ubelong		<0xfeffff03	
+# skip EFI executables by looking for memo text
+>>>>>>>>>>>>512	ubelong		>0x1F202020	
+>>>>>>>>>>>>>513 ubyte		>0		
+# unusual dBASE III DBT like adressen.dbt
+>>>>>>>>>>>>>>0	use		dbase3-memo-print
+# dBASE III DBT like angest.dbt, or garbage PCX DBF
+>>>>>>>>8	ubelong		!0		
+# skip PCX and some DBF by test for for reserved NULL bytes
+>>>>>>>>>510	ubeshort	0		
+# skip some DBF by test of invalid version
+>>>>>>>>>>0	ubyte		>5		
+>>>>>>>>>>>0	ubyte		<48		
+>>>>>>>>>>>>0	use		dbase3-memo-print
+# dBASE IV DBT with positive block size
+>>>>>>>20	uleshort	>0		
+>>>>>>>>0	use		dbase4-memo-print
+
+#		Print the information of dBase III DBT memo file 
+0	name				dbase3-memo-print
+>0	ubyte			x		dBase III DBT
+# instead 3 as version number 0 for unusual examples like biblio.dbt
+>16	ubyte			!3		\b, version number %u
+# Number of next available block for appending data
+#>0	lelong			=0		\b, next free block index %u
+>0	lelong			!0		\b, next free block index %u
+# no positiv block length
+#>20	uleshort		=0		\b, block length %u
+>20	uleshort		!0		\b, block length %u
+# dBase III memo field terminated by \032\032
+>512	string			>\0		\b, 1st item "%s"
+#		Print the information of dBase IV DBT memo file 
+0	name				dbase4-memo-print
+>0		lelong		x		dBase IV DBT
+# 8 character shorted main name of coresponding dBASE IV DBF file
+>8		ubelong		>0x20000000	
+# skip unusual like for angest.dbt
+>>20		uleshort	>0	
+>>>8		string		>\0		\b of %-.8s.DBF
+# value 0 implies 512 as size
+#>4		ulelong		=0		\b, blocks size %u
+# size of blocks not reliable like 0x2020204C in angest.dbt
+>4		ulelong		!0		
+>>4		ulelong&0x0000003f	0	\b, blocks size %u
+# dBase IV DBT with positive block length (found 512 , 1024)
+>20		uleshort	>0		\b, block length %u
+# next available block
+#>0		lelong		=0		\b, next free block index %u
+>0		lelong		!0		\b, next free block index %u
+>20		uleshort	>0		
+>>(20.s)	ubelong		x		
+>>>&-4		use		dbase4-memofield-print
+# unusual dBase IV DBT without block length (implies 512 as length)
+>20		uleshort	=0		
+>>512		ubelong		x		
+>>>&-4		use				dbase4-memofield-print
+#		Print the information of dBase IV memo field 
+0	name			dbase4-memofield-print
+# free dBase IV memo field
+>0		ubelong		!0xFFFF0800	
+>>0		lelong		x		\b, next free block %u
+>>4		lelong		x		\b, next used block %u
+# used dBase IV memo field
+>0		ubelong		=0xFFFF0800	
+# length of memo field
+>>4		lelong		x		\b, field length %d
+>>>8		string		>\0		\b, 1st used item "%s"
+#		Print the information of FoxPro FPT memo file 
+0	name				foxpro-memo-print
+>0		belong		x		FoxPro FPT
+# Size of blocks for FoxPro ( 64,256 )
+>6		ubeshort	x		\b, blocks size %u
+# next available block
+#>0		belong		=0		\b, next free block index %u
+>0		belong		!0		\b, next free block index %u
+# field type ( 0~picture, 1~memo, 2~object ) 
+>512		ubelong		<3		\b, field type %u
+# length of memo field
+>512		ubelong		1		
+>>516		belong		>0		\b, field length %d
+>>>520		string		>\0		\b, 1st item "%s"
+
+# TODO: 
+# DBASE index file *.NDX
+# DBASE Compound Index file *.CDX
+# dBASE IV Printer Driver *.PRF
+## End of XBase database stuff
+
+# MS Access database
+4	string	Standard\ Jet\ DB	Microsoft Access Database
+!:mime	application/x-msaccess
+4	string	Standard\ ACE\ DB	Microsoft Access Database
+!:mime	application/x-msaccess
+
+# TDB database from Samba et al - Martin Pool <mbp@samba.org>
+0	string	TDB\ file		TDB database
+>32	lelong	0x2601196D		version 6, little-endian
+>>36	lelong	x			hash size %d bytes
+
+# SE Linux policy database
+0       lelong  0xf97cff8c      SE Linux policy
+>16     lelong  x               v%d
+>20     lelong  1      MLS
+>24     lelong  x       %d symbols
+>28     lelong  x       %d ocons
+
+# ICE authority file data (Wolfram Kleff)
+2	string		ICE		ICE authority data
+
+# X11 Xauthority file (Wolfram Kleff)
+10	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+11	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+12	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+13	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+14	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+15	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+16	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+17	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+18	string		MIT-MAGIC-COOKIE-1	X11 Xauthority data
+
+# From: Maxime Henrion <mux@FreeBSD.org>
+# PostgreSQL's custom dump format, Maxime Henrion <mux@FreeBSD.org>
+0	string		PGDMP		PostgreSQL custom database dump
+>5	byte		x		- v%d
+>6	byte		x		\b.%d
+>5	beshort		<0x101		\b-0
+>5	beshort		>0x100
+>>7	byte		x		\b-%d
+
+# Type: Advanced Data Format (ADF) database
+# URL:  http://www.grc.nasa.gov/WWW/cgns/adf/
+# From: Nicolas Chauvat <nicolas.chauvat@logilab.fr>
+0	string	@(#)ADF\ Database	CGNS Advanced Data Format
+
+# Tokyo Cabinet magic data
+# http://tokyocabinet.sourceforge.net/index.html
+0	string		ToKyO\ CaBiNeT\n	Tokyo Cabinet
+>14	string		x			\b (%s)
+>32	byte		0			\b, Hash
+!:mime	application/x-tokyocabinet-hash
+>32	byte		1			\b, B+ tree
+!:mime	application/x-tokyocabinet-btree
+>32	byte		2			\b, Fixed-length
+!:mime	application/x-tokyocabinet-fixed
+>32	byte		3			\b, Table
+!:mime	application/x-tokyocabinet-table
+>33	byte		&1			\b, [open]
+>33	byte		&2			\b, [fatal]
+>34	byte		x			\b, apow=%d
+>35	byte		x			\b, fpow=%d
+>36	byte		&0x01			\b, [large]
+>36	byte		&0x02			\b, [deflate]
+>36	byte		&0x04			\b, [bzip]
+>36	byte		&0x08			\b, [tcbs]
+>36	byte		&0x10			\b, [excodec]
+>40	lequad		x			\b, bnum=%lld
+>48	lequad		x			\b, rnum=%lld
+>56	lequad		x			\b, fsiz=%lld
+
+# Type:	QDBM Quick Database Manager
+# From:	Benoit Sibaud <bsibaud@april.org>
+0	string		\\[depot\\]\n\f		Quick Database Manager, little endian
+0	string		\\[DEPOT\\]\n\f		Quick Database Manager, big endian
+
+# Type:	TokyoCabinet database
+# URL:	http://tokyocabinet.sourceforge.net/
+# From:	Benoit Sibaud <bsibaud@april.org>
+0	string		ToKyO\ CaBiNeT\n	TokyoCabinet database
+>14	string		x			(version %s)
+
+# From:  Stephane Blondon http://www.yaal.fr
+# Database file for Zope (done by FileStorage)
+0	string		FS21	Zope Object Database File Storage (data)
+# Cache file for the database of Zope (done by ClientStorage)
+0	string		ZEC3	Zope Object Database Client Cache File (data)
+
+# IDA (Interactive Disassembler) database
+0	string		IDA1	IDA (Interactive Disassembler) database
+
+#------------------------------------------------------------------------------
+# $File$
+# diamond:  file(1) magic for Diamond system
+#
+# ... diamond is a multi-media mail and electronic conferencing system....
+#
+# XXX - I think it was either renamed Slate, or replaced by Slate....
+#
+#	The full deal is too long...
+#0	string	<list>\n<protocol\ bbn-multimedia-format>	Diamond Multimedia Document
+0	string	=<list>\n<protocol\ bbn-m	Diamond Multimedia Document
+
+#------------------------------------------------------------------------------
+# $File: diff,v 1.13 2012/06/16 14:43:36 christos Exp $
+# diff:  file(1) magic for diff(1) output
+#
+0	search/1	diff\ 		diff output text
+!:mime	text/x-diff
+0	search/1	***\ 		diff output text
+!:mime	text/x-diff
+0	search/1	Only\ in\ 	diff output text
+!:mime	text/x-diff
+0	search/1	Common\ subdirectories:\ 	diff output text
+!:mime	text/x-diff
+
+0	search/1	Index:		RCS/CVS diff output text
+!:mime	text/x-diff
+
+# bsdiff:  file(1) magic for bsdiff(1) output
+0	string/b		BSDIFF40	bsdiff(1) patch file
+
+
+# unified diff
+0	search/4096	---\ 
+>&0	search/1024 \n
+>>&0	search/1 +++\ 
+>>>&0	search/1024 \n
+>>>>&0	search/1 @@	unified diff output text
+!:mime	text/x-diff
+!:strength + 90
+
+# librsync -- the library for network deltas
+#
+# Copyright (C) 2001 by Martin Pool.  You may do whatever you want with
+# this file.
+#
+0	belong		0x72730236	rdiff network-delta data
+
+0	belong		0x72730136	rdiff network-delta signature data
+>4	belong		x		(block length=%d,
+>8	belong		x		signature strength=%d)
+
+#------------------------------------------------------------------------------
+# $File: digital,v 1.10 2011/05/03 01:44:17 christos Exp $
+#  Digital UNIX - Info
+#
+0	string	=!<arch>\n________64E	Alpha archive
+>22	string	X			-- out of date
+#
+
+0	leshort		0603
+>24	leshort		0410		COFF format alpha pure
+>24	leshort		0413		COFF format alpha demand paged
+>>22	leshort&030000	!020000		executable
+>>22	leshort&020000	!0		dynamically linked
+>>16	lelong		!0		not stripped
+>>16	lelong		0		stripped
+>>27	byte		x		- version %d
+>>26	byte		x		\b.%d
+>>28	byte		x		\b-%d
+>24	leshort		0407		COFF format alpha object
+>>22	leshort&030000	020000		shared library
+>>27	byte		x		- version %d
+>>26	byte		x		\b.%d
+>>28	byte		x		\b-%d
+
+# Basic recognition of Digital UNIX core dumps - Mike Bremford <mike@opac.bl.uk>
+#
+# The actual magic number is just "Core", followed by a 2-byte version
+# number; however, treating any file that begins with "Core" as a Digital
+# UNIX core dump file may produce too many false hits, so we include one
+# byte of the version number as well; DU 5.0 appears only to be up to
+# version 2.
+#
+0	string		Core\001	Alpha COFF format core dump (Digital UNIX)
+>24	string		>\0		\b, from '%s'
+0	string		Core\002	Alpha COFF format core dump (Digital UNIX)
+>24	string		>\0		\b, from '%s'
+#
+# The next is incomplete, we could tell more about this format,
+# but its not worth it.
+0	leshort		0x188	Alpha compressed COFF
+0	leshort		0x18f	Alpha u-code object
+#
+#
+# Some other interesting Digital formats,
+0	string	\377\377\177		ddis/ddif
+0	string	\377\377\174		ddis/dots archive
+0	string	\377\377\176		ddis/dtif table data
+0	string	\033c\033		LN03 output
+0	long	04553207		X image
+#
+0	string	=!<PDF>!\n		profiling data file
+#
+# Locale data tables (MIPS and Alpha).
+#
+0	short		0x0501		locale data table
+>6	short		0x24		for MIPS
+>6	short		0x40		for Alpha
+
+#------------------------------------------------------------------------------
+# $File: dolby,v 1.6 2012/10/31 13:39:42 christos Exp $
+# ATSC A/53 aka AC-3 aka Dolby Digital <ashitaka@gmx.at>
+# from http://www.atsc.org/standards/a_52a.pdf
+# corrections, additions, etc. are always welcome!
+#
+# syncword
+0	beshort		0x0b77	ATSC A/52 aka AC-3 aka Dolby Digital stream,
+# Proposed audio/ac3 RFC/4184
+!:mime	audio/vnd.dolby.dd-raw
+# fscod
+>4	byte&0xc0 = 0x00	48 kHz,
+>4	byte&0xc0 = 0x40	44.1 kHz,
+>4	byte&0xc0 = 0x80	32 kHz,
+# is this one used for 96 kHz?
+>4	byte&0xc0 = 0xc0	reserved frequency,
+#
+>5	byte&0x07 = 0x00	\b, complete main (CM)
+>5	byte&0x07 = 0x01	\b, music and effects (ME)
+>5	byte&0x07 = 0x02	\b, visually impaired (VI)
+>5	byte&0x07 = 0x03	\b, hearing impaired (HI)
+>5	byte&0x07 = 0x04	\b, dialogue (D)
+>5	byte&0x07 = 0x05	\b, commentary (C)
+>5	byte&0x07 = 0x06	\b, emergency (E)
+>5	beshort&0x07e0  0x0720	\b, voiceover (VO) 
+>5	beshort&0x07e0 >0x0720	\b, karaoke
+# acmod
+>6	byte&0xe0 = 0x00	1+1 front,
+>>6	byte&0x10 = 0x10	LFE on,
+>6	byte&0xe0 = 0x20	1 front/0 rear,
+>>6	byte&0x10 = 0x10	LFE on,
+>6	byte&0xe0 = 0x40	2 front/0 rear,
+# dsurmod (for stereo only)
+>>6	byte&0x18 = 0x00	Dolby Surround not indicated
+>>6	byte&0x18 = 0x08	not Dolby Surround encoded
+>>6	byte&0x18 = 0x10	Dolby Surround encoded
+>>6	byte&0x18 = 0x18	reserved Dolby Surround mode
+>>6	byte&0x04 = 0x04	LFE on,
+>6	byte&0xe0 = 0x60	3 front/0 rear,
+>>6	byte&0x04 = 0x04	LFE on,
+>6	byte&0xe0 = 0x80	2 front/1 rear,
+>>6	byte&0x04 = 0x04	LFE on,
+>6	byte&0xe0 = 0xa0	3 front/1 rear,
+>>6	byte&0x01 = 0x01	LFE on,
+>6	byte&0xe0 = 0xc0	2 front/2 rear,
+>>6	byte&0x04 = 0x04	LFE on,
+>6	byte&0xe0 = 0xe0	3 front/2 rear,
+>>6	byte&0x01 = 0x01	LFE on,
+#
+>4	byte&0x3e = 0x00	\b, 32 kbit/s
+>4	byte&0x3e = 0x02	\b, 40 kbit/s
+>4	byte&0x3e = 0x04	\b, 48 kbit/s
+>4	byte&0x3e = 0x06	\b, 56 kbit/s
+>4	byte&0x3e = 0x08	\b, 64 kbit/s
+>4	byte&0x3e = 0x0a	\b, 80 kbit/s
+>4	byte&0x3e = 0x0c	\b, 96 kbit/s
+>4	byte&0x3e = 0x0e	\b, 112 kbit/s
+>4	byte&0x3e = 0x10	\b, 128 kbit/s
+>4	byte&0x3e = 0x12	\b, 160 kbit/s
+>4	byte&0x3e = 0x14	\b, 192 kbit/s
+>4	byte&0x3e = 0x16	\b, 224 kbit/s
+>4	byte&0x3e = 0x18	\b, 256 kbit/s
+>4	byte&0x3e = 0x1a	\b, 320 kbit/s
+>4	byte&0x3e = 0x1c	\b, 384 kbit/s
+>4	byte&0x3e = 0x1e	\b, 448 kbit/s
+>4	byte&0x3e = 0x20	\b, 512 kbit/s
+>4	byte&0x3e = 0x22	\b, 576 kbit/s
+>4	byte&0x3e = 0x24	\b, 640 kbit/s
+
+#------------------------------------------------------------------------------
+# $File: dump,v 1.12 2012/11/01 04:26:40 christos Exp $
+# dump:  file(1) magic for dump file format--for new and old dump filesystems
+#
+# We specify both byte orders in order to recognize byte-swapped dumps.
+#
+0	name	new-dump-be
+>4	bedate	x		Previous dump %s,
+>8	bedate	x		This dump %s,
+>12	belong	>0		Volume %d,
+>692	belong	0		Level zero, type:
+>692	belong	>0		Level %d, type:
+>0	belong	1		tape header,
+>0	belong	2		beginning of file record,
+>0	belong	3		map of inodes on tape,
+>0	belong	4		continuation of file record,
+>0	belong	5		end of volume,
+>0	belong	6		map of inodes deleted,
+>0	belong	7		end of medium (for floppy),
+>676	string	>\0		Label %s,
+>696	string	>\0		Filesystem %s,
+>760	string	>\0		Device %s,
+>824	string	>\0		Host %s,
+>888	belong	>0		Flags %x
+
+0	name	old-dump-be
+#>4	bedate	x		Previous dump %s,
+#>8	bedate	x		This dump %s,
+>12	belong	>0		Volume %d,
+>692	belong	0		Level zero, type:
+>692	belong	>0		Level %d, type:
+>0	belong	1		tape header,
+>0	belong	2		beginning of file record,
+>0	belong	3		map of inodes on tape,
+>0	belong	4		continuation of file record,
+>0	belong	5		end of volume,
+>0	belong	6		map of inodes deleted,
+>0	belong	7		end of medium (for floppy),
+>676	string	>\0		Label %s,
+>696	string	>\0		Filesystem %s,
+>760	string	>\0		Device %s,
+>824	string	>\0		Host %s,
+>888	belong	>0		Flags %x
+
+0	name	ufs2-dump-be
+>896	beqdate	x		Previous dump %s,
+>904	beqdate	x		This dump %s,
+>12	belong	>0		Volume %d,
+>692	belong	0		Level zero, type:
+>692	belong	>0		Level %d, type:
+>0	belong	1		tape header,
+>0	belong	2		beginning of file record,
+>0	belong	3		map of inodes on tape,
+>0	belong	4		continuation of file record,
+>0	belong	5		end of volume,
+>0	belong	6		map of inodes deleted,
+>0	belong	7		end of medium (for floppy),
+>676	string	>\0		Label %s,
+>696	string	>\0		Filesystem %s,
+>760	string	>\0		Device %s,
+>824	string	>\0		Host %s,
+>888	belong	>0		Flags %x
+
+24	belong	60012		new-fs dump file (big endian), 
+>0	use	new-dump-be
+
+24	belong	60011		old-fs dump file (big endian), 
+>0	use	old-dump-be
+
+24	lelong	60012		new-fs dump file (little endian), 
+>0	use	\^new-dump-be
+
+24	lelong	60011		old-fs dump file (little endian), 
+>0	use	\^old-dump-be
+
+
+24	belong	0x19540119	new-fs dump file (ufs2, big endian), 
+>0	use	ufs2-dump-be
+
+24	lelong	0x19540119	new-fs dump file (ufs2, little endian), 
+>0	use	\^ufs2-dump-be
+
+18	leshort	60011		old-fs dump file (16-bit, assuming PDP-11 endianness),
+>2	medate	x		Previous dump %s,
+>6	medate	x		This dump %s,
+>10	leshort	>0		Volume %d,
+>0	leshort	1		tape header.
+>0	leshort	2		beginning of file record.
+>0	leshort	3		map of inodes on tape.
+>0	leshort	4		continuation of file record.
+>0	leshort	5		end of volume.
+>0	leshort	6		map of inodes deleted.
+>0	leshort	7		end of medium (for floppy).
+
+#------------------------------------------------------------------------------
+# $File: dyadic,v 1.5 2010/09/20 18:55:20 rrt Exp $
+# Dyadic: file(1) magic for Dyalog APL.
+#
+# updated by Joerg Jenderek at Oct 2013
+# http://en.wikipedia.org/wiki/Dyalog_APL
+# http://www.dyalog.com/
+# .DXV Dyalog APL External Variable
+# .DIN Dyalog APL Input Table
+# .DOT Dyalog APL Output Table
+# .DFT Dyalog APL Format File
+0	ubeshort&0xFF60	0xaa00		
+# skip biblio.dbt
+>1	byte		!4		
+# real Dyalog APL have non zero version numbers like 7.3 or 13.4
+>>2	ubeshort	>0x0000		Dyalog APL
+>>>1	byte		0x00		aplcore
+#>>>1	byte		0x00		incomplete workspace
+# *.DCF Dyalog APL Component File
+>>>1	byte		0x01		component file 32-bit non-journaled non-checksummed
+#>>>1	byte		0x01		component file
+>>>1	byte		0x02		external variable exclusive
+#>>>1	byte		0x02		external variable
+# *.DWS Dyalog APL Workspace
+>>>1	byte		0x03		workspace
+>>>>7	byte&0x28	0x00		32-bit
+>>>>7	byte&0x28	0x20		64-bit
+>>>>7	byte&0x0c	0x00		classic
+>>>>7	byte&0x0c	0x04		unicode
+>>>>7	byte&0x88	0x00		big-endian
+>>>>7	byte&0x88	0x80		little-endian
+>>>1	byte		0x06		external variable shared
+# *.DSE Dyalog APL Session , *.DLF Dyalog APL Session Log File
+>>>1	byte		0x07		session
+>>>1	byte		0x08		mapped file 32-bit
+>>>1	byte		0x09		component file 64-bit non-journaled non-checksummed
+>>>1	byte		0x0a		mapped file 64-bit
+>>>1	byte		0x0b		component file 32-bit level 1 journaled non-checksummed
+>>>1	byte		0x0c		component file 64-bit level 1 journaled non-checksummed
+>>>1	byte		0x0d		component file 32-bit level 1 journaled checksummed
+>>>1	byte		0x0e		component file 64-bit level 1 journaled checksummed
+>>>1	byte		0x0f		component file 32-bit level 2 journaled checksummed
+>>>1	byte		0x10		component file 64-bit level 2 journaled checksummed
+>>>1	byte		0x11		component file 32-bit level 3 journaled checksummed
+>>>1	byte		0x12		component file 64-bit level 3 journaled checksummed
+>>>1	byte		0x13		component file 32-bit non-journaled checksummed
+>>>1	byte		0x14		component file 64-bit non-journaled checksummed
+>>>1	byte		0x80		DDB
+>>>2	byte		x		version %d
+>>>3	byte		x		\b.%d
+#>>>2	byte		x		type %d
+#>>>3	byte		x		subtype %d
+
+# *.DXF Dyalog APL Transfer File
+0	short		0x6060		Dyalog APL transfer
+
+#------------------------------------------------------------------------------
+# $File$
+# ebml:  file(1) magic for various Extensible Binary Meta Language
+# http://www.matroska.org/technical/specs/index.html#track
+0	belong	0x1a45dfa3	EBML file
+>4	search/b/100	\102\202
+>>&1	string	x		\b, creator %.8s
+
+#------------------------------------------------------------------------------
+# $File$
+# T602 editor documents 
+# by David Necas <yeti@physics.muni.cz>
+0	string	@CT\ 	T602 document data,
+>4	string	0	Kamenicky
+>4	string	1	CP 852
+>4	string	2	KOI8-CS
+>4	string	>2	unknown encoding
+
+# Vi IMproved Encrypted file 
+# by David Necas <yeti@physics.muni.cz>
+0	string	VimCrypt~	Vim encrypted file data
+# Vi IMproved Swap file
+# by Sven Wegener <swegener@gentoo.org>
+0	string	b0VIM\ 		Vim swap file
+>&0	string	>\0		\b, version %s
+
+#------------------------------------------------------------------------------
+# $File: efi,v 1.4 2009/09/19 16:28:09 christos Exp $
+# efi:  file(1) magic for Universal EFI binaries
+
+0	lelong	0x0ef1fab9
+>4	lelong	1		Universal EFI binary with 1 architecture
+>>&0	lelong	7		\b, i386
+>>&0	lelong	0x01000007	\b, x86_64
+>4	lelong	2		Universal EFI binary with 2 architectures
+>>&0	lelong	7		\b, i386
+>>&0	lelong	0x01000007	\b, x86_64
+>>&20	lelong	7		\b, i386
+>>&20	lelong	0x01000007	\b, x86_64
+>4	lelong	>2		Universal EFI binary with %d architectures
+
+#------------------------------------------------------------------------------
+# $File: elf,v 1.67 2014/06/12 13:52:48 christos Exp $
+# elf:  file(1) magic for ELF executables
+#
+# We have to check the byte order flag to see what byte order all the
+# other stuff in the header is in.
+#
+# What're the correct byte orders for the nCUBE and the Fujitsu VPP500?
+#
+# Created by: unknown
+# Modified by (1): Daniel Quinlan <quinlan@yggdrasil.com>
+# Modified by (2): Peter Tobias <tobias@server.et-inf.fho-emden.de> (core support)
+# Modified by (3): Christian 'Dr. Disk' Hechelmann <drdisk@ds9.au.s.shuttle.de> (fix of core support)
+# Modified by (4): <gerardo.cacciari@gmail.com> (VMS Itanium)
+# Modified by (5): Matthias Urlichs <smurf@debian.org> (Listing of many architectures)
+
+0	name		elf-le
+>16	leshort		0		no file type,
+!:mime	application/octet-stream
+>16	leshort		1		relocatable,
+!:mime	application/x-object
+>16	leshort		2		executable,
+!:mime	application/x-executable
+>16	leshort		3		shared object,
+!:mime	application/x-sharedlib
+>16	leshort		4		core file
+!:mime	application/x-coredump
+# Core file detection is not reliable.
+#>>>(0x38+0xcc) string	>\0		of '%s'
+#>>>(0x38+0x10) lelong	>0		(signal %d),
+>16	leshort		&0xff00		processor-specific,
+>18	clear		x
+>18	leshort		0		no machine,
+>18	leshort		1		AT&T WE32100,
+>18	leshort		2		SPARC,
+>18	leshort		3		Intel 80386,
+>18	leshort		4		Motorola m68k,
+>>4	byte		1
+>>>36	lelong		&0x01000000	68000,
+>>>36	lelong		&0x00810000	CPU32,
+>>>36	lelong		0		68020,
+>18	leshort		5		Motorola m88k,
+>18	leshort		6		Intel 80486,
+>18	leshort		7		Intel 80860,
+# The official e_machine number for MIPS is now #8, regardless of endianness.
+# The second number (#10) will be deprecated later. For now, we still
+# say something if #10 is encountered, but only gory details for #8.
+>18	leshort		8		MIPS,
+>>4	byte		1
+>>>36	lelong		&0x20		N32
+>18	leshort		10		MIPS,
+>>4	byte		1
+>>>36	lelong		&0x20		N32
+>18	leshort		8
+# only for 32-bit
+>>4	byte		1
+>>>36  lelong&0xf0000000	0x00000000	MIPS-I
+>>>36  lelong&0xf0000000	0x10000000	MIPS-II
+>>>36  lelong&0xf0000000	0x20000000	MIPS-III
+>>>36  lelong&0xf0000000	0x30000000	MIPS-IV
+>>>36  lelong&0xf0000000	0x40000000	MIPS-V
+>>>36  lelong&0xf0000000	0x50000000	MIPS32
+>>>36  lelong&0xf0000000	0x60000000	MIPS64
+>>>36  lelong&0xf0000000	0x70000000	MIPS32 rel2
+>>>36  lelong&0xf0000000	0x80000000	MIPS64 rel2
+# only for 64-bit
+>>4	byte		2
+>>>48  lelong&0xf0000000	0x00000000	MIPS-I
+>>>48  lelong&0xf0000000	0x10000000	MIPS-II
+>>>48  lelong&0xf0000000	0x20000000	MIPS-III
+>>>48  lelong&0xf0000000	0x30000000	MIPS-IV
+>>>48  lelong&0xf0000000	0x40000000	MIPS-V
+>>>48  lelong&0xf0000000	0x50000000	MIPS32
+>>>48  lelong&0xf0000000	0x60000000	MIPS64
+>>>48  lelong&0xf0000000	0x70000000	MIPS32 rel2
+>>>48  lelong&0xf0000000	0x80000000	MIPS64 rel2
+>18	leshort		9		Amdahl,
+>18	leshort		10		MIPS (deprecated),
+>18	leshort		11		RS6000,
+>18	leshort		15		PA-RISC,
+# only for 32-bit
+>>4	byte		1
+>>>38	leshort		0x0214		2.0
+>>>36	leshort		&0x0008		(LP64)
+# only for 64-bit
+>>4	byte		2
+>>>50	leshort		0x0214		2.0
+>>>48	leshort		&0x0008		(LP64)
+>18	leshort		16		nCUBE,
+>18	leshort		17		Fujitsu VPP500,
+>18	leshort		18		SPARC32PLUS,
+# only for 32-bit
+>>4	byte		1
+>>>36	lelong&0xffff00	0x000100	V8+ Required,
+>>>36	lelong&0xffff00	0x000200	Sun UltraSPARC1 Extensions Required,
+>>>36	lelong&0xffff00	0x000400	HaL R1 Extensions Required,
+>>>36	lelong&0xffff00	0x000800	Sun UltraSPARC3 Extensions Required,
+>18	leshort		19		Intel 80960,
+>18	leshort		20		PowerPC or cisco 4500,
+>18	leshort		21		64-bit PowerPC or cisco 7500,
+>18	leshort		22		IBM S/390,
+>18	leshort		23		Cell SPU,
+>18	leshort		24		cisco SVIP,
+>18	leshort		25		cisco 7200,
+>18	leshort		36		NEC V800 or cisco 12000,
+>18	leshort		37		Fujitsu FR20,
+>18	leshort		38		TRW RH-32,
+>18	leshort		39		Motorola RCE,
+>18	leshort		40		ARM,
+>>4	byte		1
+>>>36	lelong&0xff000000	0x04000000	EABI4
+>>>36	lelong&0xff000000	0x05000000	EABI5
+>>>36	lelong		&0x00800000	BE8
+>>>36	lelong		&0x00400000	LE8
+>18	leshort		41		Alpha,
+>18	leshort		42		Renesas SH,
+>18	leshort		43		SPARC V9,
+>>4	byte		2
+>>>48	lelong&0xffff00	0x000200	Sun UltraSPARC1 Extensions Required,
+>>>48	lelong&0xffff00	0x000400	HaL R1 Extensions Required,
+>>>48	lelong&0xffff00	0x000800	Sun UltraSPARC3 Extensions Required,
+>>>48	lelong&0x3	0		total store ordering,
+>>>48	lelong&0x3	1		partial store ordering,
+>>>48	lelong&0x3	2		relaxed memory ordering,
+>18	leshort		44		Siemens Tricore Embedded Processor,
+>18	leshort		45		Argonaut RISC Core, Argonaut Technologies Inc.,
+>18	leshort		46		Renesas H8/300,
+>18	leshort		47		Renesas H8/300H,
+>18	leshort		48		Renesas H8S,
+>18	leshort		49		Renesas H8/500,
+>18	leshort		50		IA-64,
+>18	leshort		51		Stanford MIPS-X,
+>18	leshort		52		Motorola Coldfire,
+>18	leshort		53		Motorola M68HC12,
+>18	leshort		54		Fujitsu MMA,
+>18	leshort		55		Siemens PCP,
+>18	leshort		56		Sony nCPU,
+>18	leshort		57		Denso NDR1,
+>18	leshort		58		Start*Core,
+>18	leshort		59		Toyota ME16,
+>18	leshort		60		ST100,
+>18	leshort		61		Tinyj emb.,
+>18	leshort		62		x86-64,
+>18	leshort		63		Sony DSP,
+>18	leshort		64		DEC PDP-10,
+>18	leshort		65		DEC PDP-11,
+>18	leshort		66		FX66,
+>18	leshort		67		ST9+ 8/16 bit,
+>18	leshort		68		ST7 8 bit,
+>18	leshort		69		MC68HC16,
+>18	leshort		70		MC68HC11,
+>18	leshort		71		MC68HC08,
+>18	leshort		72		MC68HC05,
+>18	leshort		73		SGI SVx or Cray NV1,
+>18	leshort		74		ST19 8 bit,
+>18	leshort		75		Digital VAX,
+>18	leshort		76		Axis cris,
+>18	leshort		77		Infineon 32-bit embedded,
+>18	leshort		78		Element 14 64-bit DSP,
+>18	leshort		79		LSI Logic 16-bit DSP,
+>18	leshort		80		MMIX,
+>18	leshort		81		Harvard machine-independent,
+>18	leshort		82		SiTera Prism,
+>18	leshort		83		Atmel AVR 8-bit,
+>18	leshort		84		Fujitsu FR30,
+>18	leshort		85		Mitsubishi D10V,
+>18	leshort		86		Mitsubishi D30V,
+>18	leshort		87		NEC v850,
+>18	leshort		88		Renesas M32R,
+>18	leshort		89		Matsushita MN10300,
+>18	leshort		90		Matsushita MN10200,
+>18	leshort		91		picoJava,
+>18	leshort		92		OpenRISC,
+>18	leshort		93		ARC Cores Tangent-A5,
+>18	leshort		94		Tensilica Xtensa,
+>18	leshort		95		Alphamosaic VideoCore,
+>18	leshort		96		Thompson Multimedia,
+>18	leshort		97		NatSemi 32k,
+>18	leshort		98		Tenor Network TPC,
+>18	leshort		99		Trebia SNP 1000,
+>18	leshort		100		STMicroelectronics ST200,
+>18	leshort		101		Ubicom IP2022,
+>18	leshort		102		MAX Processor,
+>18	leshort		103		NatSemi CompactRISC,
+>18	leshort		104		Fujitsu F2MC16,
+>18	leshort		105		TI msp430,
+>18	leshort		106		Analog Devices Blackfin,
+>18	leshort		107		S1C33 Family of Seiko Epson,
+>18	leshort		108		Sharp embedded,
+>18	leshort		109		Arca RISC,
+>18	leshort		110		PKU-Unity Ltd.,
+>18	leshort		111		eXcess: 16/32/64-bit,
+>18	leshort		112		Icera Deep Execution Processor,
+>18	leshort		113		Altera Nios II,
+>18	leshort		114		NatSemi CRX,
+>18	leshort		115		Motorola XGATE,
+>18	leshort		116		Infineon C16x/XC16x,
+>18	leshort		117		Renesas M16C series,
+>18	leshort		118		Microchip dsPIC30F,
+>18	leshort		119		Freescale RISC core,
+>18	leshort		120		Renesas M32C series,
+>18	leshort		131		Altium TSK3000 core,
+>18	leshort		132		Freescale RS08,
+>18	leshort		134		Cyan Technology eCOG2,
+>18	leshort		135		Sunplus S+core7 RISC,
+>18	leshort		136		New Japan Radio (NJR) 24-bit DSP,
+>18	leshort		137		Broadcom VideoCore III,
+>18	leshort		138		LatticeMico32,
+>18	leshort		139		Seiko Epson C17 family,
+>18	leshort		140		TI TMS320C6000 DSP family,
+>18	leshort		141		TI TMS320C2000 DSP family,
+>18	leshort		142		TI TMS320C55x DSP family,
+>18	leshort		160		STMicroelectronics 64bit VLIW DSP,
+>18	leshort		161		Cypress M8C,
+>18	leshort		162		Renesas R32C series,
+>18	leshort		163		NXP TriMedia family,
+>18	leshort		164		QUALCOMM DSP6,
+>18	leshort		165		Intel 8051 and variants,
+>18	leshort		166		STMicroelectronics STxP7x family,
+>18	leshort		167		Andes embedded RISC,
+>18	leshort		168		Cyan eCOG1X family,
+>18	leshort		169		Dallas MAXQ30,
+>18	leshort		170		New Japan Radio (NJR) 16-bit DSP,
+>18	leshort		171		M2000 Reconfigurable RISC,
+>18	leshort		172		Cray NV2 vector architecture,
+>18	leshort		173		Renesas RX family,
+>18	leshort		174		META,
+>18	leshort		175		MCST Elbrus,
+>18	leshort		176		Cyan Technology eCOG16 family,
+>18	leshort		177		NatSemi CompactRISC,
+>18	leshort		178		Freescale Extended Time Processing Unit,
+>18	leshort		179		Infineon SLE9X,
+>18	leshort		180		Intel L1OM,
+>18	leshort		181		Intel K1OM,
+>18	leshort		183		ARM aarch64,
+>18	leshort		185		Atmel 32-bit family,
+>18	leshort		186		STMicroeletronics STM8 8-bit,
+>18	leshort		187		Tilera TILE64,
+>18	leshort		188		Tilera TILEPro,
+>18	leshort		189		Xilinx MicroBlaze 32-bit RISC,
+>18	leshort		190		NVIDIA CUDA architecture,
+>18	leshort		191		Tilera TILE-Gx,
+>18	leshort		197		Renesas RL78 family,
+>18	leshort		199		Renesas 78K0R,
+>18	leshort		200		Freescale 56800EX,
+>18	leshort		201		Beyond BA1,
+>18	leshort		202		Beyond BA2,
+>18	leshort		203		XMOS xCORE,
+>18	leshort		204		Microchip 8-bit PIC(r),
+>18	leshort		210		KM211 KM32,
+>18	leshort		211		KM211 KMX32,
+>18	leshort		212		KM211 KMX16,
+>18	leshort		213		KM211 KMX8,
+>18	leshort		214		KM211 KVARC,
+>18	leshort		215		Paneve CDP,
+>18	leshort		216		Cognitive Smart Memory,
+>18	leshort		217		iCelero CoolEngine,
+>18	leshort		218		Nanoradio Optimized RISC,
+>18	leshort		243		UCB RISC-V,
+>18	leshort		0x1057		AVR (unofficial),
+>18	leshort		0x1059		MSP430 (unofficial),
+>18	leshort		0x1223		Adapteva Epiphany (unofficial),
+>18	leshort		0x2530		Morpho MT (unofficial),
+>18	leshort		0x3330		FR30 (unofficial),
+>18	leshort		0x3426		OpenRISC (obsolete),
+>18	leshort		0x4688		Infineon C166 (unofficial),
+>18	leshort		0x5441		Cygnus FRV (unofficial),
+>18	leshort		0x5aa5		DLX (unofficial),
+>18	leshort		0x7650		Cygnus D10V (unofficial),
+>18	leshort		0x7676		Cygnus D30V (unofficial),
+>18	leshort		0x8217		Ubicom IP2xxx (unofficial),
+>18	leshort		0x8472		OpenRISC (obsolete),
+>18	leshort		0x9025		Cygnus PowerPC (unofficial),
+>18	leshort		0x9026		Alpha (unofficial),
+>18	leshort		0x9041		Cygnus M32R (unofficial),
+>18	leshort		0x9080		Cygnus V850 (unofficial),
+>18	leshort		0xa390		IBM S/390 (obsolete),
+>18	leshort		0xabc7		Old Xtensa (unofficial),
+>18	leshort		0xad45		xstormy16 (unofficial),
+>18	leshort		0xbaab		Old MicroBlaze (unofficial),,
+>18	leshort		0xbeef		Cygnus MN10300 (unofficial),
+>18	leshort		0xdead		Cygnus MN10200 (unofficial),
+>18	leshort		0xf00d		Toshiba MeP (unofficial),
+>18	leshort		0xfeb0		Renesas M32C (unofficial),
+>18	leshort		0xfeba		Vitesse IQ2000 (unofficial),
+>18	leshort		0xfebb		NIOS (unofficial),
+>18	leshort		0xfeed		Moxie (unofficial),
+>18	default		x
+>>18	leshort		x		*unknown arch 0x%x*
+>20	lelong		0		invalid version
+>20	lelong		1		version 1
+
+0	string		\177ELF		ELF
+!:strength *2
+>4	byte		0		invalid class
+>4	byte		1		32-bit
+>4	byte		2		64-bit
+>5	byte		0		invalid byte order
+>5	byte		1		LSB
+>>0	use		elf-le
+>5	byte		2		MSB
+>>0	use		\^elf-le
+# Up to now only 0, 1 and 2 are defined; I've seen a file with 0x83, it seemed
+# like proper ELF, but extracting the string had bad results.
+>4      byte            <0x80
+>>8	string		>\0		(%s)
+>8	string		\0
+>>7	byte		0		(SYSV)
+>>7	byte		1		(HP-UX)
+>>7	byte		2		(NetBSD)
+>>7	byte		3		(GNU/Linux)
+>>7	byte		4		(GNU/Hurd)
+>>7	byte		5		(86Open)
+>>7	byte		6		(Solaris)
+>>7	byte		7		(Monterey)
+>>7	byte		8		(IRIX)
+>>7	byte		9		(FreeBSD)
+>>7	byte		10		(Tru64)
+>>7	byte		11		(Novell Modesto)
+>>7	byte		12		(OpenBSD)
+>8      string          \2
+>>7     byte            13              (OpenVMS)
+>>7	byte		97		(ARM)
+>>7	byte		255		(embedded)
+
+#------------------------------------------------------------------------------
+# $File: encore,v 1.6 2009/09/19 16:28:09 christos Exp $
+# encore:  file(1) magic for Encore machines
+#
+# XXX - needs to have the byte order specified (NS32K was little-endian,
+# dunno whether they run the 88K in little-endian mode or not).
+#
+0	short		0x154		Encore
+>20	short		0x107		executable
+>20	short		0x108		pure executable
+>20	short		0x10b		demand-paged executable
+>20	short		0x10f		unsupported executable
+>12	long		>0		not stripped
+>22	short		>0		- version %d
+>22	short		0		-
+#>4	date		x		stamp %s
+0	short		0x155		Encore unsupported executable
+>12	long		>0		not stripped
+>22	short		>0		- version %d
+>22	short		0		-
+#>4	date		x		stamp %s
+
+#------------------------------------------------------------------------------
+# $File: epoc,v 1.8 2012/06/16 14:43:36 christos Exp $
+# EPOC : file(1) magic for EPOC documents [Psion Series 5/Osaris/Geofox 1]
+# Stefan Praszalowicz <hpicollo@worldnet.fr> and Peter Breitenlohner <peb@mppmu.mpg.de>
+# Useful information for improving this file can be found at:
+# http://software.frodo.looijaard.name/psiconv/formats/Index.html
+#------------------------------------------------------------------------------
+0	lelong		0x10000037	Psion Series 5
+>4	lelong		0x10000039	font file
+>4	lelong		0x1000003A	printer driver
+>4	lelong		0x1000003B	clipboard
+>4	lelong		0x10000042	multi-bitmap image
+!:mime image/x-epoc-mbm
+>4	lelong		0x1000006A	application information file
+>4	lelong		0x1000006D
+>>8	lelong		0x1000007D	Sketch image
+!:mime image/x-epoc-sketch
+>>8	lelong		0x1000007E	voice note
+>>8	lelong		0x1000007F	Word file
+!:mime application/x-epoc-word
+>>8	lelong		0x10000085	OPL program (TextEd)
+!:mime application/x-epoc-opl
+>>8	lelong		0x10000087	Comms settings
+>>8	lelong		0x10000088	Sheet file
+!:mime application/x-epoc-sheet
+>>8	lelong		0x100001C4	EasyFax initialisation file
+>4	lelong		0x10000073	OPO module
+!:mime application/x-epoc-opo
+>4	lelong		0x10000074	OPL application
+!:mime application/x-epoc-app
+>4	lelong		0x1000008A	exported multi-bitmap image
+>4	lelong		0x1000016D
+>>8	lelong		0x10000087	Comms names
+
+0	lelong		0x10000041	Psion Series 5 ROM multi-bitmap image
+
+0	lelong		0x10000050	Psion Series 5
+>4	lelong		0x1000006D	database
+>>8	lelong		0x10000084	Agenda file
+!:mime application/x-epoc-agenda
+>>8	lelong		0x10000086	Data file
+!:mime application/x-epoc-data
+>>8	lelong		0x10000CEA	Jotter file
+!:mime application/x-epoc-jotter
+>4	lelong		0x100000E4	ini file
+
+0	lelong		0x10000079	Psion Series 5 binary:
+>4	lelong		0x00000000	DLL
+>4	lelong		0x10000049	comms hardware library
+>4	lelong		0x1000004A	comms protocol library
+>4	lelong		0x1000005D	OPX
+>4	lelong		0x1000006C	application
+>4	lelong		0x1000008D	DLL
+>4	lelong		0x100000AC	logical device driver
+>4	lelong		0x100000AD	physical device driver
+>4	lelong		0x100000E5	file transfer protocol
+>4	lelong		0x100000E5	file transfer protocol
+>4	lelong		0x10000140	printer definition
+>4	lelong		0x10000141	printer definition
+
+0	lelong		0x1000007A	Psion Series 5 executable
+
+#------------------------------------------------------------------------------
+# $File: erlang,v 1.5 2009/09/19 16:28:09 christos Exp $
+# erlang:  file(1) magic for Erlang JAM and BEAM files
+# URL:  http://www.erlang.org/faq/x779.html#AEN812
+
+# OTP R3-R4
+0	string	\0177BEAM!	Old Erlang BEAM file
+>6	short	>0		- version %d
+
+# OTP R5 and onwards
+0	string	FOR1
+>8	string	BEAM		Erlang BEAM file
+
+# 4.2 version may have a copyright notice!
+4	string	Tue\ Jan\ 22\ 14:32:44\ MET\ 1991	Erlang JAM file - version 4.2
+79	string	Tue\ Jan\ 22\ 14:32:44\ MET\ 1991	Erlang JAM file - version 4.2
+
+4	string	1.0\ Fri\ Feb\ 3\ 09:55:56\ MET\ 1995	Erlang JAM file - version 4.3
+
+0	bequad	0x0000000000ABCDEF	Erlang DETS file
+
+#------------------------------------------------------------------------------
+# $File$
+# ESRI Shapefile format (.shp .shx .dbf=DBaseIII)
+# Based on info from
+# <URL:http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf>
+0	belong	9994	ESRI Shapefile
+>4	belong	=0
+>8	belong	=0
+>12	belong	=0
+>16	belong	=0
+>20	belong	=0
+>28	lelong	x	version %d
+>24	belong	x	length %d
+>32	lelong	=0	type Null Shape
+>32	lelong	=1	type Point
+>32	lelong	=3	type PolyLine
+>32	lelong	=5	type Polygon
+>32	lelong	=8	type MultiPoint
+>32	lelong	=11	type PointZ
+>32	lelong	=13	type PolyLineZ
+>32	lelong	=15	type PolygonZ
+>32	lelong	=18	type MultiPointZ
+>32	lelong	=21	type PointM
+>32	lelong	=23	type PolyLineM
+>32	lelong	=25	type PolygonM
+>32	lelong	=28	type MultiPointM
+>32	lelong	=31	type MultiPatch
+
+#------------------------------------------------------------------------------
+# $File$
+# fcs: file(1) magic for FCS (Flow Cytometry Standard) data files
+# From Roger Leigh <roger@whinlatter.uklinux.net>
+0       string          FCS1.0          Flow Cytometry Standard (FCS) data, version 1.0
+0       string          FCS2.0          Flow Cytometry Standard (FCS) data, version 2.0
+0       string          FCS3.0          Flow Cytometry Standard (FCS) data, version 3.0
+
+#------------------------------------------------------------------------------
+# $File: filesystems,v 1.108 2015/01/01 17:43:47 christos Exp $
+# filesystems:  file(1) magic for different filesystems
+#
+0	name	partid  
+>0	ubyte	0x00	Unused
+>0	ubyte	0x01	12-bit FAT
+>0	ubyte	0x02	XENIX /
+>0	ubyte	0x03	XENIX /usr
+>0	ubyte	0x04	16-bit FAT, less than 32M
+>0	ubyte	0x05	extended partition
+>0	ubyte	0x06	16-bit FAT, more than 32M
+>0	ubyte	0x07	OS/2 HPFS, NTFS, QNX2, Adv. UNIX
+>0	ubyte	0x08	AIX or os, or etc.
+>0	ubyte	0x09	AIX boot partition or Coherent
+>0	ubyte	0x0a	O/2 boot manager or Coherent swap
+>0	ubyte	0x0b	32-bit FAT
+>0	ubyte	0x0c	32-bit FAT, LBA-mapped
+>0	ubyte	0x0d	7XXX, LBA-mapped
+>0	ubyte	0x0e	16-bit FAT, LBA-mapped
+>0	ubyte	0x0f	extended partition, LBA-mapped
+>0	ubyte	0x10	OPUS
+>0	ubyte	0x11 	OS/2 DOS 12-bit FAT
+>0	ubyte	0x12 	Compaq diagnostics
+>0	ubyte	0x14 	OS/2 DOS 16-bit FAT <32M
+>0	ubyte	0x16 	OS/2 DOS 16-bit FAT >=32M
+>0	ubyte	0x17 	OS/2 hidden IFS
+>0	ubyte	0x18 	AST Windows swapfile
+>0	ubyte	0x19 	Willowtech Photon coS
+>0	ubyte	0x1b 	hidden win95 fat 32
+>0	ubyte	0x1c 	hidden win95 fat 32 lba
+>0	ubyte	0x1d	hidden win95 fat 16 lba
+>0	ubyte	0x20 	Willowsoft OFS1
+>0	ubyte	0x21 	reserved
+>0	ubyte	0x23 	reserved
+>0	ubyte	0x24	NEC DOS
+>0	ubyte	0x26 	reserved
+>0	ubyte	0x31 	reserved
+>0	ubyte	0x32	Alien Internet Services NOS
+>0	ubyte	0x33 	reserved
+>0	ubyte	0x34 	reserved
+>0	ubyte	0x35 	JFS on OS2
+>0	ubyte	0x36 	reserved
+>0	ubyte	0x38 	Theos
+>0	ubyte	0x39 	Plan 9, or Theos spanned
+>0	ubyte	0x3a 	Theos ver 4 4gb partition
+>0	ubyte	0x3b 	Theos ve 4 extended partition
+>0	ubyte	0x3c 	PartitionMagic recovery
+>0	ubyte	0x3d 	Hidden Netware
+>0	ubyte	0x40 	VENIX 286 or LynxOS
+>0	ubyte	0x41	PReP
+>0	ubyte	0x42	linux swap sharing DRDOS disk
+>0	ubyte	0x43	linux sharing DRDOS disk
+>0	ubyte	0x44	GoBack change utility
+>0	ubyte	0x45	Boot US Boot manager
+>0	ubyte	0x46	EUMEL/Elan or Ergos 3
+>0	ubyte	0x47	EUMEL/Elan or Ergos 3
+>0	ubyte	0x48	EUMEL/Elan or Ergos 3
+>0	ubyte	0x4a	ALFX/THIN filesystem for DOS
+>0	ubyte	0x4c	Oberon partition
+>0	ubyte	0x4d 	QNX4.x
+>0	ubyte	0x4e 	QNX4.x 2nd part
+>0	ubyte	0x4f 	QNX4.x 3rd part
+>0	ubyte	0x50 	DM (disk manager)
+>0	ubyte	0x51 	DM6 Aux1 (or Novell)
+>0	ubyte	0x52 	CP/M or Microport SysV/AT
+>0	ubyte	0x53 	DM6 Aux3
+>0	ubyte	0x54	DM6 DDO
+>0	ubyte	0x55	EZ-Drive (disk manager)
+>0	ubyte	0x56	Golden Bow (disk manager)
+>0	ubyte	0x57	Drive PRO
+>0	ubyte	0x5c	Priam Edisk (disk manager)
+>0	ubyte	0x61	SpeedStor
+>0	ubyte	0x63	GNU HURD or Mach or Sys V/386
+>0	ubyte	0x64	Novell Netware 2.xx or Speedstore
+>0	ubyte	0x65	Novell Netware 3.xx
+>0	ubyte	0x66	Novell 386 Netware
+>0	ubyte	0x67	Novell
+>0	ubyte	0x68	Novell
+>0	ubyte	0x69	Novell
+>0	ubyte	0x70	DiskSecure Multi-Boot
+>0	ubyte	0x71	reserved
+>0	ubyte	0x73	reserved
+>0	ubyte	0x74	reserved
+>0	ubyte	0x75	PC/IX
+>0	ubyte	0x76	reserved
+>0	ubyte	0x77	M2FS/M2CS partition
+>0	ubyte	0x78	XOSL boot loader filesystem
+>0	ubyte	0x80	MINIX until 1.4a
+>0	ubyte	0x81	MINIX since 1.4b
+>0	ubyte	0x82	Linux swap or Solaris
+>0	ubyte	0x83	Linux native
+>0	ubyte	0x84	OS/2 hidden C: drive
+>0	ubyte	0x85	Linux extended partition
+>0	ubyte	0x86	NT FAT volume set
+>0	ubyte	0x87	NTFS volume set or HPFS mirrored
+>0	ubyte	0x8a	Linux Kernel AiR-BOOT partition
+>0	ubyte	0x8b	Legacy Fault tolerant FAT32
+>0	ubyte	0x8c	Legacy Fault tolerant FAT32 ext
+>0	ubyte	0x8d	Hidden free FDISK FAT12
+>0	ubyte	0x8e	Linux Logical Volume Manager
+>0	ubyte	0x90	Hidden free FDISK FAT16
+>0	ubyte	0x91	Hidden free FDISK DOS EXT
+>0	ubyte	0x92	Hidden free FDISK FAT16 Big
+>0	ubyte	0x93	Amoeba filesystem
+>0	ubyte	0x94	Amoeba bad block table
+>0	ubyte	0x95	MIT EXOPC native partitions
+>0	ubyte	0x97	Hidden free FDISK FAT32
+>0	ubyte	0x98	Datalight ROM-DOS Super-Boot
+>0	ubyte	0x99	Mylex EISA SCSI
+>0	ubyte	0x9a	Hidden free FDISK FAT16 LBA
+>0	ubyte	0x9b	Hidden free FDISK EXT LBA
+>0	ubyte	0x9f	BSDI?
+>0	ubyte	0xa0	IBM Thinkpad hibernation
+>0	ubyte	0xa1	HP Volume expansion (SpeedStor)
+>0	ubyte	0xa3	HP Volume expansion (SpeedStor)
+>0	ubyte	0xa4	HP Volume expansion (SpeedStor)
+>0	ubyte	0xa5	386BSD partition type
+>0	ubyte	0xa6	OpenBSD partition type
+>0	ubyte	0xa7	NeXTSTEP 486
+>0	ubyte	0xa8	Apple UFS
+>0	ubyte	0xa9	NetBSD partition type
+>0	ubyte	0xaa	Olivetty Fat12 1.44MB Service part
+>0	ubyte	0xab	Apple Boot
+>0	ubyte	0xae	SHAG OS filesystem
+>0	ubyte	0xaf	Apple HFS
+>0	ubyte	0xb0	BootStar Dummy
+>0	ubyte	0xb1	reserved
+>0	ubyte	0xb3	reserved
+>0	ubyte	0xb4	reserved
+>0	ubyte	0xb6	reserved
+>0	ubyte	0xb7	BSDI BSD/386 filesystem
+>0	ubyte	0xb8	BSDI BSD/386 swap
+>0	ubyte	0xbb	Boot Wizard Hidden
+>0	ubyte	0xbe	Solaris 8 partition type
+>0	ubyte	0xbf	Solaris partition type
+>0	ubyte	0xc0 	CTOS
+>0	ubyte	0xc1 	DRDOS/sec (FAT-12)
+>0	ubyte	0xc2 	Hidden Linux
+>0	ubyte	0xc3 	Hidden Linux swap
+>0	ubyte	0xc4 	DRDOS/sec (FAT-16, < 32M)
+>0	ubyte	0xc5 	DRDOS/sec (EXT)
+>0	ubyte	0xc6 	DRDOS/sec (FAT-16, >= 32M)
+>0	ubyte	0xc7 	Syrinx (Cyrnix?) or HPFS disabled
+>0	ubyte	0xc8 	Reserved for DR-DOS 8.0+
+>0	ubyte	0xc9 	Reserved for DR-DOS 8.0+
+>0	ubyte	0xca 	Reserved for DR-DOS 8.0+
+>0	ubyte	0xcb 	DR-DOS 7.04+ Secured FAT32 CHS
+>0	ubyte	0xcc 	DR-DOS 7.04+ Secured FAT32 LBA
+>0	ubyte	0xcd	CTOS Memdump
+>0	ubyte	0xce 	DR-DOS 7.04+ FAT16X LBA
+>0	ubyte	0xcf 	DR-DOS 7.04+ EXT LBA
+>0	ubyte	0xd0 	REAL/32 secure big partition
+>0	ubyte	0xd1 	Old Multiuser DOS FAT12
+>0	ubyte	0xd4 	Old Multiuser DOS FAT16 Small
+>0	ubyte	0xd5 	Old Multiuser DOS Extended
+>0	ubyte	0xd6 	Old Multiuser DOS FAT16 Big
+>0	ubyte	0xd8 	CP/M 86
+>0	ubyte	0xdb 	CP/M or Concurrent CP/M
+>0	ubyte	0xdd 	Hidden CTOS Memdump
+>0	ubyte	0xde 	Dell PowerEdge Server utilities
+>0	ubyte	0xdf 	DG/UX virtual disk manager
+>0	ubyte	0xe0 	STMicroelectronics ST AVFS
+>0	ubyte	0xe1 	DOS access or SpeedStor 12-bit
+>0	ubyte	0xe3 	DOS R/O or Storage Dimensions
+>0	ubyte	0xe4 	SpeedStor 16-bit FAT < 1024 cyl.
+>0	ubyte	0xe5	reserved
+>0	ubyte	0xe6	reserved
+>0	ubyte	0xeb 	BeOS
+>0	ubyte	0xee	GPT Protective MBR
+>0	ubyte	0xef	EFI system partition
+>0	ubyte	0xf0 	Linux PA-RISC boot loader
+>0	ubyte	0xf1 	SpeedStor or Storage Dimensions
+>0	ubyte	0xf2 	DOS 3.3+ Secondary
+>0	ubyte	0xf3	reserved
+>0	ubyte	0xf4	SpeedStor large partition
+>0	ubyte	0xf5	Prologue multi-volumen partition
+>0	ubyte	0xf6 	reserved
+>0	ubyte	0xf9 	pCache: ext2/ext3 persistent cache
+>0	ubyte	0xfa 	Bochs x86 emulator
+>0	ubyte	0xfb 	VMware File System
+>0	ubyte	0xfc 	VMware Swap
+>0	ubyte	0xfd 	Linux RAID partition persistent sb
+>0	ubyte	0xfe	LANstep or IBM PS/2 IML
+>0	ubyte	0xff 	Xenix Bad Block Table
+
+0	string	\366\366\366\366	PC formatted floppy with no filesystem
+# Sun disk labels
+# From /usr/include/sun/dklabel.h:
+0774	beshort		0xdabe		
+# modified by Joerg Jenderek, because original test
+# succeeds for Cabinet archive dao360.dl_ with negative blocks
+>0770	long		>0		Sun disk label
+>>0	string		x		'%s
+>>>31	string		>\0		\b%s
+>>>>63	string		>\0		\b%s
+>>>>>95	string		>\0		\b%s
+>>0	string		x		\b'
+>>0734	short		>0		%d rpm,
+>>0736	short		>0		%d phys cys,
+>>0740	short		>0		%d alts/cyl,
+>>0746	short		>0		%d interleave,
+>>0750	short		>0		%d data cyls,
+>>0752	short		>0		%d alt cyls,
+>>0754	short		>0		%d heads/partition,
+>>0756	short		>0		%d sectors/track,
+>>0764	long		>0		start cyl %d,
+>>0770	long		x		%d blocks
+# Is there a boot block written 1 sector in?
+>512    belong&077777777	0600407	\b, boot block present
+
+# Joerg Jenderek: Smart Boot Manager backup file is 25 (MSDOS) or 41 (LINUX) byte header + first sectors of disk
+# (http://btmgr.sourceforge.net/docs/user-guide-3.html)
+0		string	SBMBAKUP_	Smart Boot Manager backup file
+>9		string	x		\b, version %-5.5s
+>>14		string	=_		
+>>>15		string	x		%-.1s
+>>>>16		string	=_		\b.
+>>>>>17		string	x		\b%-.1s
+>>>>>>18	string	=_		\b.
+>>>>>>>19	string	x		\b%-.1s
+>>>22		ubyte	0		
+>>>>21		ubyte	x		\b, from drive 0x%x
+>>>22		ubyte	>0		
+>>>>21		string	x		\b, from drive %s
+>>>535		search/17	\x55\xAA	
+>>>>&-512	indirect	x	\b; contains 
+
+# updated by Joerg Jenderek at Nov 2012
+# DOS Emulator image is 128 byte, null right padded header + harddisc image
+0	string	DOSEMU\0			
+>0x27E	leshort	0xAA55			
+#offset is 128
+>>19	ubyte	128			
+>>>(19.b-1)	ubyte	0x0	DOS Emulator image
+>>>>7	ulelong	>0		\b, %u heads
+>>>>11	ulelong	>0		\b, %d sectors/track
+>>>>15	ulelong	>0		\b, %d cylinders
+>>>>128	indirect	x	\b; contains 
+
+# added by Joerg Jenderek at Nov 2012
+# http://www.thenakedpc.com/articles/v04/08/0408-05.html
+# Symantec (Peter Norton) Image.dat file consists of variable header, bootrecord, part of FAT and root directory data
+0	string	PNCIHISK\0		Norton Utilities disc image data
+# real x86 boot sector with jump instruction
+>509	search/1026	\x55\xAA\xeb	
+>>&-1	indirect	x		\b; contains 
+# http://file-extension.net/seeker/file_extension_dat
+0	string	PNCIUNDO		Norton Disk Doctor UnDo file
+#
+
+# DOS/MBR boot sector updated by Joerg Jenderek at Sep 2007,May 2011,2013
+# for any allowed sector sizes
+30		search/481	\x55\xAA	
+# to display DOS/MBR boot sector (40) before old one (strength=50+21),Syslinux bootloader (71),SYSLINUX MBR (37+36),NetBSD mbr (110),AdvanceMAME mbr (111)
+# DOS BPB information (70) and after DOS floppy (120) like in previous file version
+!:strength +65
+# for sector sizes < 512 Bytes
+>11		uleshort	<512		
+>>(11.s-2)	uleshort	0xAA55		DOS/MBR boot sector
+# for sector sizes with 512 or more Bytes
+>0x1FE		leshort		0xAA55		DOS/MBR boot sector
+
+# keep old DOS/MBR boot sector as dummy for mbr and bootloader displaying
+# only for sector sizes with 512 or more Bytes
+0x1FE          leshort         0xAA55         	DOS/MBR boot sector
+#
+# to display information (50) before DOS BPB (strength=70) and after DOS floppy (120) like in old file version
+!:strength +65
+>2		string		OSBS		OS/BS MBR
+# added by Joerg Jenderek at Feb 2013 according to http://thestarman.pcministry.com/asm/mbr/
+# and http://en.wikipedia.org/wiki/Master_Boot_Record
+# test for nearly all MS-DOS Master Boot Record initial program loader (IPL) is now done by 
+# characteristic assembler instructions: xor ax,ax;mov ss,ax;mov sp,7c00
+>0	search/2	\x33\xc0\x8e\xd0\xbc\x00\x7c	MS-MBR
+# Microsoft Windows 95A and early ( http://thestarman.pcministry.com/asm/mbr/STDMBR.htm )
+# assembler instructions: mov si,sp;push ax;pop es;push ax;pop ds;sti;cld
+>>8	ubequad		0x8bf45007501ffbfc		
+# http://thestarman.pcministry.com/asm/mbr/200MBR.htm
+>>>0x16	ubyte		0xF3				\b,DOS 2
+>>>>219	regex		Author\ -\ 			Author:
+# found "David Litton" , "A Pehrsson  "
+>>>>>&0	string		x				"%s"
+>>>0x16	ubyte		0xF2				
+# NEC MS-DOS 3.30 Rev. 3 . See http://thestarman.pcministry.com/asm/mbr/DOS33MBR.htm
+# assembler instructions: mov di,077c;cmp word ptrl[di],a55a;jnz
+>>>>0x22	ubequad	0xbf7c07813d5aa575		\b,NEC 3.3
+# version MS-DOS 3.30 til MS-Windows 95A (WinVer=4.00.1111)
+>>>>0x22	default	x				\b,D0S version 3.3-7.0
+# error messages are printed by assembler instructions: mov si,06nn;...;int 10 (0xBEnn06;...)
+# where nn is string offset varying for different languages
+# "Invalid partition table"				nn=0x8b for english version
+>>>>>(0x49.b)	string		Invalid\ partition\ table		english
+>>>>>(0x49.b)	string		Ung\201ltige\ Partitionstabelle		german
+>>>>>(0x49.b)	string		Table\ de\ partition\ invalide		french
+>>>>>(0x49.b)	string		Tabela\ de\ parti\207ao\ inv\240lida	portuguese
+>>>>>(0x49.b)	string		Tabla\ de\ partici\242n\ no\ v\240lida	spanish
+>>>>>(0x49.b)	string		Tavola\ delle\ partizioni\ non\ valida	italian
+>>>>>0x49	ubyte		>0			at offset 0x%x
+>>>>>>(0x49.b)	string		>\0			"%s"
+# "Error loading operating system"			nn=0xa3 for english version
+# "Fehler beim Laden des Betriebssystems"		nn=0xa7 for german version
+# "Erreur en chargeant syst\212me d'exploitation"	nn=0xa7 for french version
+# "Erro na inicializa\207ao do sistema operacional"	nn=0xa7 for portuguese Brazilian version
+# "Error al cargar sistema operativo"			nn=0xa8 for spanish version
+# "Errore durante il caricamento del sistema operativo"	nn=0xae for italian version
+>>>>>0x74	ubyte		>0			at offset 0x%x
+>>>>>>(0x74.b)	string		>\0			"%s"
+# "Missing operating system"				nn=0xc2 for english version
+# "Betriebssystem fehlt"				nn=0xcd for german version
+# "Syst\212me d'exploitation absent"			nn=0xd2 for french version
+# "Sistema operacional nao encontrado"			nn=0xd4 for portuguese Brazilian version
+# "Falta sistema operativo"				nn=0xca for spanish version
+# "Sistema operativo mancante"				nn=0xe2 for italian version
+>>>>>0x79	ubyte		>0			at offset 0x%x
+>>>>>>(0x79.b)	string		>\0			"%s"
+# Microsoft Windows 95B to XP (http://thestarman.pcministry.com/asm/mbr/95BMEMBR.htm)
+# assembler instructions: push ax;pop es;push  ax;pop ds;cld;mov si,7c1b
+>>8	ubequad		0x5007501ffcbe1b7c		
+# assembler instructions: rep;movsb;retf;mov si,07be;mov cl,04
+>>>24		ubequad	0xf3a4cbbebe07b104		9M
+# "Invalid partition table"				nn=0x10F for english version
+# "Ung\201ltige Partitionstabelle"				nn=0x10F for german version
+# "Table de partition erron\202e"				nn=0x10F for french version
+# "\216\257\245\340\240\346\250\256\255\255\240\357 \341\250\341\342\245\254\240 \255\245 \255\240\251\244\245\255\240"	nn=0x10F for russian version
+>>>>(0x3C.b+0x0FF)	string	Invalid\ partition\ table		english
+>>>>(0x3C.b+0x0FF)	string	Ung\201ltige\ Partitionstabelle		german
+>>>>(0x3C.b+0x0FF)	string	Table\ de\ partition\ erron\202e	french
+>>>>(0x3C.b+0x0FF)	string	\215\245\257\340\240\242\250\253\354\255\240\357\ \342\240\241\253\250\346\240	russian
+>>>>0x3C		ubyte	x			at offset 0x%x+0xFF
+>>>>(0x3C.b+0x0FF)	string	>\0			"%s"
+# "Error loading operating system"			nn=0x127 for english version
+# "Fehler beim Laden des Betriebssystems"		nn=0x12b for german version
+# "Erreur lors du chargement du syst\212me d'exploitation"	nn=0x12a for french version
+# "\216\350\250\241\252\240 \257\340\250 \247\240\243\340\343\247\252\245 \256\257\245\340\240\346\250\256\255\255\256\251 \341\250\341\342\245\254\353"	nn=0x12d for russian version
+>>>>0xBD		ubyte	x			at offset 0x1%x
+>>>>(0xBD.b+0x100)	string	>\0			"%s"
+# "Missing operating system"				nn=0x146 for english version
+# "Betriebssystem fehlt"				nn=0x151 for german version
+# "Syst\212me d'exploitation manquant"			nn=0x15e for french version
+# "\216\257\245\340\240\346\250\256\255\255\240\357 \341\250\341\342\245\254\240 \255\245 \255\240\251\244\245\255\240"	nn=0x156 for russian version
+>>>>0xA9		ubyte	x			at offset 0x1%x
+>>>>(0xA9.b+0x100)	string	>\0			"%s"
+# http://thestarman.pcministry.com/asm/mbr/Win2kmbr.htm
+# assembler instructions: rep;movsb;retf;mov BP,07be;mov cl,04
+>>>24		ubequad	0xf3a4cbbdbe07b104		XP
+# where xxyyzz are lower bits from offsets of error messages varying for different languages
+>>>>0x1B4	ubelong&0x00FFFFFF	0x002c4463	english
+>>>>0x1B4	ubelong&0x00FFFFFF	0x002c486e	german
+# "Invalid partition table"				xx=0x12C for english version
+# "Ung\201ltige Partitionstabelle"				xx=0x12C for german version
+>>>>0x1b5	ubyte		>0			at offset 0x1%x
+>>>>(0x1b5.b+0x100)	string	>\0			"%s"
+# "Error loading operating system"			yy=0x144 for english version
+# "Fehler beim Laden des Betriebssystems"		yy=0x148 for german version
+>>>>0x1b6	ubyte		>0			at offset 0x1%x
+>>>>(0x1b6.b+0x100)	string	>\0			"%s"
+# "Missing operating system"				zz=0x163 for english version
+# "Betriebssystem nicht vorhanden"			zz=0x16e for german version
+>>>>0x1b7	ubyte		>0			at offset 0x1%x
+>>>>(0x1b7.b+0x100)	string	>\0			"%s"
+# Microsoft Windows Vista or 7
+# assembler instructions: ..;mov ds,ax;mov si,7c00;mov di,..00
+>>8	ubequad		0xc08ed8be007cbf00		
+# Microsoft Windows Vista (http://thestarman.pcministry.com/asm/mbr/VistaMBR.htm)
+# assembler instructions: jnz 0729;cmp ebx,"TCPA"
+>>>0xEC		ubequad	0x753b6681fb544350		Vista
+# where xxyyzz are lower bits from offsets of error messages varying for different languages
+>>>>0x1B4	ubelong&0x00FFFFFF	0x00627a99	english
+#>>>>0x1B4	ubelong&0x00FFFFFF	?		german
+# "Invalid partition table"				xx=0x162 for english version
+# "Ung\201ltige Partitionstabelle"				xx=0x1?? for german version
+>>>>0x1b5	ubyte		>0			at offset 0x1%x
+>>>>(0x1b5.b+0x100)	string	>\0			"%s"
+# "Error loading operating system"			yy=0x17a for english version
+# "Fehler beim Laden des Betriebssystems"		yy= 0x1?? for german version
+>>>>0x1b6	ubyte		>0			at offset 0x1%x
+>>>>(0x1b6.b+0x100)	string	>\0			"%s"
+# "Missing operating system"				zz=0x199 for english version
+# "Betriebssystem nicht vorhanden"			zz=0x1?? for german version
+>>>>0x1b7	ubyte		>0			at offset 0x1%x
+>>>>(0x1b7.b+0x100)	string	>\0			"%s"
+# Microsoft Windows 7 (http://thestarman.pcministry.com/asm/mbr/W7MBR.htm)
+# assembler instructions: cmp ebx,"TCPA";cmp
+>>>0xEC		ubequad	0x6681fb5443504175		Windows 7
+# where xxyyzz are lower bits from offsets of error messages varying for different languages
+>>>>0x1B4	ubelong&0x00FFFFFF	0x00637b9a	english
+#>>>>0x1B4	ubelong&0x00FFFFFF	?		german
+# "Invalid partition table"				xx=0x163 for english version
+# "Ung\201ltige Partitionstabelle"				xx=0x1?? for german version
+>>>>0x1b5	ubyte		>0			at offset 0x1%x
+>>>>(0x1b5.b+0x100)	string	>\0			"%s"
+# "Error loading operating system"			yy=0x17b for english version
+# "Fehler beim Laden des Betriebssystems"		yy=0x1?? for german version
+>>>>0x1b6	ubyte		>0			at offset 0x1%x
+>>>>(0x1b6.b+0x100)	string	>\0			"%s"
+# "Missing operating system"				zz=0x19a for english version
+# "Betriebssystem nicht vorhanden"			zz=0x1?? for german version
+>>>>0x1b7	ubyte		>0			at offset 0x1%x
+>>>>(0x1b7.b+0x100)	string	>\0			"%s"
+# http://thestarman.pcministry.com/asm/mbr/Win2kmbr.htm#DiskSigs
+# http://en.wikipedia.org/wiki/MBR_disk_signature#ID
+>>0x1b8	ulelong		>0				\b, disk signature 0x%-.4x
+# driveID/timestamp for Win 95B,98,98SE and ME. See http://thestarman.pcministry.com/asm/mbr/mystery.htm
+>>0xDA	uleshort		0			
+>>>0xDC 	ulelong		>0			\b, created
+# physical drive number (0x80-0xFF) when the Windows wrote that byte to the drive
+>>>>0xDC	ubyte		x			with driveID 0x%x
+# hours, minutes and seconds 
+>>>>0xDf	ubyte		x			at %x
+>>>>0xDe	ubyte		x			\b:%x
+>>>>0xDd	ubyte		x			\b:%x
+# special case for Microsoft MS-DOS 3.21 spanish
+# assembler instructions: cli;mov $0x30,%ax;mov %ax,%ss;mov 
+>0	ubequad		0xfab830008ed0bc00		
+# assembler instructions: $0x1f00,%sp;mov $0x80cb,%di;add %cl,(%bx,%si);in (%dx),%ax;mov 
+>>8	ubequad		0x1fbfcb800008ed8		MS-MBR,D0S version 3.21 spanish
+# Microsoft MBR IPL end
+
+# dr-dos with some upper-, lowercase variants
+>0x9D	string	Invalid\ partition\ table$	
+>>181	string	No\ Operating\ System$		
+>>>201	string	Operating\ System\ load\ error$	\b, DR-DOS MBR, Version 7.01 to 7.03
+>0x9D	string	Invalid\ partition\ table$	
+>>181	string	No\ operating\ system$		
+>>>201	string	Operating\ system\ load\ error$	\b, DR-DOS MBR, Version 7.01 to 7.03
+>342	string	Invalid\ partition\ table$	
+>>366	string	No\ operating\ system$		
+>>>386	string	Operating\ system\ load\ error$	\b, DR-DOS MBR, version 7.01 to 7.03
+>295	string	NEWLDR\0				
+>>302	string	Bad\ PT\ $				
+>>>310	string	No\ OS\ $				
+>>>>317	string	OS\ load\ err$				
+>>>>>329	string	Moved\ or\ missing\ IBMBIO.LDR\n\r	
+>>>>>>358	string	Press\ any\ key\ to\ continue.\n\r$	
+>>>>>>>387	string	Copyright\ (c)\ 1984,1998	
+>>>>>>>>411	string	Caldera\ Inc.\0		\b, DR-DOS MBR (IBMBIO.LDR)
+#
+# tests for different MS-DOS Master Boot Records (MBR) moved and merged
+#
+#>0x145	string	Default:\ F				\b, FREE-DOS MBR
+#>0x14B	string	Default:\ F				\b, FREE-DOS 1.0 MBR
+>0x145	search/7	Default:\ F			\b, FREE-DOS MBR
+#>>313		string	F0\ .\ .\ .			
+#>>>322		string	disk\ 1				
+#>>>>382	string	FAT3				
+>64	string	no\ active\ partition\ found	
+>>96	string	read\ error\ while\ reading\ drive	\b, FREE-DOS Beta 0.9 MBR
+# Ranish Partition Manager http://www.ranish.com/part/
+>387	search/4	\0\ Error!\r			
+>>378	search/7	Virus! 				
+>>>397	search/4	Booting\ 			
+>>>>408	search/4	HD1/\0	 			\b, Ranish MBR (
+>>>>>416	string	Writing\ changes...		\b2.37
+>>>>>>438	ubyte		x			\b,0x%x dots
+>>>>>>440	ubyte		>0			\b,virus check
+>>>>>>441	ubyte		>0			\b,partition %c
+#2.38,2.42,2.44
+>>>>>416	string	!Writing\ changes...		\b
+>>>>>>418	ubyte	1				\bvirus check,
+>>>>>>419	ubyte	x				\b0x%x seconds
+>>>>>>420	ubyte&0x0F	>0			\b,partition
+>>>>>>>420	ubyte&0x0F	<5			\b %x
+>>>>>>>420	ubyte&0x0F	0Xf			\b ask
+>>>>>420	ubyte		x			\b)
+#
+# SYSLINUX MBR moved
+# http://www.acronis.de/
+>362	string	MBR\ Error\ \0\r			
+>>376	string	ress\ any\ key\ to\ 			
+>>>392	string	boot\ from\ floppy...\0			\b, Acronis MBR
+# added by Joerg Jenderek
+# http://www.visopsys.org/
+# http://partitionlogic.org.uk/
+>309	string	No\ bootable\ partition\ found\r	
+>>339	string	I/O\ Error\ reading\ boot\ sector\r	\b, Visopsys MBR
+>349	string	No\ bootable\ partition\ found\r	
+>>379	string	I/O\ Error\ reading\ boot\ sector\r	\b, simple Visopsys MBR
+# bootloader, bootmanager
+>0x40	string	SBML				
+# label with 11 characters of FAT 12 bit filesystem
+>>43	string	SMART\ BTMGR			
+>>>430	string	SBMK\ Bad!\r			\b, Smart Boot Manager
+# OEM-ID not always "SBM"
+#>>>>3	strings	SBM				
+>>>>6	string	>\0                             \b, version %s
+>382	string	XOSLLOADXCF			\b, eXtended Operating System Loader
+>6	string	LILO				\b, LInux i386 boot LOader
+>>120	string	LILO				\b, version 22.3.4 SuSe
+>>172	string	LILO				\b, version 22.5.8 Debian
+# updated by Joerg Jenderek at Oct 2008
+# variables according to grub-0.97/stage1/stage1.S or
+# http://www.gnu.org/software/grub/manual/grub.html#Embedded-data
+# usual values are marked with comments to get only informations of strange GRUB loaders
+>342		search/60	\0Geom\0	
+#>0		ulelong		x		%x=0x009048EB ,	0x2a9048EB  0
+>>0x41		ubyte		<2		
+>>>0x3E		ubyte		>2		\b; GRand Unified Bootloader
+# 0x3 for 0.5.95,0.93,0.94,0.96 0x4 for 1.90 
+>>>>0x3E	ubyte		x		\b, stage1 version 0x%x
+#If it is 0xFF, use a drive passed by BIOS
+>>>>0x40	ubyte		<0xFF		\b, boot drive 0x%x
+# in most case 0,1,0x2e for GRUB 0.5.95
+>>>>0x41	ubyte		>0		\b, LBA flag 0x%x
+>>>>0x42	uleshort	<0x8000		\b, stage2 address 0x%x
+#>>>>0x42	uleshort	=0x8000		\b, stage2 address 0x%x (usual)
+>>>>0x42	uleshort	>0x8000		\b, stage2 address 0x%x
+#>>>>0x44	ulelong		=1		\b, 1st sector stage2 0x%x (default)
+>>>>0x44	ulelong		>1		\b, 1st sector stage2 0x%x
+>>>>0x48	uleshort	<0x800		\b, stage2 segment 0x%x
+#>>>>0x48	uleshort	=0x800		\b, stage2 segment 0x%x (usual)
+>>>>0x48	uleshort	>0x800		\b, stage2 segment 0x%x
+>>>>402		string	Geom\0Hard\ Disk\0Read\0\ Error\0
+>>>>>394	string	stage1			\b, GRUB version 0.5.95
+>>>>382		string	Geom\0Hard\ Disk\0Read\0\ Error\0
+>>>>>376	string	GRUB\ \0		\b, GRUB version 0.93 or 1.94
+>>>>383		string	Geom\0Hard\ Disk\0Read\0\ Error\0
+>>>>>377	string	GRUB\ \0		\b, GRUB version 0.94
+>>>>385		string	Geom\0Hard\ Disk\0Read\0\ Error\0
+>>>>>379	string	GRUB\ \0		\b, GRUB version 0.95 or 0.96
+>>>>391		string	Geom\0Hard\ Disk\0Read\0\ Error\0
+>>>>>385	string	GRUB\ \0		\b, GRUB version 0.97
+# unknown version
+>>>343		string	Geom\0Read\0\ Error\0	
+>>>>321		string	Loading\ stage1.5	\b, GRUB version x.y
+>>>380		string	Geom\0Hard\ Disk\0Read\0\ Error\0
+>>>>374		string	GRUB\ \0		\b, GRUB version n.m
+# SYSLINUX bootloader moved
+>395	string	chksum\0\ ERROR!\0		\b, Gujin bootloader
+# http://www.bcdwb.de/bcdw/index_e.htm
+>3	string	BCDL				
+>>498	string	BCDL\ \ \ \ BIN			\b, Bootable CD Loader (1.50Z)
+# mbr partition table entries updated by Joerg Jenderek at Sep 2013
+# skip Norton Utilities disc image data
+>3		string		!IHISK		
+# skip Linux style boot sector starting with assember instructions mov 0x7c0,ax;
+>>0		belong		!0xb8c0078e		
+# not Linux kernel 
+>>>514		string		!HdrS			
+# not BeOS
+>>>>422		string		!Be\ Boot\ Loader	
+>>>>>32769	string    CD001
+>>>>>>0	use cdrom
+# jump over BPB instruction implies DOS bootsector or AdvanceMAME mbr 
+>>>>>0		ubelong&0xFD000000	=0xE9000000	
+# AdvanceMAME mbr
+>>>>>>(1.b+2)	ubequad		0xfa31c08ed88ec08e	
+>>>>>>>446	use		partition-table
+# mbr, Norton Utilities disc image data, or 2nd,etc. sector of x86 bootloader
+>>>>>0		ubelong&0xFD000000	!0xE9000000	
+# skip FSInfosector
+>>>>>>0		string		!RRaA		
+# skip 3rd sector of MS x86 bootloader with assember instructions cli;MOVZX EAX,BYTE PTR [BP+10];MOV ECX,
+# http://thestarman.pcministry.com/asm/mbr/MSWIN41.htm
+>>>>>>>0	ubequad		!0xfa660fb64610668b	
+# skip 13rd sector of MS x86 bootloader
+>>>>>>>>0	ubequad		!0x660fb64610668b4e	
+# skip sector starting with DOS new line
+>>>>>>>>>0	string		!\r\n			
+# allowed active flag 0,80h-FFh
+>>>>>>>>>>446	ubyte		0			
+>>>>>>>>>>>446	use		partition-table
+>>>>>>>>>>446	ubyte		>0x7F			
+>>>>>>>>>>>446	use		partition-table
+# TODO: test for extended bootrecord (ebr) moved and merged with mbr partition table entries
+# mbr partition table entries end
+# http://www.acronis.de/
+#FAT label=ACRONIS\ SZ
+#OEM-ID=BOOTWIZ0
+>442	string	Non-system\ disk,\ 	
+>>459	string	press\ any\ key...\x7\0		\b, Acronis Startup Recovery Loader
+# updated by Joerg Jenderek at Nov 2012, Sep 2013
+# DOS names like F11.SYS or BOOTWIZ.SYS are 8 right space padded bytes+3 bytes
+# display 1 space
+>>>447	ubyte	x		\b 
+>>>477	use	DOS-filename
+#
+>185	string	FDBOOT\ Version\ 			
+>>204	string	\rNo\ Systemdisk.\ 			
+>>>220	string	Booting\ from\ harddisk.\n\r		
+>>>245	string	Cannot\ load\ from\ harddisk.\n\r	
+>>>>273 string	Insert\ Systemdisk\ 			
+>>>>>291 string and\ press\ any\ key.\n\r		\b, FDBOOT harddisk Bootloader
+>>>>>>200 string	>\0                             \b, version %-3s
+>242	string	Bootsector\ from\ C.H.\ Hochst\204	
+# http://freecode.com/projects/dosfstools	dosfstools-n.m/src/mkdosfs.c
+# updated by Joerg Jenderek at Nov 2012. Use search directive with offset instead of string
+# skip name "C.H. Hochstaetter" partly because it is sometimes written without umlaut
+>242	search/127	Bootsector\ from\ C.H.\ Hochst			
+>>278	search/127	No\ Systemdisk.\ Booting\ from\ harddisk	
+# followed by variants with point,CR-NL or NL-CR
+>>>208	search/261	Cannot\ load\ from\ harddisk.			
+# followed by variants CR-NL or NL-CR
+>>>>236	search/235	Insert\ Systemdisk\ and\ press\ any\ key.	
+# followed by variants with point,CR-NL or NL-CR
+>>>>>180	search/96	Disk\ formatted\ with\ WinImage\ 	\b, WinImage harddisk Bootloader
+# followed by string like "6.50 (c) 1993-2004 Gilles Vollant"
+>>>>>>&0	string		x 					\b, version %-4.4s
+>(1.b+2)	ubyte		0xe			
+>>(1.b+3)	ubyte		0x1f			
+>>>(1.b+4)	ubyte		0xbe			
+# message offset found at (1.b+5) is 0x77 for FAT32 or 0x5b for others
+>>>>(1.b+5)	ubyte&0xd3	0x53			
+>>>>>(1.b+6)	ubyte		0x7c			
+# assembler instructions: lodsb;and al,al;jz 0xb;push si;mov ah,
+>>>>>>(1.b+7)	ubyte		0xac			
+>>>>>>>(1.b+8)	ubyte		0x22			
+>>>>>>>>(1.b+9)	ubyte		0xc0			
+>>>>>>>>>(1.b+10)	ubyte	0x74			
+>>>>>>>>>>(1.b+11)	ubyte	0x0b			
+>>>>>>>>>>>(1.b+12)	ubyte	0x56			
+>>>>>>>>>>>>(1.b+13)	ubyte	0xb4			\b, mkdosfs boot message display
+# FAT1X version
+>>>>>>>>>>>>>(1.b+5)	ubyte	0x5b			
+>>>>>>>>>>>>>>0x5b	string	>\0			"%-s"
+# FAT32 version
+>>>>>>>>>>>>>(1.b+5)	ubyte	0x77			
+>>>>>>>>>>>>>>0x77	string	>\0			"%-s"
+>214	string	Please\ try\ to\ install\ FreeDOS\ 	\b, DOS Emulator boot message display
+#>>244	string	from\ dosemu-freedos-*-bin.tgz\r	
+#>>>170	string	Sorry,\ could\ not\ load\ an\ 		
+#>>>>195	string	operating\ system.\r\n		
+#
+>103	string	This\ is\ not\ a\ bootable\ disk.\ 	
+>>132	string	Please\ insert\ a\ bootable\ 		
+>>>157	string	floppy\ and\r\n				
+>>>>169	string	press\ any\ key\ to\ try\ again...\r	\b, FREE-DOS message display
+#
+>66	string	Solaris\ Boot\ Sector    		
+>>99	string	Incomplete\ MDBoot\ load.		
+>>>89	string	Version 				\b, Sun Solaris Bootloader
+>>>>97	byte	x					version %c
+#
+>408	string	OS/2\ !!\ SYS01475\r\0			
+>>429	string	OS/2\ !!\ SYS02025\r\0			
+>>>450	string	OS/2\ !!\ SYS02027\r\0			
+>>>469	string	OS2BOOT\ \ \ \ 				\b, IBM OS/2 Warp bootloader
+#
+>409	string	OS/2\ !!\ SYS01475\r\0			
+>>430	string	OS/2\ !!\ SYS02025\r\0			
+>>>451	string	OS/2\ !!\ SYS02027\r\0			
+>>>470	string	OS2BOOT\ \ \ \ 				\b, IBM OS/2 Warp Bootloader
+>112		string	This\ disk\ is\ not\ bootable\r			
+>>142		string	If\ you\ wish\ to\ make\ it\ bootable		
+>>>176		string	run\ the\ DOS\ program\ SYS\  			
+>>>200		string	after\ the\r					
+>>>>216		string	system\ has\ been\ loaded\r\n			
+>>>>>242	string	Please\ insert\ a\ DOS\ diskette\ 		
+>>>>>271	string	into\r\n\ the\ drive\ and\ 			
+>>>>>>292	string	strike\ any\ key...\0		\b, IBM OS/2 Warp message display
+# XP
+>430	string	NTLDR\ is\ missing\xFF\r\n		
+>>449	string	Disk\ error\xFF\r\n			
+>>>462	string	Press\ any\ key\ to\ restart\r		\b, Microsoft Windows XP Bootloader
+# DOS names like NTLDR,CMLDR,$LDR$ are 8 right space padded bytes+3 bytes
+>>>>417		ubyte&0xDF	>0			
+>>>>>417	string		x			%-.5s
+>>>>>>422	ubyte&0xDF	>0			
+>>>>>>>422	string		x 			\b%-.3s
+>>>>>425	ubyte&0xDF	>0			
+>>>>>>425	string		>\ 			\b.%-.3s
+#
+>>>>371		ubyte		>0x20			
+>>>>>368	ubyte&0xDF	>0			
+>>>>>>368	string		x 			%-.5s
+>>>>>>>373	ubyte&0xDF	>0			
+>>>>>>>>373	string		x 			\b%-.3s
+>>>>>>376	ubyte&0xDF	>0			
+>>>>>>>376	string		x 			\b.%-.3s
+#
+>430	string	NTLDR\ nicht\ gefunden\xFF\r\n		
+>>453	string	Datentr\204gerfehler\xFF\r\n		
+>>>473	string	Neustart\ mit\ beliebiger\ Taste\r	\b, Microsoft Windows XP Bootloader (german)
+>>>>417		ubyte&0xDF	>0			
+>>>>>417	string		x			%-.5s
+>>>>>>422	ubyte&0xDF	>0			
+>>>>>>>422	string		x 			\b%-.3s
+>>>>>425	ubyte&0xDF	>0			
+>>>>>>425	string		>\ 			\b.%-.3s
+# offset variant
+>>>>379	string	\0					
+>>>>>368	ubyte&0xDF	>0			
+>>>>>>368	string		x 			%-.5s
+>>>>>>>373	ubyte&0xDF	>0			
+>>>>>>>>373	string		x 			\b%-.3s
+#
+>430	string	NTLDR\ fehlt\xFF\r\n			
+>>444	string	Datentr\204gerfehler\xFF\r\n		
+>>>464	string	Neustart\ mit\ beliebiger\ Taste\r	\b, Microsoft Windows XP Bootloader (2.german)
+>>>>417		ubyte&0xDF	>0			
+>>>>>417	string		x			%-.5s
+>>>>>>422	ubyte&0xDF	>0			
+>>>>>>>422	string		x 			\b%-.3s
+>>>>>425	ubyte&0xDF	>0			
+>>>>>>425	string		>\ 			\b.%-.3s
+# variant
+>>>>371		ubyte		>0x20			
+>>>>>368	ubyte&0xDF	>0			
+>>>>>>368	string		x 			%-.5s
+>>>>>>>373	ubyte&0xDF	>0			
+>>>>>>>>373	string		x 			\b%-.3s
+>>>>>>376	ubyte&0xDF	>0			
+>>>>>>>376	string		x 			\b.%-.3s
+#
+>430	string	NTLDR\ fehlt\xFF\r\n			
+>>444	string	Medienfehler\xFF\r\n			
+>>>459	string	Neustart:\ Taste\ dr\201cken\r		\b, Microsoft Windows XP Bootloader (3.german)
+>>>>371		ubyte		>0x20			
+>>>>>368	ubyte&0xDF	>0			
+>>>>>>368	string		x 			%-.5s
+>>>>>>>373	ubyte&0xDF	>0			
+>>>>>>>>373	string		x 			\b%-.3s
+>>>>>>376	ubyte&0xDF	>0			
+>>>>>>>376	string		x 			\b.%-.3s
+# variant
+>>>>417		ubyte&0xDF	>0			
+>>>>>417	string		x			%-.5s
+>>>>>>422	ubyte&0xDF	>0			
+>>>>>>>422	string		x 			\b%-.3s
+>>>>>425	ubyte&0xDF	>0			
+>>>>>>425	string		>\ 			\b.%-.3s
+#
+>430	string	Datentr\204ger\ entfernen\xFF\r\n	
+>>454	string	Medienfehler\xFF\r\n			
+>>>469	string	Neustart:\ Taste\ dr\201cken\r		\b, Microsoft Windows XP Bootloader (4.german)
+>>>>379		string		\0			
+>>>>>368	ubyte&0xDF	>0			
+>>>>>>368	string		x 			%-.5s
+>>>>>>>373	ubyte&0xDF	>0			
+>>>>>>>>373	string		x 			\b%-.3s
+>>>>>>376	ubyte&0xDF	>0			
+>>>>>>>376	string		x 			\b.%-.3s
+# variant
+>>>>417		ubyte&0xDF	>0			
+>>>>>417	string		x			%-.5s
+>>>>>>422	ubyte&0xDF	>0			
+>>>>>>>422	string		x 			\b%-.3s
+>>>>>425	ubyte&0xDF	>0			
+>>>>>>425	string		>\ 			\b.%-.3s
+#
+
+#>3	string	NTFS\ \ \ \ 				
+>389	string	Fehler\ beim\ Lesen\ 
+>>407	string	des\ Datentr\204gers
+>>>426	string	NTLDR\ fehlt				
+>>>>440	string	NTLDR\ ist\ komprimiert
+>>>>>464 string	Neustart\ mit\ Strg+Alt+Entf\r		\b, Microsoft Windows XP Bootloader NTFS (german)
+#>3	string	NTFS\ \ \ \ 				
+>313	string	A\ disk\ read\ error\ occurred.\r
+>>345	string	A\ kernel\ file\ is\ missing\ 	
+>>>370	string	from\ the\ disk.\r		
+>>>>484	string	NTLDR\ is\ compressed		
+>>>>>429 string	Insert\ a\ system\ diskette\ 	
+>>>>>>454 string and\ restart\r\nthe\ system.\r		\b, Microsoft Windows XP Bootloader NTFS
+# DOS loader variants different languages,offsets
+>472	ubyte&0xDF	>0
+>>389	string	Invalid\ system\ disk\xFF\r\n		
+>>>411	string	Disk\ I/O\ error			
+>>>>428	string	Replace\ the\ disk,\ and\ 		
+>>>>>455 string	press\ any\ key				\b, Microsoft Windows 98 Bootloader
+#IO.SYS
+>>>>>>472	ubyte&0xDF	>0			
+>>>>>>>472	string		x 			\b %-.2s
+>>>>>>>>474	ubyte&0xDF	>0			
+>>>>>>>>>474	string		x 			\b%-.5s
+>>>>>>>>>>479	ubyte&0xDF	>0			
+>>>>>>>>>>>479 string		x 			\b%-.1s
+>>>>>>>480	ubyte&0xDF	>0			
+>>>>>>>>480	string		x 			\b.%-.3s
+#MSDOS.SYS
+>>>>>>>483	ubyte&0xDF	>0			\b+
+>>>>>>>>483	string		x 			\b%-.5s
+>>>>>>>>>488	ubyte&0xDF	>0			
+>>>>>>>>>>488	string		x 			\b%-.3s
+>>>>>>>>491	ubyte&0xDF	>0			
+>>>>>>>>>491	string		x 			\b.%-.3s
+#
+>>390	string	Invalid\ system\ disk\xFF\r\n		
+>>>412	string	Disk\ I/O\ error\xFF\r\n		
+>>>>429	string	Replace\ the\ disk,\ and\ 		
+>>>>>451 string	then\ press\ any\ key\r			\b, Microsoft Windows 98 Bootloader
+>>388	string	Ungueltiges\ System\ \xFF\r\n		
+>>>410	string	E/A-Fehler\ \ \ \ \xFF\r\n		
+>>>>427	string	Datentraeger\ wechseln\ und\ 		
+>>>>>453 string	Taste\ druecken\r			\b, Microsoft Windows 95/98/ME Bootloader (german)
+#WINBOOT.SYS only not spaces (0xDF)
+>>>>>>497	ubyte&0xDF	>0			
+>>>>>>>497	string		x 			%-.5s
+>>>>>>>>502	ubyte&0xDF	>0			
+>>>>>>>>>502	string		x 			\b%-.1s
+>>>>>>>>>>503	ubyte&0xDF	>0			
+>>>>>>>>>>>503	string		x 			\b%-.1s
+>>>>>>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>>>>>>504 string		x 			\b%-.1s
+>>>>>>505	ubyte&0xDF	>0			
+>>>>>>>505	string		x 			\b.%-.3s
+#IO.SYS
+>>>>>>472	ubyte&0xDF	>0			or
+>>>>>>>472	string		x 			\b %-.2s
+>>>>>>>>474	ubyte&0xDF	>0			
+>>>>>>>>>474	string		x 			\b%-.5s
+>>>>>>>>>>479	ubyte&0xDF	>0			
+>>>>>>>>>>>479 string		x 			\b%-.1s
+>>>>>>>480	ubyte&0xDF	>0			
+>>>>>>>>480	string		x 			\b.%-.3s
+#MSDOS.SYS
+>>>>>>>483	ubyte&0xDF	>0			\b+
+>>>>>>>>483	string		x 			\b%-.5s
+>>>>>>>>>488	ubyte&0xDF	>0			
+>>>>>>>>>>488	string		x 			\b%-.3s
+>>>>>>>>491	ubyte&0xDF	>0			
+>>>>>>>>>491	string		x 			\b.%-.3s
+#
+>>390	string	Ungueltiges\ System\ \xFF\r\n		
+>>>412	string	E/A-Fehler\ \ \ \ \xFF\r\n		
+>>>>429	string	Datentraeger\ wechseln\ und\ 		
+>>>>>455 string	Taste\ druecken\r			\b, Microsoft Windows 95/98/ME Bootloader (German)
+#WINBOOT.SYS only not spaces (0xDF)
+>>>>>>497	ubyte&0xDF	>0			
+>>>>>>>497	string		x 			%-.7s
+>>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>>504	string		x 			\b%-.1s
+>>>>>>505	ubyte&0xDF	>0			
+>>>>>>>505	string		x 			\b.%-.3s
+#IO.SYS
+>>>>>>472	ubyte&0xDF	>0			or
+>>>>>>>472	string		x 			\b %-.2s
+>>>>>>>>474	ubyte&0xDF	>0			
+>>>>>>>>>474	string		x 			\b%-.6s
+>>>>>>>480	ubyte&0xDF	>0			
+>>>>>>>>480	string		x 			\b.%-.3s
+#MSDOS.SYS
+>>>>>>>483	ubyte&0xDF	>0			\b+
+>>>>>>>>483	string		x 			\b%-.5s
+>>>>>>>>>488	ubyte&0xDF	>0			
+>>>>>>>>>>488	string		x 			\b%-.3s
+>>>>>>>>491	ubyte&0xDF	>0			
+>>>>>>>>>491	string		x 			\b.%-.3s
+#
+>>389	string	Ungueltiges\ System\ \xFF\r\n		
+>>>411	string	E/A-Fehler\ \ \ \ \xFF\r\n		
+>>>>428	string	Datentraeger\ wechseln\ und\ 		
+>>>>>454 string	Taste\ druecken\r			\b, Microsoft Windows 95/98/ME Bootloader (GERMAN)
+# DOS names like IO.SYS,WINBOOT.SYS,MSDOS.SYS,WINBOOT.INI are 8 right space padded bytes+3 bytes
+>>>>>>472	string		x 			%-.2s
+>>>>>>>474	ubyte&0xDF	>0			
+>>>>>>>>474	string		x 			\b%-.5s
+>>>>>>>>479	ubyte&0xDF	>0			
+>>>>>>>>>479	string		x 			\b%-.1s
+>>>>>>480	ubyte&0xDF	>0			
+>>>>>>>480	string		x 			\b.%-.3s
+>>>>>>483	ubyte&0xDF	>0			\b+
+>>>>>>>483	string		x 			\b%-.5s
+>>>>>>>488	ubyte&0xDF	>0			
+>>>>>>>>488	string		x 			\b%-.2s
+>>>>>>>>490	ubyte&0xDF	>0			
+>>>>>>>>>490	string		x 			\b%-.1s
+>>>>>>>491	ubyte&0xDF	>0			
+>>>>>>>>491	string		x 			\b.%-.3s
+>479	ubyte&0xDF	>0
+>>416	string	Kein\ System\ oder\ 			
+>>>433	string	Laufwerksfehler				
+>>>>450	string	Wechseln\ und\ Taste\ dr\201cken	\b, Microsoft DOS Bootloader (german)
+#IO.SYS
+>>>>>479	string		x 			\b %-.2s
+>>>>>>481	ubyte&0xDF	>0			
+>>>>>>>481	string		x 			\b%-.6s
+>>>>>487	ubyte&0xDF	>0			
+>>>>>>487	string		x 			\b.%-.3s
+#MSDOS.SYS
+>>>>>>490	ubyte&0xDF	>0			\b+
+>>>>>>>490	string		x 			\b%-.5s
+>>>>>>>>495	ubyte&0xDF	>0			
+>>>>>>>>>495	string		x 			\b%-.3s
+>>>>>>>498	ubyte&0xDF	>0			
+>>>>>>>>498	string		x 			\b.%-.3s
+#
+>376	search/41	Non-System\ disk\ or\ 		
+>>395	search/41	disk\ error\r			
+>>>407	search/41	Replace\ and\ 			
+>>>>419	search/41	press\ 				\b,
+>>>>419	search/41	strike\ 			\b, old
+>>>>426	search/41	any\ key\ when\ ready\r		MS or PC-DOS bootloader
+#449			Disk\ Boot\ failure\r		MS 3.21
+#466			Boot\ Failure\r			MS 3.30
+>>>>>468 search/18	\0				
+#IO.SYS,IBMBIO.COM
+>>>>>>&0	string		x 			\b %-.2s
+>>>>>>>&-20	ubyte&0xDF	>0			
+>>>>>>>>&-1	string		x 			\b%-.4s
+>>>>>>>>>&-16	ubyte&0xDF	>0			
+>>>>>>>>>>&-1	string		x 			\b%-.2s
+>>>>>>&8	ubyte&0xDF	>0			\b.
+>>>>>>>&-1	string		x 			\b%-.3s
+#MSDOS.SYS,IBMDOS.COM
+>>>>>>&11	ubyte&0xDF	>0			\b+
+>>>>>>>&-1	string		x 			\b%-.5s
+>>>>>>>>&-6	ubyte&0xDF	>0			
+>>>>>>>>>&-1	string		x 			\b%-.1s
+>>>>>>>>>>&-5	ubyte&0xDF	>0			
+>>>>>>>>>>>&-1	string		x 			\b%-.2s
+>>>>>>>&7	ubyte&0xDF	>0			\b.
+>>>>>>>>&-1	string		x 			\b%-.3s
+>441	string	Cannot\ load\ from\ harddisk.\n\r
+>>469	string	Insert\ Systemdisk\ 			
+>>>487	string	and\ press\ any\ key.\n\r		\b, MS (2.11) DOS bootloader
+#>43	string	\224R-LOADER\ \ SYS			=label					
+>54	string	SYS
+>>324	string	VASKK
+>>>495	string	NEWLDR\0				\b, DR-DOS Bootloader (LOADER.SYS)
+#
+>98	string	Press\ a\ key\ to\ retry\0\r		
+>>120	string	Cannot\ find\ file\ \0\r		
+>>>139	string	Disk\ read\ error\0\r			
+>>>>156	string	Loading\ ...\0				\b, DR-DOS (3.41) Bootloader
+#DRBIOS.SYS
+>>>>>44		ubyte&0xDF	>0			
+>>>>>>44	string		x			\b %-.6s
+>>>>>>>50	ubyte&0xDF	>0			
+>>>>>>>>50	string		x 			\b%-.2s
+>>>>>>52	ubyte&0xDF	>0			
+>>>>>>>52	string		x 			\b.%-.3s
+#
+>70	string	IBMBIO\ \ COM				
+>>472	string	Cannot\ load\ DOS!\ 			
+>>>489	string	Any\ key\ to\ retry			\b, DR-DOS Bootloader
+>>471	string	Cannot\ load\ DOS\ 			
+>>487	string	press\ key\ to\ retry			\b, Open-DOS Bootloader
+#??
+>444	string	KERNEL\ \ SYS					
+>>314	string	BOOT\ error!				\b, FREE-DOS Bootloader
+>499	string	KERNEL\ \ SYS				
+>>305	string	BOOT\ err!\0				\b, Free-DOS Bootloader
+>449	string	KERNEL\ \ SYS				
+>>319	string	BOOT\ error!				\b, FREE-DOS 0.5 Bootloader
+#
+>449	string	Loading\ FreeDOS			
+>>0x1AF		ulelong		>0			\b, FREE-DOS 0.95,1.0 Bootloader
+>>>497		ubyte&0xDF	>0			
+>>>>497		string		x 			\b %-.6s
+>>>>>503	ubyte&0xDF	>0			
+>>>>>>503	string		x 			\b%-.1s
+>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>504	string		x 			\b%-.1s
+>>>>505		ubyte&0xDF	>0			
+>>>>>505	string		x 			\b.%-.3s
+#
+>331	string	Error!.0				\b, FREE-DOS 1.0 bootloader
+#
+>125	string	Loading\ FreeDOS...\r			
+>>311	string	BOOT\ error!\r				\b, FREE-DOS bootloader
+>>>441		ubyte&0xDF	>0			
+>>>>441		string		x 			\b %-.6s
+>>>>>447	ubyte&0xDF	>0			
+>>>>>>447	string		x 			\b%-.1s
+>>>>>>>448	ubyte&0xDF	>0			
+>>>>>>>>448	string		x 			\b%-.1s
+>>>>449		ubyte&0xDF	>0			
+>>>>>449	string		x 			\b.%-.3s
+>124	string	FreeDOS\0				
+>>331	string	\ err\0					\b, FREE-DOS BETa 0.9 Bootloader
+# DOS names like KERNEL.SYS,KERNEL16.SYS,KERNEL32.SYS,METAKERN.SYS are 8 right space padded bytes+3 bytes
+>>>497		ubyte&0xDF	>0			
+>>>>497		string		x 			\b %-.6s
+>>>>>503	ubyte&0xDF	>0			
+>>>>>>503	string		x 			\b%-.1s
+>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>504	string		x 			\b%-.1s
+>>>>505		ubyte&0xDF	>0			
+>>>>>505	string		x 			\b.%-.3s
+>>333	string	\ err\0					\b, FREE-DOS BEta 0.9 Bootloader
+>>>497		ubyte&0xDF	>0			
+>>>>497		string		x 			\b %-.6s
+>>>>>503	ubyte&0xDF	>0			
+>>>>>>503	string		x 			\b%-.1s
+>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>504	string		x 			\b%-.1s
+>>>>505		ubyte&0xDF	>0			
+>>>>>505	string		x 			\b.%-.3s
+>>334	string	\ err\0					\b, FREE-DOS Beta 0.9 Bootloader
+>>>497		ubyte&0xDF	>0			
+>>>>497		string		x 			\b %-.6s
+>>>>>503	ubyte&0xDF	>0			
+>>>>>>503	string		x 			\b%-.1s
+>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>504	string		x 			\b%-.1s
+>>>>505		ubyte&0xDF	>0			
+>>>>>505	string		x 			\b.%-.3s
+>336	string	Error!\ 				
+>>343	string	Hit\ a\ key\ to\ reboot.		\b, FREE-DOS Beta 0.9sr1 Bootloader
+>>>497		ubyte&0xDF	>0			
+>>>>497		string		x 			\b %-.6s
+>>>>>503	ubyte&0xDF	>0			
+>>>>>>503	string		x 			\b%-.1s
+>>>>>>>504	ubyte&0xDF	>0			
+>>>>>>>>504	string		x 			\b%-.1s
+>>>>505		ubyte&0xDF	>0			
+>>>>>505	string		x 			\b.%-.3s
+# added by Joerg Jenderek
+# http://www.visopsys.org/
+# http://partitionlogic.org.uk/
+# OEM-ID=Visopsys
+>478		ulelong	0					
+>>(1.b+326)	string	I/O\ Error\ reading\ 			
+>>>(1.b+344)	string	Visopsys\ loader\r			
+>>>>(1.b+361)	string	Press\ any\ key\ to\ continue.\r	\b, Visopsys loader
+# http://alexfru.chat.ru/epm.html#bootprog
+>494	ubyte	>0x4D					
+>>495	string	>E					
+>>>495	string	<S					
+#OEM-ID is not reliable
+>>>>3	string	BootProg				
+# It just looks for a program file name at the root directory
+# and loads corresponding file with following execution.
+# DOS names like STARTUP.BIN,STARTUPC.COM,STARTUPE.EXE are 8 right space padded bytes+3 bytes
+>>>>499			ubyte&0xDF	>0		\b, COM/EXE Bootloader 
+>>>>>499		use		DOS-filename
+#If the boot sector fails to read any other sector,
+#it prints a very short message ("RE") to the screen and hangs the computer.
+#If the boot sector fails to find needed program in the root directory,
+#it also hangs with another message ("NF").
+>>>>>492		string		RENF		\b, FAT (12 bit)
+>>>>>495		string		RENF		\b, FAT (16 bit)
+#If the boot sector fails to read any other sector,
+#it prints a very short message ("RE") to the screen and hangs the computer.
+# x86 bootloader end
+
+# added by Joerg Jenderek at Feb 2013 according to http://thestarman.pcministry.com/asm/mbr/MSWIN41.htm#FSINFO
+# and http://en.wikipedia.org/wiki/File_Allocation_Table#FS_Information_Sector
+>0		string		RRaA		
+>>0x1E4		string		rrAa		\b, FSInfosector
+#>>0x1FC	uleshort	=0		SHOULD BE ZERO
+>>>0x1E8	ulelong		<0xffffffff	\b, %u free clusters
+>>>0x1EC	ulelong		<0xffffffff	\b, last allocated cluster %u
+
+# updated by Joerg Jenderek at Sep 2007
+>3	ubyte	0			
+#no active flag
+>>446	ubyte	0			
+# partition 1 not empty
+>>>450	ubyte	>0			
+# partitions 3,4 empty
+>>>>482		ubyte	0			
+>>>>>498	ubyte	0			
+# partition 2 ID=0,5,15
+>>>>>>466	ubyte	<0x10			
+>>>>>>>466	ubyte	0x05			\b, extended partition table
+>>>>>>>466	ubyte	0x0F			\b, extended partition table (LBA)
+>>>>>>>466	ubyte	0x0			\b, extended partition table (last)
+
+# DOS x86 sector separated and moved from "DOS/MBR boot sector" by Joerg Jenderek at May 2011
+
+>0x200	lelong	0x82564557		\b, BSD disklabel
+
+# by Joerg Jenderek at Apr 2013
+#	Print the DOS filenames from directory entry form with 8 right space padded bytes + 3 bytes for extension
+#	like IO.SYS. MSDOS.SYS , KERNEL.SYS , DRBIO.SYS
+0	name			DOS-filename
+# space=0x20 (00100000b) means empty 
+>0			ubyte&0xDF	>0		
+>>0			ubyte		x 		\b%c
+>>>1			ubyte&0xDF	>0		
+>>>>1			ubyte		x 		\b%c
+>>>>>2			ubyte&0xDF	>0		
+>>>>>>2			ubyte		x 		\b%c
+>>>>>>>3		ubyte&0xDF	>0		
+>>>>>>>>3		ubyte		x 		\b%c
+>>>>>>>>>4		ubyte&0xDF	>0		
+>>>>>>>>>>4		ubyte		x 		\b%c
+>>>>>>>>>>>5		ubyte&0xDF	>0		
+>>>>>>>>>>>>5		ubyte		x 		\b%c
+>>>>>>>>>>>>>6		ubyte&0xDF	>0		
+>>>>>>>>>>>>>>6		ubyte		x 		\b%c
+>>>>>>>>>>>>>>>7	ubyte&0xDF	>0		
+>>>>>>>>>>>>>>>>7	ubyte		x 		\b%c
+# DOS filename extension
+>>8			ubyte&0xDF	>0		\b.
+>>>8			ubyte		x 		\b%c
+>>>>9			ubyte&0xDF	>0		
+>>>>>9			ubyte		x 		\b%c
+>>>>>>10		ubyte&0xDF	>0		
+>>>>>>>10		ubyte		x 		\b%c
+#	Print 2 following DOS filenames from directory entry form
+#	like IO.SYS+MSDOS.SYS or ibmbio.com+ibmdos.com
+0	name			2xDOS-filename
+# display 1 space
+>0			ubyte		x		\b 
+>0			use		DOS-filename
+>11			ubyte		x		\b+
+>11			use		DOS-filename
+
+# http://en.wikipedia.org/wiki/Master_boot_record#PTE
+# display standard partition table
+0	name				partition-table
+#>0		ubyte		x	PARTITION-TABLE
+# test and display 1st til 4th partition table entry
+>0		use			partition-entry-test
+>16		use			partition-entry-test
+>32		use			partition-entry-test
+>48		use			partition-entry-test
+#		test for entry of partition table
+0	name				partition-entry-test
+# partition type ID > 0
+>4		ubyte		>0
+# active flag 0
+>>0		ubyte		0	
+>>>0		use		partition-entry
+# active flag 0x80, 0x81, ... 
+>>0		ubyte		>0x7F	
+>>>0		use		partition-entry
+#		Print entry of partition table
+0	name				partition-entry
+# partition type ID > 0
+>4		ubyte		>0	\b; partition
+>>64		leshort		0xAA55	1
+>>48		leshort		0xAA55	2
+>>32		leshort		0xAA55	3
+>>16		leshort		0xAA55	4
+>>4		ubyte		x	: ID=0x%x
+>>0		ubyte&0x80	0x80	\b, active
+>>0		ubyte		>0x80	0x%x
+>>1		ubyte		x	\b, start-CHS (
+>>1		use		partition-chs
+>>5		ubyte		x	\b), end-CHS (
+>>5		use		partition-chs
+>>8		ulelong		x	\b), startsector %u
+>>12		ulelong		x	\b, %u sectors
+#		Print cylinder,head,sector (CHS) of partition entry
+0	name				partition-chs
+# cylinder
+>1		ubyte		x	\b0x
+>1		ubyte&0xC0	0x40	\b1
+>1		ubyte&0xC0	0x80	\b2
+>1		ubyte&0xC0	0xC0	\b3
+>2		ubyte		x	\b%x
+# head
+>0		ubyte		x	\b,%u
+# sector
+>1		ubyte&0x3F	x	\b,%u
+
+# FATX 
+0		string		FATX		FATX filesystem data
+
+# romfs filesystems - Juan Cespedes <cespedes@debian.org>
+0	string		-rom1fs-	romfs filesystem, version 1
+>8	belong	x			%d bytes,
+>16	string	x			named %s.
+
+# netboot image - Juan Cespedes <cespedes@debian.org>
+0	lelong		0x1b031336L	Netboot image,
+>4	lelong&0xFFFFFF00	0
+>>4	lelong&0x100	0x000		mode 2
+>>4	lelong&0x100	0x100		mode 3
+>4	lelong&0xFFFFFF00	!0	unknown mode
+
+0x18b	string	OS/2	OS/2 Boot Manager
+
+# updated by Joerg Jenderek at Oct 2008 and Sep 2012
+# http://syslinux.zytor.com/iso.php
+# tested with versions 1.47,1.48,1.49,1.50,1.62,1.76,2.00,2.10;3.00,3.11,3.31,;3.70,3.71,3.73,3.75,3.80,3.82,3.84,3.86,4.01,4.03 and 4.05
+# assembler instructions: cli;jmp 0:7Cyy (yy=0x40,0x5e,0x6c,0x6e,0x77);nop;nop
+0	ulequad&0x909000007cc0eafa	0x909000007c40eafa	
+>631	search/689	ISOLINUX\ 	isolinux Loader
+>>&0	string		x		(version %-4.4s)
+# http://syslinux.zytor.com/pxe.php
+# assembler instructions: jmp 7C05
+0	ulelong	0x007c05ea		pxelinux loader (version 2.13 or older)
+# assembler instructions: pushfd;pushad
+0	ulelong	0x60669c66		pxelinux loader
+# assembler instructions: jmp 05
+0	ulelong	0xc00005ea		pxelinux loader (version 3.70 or newer)
+# http://syslinux.zytor.com/wiki/index.php/SYSLINUX
+0	string	LDLINUX\ SYS\ 		SYSLINUX loader
+>12	string	x			(older version %-4.4s)
+0	string	\r\nSYSLINUX\ 		SYSLINUX loader
+>11	string	x			(version %-4.4s)
+# syslinux updated and separated from "DOS/MBR boot sector" by Joerg Jenderek at Sep 2012
+# assembler instructions: jmp yy (yy=0x3c,0x58);nop;"SYSLINUX"
+0	ulelong&0x80909bEB	0x009018EB	
+# OEM-ID not always "SYSLINUX"
+>434	search/47	Boot\ failed		
+# followed by \r\n\0 or :\ 
+>>482	search/132	\0LDLINUX\ SYS		Syslinux bootloader (version 2.13 or older)
+>>1	ubyte		0x58			Syslinux bootloader (version 3.0-3.9)
+>459	search/30	Boot\ error\r\n\0	
+>>1	ubyte		0x58			Syslinux bootloader (version 3.10 or newer)
+# SYSLINUX MBR updated and separated from "DOS/MBR boot sector" by Joerg Jenderek at Sep 2012
+# assembler instructions: mov di,0600h;mov cx,0100h
+16	search/4	\xbf\x00\x06\xb9\x00\x01		
+# to display SYSLINUX MBR (36) before old DOS/MBR boot sector one with partition table (strength=50+21)
+!:strength +36
+>94	search/249	Missing\ operating\ system		
+# followed by \r for versions older 3.35 , .\r for versions newer 3.52 and point for other
+# skip Ranish MBR
+>>408	search/4	HD1/\0	 				
+>>408	default		x					
+>>>250	search/118	\0Operating\ system\ load		SYSLINUX MBR
+# followed by "ing " or space
+>>>>292	search/98	error   				
+>>>>>&0	string		\r		    			(version 3.35 or older)
+>>>>>&0	string		.\r					(version 3.52 or newer)
+>>>>>&0	default		x					(version 3.36-3.51 )
+>368	search/106	\0Disk\ error\ on\ boot\r\n		SYSLINUX GPT-MBR
+>>156	search/10	\0Boot\ partition\ not\ found\r\n	
+>>>270	search/10	\0OS\ not\ bootable\r\n			(version 3.86 or older)
+>>174	search/10	\0Missing\ OS\r\n			
+>>>189	search/10	\0Multiple\ active\ partitions\r\n	(version 4.00 or newer)
+# SYSLINUX END
+
+# NetBSD mbr variants (master-boot-code version 1.22) added by Joerg Jenderek at Nov 2012
+# assembler instructions: xor ax,ax;mov	ax,ss;mov sp,0x7c00;mov	ax,
+0	ubequad		0x31c08ed0bc007c8e			
+# mbr_bootsel magic before partition table not reliable with small ipl fragments
+#>444	uleshort	0xb5e1					
+>0004	uleshort	x					
+# ERRorTeXT
+>>181	search/166		Error\ \0\r\n				NetBSD mbr
+# NT Drive Serial Number http://thestarman.pcministry.com/asm/mbr/Win2kmbr.htm#DS
+>>>0x1B8	ubelong		>0					\b,Serial 0x%-.8x
+# BOOTSEL definitions contains assembler instructions: int 0x13;pop dx;push dx;push dx
+>>>0xbb		search/71	\xcd\x13\x5a\x52\x52			\b,bootselector
+# BOOT_EXTENDED definitions contains assembler instructions: 
+# xchg ecx,edx;addl ecx,edx;movw lba_info,si;movb 0x42,ah;pop dx;push dx;int 0x13
+>>>0x96	search/1	\x66\x87\xca\x66\x01\xca\x66\x89\x16\x3a\x07\xbe\x32\x07\xb4\x42\x5a\x52\xcd\x13	\b,boot extended
+# COM_PORT_VAL definitions contains assembler instructions: outb al,dx;add 5,dl;inb %dx;test 0x40,al
+>>>0x130	search/55	\xee\x80\xc2\x05\xec\xa8\x40		\b,serial IO
+# not TERSE_ERROR
+>>>196		search/106	No\ active\ partition\0			
+>>>>&0		string		Disk\ read\ error\0			
+>>>>>&0		string		No\ operating\ system\0			\b,verbose
+# not NO_CHS definitions contains assembler instructions: pop dx;push dx;movb $8,ah;int0x13
+>>>0x7d		search/7	\x5a\x52\xb4\x08\xcd\x13		\b,CHS
+# not NO_LBA_CHECK definitions contains assembler instructions: movw 0x55aa,bx;movb 0x41,ah;pop	dx;push	dx;int 0x13
+>>>0xa4		search/84	\xbb\xaa\x55\xb4\x41\x5a\x52\xcd\x13	\b,LBA-check
+# assembler instructions: movw nametab,bx
+>>>0x26	    search/21	\xBB\x94\x07					
+# not NO_BANNER definitions contains assembler instructions: mov banner,si;call message_crlf
+>>>>&-9	ubequad&0xBE00f0E800febb94	0xBE0000E80000bb94		
+>>>>>181	search/166		Error\ \0			
+# "a: disk" , "Fn: diskn" or "NetBSD MBR boot"
+>>>>>>&3	string			x				\b,"%s"
+>>>446	use		partition-table
+# Andrea Mazzoleni AdvanceCD mbr loader of http://advancemame.sourceforge.net/boot-readme.html
+# added by Joerg Jenderek at Nov 2012 for versions 1.3 - 1.4
+# assembler instructions: jmp short 0x58;nop;ASCII
+0	ubequad&0xeb58908000000000	0xeb58900000000000	
+# assembler instructions: cli;xor ax,ax;mov ds,ax;mov es,ax;mov ss,
+>(1.b+2)	ubequad			0xfa31c08ed88ec08e	
+# Error messages at end of code
+>>376		string	No\ operating\ system\r\n\0		
+>>>398		string	Disk\ error\r\n\0FDD\0HDD\0		
+>>>>419		string	\ EBIOS\r\n\0				AdvanceMAME mbr
+
+# Neil Turton mbr loader variant of http://www.chiark.greenend.org.uk/~neilt/mbr/ 
+# added by Joerg Jenderek at Mar 2011 for versions 1.0.0 - 1.1.11
+# for 1st version assembler instructions:	cld;xor ax,ax;mov DS,ax;MOV ES,AX;mov SI,
+# or  	  	  	    			cld;xor ax,ax;mov SS,ax;XOR SP,SP;mov DS,
+0	ulequad&0xcE1b40D48EC031FC	0x8E0000D08EC031FC	
+# pointer to the data starting with Neil Turton signature string
+>(0x1BC.s)		string		NDTmbr			
+>>&-14			string		1234F\0			Turton mbr (
+# parameters also viewed by install-mbr --list
+>>>(0x1BC.s+7)		ubyte		x			\b%u<=
+>>>(0x1BC.s+9)		ubyte		x			\bVersion<=%u
+#>>>(0x1BC.s+8)		ubyte		x			asm_flag_%x
+>>>(0x1BC.s+8)		ubyte&1		1			\b,Y2K-Fix
+# variant used by testdisk of http://www.cgsecurity.org/wiki/Menu_MBRCode
+>>>(0x1BC.s+8)		ubyte&2		2			\b,TestDisk
+#0x1~1,..,0x8~4,0x10~F,0x80~A enabled
+#>>>(0x1BC.s+10)		ubyte		x			\b,flags 0x%x
+#0x0~1,0x1~2,...,0x3~4,0x4~F,0x7~D default boot
+#>>>(0x1BC.s+11)		ubyte		x			\b,cfg_def 0x%x
+# for older versions
+>>>(0x1BC.s+9)		ubyte		<2			
+#>>>>(0x1BC.s+12)	ubyte		18			\b,%hhu/18 seconds
+>>>>(0x1BC.s+12)	ubyte		!18			\b,%u/18 seconds
+# floppy A: or B:
+>>>>(0x1BC.s+13)	ubyte		<2			\b,floppy 0x%x
+>>>>(0x1BC.s+13)	ubyte		>1			
+# 1st hard disc
+#>>>>>(0x1BC.s+13)	ubyte		0x80			\b,drive 0x%x
+# not 1st hard disc
+>>>>>(0x1BC.s+13)	ubyte		!0x80			\b,drive 0x%x
+# for version >= 2 maximal timeout can be 65534
+>>>(0x1BC.s+9)		ubyte		>1			
+#>>>>(0x1BC.s+12)	uleshort	18			\b,%u/18 seconds
+>>>>(0x1BC.s+12)	uleshort	!18			\b,%u/18 seconds
+# floppy A: or B:
+>>>>(0x1BC.s+14)	ubyte		<2			\b,floppy 0x%x
+>>>>(0x1BC.s+14)	ubyte		>1			
+# 1st hard disc
+#>>>>>(0x1BC.s+14)	ubyte		0x80			\b,drive 0x%x
+# not 1st hard disc
+>>>>>(0x1BC.s+14)	ubyte		!0x80			\b,drive 0x%x
+>>>0	ubyte		x					\b)
+
+# added by Joerg Jenderek
+# In the second sector (+0x200) are variables according to grub-0.97/stage2/asm.S or
+# grub-1.94/kern/i386/pc/startup.S
+# http://www.gnu.org/software/grub/manual/grub.html#Embedded-data
+# usual values are marked with comments to get only informations of strange GRUB loaders
+0x200	uleshort		0x70EA		
+# found only version 3.{1,2}
+>0x206		ubeshort	>0x0300		
+# GRUB version (0.5.)95,0.93,0.94,0.96,0.97 > "00"
+>>0x212 	ubyte		>0x29		
+>>>0x213 	ubyte		>0x29		
+# not iso9660_stage1_5
+#>>>0	ulelong&0x00BE5652	0x00BE5652	
+>>>>0x213 	ubyte		>0x29		GRand Unified Bootloader
+# config_file for stage1_5 is 0xffffffff + default "/boot/grub/stage2"
+>>>>0x217 	ubyte		0xFF		stage1_5
+>>>>0x217 	ubyte		<0xFF		stage2
+>>>>0x206	ubyte		x		\b version %u
+>>>>0x207	ubyte		x		\b.%u
+# module_size for 1.94
+>>>>0x208	ulelong		<0xffffff	\b, installed partition %u
+#>>>>0x208	ulelong		=0xffffff	\b, %lu (default)
+>>>>0x208	ulelong		>0xffffff	\b, installed partition %u
+# GRUB 0.5.95 unofficial
+>>>>0x20C	ulelong&0x2E300000 0x2E300000	
+# 0=stage2	1=ffs	2=e2fs	3=fat	4=minix	5=reiserfs
+>>>>>0x20C	ubyte		x		\b, identifier 0x%x
+#>>>>>0x20D	ubyte		=0		\b, LBA flag 0x%x (default)
+>>>>>0x20D	ubyte		>0		\b, LBA flag 0x%x
+# GRUB version as string
+>>>>>0x20E 	string		>\0		\b, GRUB version %-s
+# for stage1_5 is 0xffffffff + config_file "/boot/grub/stage2" default
+>>>>>>0x215 	ulong		0xffffffff	
+>>>>>>>0x219 	string		>\0		\b, configuration file %-s
+>>>>>>0x215 	ulong		!0xffffffff	
+>>>>>>>0x215 	string		>\0		\b, configuration file %-s
+# newer GRUB versions
+>>>>0x20C	ulelong&0x2E300000 !0x2E300000	
+##>>>>>0x20C	ulelong		=0		\b, saved entry %d (usual)
+>>>>>0x20C	ulelong		>0		\b, saved entry %d
+# for 1.94 contains kernel image size
+# for 0.93,0.94,0.96,0.97
+# 0=stage2	1=ffs	2=e2fs	3=fat	4=minix	5=reiserfs	6=vstafs	7=jfs	8=xfs	9=iso9660	a=ufs2	
+>>>>>0x210	ubyte		x		\b, identifier 0x%x
+# The flag for LBA forcing is in most cases 0
+#>>>>>0x211	ubyte		=0		\b, LBA flag 0x%x (default)
+>>>>>0x211	ubyte		>0		\b, LBA flag 0x%x
+# GRUB version as string
+>>>>>0x212 	string		>\0		\b, GRUB version %-s
+# for stage1_5 is 0xffffffff + config_file "/boot/grub/stage2" default
+>>>>>0x217 	ulong		0xffffffff	
+>>>>>>0x21b 	string		>\0		\b, configuration file %-s
+>>>>>0x217 	ulong		!0xffffffff	
+>>>>>>0x217 	string		>\0		\b, configuration file %-s
+
+# DOS x86 sector updated and separated from "DOS/MBR boot sector" by Joerg Jenderek at May 2011
+# JuMP short     bootcodeoffset NOP assembler instructions will usually be EB xx 90
+# over BIOS parameter block (BPB)
+# http://thestarman.pcministry.com/asm/2bytejumps.htm#FWD
+# older drives may use Near JuMP instruction E9 xx xx
+# minimal short forward jump found 0x29 for bootloaders or 0x0
+# maximal short forward jump is 0x7f
+# OEM-ID is empty or contain readable bytes
+0		ulelong&0x804000E9	0x000000E9
+!:strength	+60
+# mtools-3.9.8/msdos.h
+# usual values are marked with comments to get only informations of strange FAT systems
+# valid sectorsize must be a power of 2 from 32 to 32768
+>11		uleshort&0x001f	0	
+>>11		uleshort	<32769		
+>>>11		uleshort	>31		
+>>>>21		ubyte&0xf0	0xF0		
+>>>>>0		ubyte		0xEB		DOS/MBR boot sector
+>>>>>>1		ubyte		x		\b, code offset 0x%x+2
+>>>>>0		ubyte		0xE9		
+>>>>>>1		uleshort	x		\b, code offset 0x%x+3
+>>>>>3		string		>\0		\b, OEM-ID "%-.8s"
+#http://mirror.href.com/thestarman/asm/debug/debug2.htm#IHC
+>>>>>>8		string		IHC		\b cached by Windows 9M
+>>>>>11		uleshort	>512		\b, Bytes/sector %u
+#>>>>>11	uleshort	=512		\b, Bytes/sector %u=512 (usual)
+>>>>>11		uleshort	<512		\b, Bytes/sector %u
+>>>>>13		ubyte		>1		\b, sectors/cluster %u
+#>>>>>13	ubyte		=1		\b, sectors/cluster %u (usual on Floppies)
+# for lazy FAT32 implementation like Transcend digital photo frame PF830
+>>>>>82		string/c	fat32		
+>>>>>>14	uleshort	!32		\b, reserved sectors %u
+#>>>>>>14	uleshort	=32		\b, reserved sectors %u (usual Fat32)
+>>>>>82		string/c	!fat32		
+>>>>>>14	uleshort	>1		\b, reserved sectors %u
+#>>>>>>14	uleshort	=1		\b, reserved sectors %u (usual FAT12,FAT16)
+#>>>>>>14	uleshort	0		\b, reserved sectors %u (usual NTFS)
+>>>>>16		ubyte		>2		\b, FATs %u
+#>>>>>16	ubyte		=2		\b, FATs %u (usual)
+>>>>>16		ubyte		=1		\b, FAT  %u
+>>>>>16		ubyte		>0
+>>>>>17		uleshort	>0		\b, root entries %u
+#>>>>>17	uleshort	=0		\b, root entries %hu=0 (usual Fat32)
+>>>>>19		uleshort	>0		\b, sectors %u (volumes <=32 MB) 
+#>>>>>19	uleshort	=0		\b, sectors %hu=0 (usual Fat32)
+>>>>>21		ubyte		>0xF0		\b, Media descriptor 0x%x
+#>>>>>21	ubyte		=0xF0		\b, Media descriptor 0x%x (usual floppy)
+>>>>>21		ubyte		<0xF0		\b, Media descriptor 0x%x
+>>>>>22		uleshort	>0		\b, sectors/FAT %u
+#>>>>>22	uleshort	=0		\b, sectors/FAT %hu=0 (usual Fat32)
+>>>>>24		uleshort	x		\b, sectors/track %u
+>>>>>26		ubyte		>2		\b, heads %u
+#>>>>>26	ubyte		=2		\b, heads %u (usual floppy)
+>>>>>26		ubyte		=1		\b, heads %u
+# valid only for sector sizes with more then 32 Bytes
+>>>>>11		uleshort	>32		
+# http://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#Extended_BIOS_Parameter_Block
+# skip for values 2,2Ah,70h,73h,DFh
+# and continue for extended boot signature values 0,28h,29h,80h
+>>>>>>38	ubyte&0x56	=0		
+>>>>>>>28	ulelong		>0		\b, hidden sectors %u
+#>>>>>>>28	ulelong		=0		\b, hidden sectors %u (usual floppy)
+>>>>>>>32	ulelong		>0		\b, sectors %u (volumes > 32 MB) 
+#>>>>>>>32	ulelong		=0		\b, sectors %u (volumes > 32 MB)
+# FAT<32 bit specific 
+>>>>>>>82	string/c	!fat32		
+#>>>>>>>>36	ubyte		0x80		\b, physical drive 0x%x=0x80 (usual harddisk)
+#>>>>>>>>36	ubyte		0		\b, physical drive 0x%x=0 (usual floppy)
+>>>>>>>>36	ubyte		!0x80		
+>>>>>>>>>36	ubyte		!0		\b, physical drive 0x%x
+# VGA-copy CRC or
+# in Windows NT bit 0 is a dirty flag to request chkdsk at boot time. bit 1 requests surface scan too
+>>>>>>>>37	ubyte		>0		\b, reserved 0x%x
+#>>>>>>>>37	ubyte		=0		\b, reserved 0x%x
+# extended boot signatur value is 0x80 for NTFS, 0x28 or 0x29 for others
+>>>>>>>>38	ubyte		!0x29		\b, dos < 4.0 BootSector (0x%x)
+>>>>>>>>38	ubyte&0xFE	=0x28
+>>>>>>>>>39	ulelong		x		\b, serial number 0x%x
+>>>>>>>>38	ubyte		=0x29
+>>>>>>>>>43	string		<NO\ NAME	\b, label: "%11.11s"
+>>>>>>>>>43	string		>NO\ NAME	\b, label: "%11.11s"
+>>>>>>>>>43	string		=NO\ NAME	\b, unlabeled
+# there exist some old floppies without word FAT at offset 54
+# a word like "FATnm   " is only a hint for a FAT size on nm-bits
+# Normally the number of clusters is calculated by the values of BPP.
+# if it is small enough FAT is 12 bit, if it is too big enough FAT is 32 bit,
+# otherwise FAT is 16 bit.
+# http://homepage.ntlworld.com/jonathan.deboynepollard/FGA/determining-fat-widths.html
+>>>>>82		string/c	!fat32		
+>>>>>>54	string		FAT12		\b, FAT (12 bit)
+>>>>>>54	string		FAT16		\b, FAT (16 bit)
+>>>>>>54	default		x		
+# determinate FAT bit size by media descriptor
+# small floppies implies FAT12
+>>>>>>>21	ubyte		<0xF0		\b, FAT (12 bit by descriptor)
+# with media descriptor F0h floppy or maybe superfloppy with FAT16
+>>>>>>>21	ubyte		=0xF0		
+# superfloppy (many sectors) implies FAT16
+>>>>>>>>32	ulelong		>0xFFFF		\b, FAT (16 bit by descriptor+sectors)
+# no superfloppy with media descriptor F0h implies FAT12
+>>>>>>>>32	default		x		\b, FAT (12 bit by descriptor+sectors)
+# with media descriptor F8h floppy or hard disc with FAT12 or FAT16
+>>>>>>>21	ubyte		=0xF8		
+# 360 KiB with media descriptor F8h, 9 sectors per track ,single sided floppy implies FAT12
+>>>>>>>>19	ubequad	0xd002f80300090001	\b, FAT (12 bit by descriptor+geometry)
+# hard disc with FAT12 or FAT16
+>>>>>>>>19	default		x		\b, FAT (1Y bit by descriptor)
+# with media descriptor FAh floppy, RAM disc with FAT12 or FAT16 or Tandy hard disc
+>>>>>>>21	ubyte		=0xFA		
+# 320 KiB with media descriptor FAh, 8 sectors per track ,single sided floppy implies FAT12
+>>>>>>>>19	ubequad	0x8002fa0200080001	\b, FAT (12 bit by descriptor+geometry)
+# RAM disc with FAT12 or FAT16 or Tandy hard disc
+>>>>>>>>19	default		x		\b, FAT (1Y bit by descriptor)
+# others are floppy
+>>>>>>>21	default		x		\b, FAT (12 bit by descriptor)
+# FAT32 bit specific
+>>>>>82		string/c	fat32		\b, FAT (32 bit)
+>>>>>>36	ulelong		x		\b, sectors/FAT %u
+# http://technet.microsoft.com/en-us/library/cc977221.aspx
+>>>>>>40	uleshort	>0		\b, extension flags 0x%x
+#>>>>>>40	uleshort	=0		\b, extension flags %hu
+>>>>>>42	uleshort	>0		\b, fsVersion %u
+#>>>>>>42	uleshort	=0		\b, fsVersion %u (usual)
+>>>>>>44	ulelong		>2		\b, rootdir cluster %u
+#>>>>>>44	ulelong		=2		\b, rootdir cluster %u
+#>>>>>>44	ulelong		=1		\b, rootdir cluster %u
+>>>>>>48	uleshort	>1		\b, infoSector %u
+#>>>>>>48	uleshort	=1		\b, infoSector %u (usual)
+>>>>>>48	uleshort	<1		\b, infoSector %u
+# 0 or 0xFFFF instead of usual 6 means no backup sector
+>>>>>>50	uleshort	=0xFFFF		\b, no Backup boot sector
+>>>>>>50	uleshort	=0		\b, no Backup boot sector
+#>>>>>>50	uleshort	=6		\b, Backup boot sector %u (usual) 
+>>>>>>50	default		x		
+>>>>>>>50	uleshort	x		\b, Backup boot sector %u
+# corrected by Joerg Jenderek at Feb 2011 according to http://thestarman.pcministry.com/asm/mbr/MSWIN41.htm#FSINFO
+>>>>>>52	ulelong		>0		\b, reserved1 0x%x
+>>>>>>56	ulelong		>0		\b, reserved2 0x%x
+>>>>>>60	ulelong		>0		\b, reserved3 0x%x
+# same structure as FAT1X 
+#>>>>>>64	ubyte		=0x80		\b, physical drive 0x%x=80 (usual harddisk)
+#>>>>>>64	ubyte		=0		\b, physical drive 0x%x=0 (usual floppy)
+>>>>>>64	ubyte		!0x80		
+>>>>>>>64	ubyte		>0		\b, physical drive 0x%x
+# in Windows NT bit 0 is a dirty flag to request chkdsk at boot time. bit 1 requests surface scan too
+>>>>>>65	ubyte		>0		\b, reserved 0x%x
+>>>>>>66	ubyte		!0x29		\b, dos < 4.0 BootSector (0x%x)
+>>>>>>66	ubyte		=0x29
+>>>>>>>67	ulelong		x		\b, serial number 0x%x
+>>>>>>>71	string		<NO\ NAME	\b, label: "%11.11s"
+>>>>>>>71	string		>NO\ NAME	\b, label: "%11.11s"
+>>>>>>>71	string		=NO\ NAME	\b, unlabeled
+# additional tests for floppy image added by Joerg Jenderek
+# no fixed disk 
+>>>>>21		ubyte		!0xF8		
+# floppy media with 12 bit FAT
+>>>>>>54	string		!FAT16		
+# test for FAT after bootsector
+>>>>>>>(11.s)	ulelong&0x00ffffF0	0x00ffffF0	\b, followed by FAT
+# floppy image
+!:mime application/x-ima
+# NTFS specific added by Joerg Jenderek at Mar 2011 according to http://thestarman.pcministry.com/asm/mbr/NTFSBR.htm
+# and http://homepage.ntlworld.com/jonathan.deboynepollard/FGA/bios-parameter-block.html
+# 0 FATs
+>>>>>16	ubyte		=0		
+# 0 root entries
+>>>>>>17	uleshort	=0		
+# 0 DOS sectors
+>>>>>>>19	uleshort	=0		
+# 0 sectors/FAT
+# dos < 4.0 BootSector value found is 0x80
+#38	ubyte		=0x80			\b, dos < 4.0 BootSector (0x%x)
+>>>>>>>>22	uleshort	=0		\b; NTFS
+>>>>>>>>>24	uleshort	>0		\b, sectors/track %u
+>>>>>>>>>36	ulelong		!0x800080	\b, physical drive 0x%x
+>>>>>>>>>40	ulequad		>0		\b, sectors %lld
+>>>>>>>>>48	ulequad		>0		\b, $MFT start cluster %lld
+>>>>>>>>>56	ulequad		>0		\b, $MFTMirror start cluster %lld
+# Values 0 to 127 represent MFT record sizes of 0 to 127 clusters.
+# Values 128 to 255 represent MFT record sizes of 2^(256-N) bytes. 
+>>>>>>>>>64	lelong		<256		
+>>>>>>>>>>64	lelong		<128		\b, clusters/RecordSegment %d
+>>>>>>>>>>64	ubyte		>127		\b, bytes/RecordSegment 2^(-1*%i)
+# Values 0 to 127 represent index block sizes of 0 to 127 clusters.
+# Values 128 to 255 represent index block sizes of 2^(256-N) byte
+>>>>>>>>>68	ulelong		<256		
+>>>>>>>>>>68	ulelong		<128		\b, clusters/index block %d
+#>>>>>>>>>>68	ulelong		>127		\b, bytes/index block 2^(256-%d)
+>>>>>>>>>>68	ubyte		>127		\b, bytes/index block 2^(-1*%i)
+>>>>>>>>>72	ulequad		x		\b, serial number 0%llx
+>>>>>>>>>80	ulelong		>0		\b, checksum 0x%x
+#>>>>>>>>>80	ulelong		=0		\b, checksum 0x%x=0 (usual)
+>>>>>>>>>0x258	ulelong&0x00009090	=0x00009090	
+>>>>>>>>>>&-92		indirect	x	\b; contains 
+# For 2nd NTFS sector added by Joerg Jenderek at Jan 2013
+# http://thestarman.pcministry.com/asm/mbr/NTFSbrHexEd.htm
+# unused assembler instructions JMP y2;NOP;NOP
+0x056		ulelong&0xFFFF0FFF	0x909002EB	
+# unicode loadername terminated by CTRL-D
+>(0.s*2)	ulelong&0xFFFFFF00	0x00040000		
+# loadernames are NTLDR,CMLDR,PELDR,$LDR$ or BOOTMGR
+>>0x002		lestring16	x	Microsoft Windows XP/VISTA bootloader %-5.5s
+>>0x12		string		$	
+>>>0x0c		lestring16	x	\b%-2.2s
+### DOS,NTFS boot sectors end
+
+9564	lelong		0x00011954	Unix Fast File system [v1] (little-endian),
+>8404	string		x		last mounted on %s,
+#>9504	ledate		x		last checked at %s,
+>8224	ledate		x		last written at %s,
+>8401	byte		x		clean flag %d,
+>8228	lelong		x		number of blocks %d,
+>8232	lelong		x		number of data blocks %d,
+>8236	lelong		x		number of cylinder groups %d,
+>8240	lelong		x		block size %d,
+>8244	lelong		x		fragment size %d,
+>8252	lelong		x		minimum percentage of free blocks %d,
+>8256	lelong		x		rotational delay %dms,
+>8260	lelong		x		disk rotational speed %drps,
+>8320	lelong		0		TIME optimization
+>8320	lelong		1		SPACE optimization
+
+42332	lelong		0x19540119	Unix Fast File system [v2] (little-endian)
+>&-1164	string		x		last mounted on %s,
+>&-696	string		>\0		volume name %s,
+>&-304	leqldate	x		last written at %s,
+>&-1167	byte		x		clean flag %d,
+>&-1168	byte		x		readonly flag %d,
+>&-296	lequad		x		number of blocks %lld,
+>&-288	lequad		x		number of data blocks %lld,
+>&-1332	lelong		x		number of cylinder groups %d,
+>&-1328	lelong		x		block size %d,
+>&-1324	lelong		x		fragment size %d,
+>&-180	lelong		x		average file size %d,
+>&-176	lelong		x		average number of files in dir %d,
+>&-272	lequad		x		pending blocks to free %lld,
+>&-264	lelong		x		pending inodes to free %d,
+>&-664	lequad		x		system-wide uuid %0llx,
+>&-1316	lelong		x		minimum percentage of free blocks %d,
+>&-1248	lelong		0		TIME optimization
+>&-1248	lelong		1		SPACE optimization
+
+66908	lelong		0x19540119	Unix Fast File system [v2] (little-endian)
+>&-1164	string		x		last mounted on %s,
+>&-696	string		>\0		volume name %s,
+>&-304	leqldate	x		last written at %s,
+>&-1167	byte		x		clean flag %d,
+>&-1168	byte		x		readonly flag %d,
+>&-296	lequad		x		number of blocks %lld,
+>&-288	lequad		x		number of data blocks %lld,
+>&-1332	lelong		x		number of cylinder groups %d,
+>&-1328	lelong		x		block size %d,
+>&-1324	lelong		x		fragment size %d,
+>&-180	lelong		x		average file size %d,
+>&-176	lelong		x		average number of files in dir %d,
+>&-272	lequad		x		pending blocks to free %lld,
+>&-264	lelong		x		pending inodes to free %d,
+>&-664	lequad		x		system-wide uuid %0llx,
+>&-1316	lelong		x		minimum percentage of free blocks %d,
+>&-1248	lelong		0		TIME optimization
+>&-1248	lelong		1		SPACE optimization
+
+9564	belong		0x00011954	Unix Fast File system [v1] (big-endian),
+>7168   belong		0x4c41424c	Apple UFS Volume
+>>7186  string		x		named %s,
+>>7176  belong		x		volume label version %d,
+>>7180  bedate		x		created on %s,
+>8404	string		x		last mounted on %s,
+#>9504	bedate		x		last checked at %s,
+>8224	bedate		x		last written at %s,
+>8401	byte		x		clean flag %d,
+>8228	belong		x		number of blocks %d,
+>8232	belong		x		number of data blocks %d,
+>8236	belong		x		number of cylinder groups %d,
+>8240	belong		x		block size %d,
+>8244	belong		x		fragment size %d,
+>8252	belong		x		minimum percentage of free blocks %d,
+>8256	belong		x		rotational delay %dms,
+>8260	belong		x		disk rotational speed %drps,
+>8320	belong		0		TIME optimization
+>8320	belong		1		SPACE optimization
+
+42332	belong		0x19540119	Unix Fast File system [v2] (big-endian)
+>&-1164	string		x		last mounted on %s,
+>&-696	string		>\0		volume name %s,
+>&-304	beqldate	x		last written at %s,
+>&-1167	byte		x		clean flag %d,
+>&-1168	byte		x		readonly flag %d,
+>&-296	bequad		x		number of blocks %lld,
+>&-288	bequad		x		number of data blocks %lld,
+>&-1332	belong		x		number of cylinder groups %d,
+>&-1328	belong		x		block size %d,
+>&-1324	belong		x		fragment size %d,
+>&-180	belong		x		average file size %d,
+>&-176	belong		x		average number of files in dir %d,
+>&-272	bequad		x		pending blocks to free %lld,
+>&-264	belong		x		pending inodes to free %d,
+>&-664	bequad		x		system-wide uuid %0llx,
+>&-1316	belong		x		minimum percentage of free blocks %d,
+>&-1248	belong		0		TIME optimization
+>&-1248	belong		1		SPACE optimization
+
+66908	belong		0x19540119	Unix Fast File system [v2] (big-endian)
+>&-1164	string		x		last mounted on %s,
+>&-696	string		>\0		volume name %s,
+>&-304	beqldate	x		last written at %s,
+>&-1167	byte		x		clean flag %d,
+>&-1168	byte		x		readonly flag %d,
+>&-296	bequad		x		number of blocks %lld,
+>&-288	bequad		x		number of data blocks %lld,
+>&-1332	belong		x		number of cylinder groups %d,
+>&-1328	belong		x		block size %d,
+>&-1324	belong		x		fragment size %d,
+>&-180	belong		x		average file size %d,
+>&-176	belong		x		average number of files in dir %d,
+>&-272	bequad		x		pending blocks to free %lld,
+>&-264	belong		x		pending inodes to free %d,
+>&-664	bequad		x		system-wide uuid %0llx,
+>&-1316	belong		x		minimum percentage of free blocks %d,
+>&-1248	belong		0		TIME optimization
+>&-1248	belong		1		SPACE optimization
+
+# ext2/ext3 filesystems - Andreas Dilger <adilger@dilger.ca>
+# ext4 filesystem - Eric Sandeen <sandeen@sandeen.net>
+# volume label and UUID Russell Coker
+# http://etbe.coker.com.au/2008/07/08/label-vs-uuid-vs-device/
+0x438   leshort         0xEF53          Linux
+>0x44c  lelong          x               rev %d
+>0x43e  leshort         x               \b.%d
+# No journal?  ext2
+>0x45c  lelong          ^0x0000004      ext2 filesystem data
+>>0x43a leshort         ^0x0000001      (mounted or unclean)
+# Has a journal?  ext3 or ext4
+>0x45c  lelong          &0x0000004
+#  and small INCOMPAT?
+>>0x460 lelong          <0x0000040
+#   and small RO_COMPAT?
+>>>0x464 lelong         <0x0000008      ext3 filesystem data
+#   else large RO_COMPAT?
+>>>0x464 lelong         >0x0000007      ext4 filesystem data
+#  else large INCOMPAT?
+>>0x460	lelong          >0x000003f      ext4 filesystem data
+>0x468	belong		x		\b, UUID=%08x
+>0x46c	beshort		x		\b-%04x
+>0x46e	beshort		x		\b-%04x
+>0x470	beshort		x		\b-%04x
+>0x472	belong		x		\b-%08x
+>0x476	beshort		x		\b%04x
+>0x478	string		>0		\b, volume name "%s"
+# General flags for any ext* fs
+>0x460	lelong          &0x0000004      (needs journal recovery)
+>0x43a	leshort         &0x0000002      (errors)
+# INCOMPAT flags
+>0x460	lelong          &0x0000001      (compressed)
+#>0x460	lelong          &0x0000002      (filetype)
+#>0x460	lelong          &0x0000010      (meta bg)
+>0x460	lelong          &0x0000040      (extents)
+>0x460	lelong          &0x0000080      (64bit)
+#>0x460	lelong          &0x0000100      (mmp)
+#>0x460	lelong          &0x0000200      (flex bg)
+# RO_INCOMPAT flags
+#>0x464	lelong          &0x0000001      (sparse super)
+>0x464	lelong          &0x0000002      (large files)
+>0x464	lelong          &0x0000008      (huge files)
+#>0x464	lelong          &0x0000010      (gdt checksum)
+#>0x464	lelong          &0x0000020      (many subdirs)
+#>0x463	lelong          &0x0000040      (extra isize)
+
+# Minix filesystems - Juan Cespedes <cespedes@debian.org>
+0x410	leshort		0x137f
+!:strength / 2
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V1, %d zones
+>0x1e	string		minix		\b, bootable
+0x410	beshort		0x137f
+!:strength / 2
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V1 (big endian), %d zones
+>0x1e	string		minix		\b, bootable
+0x410	leshort		0x138f
+!:strength / 2
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V1, 30 char names, %d zones
+>0x1e	string		minix		\b, bootable
+0x410	beshort		0x138f
+!:strength / 2
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V1, 30 char names (big endian), %d zones
+>0x1e	string		minix		\b, bootable
+0x410	leshort		0x2468
+>0x402	beshort		< 100
+>>0x402	beshort		> -1		Minix filesystem, V2, %d zones
+>0x1e	string		minix		\b, bootable
+0x410	beshort		0x2468
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V2 (big endian), %d zones
+>0x1e	string		minix		\b, bootable
+
+0x410	leshort		0x2478
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V2, 30 char names, %d zones
+>0x1e	string		minix		\b, bootable
+0x410	leshort		0x2478
+>0x402	beshort		< 100
+>0x402	beshort		> -1		Minix filesystem, V2, 30 char names, %d zones
+>0x1e	string		minix		\b, bootable
+0x410	beshort		0x2478
+>0x402	beshort		!0		Minix filesystem, V2, 30 char names (big endian), %d zones
+>0x1e	string		minix		\b, bootable
+0x410	leshort		0x4d5a
+>0x402	beshort		!0		Minix filesystem, V3, %d zones
+>0x1e	string		minix		\b, bootable
+
+# SGI disk labels - Nathan Scott <nathans@debian.org>
+0	belong		0x0BE5A941	SGI disk label (volume header)
+
+# SGI XFS filesystem - Nathan Scott <nathans@debian.org>
+0	belong		0x58465342	SGI XFS filesystem data
+>0x4	belong		x		(blksz %d,
+>0x68	beshort		x		inosz %d,
+>0x64	beshort		^0x2004		v1 dirs)
+>0x64	beshort		&0x2004		v2 dirs)
+
+############################################################################
+# Minix-ST kernel floppy
+0x800	belong		0x46fc2700	Atari-ST Minix kernel image
+# http://en.wikipedia.org/wiki/BIOS_parameter_block
+# floppies with valid BPB and any instruction at beginning
+>19	string		\240\005\371\005\0\011\0\2\0	\b, 720k floppy
+>19	string		\320\002\370\005\0\011\0\1\0	\b, 360k floppy
+
+############################################################################
+# Hmmm, is this a better way of detecting _standard_ floppy images ?
+19	string		\320\002\360\003\0\011\0\1\0	DOS floppy 360k
+>0x1FE	leshort		0xAA55		\b, DOS/MBR hard disk boot sector
+19	string		\240\005\371\003\0\011\0\2\0	DOS floppy 720k
+>0x1FE	leshort		0xAA55		\b, DOS/MBR hard disk boot sector
+19	string		\100\013\360\011\0\022\0\2\0	DOS floppy 1440k
+>0x1FE	leshort		0xAA55		\b, DOS/MBR hard disk boot sector
+
+19	string		\240\005\371\005\0\011\0\2\0	DOS floppy 720k, IBM
+>0x1FE	leshort		0xAA55		\b, DOS/MBR hard disk boot sector
+19	string		\100\013\371\005\0\011\0\2\0	DOS floppy 1440k, mkdosfs
+>0x1FE	leshort		0xAA55		\b, DOS/MBR hard disk boot sector
+
+19	string		\320\002\370\005\0\011\0\1\0	Atari-ST floppy 360k
+19	string		\240\005\371\005\0\011\0\2\0	Atari-ST floppy 720k
+#			|       |   |     |     |
+#			|       |   |     |     heads
+#			|       |   |     sectors/track
+#			|       |   sectors/FAT
+#			|       media descriptor
+#		BPB:	sectors
+
+#  Valid media descriptor bytes for MS-DOS:
+#
+#     Byte   Capacity   Media Size and Type
+#     -------------------------------------------------
+#
+#     F0     2.88 MB    3.5-inch, 2-sided, 36-sector
+#     F0     1.44 MB    3.5-inch, 2-sided, 18-sector
+#     F9     720K       3.5-inch, 2-sided, 9-sector
+#     F9     1.2 MB     5.25-inch, 2-sided, 15-sector
+#     FD     360K       5.25-inch, 2-sided, 9-sector
+#     FF     320K       5.25-inch, 2-sided, 8-sector
+#     FC     180K       5.25-inch, 1-sided, 9-sector
+#     FE     160K       5.25-inch, 1-sided, 8-sector
+#     FE     250K       8-inch, 1-sided, single-density
+#     FD     500K       8-inch, 2-sided, single-density
+#     FE     1.2 MB     8-inch, 2-sided, double-density
+#     F8     -----      Fixed disk 
+#
+#     FC     xxxK       Apricot 70x1x9 boot disk.
+#
+# Originally a bitmap:
+#  xxxxxxx0	Not two sided
+#  xxxxxxx1	Double sided
+#  xxxxxx0x	Not 8 SPT
+#  xxxxxx1x	8 SPT
+#  xxxxx0xx	Not Removable drive
+#  xxxxx1xx	Removable drive
+#  11111xxx	Must be one.
+#
+# But now it's rather random:
+#  111111xx	Low density disk
+#        00	SS, Not 8 SPT
+#        01	DS, Not 8 SPT
+#        10	SS, 8 SPT
+#        11	DS, 8 SPT
+#
+#  11111001	Double density 3 1/2 floppy disk, high density 5 1/4
+#  11110000	High density 3 1/2 floppy disk
+#  11111000	Hard disk any format
+#
+
+# all FAT12 (strength=70) floppies with sectorsize 512 added by Joerg Jenderek at Jun 2013
+# http://en.wikipedia.org/wiki/File_Allocation_Table#Exceptions
+# Too Weak.
+#512		ubelong&0xE0ffff00	0xE0ffff00		
+# without valid Media descriptor in place of BPB, cases with are done at other places
+#>21		ubyte			<0xE5			floppy with old FAT filesystem
+# but valid Media descriptor at begin of FAT
+#>>512		ubyte			=0xed			720k
+#>>512		ubyte			=0xf0			1440k
+#>>512		ubyte			=0xf8			720k
+#>>512		ubyte			=0xf9			1220k
+#>>512		ubyte			=0xfa			320k
+#>>512		ubyte			=0xfb			640k
+#>>512		ubyte			=0xfc			180k
+# look like an an old DOS directory entry
+#>>>0xA0E	ubequad			0			
+#>>>>0xA00	ubequad			!0			
+#!:mime application/x-ima
+#>>512		ubyte			=0xfd			
+# look for 2nd FAT at different location to distinguish between 360k and 500k
+#>>>0x600	ubelong&0xE0ffff00	0xE0ffff00		360k
+#>>>0x500	ubelong&0xE0ffff00	0xE0ffff00		500k
+#>>>0xA0E	ubequad			0			
+#!:mime application/x-ima
+#>>512		ubyte			=0xfe			
+#>>>0x400	ubelong&0xE0ffff00	0xE0ffff00		160k
+#>>>>0x60E	ubequad			0			
+#>>>>>0x600	ubequad			!0			
+#!:mime application/x-ima
+#>>>0xC00	ubelong&0xE0ffff00	0xE0ffff00		1200k
+#>>512		ubyte			=0xff			320k
+#>>>0x60E	ubequad			0			
+#>>>>0x600	ubequad			!0			
+#!:mime application/x-ima
+#>>512		ubyte			x			\b, Media descriptor 0x%x
+# without x86 jump instruction
+#>>0		ulelong&0x804000E9	!0x000000E9		
+# assembler instructions: CLI;MOV SP,1E7;MOV AX;07c0;MOV 	
+#>>>0	ubequad				0xfabce701b8c0078e	\b, MS-DOS 1.12 bootloader
+# IOSYS.COM+MSDOS.COM
+#>>>>0xc4	use			2xDOS-filename
+#>>0		ulelong&0x804000E9	=0x000000E9	
+# only x86 short jump instruction found
+#>>>0		ubyte			=0xEB
+#>>>>1		ubyte			x			\b, code offset 0x%x+2
+# http://thestarman.pcministry.com/DOS/ibm100/Boot.htm
+# assembler instructions: CLI;MOV AX,CS;MOV DS,AX;MOV DX,0		
+#>>>>(1.b+2)	ubequad			0xfa8cc88ed8ba0000	\b, PC-DOS 1.0 bootloader 
+# ibmbio.com+ibmdos.com
+#>>>>>0x176	use			DOS-filename
+#>>>>>0x181	ubyte			x			\b+
+#>>>>>0x182	use			DOS-filename
+# http://thestarman.pcministry.com/DOS/ibm110/Boot.htm
+# assembler instructions: CLI;MOV AX,CS;MOV DS,AX;XOR DX,DX;MOV		
+#>>>>(1.b+2)	ubequad			0xfa8cc88ed833d28e	\b, PC-DOS 1.1 bootloader 
+# ibmbio.com+ibmdos.com
+#>>>>>0x18b	use			DOS-filename
+#>>>>>0x196	ubyte			x			\b+
+#>>>>>0x197	use			DOS-filename
+# http://en.wikipedia.org/wiki/Zenith_Data_Systems
+# assembler instructions: MOV BX,07c0;MOV SS,BX;MOV SP,01c6		
+#>>>>(1.b+2)	ubequad			0xbbc0078ed3bcc601	\b, Zenith Data Systems MS-DOS 1.25 bootloader
+# IO.SYS+MSDOS.SYS
+#>>>>>0x20	use			2xDOS-filename
+# http://en.wikipedia.org/wiki/Corona_Data_Systems
+# assembler instructions: MOV AX,CS;MOV DS,AX;CLI;MOV SS,AX;		
+#>>>>(1.b+2)	ubequad			0x8cc88ed8fa8ed0bc	\b, MS-DOS 1.25 bootloader
+# IO.SYS+MSDOS.SYS
+#>>>>>0x69	use			2xDOS-filename
+# assembler instructions: CLI;PUSH CS;POP SS;MOV SP,7c00;		
+#>>>>(1.b+2)	ubequad			0xfa0e17bc007cb860	\b, MS-DOS 2.11 bootloader
+# defect IO.SYS+MSDOS.SYS ?
+#>>>>>0x162	use			2xDOS-filename
+
+0	name				cdrom
+>38913	string   !NSR0      ISO 9660 CD-ROM filesystem data
+!:mime	application/x-iso9660-image
+>38913	string    NSR0      UDF filesystem data
+!:mime	application/x-iso9660-image
+>>38917	string    1         (version 1.0)
+>>38917	string    2         (version 1.5)
+>>38917	string    3         (version 2.0)
+>>38917	byte     >0x33      (unknown version, ID 0x%X)
+>>38917	byte     <0x31      (unknown version, ID 0x%X)
+>0x1FE	leshort  0xAA55     (DOS/MBR boot sector)
+# "application id" which appears to be used as a volume label
+>32808	string/T  >\0       '%s'
+>34816	string    \000CD001\001EL\ TORITO\ SPECIFICATION    (bootable)
+37633	string    CD001     ISO 9660 CD-ROM filesystem data (raw 2352 byte sectors)
+!:mime	application/x-iso9660-image
+32777	string    CDROM     High Sierra CD-ROM filesystem data
+
+# CDROM Filesystems
+# https://en.wikipedia.org/wiki/ISO_9660
+# Modified for UDF by gerardo.cacciari@gmail.com
+32769	string    CD001
+# mime line at that position does not work
+# to display CD-ROM (70=81-11) after MBR (113=40+72+1), partition-table (71=50+21) and before Apple Driver Map (51)
+!:strength -11
+# to display CD-ROM (114=81+33) before MBR (113=40+72+1), partition-table (71=50+21) and Apple Driver Map (51)
+# does not work
+#!:strength +33
+>0	use cdrom
+
+# .cso files
+0    string    CISO	Compressed ISO CD image
+
+# cramfs filesystem - russell@coker.com.au
+0       lelong    0x28cd3d45      Linux Compressed ROM File System data, little endian
+>4      lelong  x size %u
+>8      lelong  &1 version #2
+>8      lelong  &2 sorted_dirs
+>8      lelong  &4 hole_support
+>32     lelong  x CRC 0x%x,
+>36     lelong  x edition %u,
+>40     lelong  x %u blocks,
+>44     lelong  x %u files
+
+0       belong    0x28cd3d45      Linux Compressed ROM File System data, big endian
+>4      belong  x size %u
+>8      belong  &1 version #2
+>8      belong  &2 sorted_dirs
+>8      belong  &4 hole_support
+>32     belong  x CRC 0x%x,
+>36     belong  x edition %u,
+>40     belong  x %u blocks,
+>44     belong  x %u files
+
+# reiserfs - russell@coker.com.au
+0x10034		string	ReIsErFs	ReiserFS V3.5
+0x10034		string	ReIsEr2Fs	ReiserFS V3.6
+0x10034		string	ReIsEr3Fs	ReiserFS V3.6.19
+>0x1002c 	leshort	x		block size %d
+>0x10032	leshort	&2		(mounted or unclean)
+>0x10000	lelong	x		num blocks %d
+>0x10040	lelong	1		tea hash
+>0x10040	lelong	2		yura hash
+>0x10040	lelong	3		r5 hash
+
+# JFFS - russell@coker.com.au
+0	lelong	0x34383931	Linux Journalled Flash File system, little endian
+0	belong	0x34383931	Linux Journalled Flash File system, big endian
+
+# EST flat binary format (which isn't, but anyway)
+# From: Mark Brown <broonie@sirena.org.uk>
+0	string	ESTFBINR	EST flat binary
+
+# Aculab VoIP firmware
+# From: Mark Brown <broonie@sirena.org.uk>
+0	string	VoIP\ Startup\ and	Aculab VoIP firmware
+>35	string	x	format %s
+
+# From: Mark Brown <broonie@sirena.org.uk> [old]
+# From: Behan Webster <behanw@websterwood.com>
+0	belong	0x27051956	u-boot legacy uImage,
+>32	string	x		%s,
+>28	byte	0		Invalid os/
+>28	byte	1		OpenBSD/
+>28	byte	2		NetBSD/
+>28	byte	3		FreeBSD/
+>28	byte	4		4.4BSD/
+>28	byte	5		Linux/
+>28	byte	6		SVR4/
+>28	byte	7		Esix/
+>28	byte	8		Solaris/
+>28	byte	9		Irix/
+>28	byte	10		SCO/
+>28	byte	11		Dell/
+>28	byte	12		NCR/
+>28	byte	13		LynxOS/
+>28	byte	14		VxWorks/
+>28	byte	15		pSOS/
+>28	byte	16		QNX/
+>28	byte	17		Firmware/
+>28	byte	18		RTEMS/
+>28	byte	19		ARTOS/
+>28	byte	20		Unity OS/
+>28	byte	21		INTEGRITY/
+>29	byte	0		\bInvalid CPU,
+>29	byte	1		\bAlpha,
+>29	byte	2		\bARM,
+>29	byte	3		\bIntel x86,
+>29	byte	4		\bIA64,
+>29	byte	5		\bMIPS,
+>29	byte	6		\bMIPS 64-bit,
+>29	byte	7		\bPowerPC,
+>29	byte	8		\bIBM S390,
+>29	byte	9		\bSuperH,
+>29	byte	10		\bSparc,
+>29	byte	11		\bSparc 64-bit,
+>29	byte	12		\bM68K,
+>29	byte	13		\bNios-32,
+>29	byte	14		\bMicroBlaze,
+>29	byte	15		\bNios-II,
+>29	byte	16		\bBlackfin,
+>29	byte	17		\bAVR32,
+>29	byte	18		\bSTMicroelectronics ST200,
+>30	byte	0		Invalid Image
+>30	byte	1		Standalone Program
+>30	byte	2		OS Kernel Image
+>30	byte	3		RAMDisk Image
+>30	byte	4		Multi-File Image
+>30	byte	5		Firmware Image
+>30	byte	6		Script File
+>30	byte	7		Filesystem Image (any type)
+>30	byte	8		Binary Flat Device Tree BLOB
+>31	byte	0		(Not compressed),
+>31	byte	1		(gzip),
+>31	byte	2		(bzip2),
+>31	byte	3		(lzma),
+>12	belong	x		%d bytes,
+>8	bedate	x		%s,
+>16	belong	x		Load Address: 0x%08X,
+>20	belong	x		Entry Point: 0x%08X,
+>4	belong	x		Header CRC: 0x%08X,
+>24	belong	x		Data CRC: 0x%08X
+
+# JFFS2 file system
+0	leshort	0x1984		Linux old jffs2 filesystem data little endian
+0	leshort	0x1985		Linux jffs2 filesystem data little endian
+
+# Squashfs
+0	string	sqsh	Squashfs filesystem, big endian,
+>28	beshort	x	version %d.
+>30	beshort x	\b%d,
+>28	beshort <3
+>>8	belong	x	%d bytes,
+>28	beshort >2
+>>28 beshort <4
+>>>63	bequad x	%lld bytes,
+>>28 beshort >3
+>>>40	bequad x	%lld bytes,
+#>>67	belong	x	%d bytes,
+>4	belong	x	%d inodes,
+>28	beshort <2
+>>32	beshort	x	blocksize: %d bytes,
+>28	beshort >1
+>>28 beshort <4
+>>>51	belong	x	blocksize: %d bytes,
+>>28 beshort >3
+>>>12	belong	x	blocksize: %d bytes,
+>28 beshort <4
+>>39	bedate	x	created: %s
+>28 beshort >3
+>>8	bedate	x	created: %s
+0	string	hsqs	Squashfs filesystem, little endian,
+>28	leshort	x	version %d.
+>30	leshort	x	\b%d,
+>28	leshort <3
+>>8	lelong	x	%d bytes,
+>28	leshort >2
+>>28 leshort <4
+>>>63	lequad x	%lld bytes,
+>>28 leshort >3
+>>>40	lequad x	%lld bytes,
+#>>63	lelong	x	%d bytes,
+>4	lelong	x	%d inodes,
+>28	leshort <2
+>>32	leshort	x	blocksize: %d bytes,
+>28	leshort >1
+>>28 leshort <4
+>>>51	lelong	x	blocksize: %d bytes,
+>>28 leshort >3
+>>>12	lelong	x	blocksize: %d bytes,
+>28 leshort <4
+>>39	ledate	x	created: %s
+>28 leshort >3
+>>8	ledate	x	created: %s
+
+# AFS Dump Magic
+# From: Ty Sarna <tsarna@sarna.org> 
+0       string                  \x01\xb3\xa1\x13\x22    AFS Dump
+>&0     belong                  x                       (v%d)
+>>&0    byte                    0x76
+>>>&0   belong                  x                       Vol %d,
+>>>>&0  byte                    0x6e
+>>>>>&0 string                  x                       %s
+>>>>>>&1        byte            0x74
+>>>>>>>&0       beshort         2
+>>>>>>>>&4      bedate          x                       on: %s
+>>>>>>>>&0      bedate          =0                      full dump
+>>>>>>>>&0      bedate          !0                      incremental since: %s
+
+#----------------------------------------------------------
+#delta ISO    Daniel Novotny (dnovotny@redhat.com)
+0	string  DISO	Delta ISO data
+!:strength +50
+>4	belong  x	version %d
+
+# VMS backup savesets - gerardo.cacciari@gmail.com
+#
+4            string  \x01\x00\x01\x00\x01\x00
+>(0.s+16)    string  \x01\x01
+>>&(&0.b+8)  byte    0x42       OpenVMS backup saveset data
+>>>40        lelong  x          (block size %d,
+>>>49        string  >\0        original name '%s',
+>>>2         short   1024       VAX generated)
+>>>2         short   2048       AXP generated)
+>>>2         short   4096       I64 generated)
+
+# Summary: Oracle Clustered Filesystem
+# Created by: Aaron Botsis <redhat@digitalmafia.org>
+8	string		OracleCFS	Oracle Clustered Filesystem,
+>4	long		x		rev %d
+>0	long		x		\b.%d,
+>560	string		x		label: %.64s,
+>136	string		x		mountpoint: %.128s
+
+# Summary: Oracle ASM tagged volume
+# Created by: Aaron Botsis <redhat@digitalmafia.org>
+32	string		ORCLDISK	Oracle ASM Volume,
+>40	string		x		Disk Name: %0.12s
+32	string		ORCLCLRD	Oracle ASM Volume (cleared),
+>40	string		x		Disk Name: %0.12s
+
+# Oracle Clustered Filesystem - Aaron Botsis <redhat@digitalmafia.org>
+8	string		OracleCFS	Oracle Clustered Filesystem,
+>4	long		x		rev %d
+>0	long		x		\b.%d,
+>560	string		x		label: %.64s,
+>136	string		x		mountpoint: %.128s
+
+# Oracle ASM tagged volume - Aaron Botsis <redhat@digitalmafia.org>
+32	string		ORCLDISK	Oracle ASM Volume,
+>40	string		x		Disk Name: %0.12s
+32	string		ORCLCLRD	Oracle ASM Volume (cleared),
+>40	string		x		Disk Name: %0.12s
+
+# Compaq/HP RILOE floppy image
+# From: Dirk Jagdmann <doj@cubic.org>
+0	string	CPQRFBLO	Compaq/HP RILOE floppy image
+
+#------------------------------------------------------------------------------
+# Files-11 On-Disk Structure (File system for various RSX-11 and VMS flavours).
+# These bits come from LBN 1 (home block) of ODS-1, ODS-2 and ODS-5 volumes,
+# which is mapped to VBN 2 of [000000]INDEXF.SYS;1 - gerardo.cacciari@gmail.com
+#
+1008    string          DECFILE11       Files-11 On-Disk Structure
+>525    byte            x               (ODS-%d);
+>1017   string          A               RSX-11, VAX/VMS or OpenVMS VAX file system;
+>1017   string          B
+>>525   byte            2               VAX/VMS or OpenVMS file system;
+>>525   byte            5               OpenVMS Alpha or Itanium file system;
+>984    string          x               volume label is '%-12.12s'
+
+# From: Thomas Klausner <wiz@NetBSD.org>
+# http://filext.com/file-extension/DAA
+# describes the daa file format. The magic would be:
+0	string		DAA\x0\x0\x0\x0\x0	PowerISO Direct-Access-Archive
+
+# From Albert Cahalan <acahalan@gmail.com>
+# really le32 operation,destination,payloadsize (but quite predictable)
+# 01 00 00 00 00 00 00 c0 00 02 00 00
+0	string		\1\0\0\0\0\0\0\300\0\2\0\0	Marvell Libertas firmware
+
+# From Eric Sandeen
+# GFS2
+0x10000         belong          0x01161970
+>0x10018        belong          0x0000051d      GFS1 Filesystem
+>>0x10024        belong          x               (blocksize %d,
+>>0x10060        string          >\0             lockproto %s)
+>0x10018        belong          0x00000709      GFS2 Filesystem
+>>0x10024        belong          x               (blocksize %d,
+>>0x10060        string          >\0             lockproto %s)
+
+# BTRFS
+0x10040         string          _BHRfS_M        BTRFS Filesystem
+>0x1012b        string          >\0             (label "%s",
+>0x10090        lelong          x               sectorsize %d,
+>0x10094        lelong          x               nodesize %d,
+>0x10098        lelong          x               leafsize %d)
+
+
+# dvdisaster's .ecc
+# From: "Nelson A. de Oliveira" <naoliv@gmail.com>
+0	string	*dvdisaster*	dvdisaster error correction file
+
+# xfs metadump image 
+# mb_magic XFSM at 0; superblock magic XFSB at 1 << mb_blocklog
+# but can we do the << ?  For now it's always 512 (0x200) anyway.
+0	string XFSM
+>0x200	string XFSB	XFS filesystem metadump image
+
+# Type:	CROM filesystem
+# From:	Werner Fink <werner@suse.de>
+0	string	CROMFS	CROMFS
+>6	string	>\0	\b version %2.2s,
+>8	ulequad	>0	\b block data at %lld,
+>16	ulequad	>0	\b fblock table at %lld,
+>24	ulequad	>0	\b inode table at %lld,
+>32	ulequad	>0	\b root at %lld,
+>40	ulelong	>0	\b fblock size = %d,
+>44	ulelong	>0	\b block size = %d,
+>48	ulequad	>0	\b bytes = %lld
+
+# Type:	xfs metadump image
+# From:	Daniel Novotny <dnovotny@redhat.com>
+# mb_magic XFSM at 0; superblock magic XFSB at 1 << mb_blocklog
+# but can we do the << ? For now it's always 512 (0x200) anyway.
+0	string	XFSM
+>0x200	string	XFSB	XFS filesystem metadump image
+
+# Type:	delta ISO
+# From:	Daniel Novotny <dnovotny@redhat.com>
+0	string	DISO	Delta ISO data,
+>4	belong	x	version %d
+
+# JFS2 (Journaling File System) image. (Old JFS1 has superblock at 0x1000.)
+# See linux/fs/jfs/jfs_superblock.h for layout; see jfs_filsys.h for flags.
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+0x8000	string	JFS1
+# Because it's text-only magic, check a binary value (version) to be sure.
+# Should always be 2, but mkfs.jfs writes it as 1. Needs to be 2 or 1 to be
+# mountable.
+>&0	lelong	<3	JFS2 filesystem image
+# Label is followed by a UUID; we have to limit string length to avoid
+# appending the UUID in the case of a 16-byte label.
+>>&144	regex	[\x20-\x7E]{1,16}	(label "%s")
+>>&0	lequad	x	\b, %lld blocks
+>>&8	lelong	x	\b, blocksize %d
+>>&32	lelong&0x00000006	>0	(dirty)
+>>&36	lelong	>0	(compressed)
+
+# LFS
+0	lelong	0x070162	LFS filesystem image
+>4	lelong	1		version 1,
+>>8	lelong	x		\b blocks %u,
+>>12	lelong	x		\b blocks per segment %u,
+>4	lelong	2		version 2,
+>>8	lelong	x		\b fragments %u,
+>>12	lelong	x		\b bytes per segment %u,
+>16	lelong	x		\b disk blocks %u,
+>20	lelong	x		\b block size %u,
+>24	lelong	x		\b fragment size %u,
+>28	lelong	x		\b fragments per block %u,
+>32	lelong	x		\b start for free list %u,
+>36	lelong	x		\b number of free blocks %d,
+>40	lelong	x		\b number of files %u,
+>44	lelong	x		\b blocks available for writing %d,
+>48	lelong	x		\b inodes in cache %d,
+>52	lelong	x		\b inode file disk address 0x%x,
+>56	lelong	x		\b inode file inode number %u,
+>60	lelong	x		\b address of last segment written 0x%x,
+>64	lelong	x		\b address of next segment to write 0x%x,
+>68	lelong	x		\b address of current segment written 0x%x
+
+0	string	td\000		floppy image data (TeleDisk, compressed)
+0	string	TD\000		floppy image data (TeleDisk)
+
+0	string	CQ\024		floppy image data (CopyQM, 
+>16	leshort	x		%d sectors, 
+>18	leshort	x		%d heads.)
+
+0	string	ACT\020Apricot\020disk\020image\032\004	floppy image data (ApriDisk)
+
+0	beshort	0xAA58		floppy image data (IBM SaveDskF, old)
+0	beshort	0xAA59		floppy image data (IBM SaveDskF)
+0	beshort	0xAA5A		floppy image data (IBM SaveDskF, compressed)
+
+0	string	\074CPM_Disk\076	disk image data (YAZE)
+
+# ReFS
+# Richard W.M. Jones <rjones@redhat.com>
+0	string	\0\0\0ReFS\0	ReFS filesystem image
+
+# EFW encase image file format:
+# Gregoire Passault
+# http://www.forensicswiki.org/wiki/Encase_image_file_format
+0	string	EVF\x09\x0d\x0a\xff\x00	EWF/Expert Witness/EnCase image file format
+
+# UBIfs
+# Linux kernel sources: fs/ubifs/ubifs-media.h
+0	lelong	0x06101831
+>0x16	leshort	0		UBIfs image
+>0x08	lequad	x		\b, sequence number %llu
+>0x10	leshort x		\b, length %u
+>0x04	lelong	x		\b, CRC 0x%08x
+
+0	lelong	0x23494255
+>0x04	leshort	<2
+>0x05	string	\0\0\0
+>0x1c	string	\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
+>0x04	leshort	x		UBI image, version %u
+
+# NEC PC-88 2D disk image
+# From Fabio R. Schmidlin <sd-snatcher@users.sourceforge.net>
+0x20		ulelong&0xFFFFFEFF	0x2A0
+>0x10		string			\0\0\0\0\0\0\0\0\0\0
+>>0x280		string			\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
+>>>0x1A		ubyte&0xEF		0
+>>>>0x1B	ubyte&0x8F		0
+>>>>>0x1B	ubyte&70		<0x40
+>>>>>>0x1C	ulelong			>0x21
+>>>>>>>0	regex	[[:print:]]*	NEC PC-88 disk image, name=%s
+>>>>>>>>0x1B	ubyte	0		\b, media=2D
+>>>>>>>>0x1B	ubyte	0x10		\b, media=2DD
+>>>>>>>>0x1B	ubyte	0x20		\b, media=2HD
+>>>>>>>>0x1B	ubyte	0x30		\b, media=1D
+>>>>>>>>0x1B	ubyte	0x40		\b, media=1DD
+>>>>>>>>0x1A	ubyte	0x10		\b, write-protected
+
+#------------------------------------------------------------------------------
+# $File: flash,v 1.10 2014/03/06 16:07:24 christos Exp $
+# flash:	file(1) magic for Macromedia Flash file format
+#
+# See
+#
+#	http://www.macromedia.com/software/flash/open/
+#	http://wwwimages.adobe.com/www.adobe.com/content/dam/Adobe/\
+#	en/devnet/swf/pdf/swf-file-format-spec.pdf page 27
+#
+
+0   name        swf-details
+>0	string		F		Macromedia Flash data
+!:mime	application/x-shockwave-flash
+>0	string		C		Macromedia Flash data (compressed)
+!:mime	application/x-shockwave-flash
+>0	string		Z		Macromedia Flash data (lzma compressed)
+!:mime	application/x-shockwave-flash
+>3   byte        x      \b, version %d
+
+1   string      WS
+>4  lelong      !0
+>>3 byte        255 Suspicious
+>>>0    use     swf-details
+
+>>3 ubyte       <32
+>>>3 ubyte      !0
+>>>>0   use     swf-details
+
+# From: Cal Peake <cp@absolutedigital.net>
+0	string		FLV\x01		Macromedia Flash Video
+!:mime	video/x-flv
+
+#
+# Yosu Gomez
+0       string AGD2\xbe\xb8\xbb\xcd\x00 Macromedia Freehand 7 Document
+0       string AGD3\xbe\xb8\xbb\xcc\x00 Macromedia Freehand 8 Document
+# From Dave Wilson
+0	string AGD4\xbe\xb8\xbb\xcb\x00	Macromedia Freehand 9 Document
+
+#------------------------------------------------------------------------------
+# $File: fonts,v 1.26 2013/03/09 22:36:00 christos Exp $
+# fonts:  file(1) magic for font data
+#
+0	search/1	FONT		ASCII vfont text
+0	short		0436		Berkeley vfont data
+0	short		017001		byte-swapped Berkeley vfont data
+
+# PostScript fonts (must precede "printer" entries), quinlan@yggdrasil.com
+0	string		%!PS-AdobeFont-1.	PostScript Type 1 font text
+>20	string		>\0			(%s)
+6	string		%!PS-AdobeFont-1.	PostScript Type 1 font program data
+0	string		%!FontType1	PostScript Type 1 font program data
+6	string		%!FontType1	PostScript Type 1 font program data
+0	string		%!PS-Adobe-3.0\ Resource-Font	PostScript Type 1 font text
+
+# X11 font files in SNF (Server Natural Format) format
+# updated by Joerg Jenderek at Feb 2013
+# http://computer-programming-forum.com/51-perl/8f22fb96d2e34bab.htm
+0	belong		00000004		X11 SNF font data, MSB first
+#>104	belong		00000004		X11 SNF font data, MSB first
+!:mime	application/x-font-sfn
+# GRR: line below too general as it catches also Xbase index file t3-CHAR.NDX
+0	lelong		00000004		
+>104	lelong		00000004		X11 SNF font data, LSB first
+!:mime	application/x-font-sfn
+
+# X11 Bitmap Distribution Format, from Daniel Quinlan (quinlan@yggdrasil.com)
+0	search/1	STARTFONT\ 		X11 BDF font text
+
+# X11 fonts, from Daniel Quinlan (quinlan@yggdrasil.com)
+# PCF must come before SGI additions ("MIPSEL MIPS-II COFF" collides)
+0	string		\001fcp			X11 Portable Compiled Font data
+>12	byte		0x02			\b, LSB first
+>12	byte		0x0a			\b, MSB first
+0	string		D1.0\015		X11 Speedo font data
+
+#------------------------------------------------------------------------------
+# FIGlet fonts and controlfiles
+# From figmagic supplied with Figlet version 2.2
+# "David E. O'Brien" <obrien@FreeBSD.ORG>
+0	string		flf		FIGlet font
+>3	string		>2a		version %-2.2s
+0	string		flc		FIGlet controlfile
+>3	string		>2a		version %-2.2s
+
+# libGrx graphics lib fonts, from Albert Cahalan (acahalan@cs.uml.edu)
+# Used with djgpp (DOS Gnu C++), sometimes Linux or Turbo C++
+0	belong		0x14025919	libGrx font data,
+>8	leshort		x		%dx
+>10	leshort		x		\b%d
+>40	string		x		%s
+# Misc. DOS VGA fonts, from Albert Cahalan (acahalan@cs.uml.edu)
+0	belong		0xff464f4e	DOS code page font data collection
+7	belong		0x00454741	DOS code page font data
+7	belong		0x00564944	DOS code page font data (from Linux?)
+4098	string		DOSFONT		DOSFONT2 encrypted font data
+
+# downloadable fonts for browser (prints type) anthon@mnt.org
+0	string		PFR1		PFR1 font
+>102	string		>0		\b: %s
+
+# True Type fonts
+0	string	\000\001\000\000\000	TrueType font data
+!:mime application/x-font-ttf
+
+0	string		\007\001\001\000Copyright\ (c)\ 199	Adobe Multiple Master font
+0	string		\012\001\001\000Copyright\ (c)\ 199	Adobe Multiple Master font
+
+# TrueType/OpenType font collections (.ttc)
+# http://www.microsoft.com/typography/otspec/otff.htm
+0	string		ttcf		TrueType font collection data
+>4	belong		0x00010000	\b, 1.0
+>>8	belong		>0		\b, %d fonts
+>4	belong		0x00020000	\b, 2.0
+>>8	belong		>0		\b, %d fonts
+# 0x44454947 = 'DSIG'
+>>>16	belong		0x44534947	\b, digitally signed
+
+# Opentype font data from Avi Bercovich
+0	string		OTTO		OpenType font data
+!:mime application/vnd.ms-opentype
+
+# Gurkan Sengun <gurkan@linuks.mine.nu>, www.linuks.mine.nu 
+0	string		SplineFontDB:	Spline Font Database 
+!:mime application/vnd.font-fontforge-sfd
+>14	string		x		version %s
+
+# EOT
+34	string		LP		Embedded OpenType (EOT)
+!:mime application/vnd.ms-fontobject
+
+# Web Open Font Format (.woff)
+# http://www.w3.org/TR/WOFF/
+0	string		wOFF	Web Open Font Format
+>4	belong		x	\b, flavor %d
+>8	belong		x	\b, length %d
+>20	beshort		x	\b, version %d
+>22	beshort		x	\b.%d
+
+#------------------------------------------------------------------------------
+# $File: fortran,v 1.7 2012/06/21 01:55:02 christos Exp $
+# FORTRAN source
+0	regex/100l	\^[Cc][\ \t]	FORTRAN program
+!:mime	text/x-fortran
+!:strength - 5
+
+#------------------------------------------------------------------------------
+# $File$
+# frame:  file(1) magic for FrameMaker files
+#
+# This stuff came on a FrameMaker demo tape, most of which is
+# copyright, but this file is "published" as witness the following:
+#
+# Note that this is the Framemaker Maker Interchange Format, not the
+# Normal format which would be application/vnd.framemaker.
+#
+0	string		\<MakerFile	FrameMaker document
+!:mime	application/x-mif
+>11	string		5.5		 (5.5
+>11	string		5.0		 (5.0
+>11	string		4.0		 (4.0
+>11	string		3.0		 (3.0
+>11	string		2.0		 (2.0
+>11	string		1.0		 (1.0
+>14	byte		x		  %c)
+0	string		\<MIFFile	FrameMaker MIF (ASCII) file
+!:mime	application/x-mif
+>9	string		4.0		 (4.0)
+>9	string		3.0		 (3.0)
+>9	string		2.0		 (2.0)
+>9	string		1.0		 (1.x)
+0	search/1	\<MakerDictionary	FrameMaker Dictionary text
+!:mime	application/x-mif
+>17	string		3.0		 (3.0)
+>17	string		2.0		 (2.0)
+>17	string		1.0		 (1.x)
+0	string		\<MakerScreenFont	FrameMaker Font file
+!:mime	application/x-mif
+>17	string		1.01		 (%s)
+0	string		\<MML		FrameMaker MML file
+!:mime	application/x-mif
+0	string		\<BookFile	FrameMaker Book file
+!:mime	application/x-mif
+>10	string		3.0		 (3.0
+>10	string		2.0		 (2.0
+>10	string		1.0		 (1.0
+>13	byte		x		  %c)
+# XXX - this book entry should be verified, if you find one, uncomment this
+#0	string		\<Book\ 	FrameMaker Book (ASCII) file
+#!:mime	application/x-mif
+#>6	string		3.0		 (3.0)
+#>6	string		2.0		 (2.0)
+#>6	string		1.0		 (1.0)
+0	string		\<Maker	Intermediate Print File	FrameMaker IPL file
+!:mime	application/x-mif
+
+#------------------------------------------------------------------------------
+# $File$
+# freebsd:  file(1) magic for FreeBSD objects
+#
+# All new-style FreeBSD magic numbers are in host byte order (i.e.,
+# little-endian on x86).
+#
+# XXX - this comes from the file "freebsd" in a recent FreeBSD version of
+# "file"; it, and the NetBSD stuff in "netbsd", appear to use different
+# schemes for distinguishing between executable images, shared libraries,
+# and object files.
+#
+# FreeBSD says:
+#
+#    Regardless of whether it's pure, demand-paged, or none of the
+#    above:
+#
+#	if the entry point is < 4096, then it's a shared library if
+#	the "has run-time loader information" bit is set, and is
+#	position-independent if the "is position-independent" bit
+#	is set;
+#
+#	if the entry point is >= 4096 (or >4095, same thing), then it's
+#	an executable, and is dynamically-linked if the "has run-time
+#	loader information" bit is set.
+#
+# On x86, NetBSD says:
+#
+#    If it's neither pure nor demand-paged:
+#
+#	if it has the "has run-time loader information" bit set, it's
+#	a dynamically-linked executable;
+#
+#	if it doesn't have that bit set, then:
+#
+#	    if it has the "is position-independent" bit set, it's
+#	    position-independent;
+#
+#	    if the entry point is non-zero, it's an executable, otherwise
+#	    it's an object file.
+#
+#    If it's pure:
+#
+#	if it has the "has run-time loader information" bit set, it's
+#	a dynamically-linked executable, otherwise it's just an
+#	executable.
+#
+#    If it's demand-paged:
+#
+#	if it has the "has run-time loader information" bit set,
+#	then:
+#
+#	    if the entry point is < 4096, it's a shared library;
+#
+#	    if the entry point is = 4096 or > 4096 (i.e., >= 4096),
+#	    it's a dynamically-linked executable);
+#
+#	if it doesn't have the "has run-time loader information" bit
+#	set, then it's just an executable.
+#
+# (On non-x86, NetBSD does much the same thing, except that it uses
+# 8192 on 68K - except for "68k4k", which is presumably "68K with 4K
+# pages - SPARC, and MIPS, presumably because Sun-3's and Sun-4's
+# had 8K pages; dunno about MIPS.)
+#
+# I suspect the two will differ only in perverse and uninteresting cases
+# ("shared" libraries that aren't demand-paged and whose pages probably
+# won't actually be shared, executables with entry points <4096).
+#
+# I leave it to those more familiar with FreeBSD and NetBSD to figure out
+# what the right answer is (although using ">4095", FreeBSD-style, is
+# probably better than separately checking for "=4096" and ">4096",
+# NetBSD-style).  (The old "netbsd" file analyzed FreeBSD demand paged
+# executables using the NetBSD technique.)
+#
+0	lelong&0377777777	041400407	FreeBSD/i386
+>20	lelong			<4096
+>>3	byte&0xC0		&0x80		shared library
+>>3	byte&0xC0		0x40		PIC object
+>>3	byte&0xC0		0x00		object
+>20	lelong			>4095
+>>3	byte&0x80		0x80		dynamically linked executable
+>>3	byte&0x80		0x00		executable
+>16	lelong			>0		not stripped
+
+0	lelong&0377777777	041400410	FreeBSD/i386 pure
+>20	lelong			<4096
+>>3	byte&0xC0		&0x80		shared library
+>>3	byte&0xC0		0x40		PIC object
+>>3	byte&0xC0		0x00		object
+>20	lelong			>4095
+>>3	byte&0x80		0x80		dynamically linked executable
+>>3	byte&0x80		0x00		executable
+>16	lelong			>0		not stripped
+
+0	lelong&0377777777	041400413	FreeBSD/i386 demand paged
+>20	lelong			<4096
+>>3	byte&0xC0		&0x80		shared library
+>>3	byte&0xC0		0x40		PIC object
+>>3	byte&0xC0		0x00		object
+>20	lelong			>4095
+>>3	byte&0x80		0x80		dynamically linked executable
+>>3	byte&0x80		0x00		executable
+>16	lelong			>0		not stripped
+
+0	lelong&0377777777	041400314	FreeBSD/i386 compact demand paged
+>20	lelong			<4096
+>>3	byte&0xC0		&0x80		shared library
+>>3	byte&0xC0		0x40		PIC object
+>>3	byte&0xC0		0x00		object
+>20	lelong			>4095
+>>3	byte&0x80		0x80		dynamically linked executable
+>>3	byte&0x80		0x00		executable
+>16	lelong			>0		not stripped
+
+# XXX gross hack to identify core files
+# cores start with a struct tss; we take advantage of the following:
+# byte 7:     highest byte of the kernel stack pointer, always 0xfe
+#      8/9:   kernel (ring 0) ss value, always 0x0010
+#      10 - 27: ring 1 and 2 ss/esp, unused, thus always 0
+#      28:    low order byte of the current PTD entry, always 0 since the
+#             PTD is page-aligned
+#
+7	string	\357\020\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0	FreeBSD/i386 a.out core file
+>1039	string	>\0	from '%s'
+
+# /var/run/ld.so.hints
+# What are you laughing about?
+0	lelong			011421044151	ld.so hints file (Little Endian
+>4	lelong			>0		\b, version %d)
+>4	belong			<1		\b)
+0	belong			011421044151	ld.so hints file (Big Endian
+>4	belong			>0		\b, version %d)
+>4	belong			<1		\b)
+
+#
+# Files generated by FreeBSD scrshot(1)/vidcontrol(1) utilities
+#
+0	string	SCRSHOT_	scrshot(1) screenshot,
+>8	byte	x		version %d,
+>9	byte	2		%d bytes in header,
+>>10	byte	x		%d chars wide by
+>>11	byte	x		%d chars high
+
+#------------------------------------------------------------------------------
+# $File: fsav,v 1.12 2013/03/23 14:15:30 christos Exp $
+# fsav:  file(1) magic for datafellows fsav virus definition files
+# Anthon van der Neut (anthon@mnt.org)
+
+# ftp://ftp.f-prot.com/pub/{macrdef2.zip,nomacro.def}
+0	beshort		0x1575		fsav macro virus signatures
+>8	leshort		>0		(%d-
+>11	byte		>0		\b%02d-
+>10	byte		>0		\b%02d)
+# ftp://ftp.f-prot.com/pub/sign.zip
+#10	ubyte		<12
+#>9	ubyte		<32
+#>>8	ubyte		0x0a
+#>>>12	ubyte		0x07
+#>>>>11	uleshort	>0		fsav DOS/Windows virus signatures (%d-
+#>>>>10	byte		0		\b01-
+#>>>>10	byte		1		\b02-
+#>>>>10	byte		2		\b03-
+#>>>>10	byte		3		\b04-
+#>>>>10	byte		4		\b05-
+#>>>>10	byte		5		\b06-
+#>>>>10	byte		6		\b07-
+#>>>>10	byte		7		\b08-
+#>>>>10	byte		8		\b09-
+#>>>>10	byte		9		\b10-
+#>>>>10	byte		10		\b11-
+#>>>>10	byte		11		\b12-
+#>>>>9	ubyte		>0		\b%02d)
+# ftp://ftp.f-prot.com/pub/sign2.zip
+#0	ubyte		0x62		
+#>1	ubyte		0xF5		
+#>>2	ubyte		0x1		
+#>>>3	ubyte		0x1		
+#>>>>4	ubyte		0x0e		
+#>>>>>13		ubyte	>0		fsav virus signatures
+#>>>>>>11	ubyte	x		size 0x%02x
+#>>>>>>12	ubyte	x		\b%02x
+#>>>>>>13	ubyte	x		\b%02x bytes
+
+# Joerg Jenderek: joerg dot jenderek at web dot de
+# http://www.clamav.net/doc/latest/html/node45.html
+# .cvd files start with a 512 bytes colon separated header
+# ClamAV-VDB:buildDate:version:signaturesNumbers:functionalityLevelRequired:MD5:Signature:builder:buildTime
+# + gzipped tarball files
+0	string		ClamAV-VDB:	
+>11	string		>\0		Clam AntiVirus database %-.23s
+>>34	string		:		
+>>>35		string		!:	\b, version 
+>>>>35		string		x 	\b%-.1s
+>>>>>36		string 		!:	
+>>>>>>36	string		x 	\b%-.1s
+>>>>>>>37	string		!:	
+>>>>>>>>37	string		x 	\b%-.1s
+>>>>>>>>>38	string		!:	
+>>>>>>>>>>38	string		x 	\b%-.1s
+>512	string		\037\213	\b, gzipped
+>769	string		ustar\0		\b, tarred
+
+# Type: Grisoft AVG AntiVirus
+# From: David Newgas <david@newgas.net>
+0	string	AVG7_ANTIVIRUS_VAULT_FILE	AVG 7 Antivirus vault file data
+
+0	string	X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR
+>33	string	-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*	EICAR virus test files
+
+#------------------------------------------------------------------------------
+# $File: mcrypt,v 1.5 2009/09/19 16:28:10 christos Exp $
+# fusecompress:   file(1) magic for fusecompress
+0	string	\037\135\211	FuseCompress(ed) data
+>3	byte	0x00	(none format)
+>3	byte	0x01	(bz2 format)
+>3	byte	0x02	(gz format)
+>3	byte	0x03	(lzo format)
+>3	byte	0x04	(xor format)
+>3	byte	>0x04	(unknown format)
+>4	long	x	uncompressed size: %d
+
+#------------------------------------------------------------------------------
+# $File: games,v 1.13 2012/02/13 22:50:50 christos Exp $
+# games:  file(1) for games
+
+# Fabio Bonelli <fabiobonelli@libero.it>
+# Quake II - III data files
+0       string  IDP2        	Quake II 3D Model file,
+>20     long    x               %u skin(s),
+>8      long    x               (%u x
+>12     long    x 		%u),
+>40     long    x               %u frame(s),
+>16     long    x               Frame size %u bytes,
+>24     long  	x               %u vertices/frame,
+>28     long    x            	%u texture coordinates,
+>32     long    x               %u triangles/frame
+
+0       string  IBSP            Quake
+>4      long    0x26            II Map file (BSP)
+>4      long    0x2E      	III Map file (BSP)
+
+0       string  IDS2            Quake II SP2 sprite file
+
+#---------------------------------------------------------------------------
+# Doom and Quake
+# submitted by Nicolas Patrois
+
+0       string  \xcb\x1dBoom\xe6\xff\x03\x01    Boom or linuxdoom demo
+# some doom lmp files don't match, I've got one beginning with \x6d\x02\x01\x01
+
+24      string  LxD\ 203        Linuxdoom save
+>0      string  x       , name=%s
+>44     string  x       , world=%s
+
+# Quake
+
+0       string  PACK    Quake I or II world or extension
+>8	lelong	>0	\b, %d entries
+
+#0       string  -1\x0a  Quake I demo
+#>30     string  x        version %.4s
+#>61     string  x        level %s       
+
+#0       string  5\x0a   Quake I save
+
+# The levels
+
+# Quake 1
+
+0	string	5\x0aIntroduction             Quake I save: start Introduction
+0	string	5\x0athe_Slipgate_Complex     Quake I save: e1m1 The slipgate complex
+0	string	5\x0aCastle_of_the_Damned     Quake I save: e1m2 Castle of the damned
+0	string	5\x0athe_Necropolis           Quake I save: e1m3 The necropolis
+0	string	5\x0athe_Grisly_Grotto        Quake I save: e1m4 The grisly grotto
+0	string	5\x0aZiggurat_Vertigo         Quake I save: e1m8 Ziggurat vertigo (secret)
+0	string	5\x0aGloom_Keep               Quake I save: e1m5 Gloom keep
+0	string	5\x0aThe_Door_To_Chthon       Quake I save: e1m6 The door to Chthon
+0	string	5\x0aThe_House_of_Chthon      Quake I save: e1m7 The house of Chthon
+0	string	5\x0athe_Installation         Quake I save: e2m1 The installation
+0	string	5\x0athe_Ogre_Citadel         Quake I save: e2m2 The ogre citadel
+0	string	5\x0athe_Crypt_of_Decay       Quake I save: e2m3 The crypt of decay (dopefish lives!)
+0	string	5\x0aUnderearth               Quake I save: e2m7 Underearth (secret)
+0	string	5\x0athe_Ebon_Fortress        Quake I save: e2m4 The ebon fortress
+0	string	5\x0athe_Wizard's_Manse       Quake I save: e2m5 The wizard's manse
+0	string	5\x0athe_Dismal_Oubliette     Quake I save: e2m6 The dismal oubliette
+0	string	5\x0aTermination_Central      Quake I save: e3m1 Termination central
+0	string	5\x0aVaults_of_Zin            Quake I save: e3m2 Vaults of Zin
+0	string	5\x0athe_Tomb_of_Terror       Quake I save: e3m3 The tomb of terror
+0	string	5\x0aSatan's_Dark_Delight     Quake I save: e3m4 Satan's dark delight
+0	string	5\x0athe_Haunted_Halls        Quake I save: e3m7 The haunted halls (secret)
+0	string	5\x0aWind_Tunnels             Quake I save: e3m5 Wind tunnels
+0	string	5\x0aChambers_of_Torment      Quake I save: e3m6 Chambers of torment
+0	string	5\x0athe_Sewage_System        Quake I save: e4m1 The sewage system
+0	string	5\x0aThe_Tower_of_Despair     Quake I save: e4m2 The tower of despair
+0	string	5\x0aThe_Elder_God_Shrine     Quake I save: e4m3 The elder god shrine
+0	string	5\x0athe_Palace_of_Hate       Quake I save: e4m4 The palace of hate
+0	string	5\x0aHell's_Atrium            Quake I save: e4m5 Hell's atrium
+0	string	5\x0athe_Nameless_City        Quake I save: e4m8 The nameless city (secret)
+0	string	5\x0aThe_Pain_Maze            Quake I save: e4m6 The pain maze
+0	string	5\x0aAzure_Agony              Quake I save: e4m7 Azure agony
+0	string	5\x0aShub-Niggurath's_Pit     Quake I save: end Shub-Niggurath's pit
+
+# Quake DeathMatch levels
+
+0	string	5\x0aPlace_of_Two_Deaths	 Quake I save: dm1 Place of two deaths
+0	string	5\x0aClaustrophobopolis		 Quake I save: dm2 Claustrophobopolis
+0	string	5\x0aThe_Abandoned_Base		 Quake I save: dm3 The abandoned base
+0	string	5\x0aThe_Bad_Place		 Quake I save: dm4 The bad place
+0	string	5\x0aThe_Cistern		 Quake I save: dm5 The cistern
+0	string	5\x0aThe_Dark_Zone		 Quake I save: dm6 The dark zone
+
+# Scourge of Armagon
+
+0	string	5\x0aCommand_HQ               Quake I save: start Command HQ
+0	string	5\x0aThe_Pumping_Station      Quake I save: hip1m1 The pumping station
+0	string	5\x0aStorage_Facility         Quake I save: hip1m2 Storage facility
+0	string	5\x0aMilitary_Complex         Quake I save: hip1m5 Military complex (secret)
+0	string	5\x0athe_Lost_Mine            Quake I save: hip1m3 The lost mine
+0	string	5\x0aResearch_Facility        Quake I save: hip1m4 Research facility
+0	string	5\x0aAncient_Realms           Quake I save: hip2m1 Ancient realms
+0	string	5\x0aThe_Gremlin's_Domain     Quake I save: hip2m6 The gremlin's domain (secret)
+0	string	5\x0aThe_Black_Cathedral      Quake I save: hip2m2 The black cathedral
+0	string	5\x0aThe_Catacombs            Quake I save: hip2m3 The catacombs
+0	string	5\x0athe_Crypt__              Quake I save: hip2m4 The crypt
+0	string	5\x0aMortum's_Keep            Quake I save: hip2m5 Mortum's keep
+0	string	5\x0aTur_Torment              Quake I save: hip3m1 Tur torment
+0	string	5\x0aPandemonium              Quake I save: hip3m2 Pandemonium
+0	string	5\x0aLimbo                    Quake I save: hip3m3 Limbo
+0	string	5\x0athe_Edge_of_Oblivion     Quake I save: hipdm1 The edge of oblivion (secret)
+0	string	5\x0aThe_Gauntlet             Quake I save: hip3m4 The gauntlet
+0	string	5\x0aArmagon's_Lair           Quake I save: hipend Armagon's lair
+
+# Malice
+
+0	string	5\x0aThe_Academy      Quake I save: start The academy
+0	string	5\x0aThe_Lab          Quake I save: d1 The lab
+0	string	5\x0aArea_33          Quake I save: d1b Area 33
+0	string	5\x0aSECRET_MISSIONS  Quake I save: d3b Secret missions
+0	string	5\x0aThe_Hospital     Quake I save: d10 The hospital (secret)
+0	string	5\x0aThe_Genetics_Lab Quake I save: d11 The genetics lab (secret)
+0	string	5\x0aBACK_2_MALICE    Quake I save: d4b Back to Malice
+0	string	5\x0aArea44           Quake I save: d1c Area 44
+0	string	5\x0aTakahiro_Towers  Quake I save: d2 Takahiro towers
+0	string	5\x0aA_Rat's_Life     Quake I save: d3 A rat's life
+0	string	5\x0aInto_The_Flood   Quake I save: d4 Into the flood
+0	string	5\x0aThe_Flood        Quake I save: d5 The flood
+0	string	5\x0aNuclear_Plant    Quake I save: d6 Nuclear plant
+0	string	5\x0aThe_Incinerator_Plant    Quake I save: d7 The incinerator plant
+0	string	5\x0aThe_Foundry              Quake I save: d7b The foundry
+0	string	5\x0aThe_Underwater_Base      Quake I save: d8 The underwater base
+0	string	5\x0aTakahiro_Base            Quake I save: d9 Takahiro base
+0	string	5\x0aTakahiro_Laboratories    Quake I save: d12 Takahiro laboratories
+0	string	5\x0aStayin'_Alive    Quake I save: d13 Stayin' alive
+0	string	5\x0aB.O.S.S._HQ      Quake I save: d14 B.O.S.S. HQ
+0	string	5\x0aSHOWDOWN!        Quake I save: d15 Showdown!
+
+# Malice DeathMatch levels
+
+0	string	5\x0aThe_Seventh_Precinct	 Quake I save: ddm1 The seventh precinct
+0	string	5\x0aSub_Station		 Quake I save: ddm2 Sub station
+0	string	5\x0aCrazy_Eights!		 Quake I save: ddm3 Crazy eights!
+0	string	5\x0aEast_Side_Invertationa	 Quake I save: ddm4 East side invertationa
+0	string	5\x0aSlaughterhouse		 Quake I save: ddm5 Slaughterhouse
+0	string	5\x0aDOMINO			 Quake I save: ddm6 Domino
+0	string	5\x0aSANDRA'S_LADDER		 Quake I save: ddm7 Sandra's ladder
+
+
+0	string	MComprHD	MAME CHD compressed hard disk image,
+>12	belong	x		version %u
+
+# doom - submitted by Jon Dowland
+
+0	string	=IWAD		doom main IWAD data
+>4	lelong	x		containing %d lumps
+0	string	=PWAD		doom patch PWAD data
+>4	lelong	x		containing %d lumps
+
+# Build engine group files (Duke Nukem, Shadow Warrior, ...)
+# Extension: .grp
+# Created by: "Ganael Laplanche" <ganael.laplanche@martymac.org>
+0	string	KenSilverman	Build engine group file
+>12	lelong	x		containing %d files
+
+# Summary: Warcraft 3 save
+# Extension: .w3g
+# Created by: "Nelson A. de Oliveira" <naoliv@gmail.com>
+0	string		Warcraft\ III\ recorded\ game	%s
+
+
+# Summary: Warcraft 3 map
+# Extension: .w3m
+# Created by: "Nelson A. de Oliveira" <naoliv@gmail.com>
+0	string		HM3W		Warcraft III map file
+
+
+# Summary: SGF Smart Game Format
+# Extension: .sgf
+# Reference: http://www.red-bean.com/sgf/
+# Created by: Eduardo Sabbatella <eduardo_sabbatella@yahoo.com.ar>
+# Modified by (1): Abel Cheung (regex, more game format)
+# FIXME: Some games don't have GM (game type)
+0	regex		\\(;.*GM\\[[0-9]{1,2}\\]	Smart Game Format
+>2	search/0x200/b	GM[
+>>&0	string		1]	(Go)
+>>&0	string		2]	(Othello)
+>>&0	string		3]	(chess)
+>>&0	string		4]	(Gomoku+Renju)
+>>&0	string		5]	(Nine Men's Morris)
+>>&0	string		6]	(Backgammon)
+>>&0	string		7]	(Chinese chess)
+>>&0	string		8]	(Shogi)
+>>&0	string		9]	(Lines of Action)
+>>&0	string		10]	(Ataxx)
+>>&0	string		11]	(Hex)
+>>&0	string		12]	(Jungle)
+>>&0	string		13]	(Neutron)
+>>&0	string		14]	(Philosopher's Football)
+>>&0	string		15]	(Quadrature)
+>>&0	string		16]	(Trax)
+>>&0	string		17]	(Tantrix)
+>>&0	string		18]	(Amazons)
+>>&0	string		19]	(Octi)
+>>&0	string		20]	(Gess)
+>>&0	string		21]	(Twixt)
+>>&0	string		22]	(Zertz)
+>>&0	string		23]	(Plateau)
+>>&0	string		24]	(Yinsh)
+>>&0	string		25]	(Punct)
+>>&0	string		26]	(Gobblet)
+>>&0	string		27]	(hive)
+>>&0	string		28]	(Exxit)
+>>&0	string		29]	(Hnefatal)
+>>&0	string		30]	(Kuba)
+>>&0	string		31]	(Tripples)
+>>&0	string		32]	(Chase)
+>>&0	string		33]	(Tumbling Down)
+>>&0	string		34]	(Sahara)
+>>&0	string		35]	(Byte)
+>>&0	string		36]	(Focus)
+>>&0	string		37]	(Dvonn)
+>>&0	string		38]	(Tamsk)
+>>&0	string		39]	(Gipf)
+>>&0	string		40]	(Kropki)
+
+##############################################
+# NetImmerse/Gamebryo game engine entries
+
+# Summary: Gamebryo game engine file
+# Extension: .nif, .kf
+# Created by: Abel Cheung <abelcheung@gmail.com>
+0		string		Gamebryo\ File\ Format,\ Version\ 	Gamebryo game engine file
+>&0		regex		[0-9a-z.]+				\b, version %s
+
+# Summary: Gamebryo game engine file
+# Extension: .kfm
+# Created by: Abel Cheung <abelcheung@gmail.com>
+0		string		;Gamebryo\ KFM\ File\ Version\ 		Gamebryo game engine animation File
+>&0		regex		[0-9a-z.]+				\b, version %s
+
+# Summary: NetImmerse game engine file
+# Extension .nif
+# Created by: Abel Cheung <abelcheung@gmail.com>
+0		string		NetImmerse\ File\ Format,\ Versio		
+>&0		string		n\ 					NetImmerse game engine file
+>>&0		regex		[0-9a-z.]+				\b, version %s
+
+# Type:	SGF Smart Game Format
+# URL:	http://www.red-bean.com/sgf/
+# From:	Eduardo Sabbatella <eduardo_sabbatella@yahoo.com.ar>
+2	regex/c	\\(;.*GM\\[[0-9]{1,2}\\]	Smart Game Format
+>2	regex/c	GM\\[1\\]			- Go Game
+>2	regex/c	GM\\[6\\]			- BackGammon Game
+>2	regex/c	GM\\[11\\]			- Hex Game
+>2	regex/c	GM\\[18\\]			- Amazons Game
+>2	regex/c	GM\\[19\\]			- Octi Game
+>2	regex/c	GM\\[20\\]			- Gess Game
+>2	regex/c	GM\\[21\\]			- twix Game
+
+# Epic Games/Unreal Engine Package
+#
+0	lelong		0x9E2A83C1	Unreal Engine Package,
+>4	leshort		x		version: %i
+>12	lelong		!0		\b, names: %i
+>28	lelong		!0		\b, imports: %i
+>20	lelong		!0		\b, exports: %i
+
+#------------------------------------------------------------------------------
+# $File$
+# gcc:  file(1) magic for GCC special files
+#
+0	string		gpch		GCC precompiled header
+
+# The version field is annoying.  It's 3 characters, not zero-terminated.
+>5	byte		x			(version %c
+>6	byte		x			\b%c
+>7	byte		x			\b%c)
+
+# 67 = 'C', 111 = 'o', 43 = '+', 79 = 'O'
+>4	byte		67			for C
+>4	byte		111			for Objective C
+>4	byte		43			for C++
+>4	byte		79			for Objective C++
+
+#------------------------------------------------------------------------------
+# $File: geo,v 1.2 2013/01/02 15:27:53 christos Exp $
+# Geo- files from Kurt Schwehr <schwehr@ccom.unh.edu>
+
+######################################################################
+#
+# Acoustic Doppler Current Profilers (ADCP)
+#
+######################################################################
+
+0	beshort	0x7f7f	RDI Acoustic Doppler Current Profiler (ADCP)
+
+######################################################################
+#
+# Metadata
+#
+######################################################################
+
+0	string	Identification_Information	FGDC ASCII metadata
+
+######################################################################
+#
+# Seimsic / Subbottom
+#
+######################################################################
+
+# Knudsen subbottom chirp profiler - Binary File Format: B9
+# KEB D409-03167 V1.75 Huffman
+0	string	KEB\ 	Knudsen seismic KEL binary (KEB) -
+>4	regex	[-A-Z0-9]*	Software: %s
+>>&1	regex	V[0-9]*\.[0-9]*	version %s
+
+######################################################################
+#
+# LIDAR - Laser altimetry or bathy
+#
+######################################################################
+
+
+# Caris LIDAR format for LADS comes as two parts... ascii location file and binary waveform data
+0	string	HCA	LADS Caris Ascii Format (CAF) bathymetric lidar
+>4	regex [0-9]*\.[0-9]*	version %s
+
+0	string	HCB	LADS Caris Binary Format (CBF) bathymetric lidar waveform data
+>3      byte    x	version %d .
+>4	byte	x	%d
+
+
+######################################################################
+#
+# MULTIBEAM SONARS http://www.ldeo.columbia.edu/res/pi/MB-System/formatdoc/
+#
+######################################################################
+
+# GeoAcoustics - GeoSwath Plus
+4	beshort	0x2002	GeoSwath RDF
+0	string	Start:-	GeoSwatch auf text file
+
+# Seabeam 2100 
+# mbsystem code mb41
+0	string SB2100	SeaBeam 2100 multibeam sonar
+0	string SB2100DR	SeaBeam 2100 DR multibeam sonar
+0	string SB2100PR SeaBeam 2100 PR multibeam sonar
+
+# This corresponds to MB-System format 94, L-3/ELAC/SeaBeam XSE vendor
+# format. It is the format of our upgraded SeaBeam 2112 on R/V KNORR.
+0    string $HSF    XSE multibeam
+
+# mb121 http://www.saic.com/maritime/gsf/
+8	string	GSF-v	SAIC generic sensor format (GSF) sonar data,
+>&0	regex [0-9]*\.[0-9]*	version %s
+
+# MGD77 - http://www.ngdc.noaa.gov/mgg/dat/geodas/docs/mgd77.htm
+# mb161
+9	string MGD77	MGD77 Header, Marine Geophysical Data Exchange Format
+
+# MBSystem processing caches the mbinfo output
+1	string	Swath\ Data\ File:	mbsystem info cache
+
+# Caris John Hughes Clark format
+0	string	HDCS	Caris multibeam sonar related data
+1	string	Start/Stop\ parameter\ header:	Caris ASCII project summary
+
+######################################################################
+#
+# Visualization and 3D modeling
+#
+######################################################################
+
+# IVS - IVS3d.com Tagged Data Represetation
+0	string	%%\ TDR\ 2.0	IVS Fledermaus TDR file
+
+# http://www.ecma-international.org/publications/standards/Ecma-363.htm
+# 3D in PDFs
+0	string	U3D	ECMA-363, Universal 3D
+
+######################################################################
+#
+# Support files
+#
+######################################################################
+
+# https://midas.psi.ch/elog/
+0	string	$@MID@$	elog journal entry
+
+# Geospatial Designs http://www.geospatialdesigns.com/surfer6_format.htm
+0	string		DSBB	Surfer 6 binary grid file
+>4	leshort		x	\b, %d
+>6	leshort		x	\bx%d
+>8	ledouble	x	\b, minx=%g
+>16	ledouble	x	\b, maxx=%g
+>24	ledouble	x	\b, miny=%g
+>32	ledouble	x	\b, maxy=%g
+>40	ledouble	x	\b, minz=%g
+>48	ledouble	x	\b, maxz=%g
+
+
+#------------------------------------------------------------------------------
+# $File$
+# GEOS files (Vidar Madsen, vidar@gimp.org)
+# semi-commonly used in embedded and handheld systems.
+0	belong	0xc745c153	GEOS
+>40	byte	1	executable
+>40	byte	2	VMFile
+>40	byte	3	binary
+>40	byte	4	directory label
+>40	byte	<1	unknown
+>40	byte	>4	unknown
+>4	string	>\0	\b, name "%s"
+#>44	short	x	\b, version %d
+#>46	short	x	\b.%d
+#>48	short	x	\b, rev %d
+#>50	short	x	\b.%d
+#>52	short	x	\b, proto %d
+#>54	short	x	\br%d
+#>168	string	>\0	\b, copyright "%s"
+
+#------------------------------------------------------------------------------
+# $File: gimp,v 1.8 2013/12/21 14:29:45 christos Exp $
+# GIMP Gradient: file(1) magic for the GIMP's gradient data files (.ggr)
+# by Federico Mena <federico@nuclecu.unam.mx>
+
+0       string/t        GIMP\ Gradient  GIMP gradient data
+
+# GIMP palette (.gpl)
+# From: Markus Heidelberg <markus.heidelberg@web.de>
+0       string/t        GIMP\ Palette   GIMP palette data
+
+#------------------------------------------------------------------------------
+# XCF:  file(1) magic for the XCF image format used in the GIMP (.xcf) developed
+#       by Spencer Kimball and Peter Mattis
+#       ('Bucky' LaDieu, nega@vt.edu)
+
+0	string		gimp\ xcf	GIMP XCF image data,
+!:mime	image/x-xcf
+>9	string		file		version 0,
+>9	string		v		version
+>>10	string		>\0		%s,
+>14	belong		x		%u x
+>18	belong		x		%u,
+>22     belong          0               RGB Color
+>22     belong          1               Greyscale
+>22     belong          2               Indexed Color
+>22	belong		>2		Unknown Image Type.
+
+#------------------------------------------------------------------------------
+# XCF:  file(1) magic for the patterns used in the GIMP (.pat), developed
+#       by Spencer Kimball and Peter Mattis
+#       ('Bucky' LaDieu, nega@vt.edu)
+
+20      string          GPAT            GIMP pattern data,
+>24     string          x               %s
+
+#------------------------------------------------------------------------------
+# XCF:  file(1) magic for the brushes used in the GIMP (.gbr), developed
+#       by Spencer Kimball and Peter Mattis
+#       ('Bucky' LaDieu, nega@vt.edu)
+
+20      string          GIMP            GIMP brush data
+
+# GIMP Curves File
+# From: "Nelson A. de Oliveira" <naoliv@gmail.com>
+0	string	#\040GIMP\040Curves\040File	GIMP curve file
+
+#------------------------------------------------------------------------------
+# $File: gnome,v 1.4 2014/04/28 12:04:50 christos Exp $
+# GNOME related files
+
+# Contributed by Josh Triplett
+# FIXME: Could be simplified if pstring supported two-byte counts
+0         string   GnomeKeyring\n\r\0\n GNOME keyring
+>&0       ubyte    0                    \b, major version 0
+>>&0      ubyte    0                    \b, minor version 0
+>>>&0     ubyte    0                    \b, crypto type 0 (AES)
+>>>&0     ubyte    >0                   \b, crypto type %u (unknown)
+>>>&1     ubyte    0                    \b, hash type 0 (MD5)
+>>>&1     ubyte    >0                   \b, hash type %u (unknown)
+>>>&2     ubelong  0xFFFFFFFF           \b, name NULL
+>>>&2     ubelong  !0xFFFFFFFF
+>>>>&-4   ubelong  >255                 \b, name too long for file's pstring type
+>>>>&-4   ubelong  <256
+>>>>>&-1  pstring  x                    \b, name "%s"
+>>>>>>&0  ubeqdate x                    \b, last modified %s
+>>>>>>&8  ubeqdate x                    \b, created %s
+>>>>>>&16 ubelong  &1
+>>>>>>>&0 ubelong  x                    \b, locked if idle for %u seconds
+>>>>>>&16 ubelong  ^1                   \b, not locked if idle
+>>>>>>&24 ubelong  x                    \b, hash iterations %u
+>>>>>>&28 ubequad  x                    \b, salt %llu
+>>>>>>&52 ubelong  x                    \b, %u item(s)
+
+# From: Alex Beregszaszi <alex@fsn.hu>
+4	string	gtktalog		GNOME Catalogue (gtktalog)
+>13	string	>\0			version %s
+
+# Summary: GStreamer binary registry
+# Extension: .bin
+# Submitted by: Josh Triplett <josh@joshtriplett.org>
+0	belong	0xc0def00d		GStreamer binary registry
+>4	string	x			\b, version %s
+
+# GVariant Database file
+# By Elan Ruusamae <glen@delfi.ee>
+# https://github.com/GNOME/gvdb/blob/master/gvdb-format.h
+# It's always "GVariant", it's byte swapped on incompatible archs
+# See https://github.com/GNOME/gvdb/blob/master/gvdb-builder.c
+# file_builder_serialise()
+# http://developer.gnome.org/glib/2.34/glib-GVariant.html#GVariant
+0	string	GVariant	GVariant Database file,
+# version is never filled. probably future extension
+>8	lelong	x		version %d
+# not sure are these usable, so commented out
+#>>16	lelong	x		start %d,
+#>>>20	lelong	x		end %d
+
+# G-IR database made by gobject-introspect toolset,
+# http://live.gnome.org/GObjectIntrospection
+0	string		GOBJ\nMETADATA\r\n\032	G-IR binary database
+>16	byte		x			\b, v%d
+>17	byte		x			\b.%d
+>20	leshort		x			\b, %d entries
+>22	leshort		x			\b/%d local
+
+#------------------------------------------------------------------------------
+# $File: gnu,v 1.14 2012/10/03 23:38:12 christos Exp $
+# gnu:  file(1) magic for various GNU tools
+#
+# GNU nlsutils message catalog file format
+#
+# GNU message catalog (.mo and .gmo files)
+
+0	string		\336\22\4\225	GNU message catalog (little endian),
+>6	leshort		x		revision %d.
+>4	leshort		>0		\b%d,
+>>8	lelong		x		%d messages,
+>>36	lelong		x		%d sysdep messages
+>4	leshort		=0		\b%d,
+>>8	lelong		x		%d messages
+
+0	string		\225\4\22\336	GNU message catalog (big endian),
+>4	beshort		x		revision %d.
+>6	beshort		>0		\b%d,
+>>8	belong		x		%d messages,
+>>36	belong		x		%d sysdep messages
+>6	beshort		=0		\b%d,
+>>8	belong		x		%d messages
+
+
+# GnuPG
+# The format is very similar to pgp
+0	string          \001gpg                 GPG key trust database
+>4	byte            x                       version %d
+# Note: magic.mime had 0x8501 for the next line instead of 0x8502
+0	beshort		0x8502			GPG encrypted data
+!:mime	text/PGP # encoding: data
+
+# This magic is not particularly good, as the keyrings don't have true
+# magic. Nevertheless, it covers many keyrings.
+0       beshort         0x9901                  GPG key public ring
+!:mime	application/x-gnupg-keyring
+
+# Symmetric encryption
+0	leshort		0x0d8c
+>4	leshort		0x0203
+>>2	leshort		0x0204		GPG symmetrically encrypted data (3DES cipher)
+>>2	leshort		0x0304		GPG symmetrically encrypted data (CAST5 cipher)
+>>2	leshort		0x0404		GPG symmetrically encrypted data (BLOWFISH cipher)
+>>2	leshort		0x0704		GPG symmetrically encrypted data (AES cipher)
+>>2	leshort		0x0804		GPG symmetrically encrypted data (AES192 cipher)
+>>2	leshort		0x0904		GPG symmetrically encrypted data (AES256 cipher)
+>>2	leshort		0x0a04		GPG symmetrically encrypted data (TWOFISH cipher)
+>>2	leshort		0x0b04		GPG symmetrically encrypted data (CAMELLIA128 cipher)
+>>2	leshort		0x0c04		GPG symmetrically encrypted data (CAMELLIA192 cipher)
+>>2	leshort		0x0d04		GPG symmetrically encrypted data (CAMELLIA256 cipher)
+
+
+# GnuPG Keybox file
+# <http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=kbx/keybox-blob.c;hb=HEAD>
+# From: Philipp Hahn <hahn@univention.de>
+0	belong	32
+>4	byte	1
+>>8	string	KBXf	GPG keybox database
+>>>5	byte	1	version %d
+>>>16	bedate	x	\b, created-at %s
+>>>20	bedate	x	\b, last-maintained %s
+
+
+# Gnumeric spreadsheet
+# This entry is only semi-helpful, as Gnumeric compresses its files, so
+# they will ordinarily reported as "compressed", but at least -z helps
+39      string          =<gmr:Workbook           Gnumeric spreadsheet
+
+# From: James Youngman <jay@gnu.org> 
+# gnu find magic
+0	string	\0LOCATE	GNU findutils locate database data
+>7	string	>\0		\b, format %s
+>7	string	02		\b (frcode)
+
+# Files produced by GNU gettext
+0	long	0xDE120495		GNU-format message catalog data
+0	long	0x950412DE		GNU-format message catalog data
+
+# gettext message catalogue
+0	regex	\^msgid\ 		GNU gettext message catalogue text
+!:mime text/x-po
+
+#------------------------------------------------------------------------------
+# $File$
+# gnumeric:  file(1) magic for Gnumeric spreadsheet
+# This entry is only semi-helpful, as Gnumeric compresses its files, so
+# they will ordinarily reported as "compressed", but at least -z helps
+39	string	=<gmr:Workbook	Gnumeric spreadsheet
+!:mime	application/x-gnumeric
+
+#------------------------------------------------------------------------------
+# $File: gpt,v 1.2 2014/04/28 12:04:50 christos Exp $
+#
+# GPT Partition table patterns.
+# Author: Rogier Goossens (goossens.rogier@gmail.com)
+# Note that a GPT-formatted disk must contain an MBR as well.
+#
+
+# The initial segment (up to >>>>>>>>422) was copied from the X86
+# partition table code (aka MBR).
+# This is kept separate, so that MBR partitions are not reported as well.
+# (use -k if you do want them as well)
+
+# First, detect the MBR partiton table
+# If more than one GPT protective MBR partition exists, don't print anything
+# (the other MBR detection code will then just print the MBR partition table)
+0x1FE			leshort		0xAA55
+>3			string		!MS
+>>3			string		!SYSLINUX
+>>>3			string		!MTOOL
+>>>>3			string		!NEWLDR
+>>>>>5			string		!DOS
+# not FAT (32 bit)
+>>>>>>82		string		!FAT32
+#not Linux kernel
+>>>>>>>514		string		!HdrS
+#not BeOS
+>>>>>>>>422		string		!Be\ Boot\ Loader
+# GPT with protective MBR entry in partition 1 (only)
+>>>>>>>>>450		ubyte		0xee
+>>>>>>>>>>466		ubyte		!0xee
+>>>>>>>>>>>482		ubyte		!0xee
+>>>>>>>>>>>>498		ubyte		!0xee
+#>>>>>>>>>>>>>446	use		gpt-mbr-partition
+>>>>>>>>>>>>>(454.l*8192)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>0			use		gpt-mbr-type
+>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>0			ubyte		x		of 8192 bytes		
+>>>>>>>>>>>>>(454.l*8192)	string		!EFI\ PART
+>>>>>>>>>>>>>>(454.l*4096)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>0		ubyte		x		of 4096 bytes
+>>>>>>>>>>>>>>(454.l*4096)	string		!EFI\ PART
+>>>>>>>>>>>>>>>(454.l*2048)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>0		ubyte		x		of 2048 bytes
+>>>>>>>>>>>>>>>(454.l*2048)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>(454.l*1024)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>0		ubyte		x		of 1024 bytes
+>>>>>>>>>>>>>>>>(454.l*1024)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>>(454.l*512)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>>0		ubyte		x		of 512 bytes
+# GPT with protective MBR entry in partition 2 (only)
+>>>>>>>>>450		ubyte		!0xee
+>>>>>>>>>>466		ubyte		0xee
+>>>>>>>>>>>482		ubyte		!0xee
+>>>>>>>>>>>>498		ubyte		!0xee
+#>>>>>>>>>>>>>462	use		gpt-mbr-partition
+>>>>>>>>>>>>>(470.l*8192)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>0			use		gpt-mbr-type
+>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>0			ubyte		x		of 8192 bytes		
+>>>>>>>>>>>>>(470.l*8192)	string		!EFI\ PART
+>>>>>>>>>>>>>>(470.l*4096)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>0		ubyte		x		of 4096 bytes
+>>>>>>>>>>>>>>(470.l*4096)	string		!EFI\ PART
+>>>>>>>>>>>>>>>(470.l*2048)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>0		ubyte		x		of 2048 bytes
+>>>>>>>>>>>>>>>(470.l*2048)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>(470.l*1024)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>0		ubyte		x		of 1024 bytes
+>>>>>>>>>>>>>>>>(470.l*1024)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>>(470.l*512)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>>0		ubyte		x		of 512 bytes
+# GPT with protective MBR entry in partition 3 (only)
+>>>>>>>>>450		ubyte		!0xee
+>>>>>>>>>>466		ubyte		!0xee
+>>>>>>>>>>>482		ubyte		0xee
+>>>>>>>>>>>>498		ubyte		!0xee
+#>>>>>>>>>>>>>478	use		gpt-mbr-partition
+>>>>>>>>>>>>>(486.l*8192)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>0			use		gpt-mbr-type
+>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>0			ubyte		x		of 8192 bytes		
+>>>>>>>>>>>>>(486.l*8192)	string		!EFI\ PART
+>>>>>>>>>>>>>>(486.l*4096)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>0		ubyte		x		of 4096 bytes
+>>>>>>>>>>>>>>(486.l*4096)	string		!EFI\ PART
+>>>>>>>>>>>>>>>(486.l*2048)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>0		ubyte		x		of 2048 bytes
+>>>>>>>>>>>>>>>(486.l*2048)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>(486.l*1024)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>0		ubyte		x		of 1024 bytes
+>>>>>>>>>>>>>>>>(486.l*1024)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>>(486.l*512)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>>0		ubyte		x		of 512 bytes
+# GPT with protective MBR entry in partition 4 (only)
+>>>>>>>>>450		ubyte		!0xee
+>>>>>>>>>>466		ubyte		!0xee
+>>>>>>>>>>>482		ubyte		!0xee
+>>>>>>>>>>>>498		ubyte		0xee
+#>>>>>>>>>>>>>494	use		gpt-mbr-partition
+>>>>>>>>>>>>>(502.l*8192)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>0			use		gpt-mbr-type
+>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>0			ubyte		x		of 8192 bytes		
+>>>>>>>>>>>>>(502.l*8192)	string		!EFI\ PART
+>>>>>>>>>>>>>>(502.l*4096)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>0		ubyte		x		of 4096 bytes
+>>>>>>>>>>>>>>(502.l*4096)	string		!EFI\ PART
+>>>>>>>>>>>>>>>(502.l*2048)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>0		ubyte		x		of 2048 bytes
+>>>>>>>>>>>>>>>(502.l*2048)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>(502.l*1024)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>0		ubyte		x		of 1024 bytes
+>>>>>>>>>>>>>>>>(502.l*1024)	string		!EFI\ PART
+>>>>>>>>>>>>>>>>>(502.l*512)	string		EFI\ PART	GPT partition table
+>>>>>>>>>>>>>>>>>>0		use		gpt-mbr-type
+>>>>>>>>>>>>>>>>>>&-8		use		gpt-table
+>>>>>>>>>>>>>>>>>>0		ubyte		x		of 512 bytes
+
+# The following code does GPT detection and processing, including
+# sector size detection.
+# It has to be duplicated above because the top-level pattern
+# (i.e. not called using 'use') must print *something* for file
+# to count it as a match. Text only printed in named patterns is
+# not counted, and causes file to continue, and try and match
+# other patterns.
+#
+# Unfortunately, when assuming sector sizes >=16k, if the sector size
+# happens to be 512 instead, we may find confusing data after the GPT
+# table...  If the GPT table has less than 128 entries, this may even
+# happen for assumed sector sizes as small as 4k
+# This could be solved by checking for the presence of the backup GPT
+# header as well, but that makes the logic extremely complex
+##0		name		gpt-mbr-partition
+##>(8.l*8192)	string		EFI\ PART
+##>>(8.l*8192)	use		gpt-mbr-type
+##>>&-8		use		gpt-table
+##>>0		ubyte		x		of 8192 bytes		
+##>(8.l*8192)	string		!EFI\ PART
+##>>(8.l*4096)	string		EFI\ PART	GPT partition table
+##>>>0		use		gpt-mbr-type
+##>>>&-8		use		gpt-table
+##>>>0		ubyte		x		of 4096 bytes
+##>>(8.l*4096)	string		!EFI\ PART
+##>>>(8.l*2048)	string		EFI\ PART	GPT partition table
+##>>>>0		use		gpt-mbr-type
+##>>>>&-8		use		gpt-table
+##>>>>0		ubyte		x		of 2048 bytes
+##>>>(8.l*2048)	string		!EFI\ PART
+##>>>>(8.l*1024)	string		EFI\ PART	GPT partition table
+##>>>>>0		use		gpt-mbr-type
+##>>>>>&-8	use		gpt-table
+##>>>>>0		ubyte		x		of 1024 bytes
+##>>>>(8.l*1024)	string		!EFI\ PART
+##>>>>>(8.l*512)	string		EFI\ PART	GPT partition table
+##>>>>>>0		use		gpt-mbr-type
+##>>>>>>&-8	use		gpt-table
+##>>>>>>0		ubyte		x		of 512 bytes
+
+# Print details of MBR type for a GPT-disk
+# Calling code ensures that there is only one 0xee partition.
+0		name		gpt-mbr-type
+# GPT with protective MBR entry in partition 1
+>450		ubyte		0xee
+>>454		ulelong		1
+>>>462		string		!\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0	\b (with hybrid MBR)
+>>454		ulelong		!1													\b (nonstandard: not at LBA 1)
+# GPT with protective MBR entry in partition 2
+>466		ubyte		0xee
+>>470		ulelong		1
+>>>478		string		\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
+>>>>446		string		!\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0					\b (with hybrid MBR)
+>>>478		string		!\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0	\b (with hybrid MBR)
+>>470		ulelong		!1									\b (nonstandard: not at LBA 1)
+# GPT with protective MBR entry in partition 3
+>482		ubyte		0xee
+>>486		ulelong		1
+>>>494		string		\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
+>>>>446		string		!\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0	\b (with hybrid MBR)
+>>>494		string		!\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0					\b (with hybrid MBR)
+>>486		ulelong		!1									\b (nonstandard: not at LBA 1)
+# GPT with protective MBR entry in partition 4
+>498		ubyte		0xee
+>>502		ulelong		1		
+>>>446		string		!\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0	\b (with hybrid MBR)
+>>502		ulelong		!1													\b (nonstandard: not at LBA 1)
+
+# Print the information from a GPT partition table structure
+0		name		gpt-table
+>10		uleshort	x		\b, version %u
+>8		uleshort	x		\b.%u
+>56		ulelong		x		\b, GUID: %08x
+>60		uleshort	x		\b-%04x
+>62		uleshort	x		\b-%04x
+>64		ubeshort	x		\b-%04x
+>66		ubeshort	x		\b-%04x
+>68		ubelong		x		\b%08x
+#>80		uleshort	x		\b, %d partition entries
+>32		ulequad+1	x		\b, disk size: %lld sectors
+
+# In case a GPT data-structure is at LBA 0, report it as well
+# This covers systems which are not GPT-aware, and which show
+# and allow access to the protective partition. This code will
+# detect the contents of such a partition.
+0		string		EFI\ PART	GPT data structure (nonstandard: at LBA 0)
+>0		use		gpt-table
+>0		ubyte		x		(sector size unknown)
+
+
+
+#------------------------------------------------------------------------------
+# $File$
+# ACE/gr and Grace type files - PLEASE DO NOT REMOVE THIS LINE
+#
+# ACE/gr binary
+0	string	\000\000\0001\000\000\0000\000\000\0000\000\000\0002\000\000\0000\000\000\0000\000\000\0003		old ACE/gr binary file
+>39	byte	>0			- version %c
+# ACE/gr ascii
+0	string	#\ xvgr\ parameter\ file	ACE/gr ascii file
+0	string	#\ xmgr\ parameter\ file	ACE/gr ascii file
+0	string	#\ ACE/gr\ parameter\ file	ACE/gr ascii file
+# Grace projects
+0	string	#\ Grace\ project\ file		Grace project file
+>23	string	@version\  			(version
+>>32	byte	>0 				%c
+>>33	string	>\0 				\b.%.2s
+>>35	string	>\0 				\b.%.2s)
+# ACE/gr fit description files
+0	string	#\ ACE/gr\ fit\ description\ 	ACE/gr fit description file
+# end of ACE/gr and Grace type files - PLEASE DO NOT REMOVE THIS LINE
+
+#------------------------------------------------------------------------------
+# $File: graphviz,v 1.7 2009/09/19 16:28:09 christos Exp $
+# graphviz:  file(1) magic for http://www.graphviz.org/
+
+# FIXME: These patterns match too generally. For example, the first
+# line matches a LaTeX file containing the word "graph" (with a {
+# following later) and the second line matches this file.
+#0	regex/100l	[\r\n\t\ ]*graph[\r\n\t\ ]+.*\\{	graphviz graph text
+#!:mime	text/vnd.graphviz
+#0	regex/100l	[\r\n\t\ ]*digraph[\r\n\t\ ]+.*\\{	graphviz digraph text
+#!:mime	text/vnd.graphviz
+
+#------------------------------------------------------------------------------
+# $File$
+# gringotts:  file(1) magic for Gringotts
+# http://devel.pluto.linux.it/projects/Gringotts/
+# author: Germano Rizzo <mano@pluto.linux.it>
+#GRG3????Y
+0	string	GRG		Gringotts data file
+#file format 1
+>3	string		1		v.1, MCRYPT S2K, SERPENT crypt, SHA-256 hash, ZLib lvl.9
+#file format 2
+>3	string		2		v.2, MCRYPT S2K, 
+>>8	byte&0x70	0x00		RIJNDAEL-128 crypt,
+>>8	byte&0x70	0x10		SERPENT crypt,
+>>8	byte&0x70	0x20		TWOFISH crypt, 
+>>8	byte&0x70	0x30		CAST-256 crypt,
+>>8	byte&0x70	0x40		SAFER+ crypt,
+>>8	byte&0x70	0x50		LOKI97 crypt,
+>>8	byte&0x70	0x60		3DES crypt,
+>>8	byte&0x70	0x70		RIJNDAEL-256 crypt,
+>>8	byte&0x08	0x00		SHA1 hash,
+>>8	byte&0x08	0x08		RIPEMD-160 hash,
+>>8	byte&0x04	0x00		ZLib
+>>8	byte&0x04	0x04		BZip2
+>>8	byte&0x03	0x00		lvl.0
+>>8	byte&0x03	0x01		lvl.3
+>>8	byte&0x03	0x02		lvl.6
+>>8	byte&0x03	0x03		lvl.9
+#file format 3
+>3	string		3		v.3, OpenPGP S2K, 
+>>8	byte&0x70	0x00		RIJNDAEL-128 crypt,
+>>8	byte&0x70	0x10		SERPENT crypt,
+>>8	byte&0x70	0x20		TWOFISH crypt, 
+>>8	byte&0x70	0x30		CAST-256 crypt,
+>>8	byte&0x70	0x40		SAFER+ crypt,
+>>8	byte&0x70	0x50		LOKI97 crypt,
+>>8	byte&0x70	0x60		3DES crypt,
+>>8	byte&0x70	0x70		RIJNDAEL-256 crypt,
+>>8	byte&0x08	0x00		SHA1 hash,
+>>8	byte&0x08	0x08		RIPEMD-160 hash,
+>>8	byte&0x04	0x00		ZLib
+>>8	byte&0x04	0x04		BZip2
+>>8	byte&0x03	0x00		lvl.0
+>>8	byte&0x03	0x01		lvl.3
+>>8	byte&0x03	0x02		lvl.6
+>>8	byte&0x03	0x03		lvl.9
+#file format >3
+>3	string		>3		v.%.1s (unknown details)
+
+#------------------------------------------------------------------------------
+# $File: grace,v 1.4 2009/09/19 16:28:09 christos Exp $
+# Guile file magic from <dalepsmith@gmail.com>
+# http://www.gnu.org/s/guile/
+# http://git.savannah.gnu.org/gitweb/?p=guile.git;f=libguile/_scm.h;hb=HEAD#l250
+
+0	string	GOOF----	Guile Object
+>8	string	LE		\b, little endian
+>8	string	BE		\b, big endian
+>11	string	4		\b, 32bit
+>11	string	8		\b, 64bit
+>13	regex	.\..		\b, bytecode v%s
+
+#------------------------------------------------------------------------------
+# $File: hitachi-sh,v 1.5 2009/09/19 16:28:09 christos Exp $
+# hitach-sh: file(1) magic for Hitachi Super-H
+#
+# Super-H COFF
+#
+# below test line conflicts with 2nd NTFS filesystem sector 
+0	beshort		0x0500		Hitachi SH big-endian COFF
+# 2nd NTFS filesystem sector often starts with 0x05004e00 for unicode string 5 NTLDR
+#0	ubelong&0xFFFFNMPQ	0x0500NMPQ     Hitachi SH big-endian COFF
+>18	beshort&0x0002	=0x0000		object
+>18	beshort&0x0002	=0x0002		executable
+>18	beshort&0x0008	=0x0008		\b, stripped
+>18	beshort&0x0008	=0x0000		\b, not stripped
+#
+0	leshort		0x0550		Hitachi SH little-endian COFF
+>18	leshort&0x0002	=0x0000		object
+>18	leshort&0x0002	=0x0002		executable
+>18	leshort&0x0008	=0x0008		\b, stripped
+>18	leshort&0x0008	=0x0000		\b, not stripped
+
+
+#------------------------------------------------------------------------------
+# $File: hp,v 1.23 2009/09/19 16:28:09 christos Exp $
+# hp:  file(1) magic for Hewlett Packard machines (see also "printer")
+#
+# XXX - somebody should figure out whether any byte order needs to be
+# applied to the "TML" stuff; I'm assuming the Apollo stuff is
+# big-endian as it was mostly 68K-based.
+#
+# I think the 500 series was the old stack-based machines, running a
+# UNIX environment atop the "SUN kernel"; dunno whether it was
+# big-endian or little-endian.
+#
+# Daniel Quinlan (quinlan@yggdrasil.com): hp200 machines are 68010 based;
+# hp300 are 68020+68881 based; hp400 are also 68k.  The following basic
+# HP magic is useful for reference, but using "long" magic is a better
+# practice in order to avoid collisions.
+#
+# Guy Harris (guy@netapp.com): some additions to this list came from
+# HP-UX 10.0's "/usr/include/sys/unistd.h" (68030, 68040, PA-RISC 1.1,
+# 1.2, and 2.0).  The 1.2 and 2.0 stuff isn't in the HP-UX 10.0
+# "/etc/magic", though, except for the "archive file relocatable library"
+# stuff, and the 68030 and 68040 stuff isn't there at all - are they not
+# used in executables, or have they just not yet updated "/etc/magic"
+# completely?
+#
+# 0	beshort		200		hp200 (68010) BSD binary
+# 0	beshort		300		hp300 (68020+68881) BSD binary
+# 0	beshort		0x20c		hp200/300 HP-UX binary
+# 0	beshort		0x20d		hp400 (68030) HP-UX binary
+# 0	beshort		0x20e		hp400 (68040?) HP-UX binary
+# 0	beshort		0x20b		PA-RISC1.0 HP-UX binary
+# 0	beshort		0x210		PA-RISC1.1 HP-UX binary
+# 0	beshort		0x211		PA-RISC1.2 HP-UX binary
+# 0	beshort		0x214		PA-RISC2.0 HP-UX binary
+
+#
+# The "misc" stuff needs a byte order; the archives look suspiciously
+# like the old 177545 archives (0xff65 = 0177545).
+#
+#### Old Apollo stuff
+0	beshort		0627		Apollo m68k COFF executable
+>18	beshort		^040000		not stripped
+>22	beshort		>0		- version %d
+0	beshort		0624		apollo a88k COFF executable
+>18	beshort		^040000		not stripped
+>22	beshort		>0		- version %d
+0       long            01203604016     TML 0123 byte-order format
+0       long            01702407010     TML 1032 byte-order format
+0       long            01003405017     TML 2301 byte-order format
+0       long            01602007412     TML 3210 byte-order format
+#### PA-RISC 1.1
+0	belong 		0x02100106	PA-RISC1.1 relocatable object
+0	belong 		0x02100107	PA-RISC1.1 executable
+>168	belong		&0x00000004	dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0	belong 		0x02100108	PA-RISC1.1 shared executable
+>168	belong&0x4	0x4		dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0	belong 		0x0210010b	PA-RISC1.1 demand-load executable
+>168	belong&0x4	0x4		dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0	belong 		0x0210010e	PA-RISC1.1 shared library
+>96	belong		>0		- not stripped
+
+0	belong 		0x0210010d	PA-RISC1.1 dynamic load library
+>96	belong		>0		- not stripped
+
+#### PA-RISC 2.0
+0	belong		0x02140106	PA-RISC2.0 relocatable object
+
+0       belong		0x02140107	PA-RISC2.0 executable
+>168	belong		&0x00000004	dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0       belong		0x02140108	PA-RISC2.0 shared executable
+>168	belong		&0x00000004	dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0       belong		0x0214010b	PA-RISC2.0 demand-load executable
+>168	belong		&0x00000004	dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0       belong		0x0214010e	PA-RISC2.0 shared library
+>96	belong		>0		- not stripped
+
+0       belong		0x0214010d	PA-RISC2.0 dynamic load library
+>96	belong		>0		- not stripped
+
+#### 800
+0	belong 		0x020b0106	PA-RISC1.0 relocatable object
+
+0	belong 		0x020b0107	PA-RISC1.0 executable
+>168	belong&0x4	0x4		dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0	belong 		0x020b0108	PA-RISC1.0 shared executable
+>168	belong&0x4	0x4		dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0	belong 		0x020b010b	PA-RISC1.0 demand-load executable
+>168	belong&0x4	0x4		dynamically linked
+>(144)	belong		0x054ef630	dynamically linked
+>96	belong		>0		- not stripped
+
+0	belong 		0x020b010e	PA-RISC1.0 shared library
+>96	belong		>0		- not stripped
+
+0	belong 		0x020b010d	PA-RISC1.0 dynamic load library
+>96	belong		>0		- not stripped
+
+0	belong		0x213c6172	archive file
+>68	belong 		0x020b0619	- PA-RISC1.0 relocatable library
+>68	belong	 	0x02100619	- PA-RISC1.1 relocatable library
+>68	belong 		0x02110619	- PA-RISC1.2 relocatable library
+>68	belong 		0x02140619	- PA-RISC2.0 relocatable library
+
+#### 500
+0	long		0x02080106	HP s500 relocatable executable
+>16	long		>0		- version %d
+
+0	long		0x02080107	HP s500 executable
+>16	long		>0		- version %d
+
+0	long		0x02080108	HP s500 pure executable
+>16	long		>0		- version %d
+
+#### 200
+0	belong 		0x020c0108	HP s200 pure executable
+>4	beshort		>0		- version %d
+>8	belong		&0x80000000	save fp regs
+>8	belong		&0x40000000	dynamically linked
+>8	belong		&0x20000000	debuggable
+>36	belong		>0		not stripped
+
+0	belong		0x020c0107	HP s200 executable
+>4	beshort		>0		- version %d
+>8	belong		&0x80000000	save fp regs
+>8	belong		&0x40000000	dynamically linked
+>8	belong		&0x20000000	debuggable
+>36	belong		>0		not stripped
+
+0	belong		0x020c010b	HP s200 demand-load executable
+>4	beshort		>0		- version %d
+>8	belong		&0x80000000	save fp regs
+>8	belong		&0x40000000	dynamically linked
+>8	belong		&0x20000000	debuggable
+>36	belong		>0		not stripped
+
+0	belong		0x020c0106	HP s200 relocatable executable
+>4	beshort		>0		- version %d
+>6	beshort		>0		- highwater %d
+>8	belong		&0x80000000	save fp regs
+>8	belong		&0x20000000	debuggable
+>8	belong		&0x10000000	PIC
+
+0	belong 		0x020a0108	HP s200 (2.x release) pure executable
+>4	beshort		>0		- version %d
+>36	belong		>0		not stripped
+
+0	belong		0x020a0107	HP s200 (2.x release) executable
+>4	beshort		>0		- version %d
+>36	belong		>0		not stripped
+
+0	belong		0x020c010e	HP s200 shared library
+>4	beshort		>0		- version %d
+>6	beshort		>0		- highwater %d
+>36	belong		>0		not stripped
+
+0	belong		0x020c010d	HP s200 dynamic load library
+>4	beshort		>0		- version %d
+>6	beshort		>0		- highwater %d
+>36	belong		>0		not stripped
+
+#### MISC
+0	long		0x0000ff65	HP old archive
+0	long		0x020aff65	HP s200 old archive
+0	long		0x020cff65	HP s200 old archive
+0	long		0x0208ff65	HP s500 old archive
+
+0	long		0x015821a6	HP core file
+
+0	long		0x4da7eee8	HP-WINDOWS font
+>8	byte		>0		- version %d
+0	string		Bitmapfile	HP Bitmapfile
+
+0	string		IMGfile	CIS 	compimg HP Bitmapfile
+# XXX - see "lif"
+#0	short		0x8000		lif file
+0	long		0x020c010c	compiled Lisp
+
+0	string		msgcat01	HP NLS message catalog,
+>8	long		>0		%d messages
+
+# Summary: HP-48/49 calculator
+# Created by: phk@data.fls.dk
+# Modified by (1): AMAKAWA Shuhei <sa264@cam.ac.uk>
+# Modified by (2): Samuel Thibault <samuel.thibault@ens-lyon.org> (HP49 support)
+0	string		HPHP		HP
+>4	string		48		48 binary
+>4	string		49		49 binary
+>7	byte		>64		- Rev %c
+>8	leshort		0x2911		(ADR)
+>8	leshort		0x2933		(REAL)
+>8	leshort		0x2955		(LREAL)
+>8	leshort		0x2977		(COMPLX)
+>8	leshort		0x299d		(LCOMPLX)
+>8	leshort		0x29bf		(CHAR)
+>8	leshort		0x29e8		(ARRAY)
+>8	leshort		0x2a0a		(LNKARRAY)
+>8	leshort		0x2a2c		(STRING)
+>8	leshort		0x2a4e		(HXS)
+>8	leshort		0x2a74		(LIST)
+>8	leshort		0x2a96		(DIR)
+>8	leshort		0x2ab8		(ALG)
+>8	leshort		0x2ada		(UNIT)
+>8	leshort		0x2afc		(TAGGED)
+>8	leshort		0x2b1e		(GROB)
+>8	leshort		0x2b40		(LIB)
+>8	leshort		0x2b62		(BACKUP)
+>8	leshort		0x2b88		(LIBDATA)
+>8	leshort		0x2d9d		(PROG)
+>8	leshort		0x2dcc		(CODE)
+>8	leshort		0x2e48		(GNAME)
+>8	leshort		0x2e6d		(LNAME)
+>8	leshort		0x2e92		(XLIB)
+
+0	string		%%HP:		HP text
+>6	string		T(0)		- T(0)
+>6	string		T(1)		- T(1)
+>6	string		T(2)		- T(2)
+>6	string		T(3)		- T(3)
+>10	string		A(D)		A(D)
+>10	string		A(R)		A(R)
+>10	string		A(G)		A(G)
+>14	string		F(.)		F(.);
+>14	string		F(,)		F(,);
+
+
+# Summary: HP-38/39 calculator
+# Created by: Samuel Thibault <samuel.thibault@ens-lyon.org>
+0	string		HP3
+>3	string		8		HP 38
+>3	string		9		HP 39
+>4	string		Bin		binary
+>4	string		Asc		ASCII
+>7	string		A		(Directory List)
+>7	string		B		(Zaplet)
+>7	string		C		(Note)
+>7	string		D		(Program)
+>7	string		E		(Variable)
+>7	string		F		(List)
+>7	string		G		(Matrix)
+>7	string		H		(Library)
+>7	string		I		(Target List)
+>7	string		J		(ASCII Vector specification)
+>7	string		K		(wildcard)
+
+# Summary: HP-38/39 calculator
+# Created by: Samuel Thibault <samuel.thibault@ens-lyon.org>
+0	string		HP3
+>3	string		8		HP 38
+>3	string		9		HP 39
+>4	string		Bin		binary
+>4	string		Asc		ASCII
+>7	string		A		(Directory List)
+>7	string		B		(Zaplet)
+>7	string		C		(Note)
+>7	string		D		(Program)
+>7	string		E		(Variable)
+>7	string		F		(List)
+>7	string		G		(Matrix)
+>7	string		H		(Library)
+>7	string		I		(Target List)
+>7	string		J		(ASCII Vector specification)
+>7	string		K		(wildcard)
+
+# hpBSD magic numbers
+0	beshort		200		hp200 (68010) BSD
+>2	beshort		0407		impure binary
+>2	beshort		0410		read-only binary
+>2	beshort		0413		demand paged binary
+0	beshort		300		hp300 (68020+68881) BSD
+>2	beshort		0407		impure binary
+>2	beshort		0410		read-only binary
+>2	beshort		0413		demand paged binary
+#
+# From David Gero <dgero@nortelnetworks.com>
+# HP-UX 10.20 core file format from /usr/include/sys/core.h
+# Unfortunately, HP-UX uses corehead blocks without specifying the order
+# There are four we care about:
+#     CORE_KERNEL, which starts with the string "HP-UX"
+#     CORE_EXEC, which contains the name of the command
+#     CORE_PROC, which contains the signal number that caused the core dump
+#     CORE_FORMAT, which contains the version of the core file format (== 1)
+# The only observed order in real core files is KERNEL, EXEC, FORMAT, PROC
+# but we include all 6 variations of the order of the first 3, and
+# assume that PROC will always be last
+# Order 1: KERNEL, EXEC, FORMAT, PROC
+0x10		string	HP-UX
+>0		belong	2
+>>0xC		belong	0x3C
+>>>0x4C		belong	0x100
+>>>>0x58	belong	0x44
+>>>>>0xA0	belong	1
+>>>>>>0xAC	belong	4
+>>>>>>>0xB0	belong	1
+>>>>>>>>0xB4	belong	4		core file
+>>>>>>>>>0x90	string	>\0		from '%s'
+>>>>>>>>>0xC4	belong	3		- received SIGQUIT
+>>>>>>>>>0xC4	belong	4		- received SIGILL
+>>>>>>>>>0xC4	belong	5		- received SIGTRAP
+>>>>>>>>>0xC4	belong	6		- received SIGABRT
+>>>>>>>>>0xC4	belong	7		- received SIGEMT
+>>>>>>>>>0xC4	belong	8		- received SIGFPE
+>>>>>>>>>0xC4	belong	10		- received SIGBUS
+>>>>>>>>>0xC4	belong	11		- received SIGSEGV
+>>>>>>>>>0xC4	belong	12		- received SIGSYS
+>>>>>>>>>0xC4	belong	33		- received SIGXCPU
+>>>>>>>>>0xC4	belong	34		- received SIGXFSZ
+# Order 2: KERNEL, FORMAT, EXEC, PROC
+>>>0x4C		belong	1
+>>>>0x58	belong	4
+>>>>>0x5C	belong	1
+>>>>>>0x60	belong	0x100
+>>>>>>>0x6C	belong	0x44
+>>>>>>>>0xB4	belong	4		core file
+>>>>>>>>>0xA4	string	>\0		from '%s'
+>>>>>>>>>0xC4	belong	3		- received SIGQUIT
+>>>>>>>>>0xC4	belong	4		- received SIGILL
+>>>>>>>>>0xC4	belong	5		- received SIGTRAP
+>>>>>>>>>0xC4	belong	6		- received SIGABRT
+>>>>>>>>>0xC4	belong	7		- received SIGEMT
+>>>>>>>>>0xC4	belong	8		- received SIGFPE
+>>>>>>>>>0xC4	belong	10		- received SIGBUS
+>>>>>>>>>0xC4	belong	11		- received SIGSEGV
+>>>>>>>>>0xC4	belong	12		- received SIGSYS
+>>>>>>>>>0xC4	belong	33		- received SIGXCPU
+>>>>>>>>>0xC4	belong	34		- received SIGXFSZ
+# Order 3: FORMAT, KERNEL, EXEC, PROC
+0x24		string	HP-UX
+>0		belong	1
+>>0xC		belong	4
+>>>0x10		belong	1
+>>>>0x14	belong	2
+>>>>>0x20	belong	0x3C
+>>>>>>0x60	belong	0x100
+>>>>>>>0x6C	belong	0x44
+>>>>>>>>0xB4	belong	4		core file
+>>>>>>>>>0xA4	string	>\0		from '%s'
+>>>>>>>>>0xC4	belong	3		- received SIGQUIT
+>>>>>>>>>0xC4	belong	4		- received SIGILL
+>>>>>>>>>0xC4	belong	5		- received SIGTRAP
+>>>>>>>>>0xC4	belong	6		- received SIGABRT
+>>>>>>>>>0xC4	belong	7		- received SIGEMT
+>>>>>>>>>0xC4	belong	8		- received SIGFPE
+>>>>>>>>>0xC4	belong	10		- received SIGBUS
+>>>>>>>>>0xC4	belong	11		- received SIGSEGV
+>>>>>>>>>0xC4	belong	12		- received SIGSYS
+>>>>>>>>>0xC4	belong	33		- received SIGXCPU
+>>>>>>>>>0xC4	belong	34		- received SIGXFSZ
+# Order 4: EXEC, KERNEL, FORMAT, PROC
+0x64		string	HP-UX
+>0		belong	0x100
+>>0xC		belong	0x44
+>>>0x54		belong	2
+>>>>0x60	belong	0x3C
+>>>>>0xA0	belong	1
+>>>>>>0xAC	belong	4
+>>>>>>>0xB0	belong	1
+>>>>>>>>0xB4	belong	4		core file
+>>>>>>>>>0x44	string	>\0		from '%s'
+>>>>>>>>>0xC4	belong	3		- received SIGQUIT
+>>>>>>>>>0xC4	belong	4		- received SIGILL
+>>>>>>>>>0xC4	belong	5		- received SIGTRAP
+>>>>>>>>>0xC4	belong	6		- received SIGABRT
+>>>>>>>>>0xC4	belong	7		- received SIGEMT
+>>>>>>>>>0xC4	belong	8		- received SIGFPE
+>>>>>>>>>0xC4	belong	10		- received SIGBUS
+>>>>>>>>>0xC4	belong	11		- received SIGSEGV
+>>>>>>>>>0xC4	belong	12		- received SIGSYS
+>>>>>>>>>0xC4	belong	33		- received SIGXCPU
+>>>>>>>>>0xC4	belong	34		- received SIGXFSZ
+# Order 5: FORMAT, EXEC, KERNEL, PROC
+0x78		string	HP-UX
+>0		belong	1
+>>0xC		belong	4
+>>>0x10		belong	1
+>>>>0x14	belong	0x100
+>>>>>0x20	belong	0x44
+>>>>>>0x68	belong	2
+>>>>>>>0x74	belong	0x3C
+>>>>>>>>0xB4	belong	4		core file
+>>>>>>>>>0x58	string	>\0		from '%s'
+>>>>>>>>>0xC4	belong	3		- received SIGQUIT
+>>>>>>>>>0xC4	belong	4		- received SIGILL
+>>>>>>>>>0xC4	belong	5		- received SIGTRAP
+>>>>>>>>>0xC4	belong	6		- received SIGABRT
+>>>>>>>>>0xC4	belong	7		- received SIGEMT
+>>>>>>>>>0xC4	belong	8		- received SIGFPE
+>>>>>>>>>0xC4	belong	10		- received SIGBUS
+>>>>>>>>>0xC4	belong	11		- received SIGSEGV
+>>>>>>>>>0xC4	belong	12		- received SIGSYS
+>>>>>>>>>0xC4	belong	33		- received SIGXCPU
+>>>>>>>>>0xC4	belong	34		- received SIGXFSZ
+# Order 6: EXEC, FORMAT, KERNEL, PROC
+>0		belong	0x100
+>>0xC		belong	0x44
+>>>0x54		belong	1
+>>>>0x60	belong	4
+>>>>>0x64	belong	1
+>>>>>>0x68	belong	2
+>>>>>>>0x74	belong	0x2C
+>>>>>>>>0xB4	belong	4		core file
+>>>>>>>>>0x44	string	>\0		from '%s'
+>>>>>>>>>0xC4	belong	3		- received SIGQUIT
+>>>>>>>>>0xC4	belong	4		- received SIGILL
+>>>>>>>>>0xC4	belong	5		- received SIGTRAP
+>>>>>>>>>0xC4	belong	6		- received SIGABRT
+>>>>>>>>>0xC4	belong	7		- received SIGEMT
+>>>>>>>>>0xC4	belong	8		- received SIGFPE
+>>>>>>>>>0xC4	belong	10		- received SIGBUS
+>>>>>>>>>0xC4	belong	11		- received SIGSEGV
+>>>>>>>>>0xC4	belong	12		- received SIGSYS
+>>>>>>>>>0xC4	belong	33		- received SIGXCPU
+>>>>>>>>>0xC4	belong	34		- received SIGXFSZ
+
+
+
+#------------------------------------------------------------------------------
+# $File$
+# human68k:  file(1) magic for Human68k (X680x0 DOS) binary formats
+# Magic too short!
+#0		string	HU		Human68k
+#>68		string	LZX		LZX compressed
+#>>72		string	>\0		(version %s)
+#>(8.L+74)	string	LZX		LZX compressed
+#>>(8.L+78)	string	>\0		(version %s)
+#>60		belong	>0		binded
+#>(8.L+66)	string	#HUPAIR		hupair
+#>0		string	HU		X executable
+#>(8.L+74)	string	#LIBCV1		- linked PD LIBC ver 1
+#>4		belong	>0		- base address 0x%x
+#>28		belong	>0		not stripped
+#>32		belong	>0		with debug information
+#0		beshort	0x601a		Human68k Z executable
+#0		beshort	0x6000		Human68k object file
+#0		belong	0xd1000000	Human68k ar binary archive
+#0		belong	0xd1010000	Human68k ar ascii archive
+#0		beshort	0x0068		Human68k lib archive
+#4		string	LZX		Human68k LZX compressed
+#>8		string	>\0		(version %s)
+#>4		string	LZX		R executable
+#2		string	#HUPAIR		Human68k hupair R executable
+
+#------------------------------------------------------------------------------
+# $File: ibm370,v 1.8 2009/09/19 16:28:09 christos Exp $
+# ibm370:  file(1) magic for IBM 370 and compatibles.
+#
+# "ibm370" said that 0x15d == 0535 was "ibm 370 pure executable".
+# What the heck *is* "USS/370"?
+# AIX 4.1's "/etc/magic" has
+#
+#	0	short		0535		370 sysV executable 
+#	>12	long		>0		not stripped
+#	>22	short		>0		- version %d
+#	>30	long		>0		- 5.2 format
+#	0	short		0530		370 sysV pure executable 
+#	>12	long		>0		not stripped
+#	>22	short		>0		- version %d
+#	>30	long		>0		- 5.2 format
+#
+# instead of the "USS/370" versions of the same magic numbers.
+#
+0	beshort		0537		370 XA sysV executable 
+>12	belong		>0		not stripped
+>22	beshort		>0		- version %d
+>30	belong		>0		- 5.2 format
+0	beshort		0532		370 XA sysV pure executable 
+>12	belong		>0		not stripped
+>22	beshort		>0		- version %d
+>30	belong		>0		- 5.2 format
+0	beshort		054001		370 sysV pure executable
+>12	belong		>0		not stripped
+0	beshort		055001		370 XA sysV pure executable
+>12	belong		>0		not stripped
+0	beshort		056401		370 sysV executable
+>12	belong		>0		not stripped
+0	beshort		057401		370 XA sysV executable
+>12	belong		>0		not stripped
+0       beshort		0531		SVR2 executable (Amdahl-UTS)
+>12	belong		>0		not stripped
+>24     belong		>0		- version %d
+0	beshort		0534		SVR2 pure executable (Amdahl-UTS)
+>12	belong		>0		not stripped
+>24	belong		>0		- version %d
+0	beshort		0530		SVR2 pure executable (USS/370)
+>12	belong		>0		not stripped
+>24	belong		>0		- version %d
+0	beshort		0535		SVR2 executable (USS/370)
+>12	belong		>0		not stripped
+>24	belong		>0		- version %d
+
+#------------------------------------------------------------------------------
+# $File: ibm6000,v 1.11 2013/01/08 20:13:01 christos Exp $
+# ibm6000:  file(1) magic for RS/6000 and the RT PC.
+#
+0	beshort		0x01df		executable (RISC System/6000 V3.1) or obj module
+>12	belong		>0		not stripped
+# Breaks sun4 statically linked execs.
+#0      beshort		0x0103		executable (RT Version 2) or obj module
+#>2	byte		0x50		pure
+#>28	belong		>0		not stripped
+#>6	beshort		>0		- version %ld
+0	beshort		0x0104		shared library
+0	beshort		0x0105		ctab data
+0	beshort		0xfe04		structured file
+0	string		0xabcdef	AIX message catalog
+0	belong		0x000001f9	AIX compiled message catalog
+0	string		\<aiaff>	archive
+0	string		\<bigaf>	archive (big format)
+
+0	beshort		0x01f7		64-bit XCOFF executable or object module
+>20	belong		0		not stripped
+# GRR: this test is still too general as it catches also many FATs of DOS filesystems
+4	belong		&0x0feeddb0	
+# real core dump could not be 32-bit and 64-bit together
+>7	byte&0x03	!3		AIX core file
+>>1	byte		&0x01		fulldump
+>>7	byte		&0x01		32-bit
+>>>0x6e0	string	>\0		\b, %s
+>>7	byte		&0x02		64-bit
+>>>0x524	string	>\0		\b, %s
+
+#------------------------------------------------------------------------------
+# $File$
+# icc:  file(1) magic for International Color Consortium file formats
+
+#
+# Color profiles as per the ICC's "Image technology colour management -
+# Architecture, profile format, and data structure" specification.
+# See
+#
+#	http://www.color.org/specification/ICC1v43_2010-12.pdf
+#
+# for Specification ICC.1:2010 (Profile version 4.3.0.0).
+#
+# Bytes 36 to 39 contain a generic profile file signature of "acsp";
+# bytes 40 to 43 "may be used to identify the primary platform/operating
+# system framework for which the profile was created".
+#
+# There are other fields that might be worth dumping as well.
+#
+
+# This appears to be what's used for Apple ColorSync profiles.
+# Instead of adding that, Apple just changed the generic "acsp" entry
+# to be for "ColorSync ICC Color Profile" rather than "Kodak Color
+# Management System, ICC Profile".
+# Yes, it's "APPL", not "AAPL"; see the spec.
+36	string		acspAPPL	ColorSync ICC Profile
+!:mime	application/vnd.iccprofile
+
+# Microsoft ICM color profile
+36	string		acspMSFT	Microsoft ICM Color Profile
+!:mime	application/vnd.iccprofile
+
+# Yes, that's a blank after "SGI".
+36	string		acspSGI\ 	SGI ICC Profile
+!:mime	application/vnd.iccprofile
+
+# XXX - is this what's used for the Sun KCMS or not?  The standard file
+# uses just "acsp" for that, but Apple's file uses it for "ColorSync",
+# and there *is* an identified "primary platform" value of SUNW.
+36	string		acspSUNW	Sun KCMS ICC Profile
+!:mime	application/vnd.iccprofile
+
+# Any other profile.
+# XXX - should we use "acsp\0\0\0\0" for "no primary platform" profiles,
+# and use "acsp" for everything else and dump the "primary platform"
+# string in those cases?
+36	string		acsp		ICC Profile
+!:mime	application/vnd.iccprofile
+
+
+
+#------------------------------------------------------------------------------
+# $File: iff,v 1.12 2009/09/19 16:28:09 christos Exp $
+# iff:	file(1) magic for Interchange File Format (see also "audio" & "images")
+#
+# Daniel Quinlan (quinlan@yggdrasil.com) -- IFF was designed by Electronic
+# Arts for file interchange.  It has also been used by Apple, SGI, and
+# especially Commodore-Amiga.
+#
+# IFF files begin with an 8 byte FORM header, followed by a 4 character
+# FORM type, which is followed by the first chunk in the FORM.
+
+0	string		FORM		IFF data
+#>4	belong		x		\b, FORM is %d bytes long
+# audio formats
+>8	string		AIFF		\b, AIFF audio
+!:mime	audio/x-aiff
+>8	string		AIFC		\b, AIFF-C compressed audio
+!:mime	audio/x-aiff
+>8	string		8SVX		\b, 8SVX 8-bit sampled sound voice
+!:mime	audio/x-aiff
+>8	string		16SV		\b, 16SV 16-bit sampled sound voice
+>8	string		SAMP		\b, SAMP sampled audio
+>8	string		MAUD		\b, MAUD MacroSystem audio
+>8	string		SMUS		\b, SMUS simple music
+>8	string		CMUS		\b, CMUS complex music
+# image formats
+>8	string		ILBMBMHD	\b, ILBM interleaved image
+>>20	beshort		x		\b, %d x
+>>22	beshort		x		%d
+>8	string		RGBN		\b, RGBN 12-bit RGB image
+>8	string		RGB8		\b, RGB8 24-bit RGB image
+>8	string		DEEP		\b, DEEP TVPaint/XiPaint image
+>8	string		DR2D		\b, DR2D 2-D object
+>8	string		TDDD		\b, TDDD 3-D rendering
+>8	string		LWOB		\b, LWOB 3-D object
+>8	string		LWO2		\b, LWO2 3-D object, v2
+>8	string		LWLO		\b, LWLO 3-D layered object
+>8	string		REAL		\b, REAL Real3D rendering
+>8	string		MC4D		\b, MC4D MaxonCinema4D rendering
+>8	string		ANIM		\b, ANIM animation
+>8	string		YAFA		\b, YAFA animation
+>8	string		SSA\ 		\b, SSA super smooth animation
+>8	string		ACBM		\b, ACBM continuous image
+>8	string		FAXX		\b, FAXX fax image
+# other formats
+>8	string		FTXT		\b, FTXT formatted text
+>8	string		CTLG		\b, CTLG message catalog
+>8	string		PREF		\b, PREF preferences
+>8	string		DTYP		\b, DTYP datatype description
+>8	string		PTCH		\b, PTCH binary patch
+>8	string		AMFF		\b, AMFF AmigaMetaFile format
+>8	string		WZRD		\b, WZRD StormWIZARD resource
+>8	string		DOC\ 		\b, DOC desktop publishing document
+>8	string		WVQA 		\b, Westwood Studios VQA Multimedia,
+>>24	leshort		x		%d video frames,
+>>26	leshort		x		%d x
+>>28	leshort		x		%d
+>8	string		MOVE		\b, Wing Commander III Video
+>>12	string		_PC_		\b, PC version
+>>12	string		3DO_		\b, 3DO version
+
+# These go at the end of the iff rules
+#
+# I don't see why these might collide with anything else.
+#
+# Interactive Fiction related formats
+#
+>8	string		IFRS		\b, Blorb Interactive Fiction
+>>24	string		Exec		with executable chunk
+>8	string          IFZS		\b, Z-machine or Glulx saved game file (Quetzal)
+
+#------------------------------------------------------------------------------
+# $File: images,v 1.105 2015/02/14 17:30:03 christos Exp $
+# images:  file(1) magic for image formats (see also "iff", and "c-lang" for
+# XPM bitmaps)
+#
+# originally from jef@helios.ee.lbl.gov (Jef Poskanzer),
+# additions by janl@ifi.uio.no as well as others. Jan also suggested
+# merging several one- and two-line files into here.
+#
+# little magic: PCX (first byte is 0x0a)
+
+# Targa - matches `povray', `ppmtotga' and `xv' outputs
+# by Philippe De Muyter <phdm@macqel.be>
+# at 2, byte ImgType must be 1, 2, 3, 9, 10 or 11
+# at 1, byte CoMapType must be 1 if ImgType is 1 or 9, 0 otherwise
+# at 3, leshort Index is 0 for povray, ppmtotga and xv outputs
+# `xv' recognizes only a subset of the following (RGB with pixelsize = 24)
+# `tgatoppm' recognizes a superset (Index may be anything)
+1	belong&0xfff7ffff	0x01010000	Targa image data - Map
+!:strength + 2
+>2	byte&8			8		- RLE
+>12	leshort			>0		%d x
+>14	leshort			>0		%d
+1	belong&0xfff7ffff	0x00020000	Targa image data - RGB
+!:strength + 2
+>2	byte&8			8		- RLE
+>12	leshort			>0		%d x
+>14	leshort			>0		%d
+1	belong&0xfff7ffff	0x00030000	Targa image data - Mono
+!:strength + 2
+>2	byte&8			8		- RLE
+>12	leshort			>0		%d x
+>14	leshort			>0		%d
+
+# PBMPLUS images
+# The next byte following the magic is always whitespace.
+# strength is changed to try these patterns before "x86 boot sector"
+0	name		netpbm
+>3	regex/s		=[0-9]{1,50}\ [0-9]{1,50}	Netpbm PPM image data
+>>&0	regex		=[0-9]{1,50} 			\b, size = %s x
+>>>&0	regex		=[0-9]{1,50}			\b %s
+
+0	search/1	P1		
+>0	use		netpbm
+>>0	string		x	\b, bitmap
+!:strength + 45
+!:mime	image/x-portable-bitmap
+
+0	search/1	P2		
+>0	use		netpbm
+>>0	string		x	\b, greymap
+!:strength + 45
+!:mime	image/x-portable-greymap
+
+0	search/1	P3
+>0	use		netpbm
+>>0	string		x	\b, pixmap
+!:strength + 45
+!:mime	image/x-portable-pixmap
+
+
+0	string		P4		
+>0	use		netpbm
+>>0	string		x	\b, rawbits, bitmap
+!:strength + 45
+!:mime	image/x-portable-bitmap
+
+0	string		P5		
+>0	use		netpbm
+>>0	string		x	\b, rawbits, greymap
+!:strength + 45
+!:mime	image/x-portable-greymap
+
+0	string		P6		
+>0	use		netpbm
+>>0	string		x	\b, rawbits, pixmap
+!:strength + 45
+!:mime	image/x-portable-pixmap
+
+0	string		P7		Netpbm PAM image file
+!:mime	image/x-portable-pixmap
+
+# From: bryanh@giraffe-data.com (Bryan Henderson)
+0	string		\117\072	Solitaire Image Recorder format
+>4	string		\013		MGI Type 11
+>4	string		\021		MGI Type 17
+0	string		.MDA		MicroDesign data
+>21	byte		48		version 2
+>21	byte		51		version 3
+0	string		.MDP		MicroDesign page data
+>21	byte		48		version 2
+>21	byte		51		version 3
+
+# NIFF (Navy Interchange File Format, a modification of TIFF) images
+# [GRR:  this *must* go before TIFF]
+0	string		IIN1		NIFF image data
+!:mime	image/x-niff
+
+# Canon RAW version 1 (CRW) files are a type of Canon Image File Format
+# (CIFF) file. These are apparently all little-endian.
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# URL: http://www.sno.phy.queensu.ca/~phil/exiftool/canon_raw.html
+0	string		II\x1a\0\0\0HEAPCCDR	Canon CIFF raw image data
+!:mime	image/x-canon-crw
+>16	leshort		x	\b, version %d.
+>14	leshort		x	\b%d
+
+# Canon RAW version 2 (CR2) files are a kind of TIFF with an extra magic
+# number. Put this above the TIFF test to make sure we detect them.
+# These are apparently all little-endian.
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# URL: http://libopenraw.freedesktop.org/wiki/Canon_CR2
+0	string		II\x2a\0\x10\0\0\0CR	Canon CR2 raw image data
+!:mime	image/x-canon-cr2
+>10	byte		x	\b, version %d.
+>11	byte		x	\b%d
+
+# Tag Image File Format, from Daniel Quinlan (quinlan@yggdrasil.com)
+# The second word of TIFF files is the TIFF version number, 42, which has
+# never changed.  The TIFF specification recommends testing for it.
+0	string		MM\x00\x2a	TIFF image data, big-endian
+!:mime	image/tiff
+>(4.L)	use		\^tiff_ifd
+0	string		II\x2a\x00	TIFF image data, little-endian
+!:mime	image/tiff
+>(4.l)	use		tiff_ifd
+
+0	name		tiff_ifd
+>0	leshort		x		\b, direntries=%d
+>2	use		tiff_entry
+
+0	name		tiff_entry
+# NewSubFileType
+>0	leshort		0xfe
+>>12	use		tiff_entry
+>0	leshort		0x100
+>>4	lelong		1
+>>>12	use		tiff_entry
+>>>8	leshort		x		\b, width=%d
+>0	leshort		0x101
+>>4	lelong		1
+>>>8	leshort		x		\b, height=%d
+>>>12	use		tiff_entry
+>0	leshort		0x102
+>>8	leshort		x		\b, bps=%d
+>>12	use		tiff_entry
+>0	leshort		0x103
+>>4	lelong		1		\b, compression=
+>>>8	leshort		1		\bnone
+>>>8	leshort		2		\bhuffman
+>>>8	leshort		3		\bbi-level group 3
+>>>8	leshort		4		\bbi-level group 4
+>>>8	leshort		5		\bLZW
+>>>8	leshort		6		\bJPEG (old)
+>>>8	leshort		7		\bJPEG
+>>>8	leshort		8		\bdeflate
+>>>8	leshort		9		\bJBIG, ITU-T T.85
+>>>8	leshort		0xa		\bJBIG, ITU-T T.43
+>>>8	leshort		0x7ffe		\bNeXT RLE 2-bit
+>>>8	leshort		0x8005		\bPackBits (Macintosh RLE)
+>>>8	leshort		0x8029		\bThunderscan RLE
+>>>8	leshort		0x807f		\bRasterPadding (CT or MP)
+>>>8	leshort		0x8080		\bRLE (Line Work)
+>>>8	leshort		0x8081		\bRLE (High-Res Cont-Tone)
+>>>8	leshort		0x8082		\bRLE (Binary Line Work)
+>>>8	leshort		0x80b2		\bDeflate (PKZIP)
+>>>8	leshort		0x80b3		\bKodak DCS
+>>>8	leshort		0x8765		\bJBIG
+>>>8	leshort		0x8798		\bJPEG2000
+>>>8	leshort		0x8799		\bNikon NEF Compressed
+>>>8	default		x	
+>>>>8	leshort		x		\b(unknown 0x%x)
+>>>12	use		tiff_entry
+>0	leshort		0x106		\b, PhotometricIntepretation=
+>>8	clear		x
+>>8	leshort		0		\bWhiteIsZero
+>>8	leshort		1		\bBlackIsZero
+>>8	leshort		2		\bRGB
+>>8	leshort		3		\bRGB Palette
+>>8	leshort		4		\bTransparency Mask
+>>8	leshort		5		\bCMYK
+>>8	leshort		6		\bYCbCr
+>>8	leshort		8		\bCIELab
+>>8	default		x
+>>>8	leshort		x		\b(unknown=0x%x)
+>>12	use		tiff_entry
+# FillOrder
+>0	leshort		0x10a
+>>4	lelong		1
+>>>12	use		tiff_entry
+# DocumentName
+>0	leshort		0x10d
+>>(8.l)	string		x		\b, name=%s
+>>>12	use		tiff_entry
+# ImageDescription
+>0	leshort		0x10e
+>>(8.l)	string		x		\b, description=%s
+>>>12	use		tiff_entry
+# Make
+>0	leshort		0x10f
+>>(8.l)	string		x		\b, manufacturer=%s
+>>>12	use		tiff_entry
+# Model
+>0	leshort		0x110
+>>(8.l)	string		x		\b, model=%s
+>>>12	use		tiff_entry
+# StripOffsets
+>0	leshort		0x111
+>>12	use		tiff_entry
+# Orientation
+>0	leshort		0x112		\b, orientation=
+>>8	leshort		1		\bupper-left
+>>8	leshort		3		\blower-right
+>>8	leshort		6		\bupper-right
+>>8	leshort		8		\blower-left
+>>8	leshort		9		\bundefined
+>>8	default		x
+>>>8	leshort		x		\b[*%d*]
+>>12	use		tiff_entry
+# XResolution
+>0	leshort		0x11a
+>>8	lelong		x		\b, xresolution=%d
+>>12	use		tiff_entry
+# YResolution
+>0	leshort		0x11b
+>>8	lelong		x		\b, yresolution=%d
+>>12	use		tiff_entry
+# ResolutionUnit
+>0	leshort		0x128
+>>8	leshort		x		\b, resolutionunit=%d
+>>12	use		tiff_entry
+# Software
+>0	leshort		0x131
+>>(8.l)	string		x		\b, software=%s
+>>12	use		tiff_entry
+# Datetime
+>0	leshort		0x132
+>>(8.l)	string		x		\b, datetime=%s
+>>12	use		tiff_entry
+# HostComputer
+>0	leshort		0x13c
+>>(8.l)	string		x		\b, hostcomputer=%s
+>>12	use		tiff_entry
+# WhitePoint
+>0	leshort		0x13e
+>>12	use		tiff_entry
+# PrimaryChromaticities
+>0	leshort		0x13f
+>>12	use		tiff_entry
+# YCbCrCoefficients
+>0	leshort		0x211
+>>12	use		tiff_entry
+# YCbCrPositioning
+>0	leshort		0x213
+>>12	use		tiff_entry
+# ReferenceBlackWhite
+>0	leshort		0x214
+>>12	use		tiff_entry
+# Copyright
+>0	leshort		0x8298
+>>(8.l)	string		x		\b, copyright=%s
+>>12	use		tiff_entry
+# ExifOffset
+>0	leshort		0x8769
+>>12	use		tiff_entry
+# GPS IFD
+>0	leshort		0x8825		\b, GPS-Data
+>>12	use		tiff_entry
+
+#>0	leshort		x		\b, unknown=0x%x
+#>>12	use		tiff_entry
+
+0	string		MM\x00\x2b	Big TIFF image data, big-endian
+!:mime	image/tiff
+0	string		II\x2b\x00	Big TIFF image data, little-endian
+!:mime	image/tiff
+
+# PNG [Portable Network Graphics, or "PNG's Not GIF"] images
+# (Greg Roelofs, newt@uchicago.edu)
+# (Albert Cahalan, acahalan@cs.uml.edu)
+#
+# 137 P N G \r \n ^Z \n [4-byte length] H E A D [HEAD data] [HEAD crc] ...
+#
+0	string		\x89PNG\x0d\x0a\x1a\x0a		PNG image data
+!:mime	image/png
+>16	belong		x		\b, %d x
+>20	belong		x		%d,
+>24	byte		x		%d-bit
+>25	byte		0		grayscale,
+>25	byte		2		\b/color RGB,
+>25	byte		3		colormap,
+>25	byte		4		gray+alpha,
+>25	byte		6		\b/color RGBA,
+#>26	byte		0		deflate/32K,
+>28	byte		0		non-interlaced
+>28	byte		1		interlaced
+
+# possible GIF replacements; none yet released!
+# (Greg Roelofs, newt@uchicago.edu)
+#
+# GRR 950115:  this was mine ("Zip GIF"):
+0	string		GIF94z		ZIF image (GIF+deflate alpha)
+!:mime	image/x-unknown
+#
+# GRR 950115:  this is Jeremy Wohl's Free Graphics Format (better):
+#					
+0	string		FGF95a		FGF image (GIF+deflate beta)
+!:mime	image/x-unknown
+#
+# GRR 950115:  this is Thomas Boutell's Portable Bitmap Format proposal
+# (best; not yet implemented):
+#					
+0	string		PBF		PBF image (deflate compression)
+!:mime	image/x-unknown
+
+# GIF
+0	string		GIF8		GIF image data
+!:mime	image/gif
+!:apple	8BIMGIFf
+>4	string		7a		\b, version 8%s,
+>4	string		9a		\b, version 8%s,
+>6	leshort		>0		%d x
+>8	leshort		>0		%d
+#>10	byte		&0x80		color mapped,
+#>10	byte&0x07	=0x00		2 colors
+#>10	byte&0x07	=0x01		4 colors
+#>10	byte&0x07	=0x02		8 colors
+#>10	byte&0x07	=0x03		16 colors
+#>10	byte&0x07	=0x04		32 colors
+#>10	byte&0x07	=0x05		64 colors
+#>10	byte&0x07	=0x06		128 colors
+#>10	byte&0x07	=0x07		256 colors
+
+# ITC (CMU WM) raster files.  It is essentially a byte-reversed Sun raster,
+# 1 plane, no encoding.
+0	string		\361\0\100\273	CMU window manager raster image data
+>4	lelong		>0		%d x
+>8	lelong		>0		%d,
+>12	lelong		>0		%d-bit
+
+# Magick Image File Format
+0	string		id=ImageMagick	MIFF image data
+
+# Artisan
+0	long		1123028772	Artisan image data
+>4	long		1		\b, rectangular 24-bit
+>4	long		2		\b, rectangular 8-bit with colormap
+>4	long		3		\b, rectangular 32-bit (24-bit with matte)
+
+# FIG (Facility for Interactive Generation of figures), an object-based format
+0	search/1	#FIG		FIG image text
+>5	string		x		\b, version %.3s
+
+# PHIGS
+0	string		ARF_BEGARF		PHIGS clear text archive
+0	string		@(#)SunPHIGS		SunPHIGS
+# version number follows, in the form m.n
+>40	string		SunBin			binary
+>32	string		archive			archive
+
+# GKS (Graphics Kernel System)
+0	string		GKSM		GKS Metafile
+>24	string		SunGKS		\b, SunGKS
+
+# CGM image files
+0	string		BEGMF		clear text Computer Graphics Metafile
+
+# MGR bitmaps  (Michael Haardt, u31b3hs@pool.informatik.rwth-aachen.de)
+0	string	yz	MGR bitmap, modern format, 8-bit aligned
+0	string	zz	MGR bitmap, old format, 1-bit deep, 16-bit aligned
+0	string	xz	MGR bitmap, old format, 1-bit deep, 32-bit aligned
+0	string	yx	MGR bitmap, modern format, squeezed
+
+# Fuzzy Bitmap (FBM) images
+0	string		%bitmap\0	FBM image data
+>30	long		0x31		\b, mono
+>30	long		0x33		\b, color
+
+# facsimile data
+1	string		PC\ Research,\ Inc	group 3 fax data
+>29	byte		0		\b, normal resolution (204x98 DPI)
+>29	byte		1		\b, fine resolution (204x196 DPI)
+# From: Herbert Rosmanith <herp@wildsau.idv.uni.linz.at>
+0	string		Sfff		structured fax file
+
+# From: Joerg Jenderek <joerg.jen.der.ek@gmx.net>
+# most files with the extension .EPA and some with .BMP
+0	string		\x11\x06	Award BIOS Logo, 136 x 84
+!:mime	image/x-award-bioslogo
+0	string		\x11\x09	Award BIOS Logo, 136 x 126
+!:mime	image/x-award-bioslogo
+#0	string		\x07\x1f	BIOS Logo corrupted?
+# http://www.blackfiveservices.co.uk/awbmtools.shtml
+# http://biosgfx.narod.ru/v3/
+# http://biosgfx.narod.ru/abr-2/
+0	string		AWBM		
+>4	leshort		<1981		Award BIOS bitmap
+!:mime	image/x-award-bmp
+# image width is a multiple of 4
+>>4	leshort&0x0003	0		
+>>>4		leshort	x		\b, %d
+>>>6		leshort	x		x %d
+>>4	leshort&0x0003	>0		\b,
+>>>4	leshort&0x0003	=1		
+>>>>4		leshort	x		%d+3
+>>>4	leshort&0x0003	=2		
+>>>>4		leshort	x		%d+2
+>>>4	leshort&0x0003	=3		
+>>>>4		leshort	x		%d+1
+>>>6		leshort	x		x %d
+# at offset 8 starts imagedata followed by "RGB " marker
+
+# PC bitmaps (OS/2, Windows BMP files)  (Greg Roelofs, newt@uchicago.edu)
+# http://en.wikipedia.org/wiki/BMP_file_format#DIB_header_.\
+# 28bitmap_information_header.29
+0	string		BM
+>14	leshort		12		PC bitmap, OS/2 1.x format
+!:mime	image/x-ms-bmp
+>>18	leshort		x		\b, %d x
+>>20	leshort		x		%d
+>14	leshort		64		PC bitmap, OS/2 2.x format
+!:mime	image/x-ms-bmp
+>>18	leshort		x		\b, %d x
+>>20	leshort		x		%d
+>14	leshort		40		PC bitmap, Windows 3.x format
+!:mime	image/x-ms-bmp
+>>18	lelong		x		\b, %d x
+>>22	lelong		x		%d x
+>>28	leshort		x		%d
+>14	leshort		124		PC bitmap, Windows 98/2000 and newer format
+!:mime	image/x-ms-bmp
+>>18	lelong		x		\b, %d x
+>>22	lelong		x		%d x
+>>28	leshort		x		%d
+>14	leshort		108		PC bitmap, Windows 95/NT4 and newer format
+!:mime	image/x-ms-bmp
+>>18	lelong		x		\b, %d x
+>>22	lelong		x		%d x
+>>28	leshort		x		%d
+>14	leshort		128		PC bitmap, Windows NT/2000 format
+!:mime	image/x-ms-bmp
+>>18	lelong		x		\b, %d x
+>>22	lelong		x		%d x
+>>28	leshort		x		%d
+# Too simple - MPi
+#0	string		IC		PC icon data
+#0	string		PI		PC pointer image data
+#0	string		CI		PC color icon data
+#0	string		CP		PC color pointer image data
+# Conflicts with other entries [BABYL]
+#0	string		BA		PC bitmap array data
+
+# XPM icons (Greg Roelofs, newt@uchicago.edu)
+0	search/1	/*\ XPM\ */	X pixmap image text
+!:mime	image/x-xpmi
+
+# Utah Raster Toolkit RLE images (janl@ifi.uio.no)
+0	leshort		0xcc52		RLE image data,
+>6	leshort		x		%d x
+>8	leshort		x		%d
+>2	leshort		>0		\b, lower left corner: %d
+>4	leshort		>0		\b, lower right corner: %d
+>10	byte&0x1	=0x1		\b, clear first
+>10	byte&0x2	=0x2		\b, no background
+>10	byte&0x4	=0x4		\b, alpha channel
+>10	byte&0x8	=0x8		\b, comment
+>11	byte		>0		\b, %d color channels
+>12	byte		>0		\b, %d bits per pixel
+>13	byte		>0		\b, %d color map channels
+
+# image file format (Robert Potter, potter@cs.rochester.edu)
+0	string		Imagefile\ version-	iff image data
+# this adds the whole header (inc. version number), informative but longish
+>10	string		>\0		%s
+
+# Sun raster images, from Daniel Quinlan (quinlan@yggdrasil.com)
+0	belong		0x59a66a95	Sun raster image data
+>4	belong		>0		\b, %d x
+>8	belong		>0		%d,
+>12	belong		>0		%d-bit,
+#>16	belong		>0		%d bytes long,
+>20	belong		0		old format,
+#>20	belong		1		standard,
+>20	belong		2		compressed,
+>20	belong		3		RGB,
+>20	belong		4		TIFF,
+>20	belong		5		IFF,
+>20	belong		0xffff		reserved for testing,
+>24	belong		0		no colormap
+>24	belong		1		RGB colormap
+>24	belong		2		raw colormap
+#>28	belong		>0		colormap is %d bytes long
+
+# SGI image file format, from Daniel Quinlan (quinlan@yggdrasil.com)
+#
+# See
+#	http://reality.sgi.com/grafica/sgiimage.html
+#
+0	beshort		474		SGI image data
+#>2	byte		0		\b, verbatim
+>2	byte		1		\b, RLE
+#>3	byte		1		\b, normal precision
+>3	byte		2		\b, high precision
+>4	beshort		x		\b, %d-D
+>6	beshort		x		\b, %d x
+>8	beshort		x		%d
+>10	beshort		x		\b, %d channel
+>10	beshort		!1		\bs
+>80	string		>0		\b, "%s"
+
+0	string		IT01		FIT image data
+>4	belong		x		\b, %d x
+>8	belong		x		%d x
+>12	belong		x		%d
+#
+0	string		IT02		FIT image data
+>4	belong		x		\b, %d x
+>8	belong		x		%d x
+>12	belong		x		%d
+#
+2048	string		PCD_IPI		Kodak Photo CD image pack file
+>0xe02	byte&0x03	0x00		, landscape mode
+>0xe02	byte&0x03	0x01		, portrait mode
+>0xe02	byte&0x03	0x02		, landscape mode
+>0xe02	byte&0x03	0x03		, portrait mode
+0	string		PCD_OPA		Kodak Photo CD overview pack file
+
+# FITS format.  Jeff Uphoff <juphoff@tarsier.cv.nrao.edu>
+# FITS is the Flexible Image Transport System, the de facto standard for
+# data and image transfer, storage, etc., for the astronomical community.
+# (FITS floating point formats are big-endian.)
+0	string	SIMPLE\ \ =	FITS image data
+>109	string	8		\b, 8-bit, character or unsigned binary integer
+>108	string	16		\b, 16-bit, two's complement binary integer
+>107	string	\ 32		\b, 32-bit, two's complement binary integer
+>107	string	-32		\b, 32-bit, floating point, single precision
+>107	string	-64		\b, 64-bit, floating point, double precision
+
+# other images
+0	string	This\ is\ a\ BitMap\ file	Lisp Machine bit-array-file
+
+# From SunOS 5.5.1 "/etc/magic" - appeared right before Sun raster image
+# stuff.
+#
+0	beshort		0x1010		PEX Binary Archive
+
+# DICOM medical imaging data
+128	string	DICM			DICOM medical imaging data
+!:mime	application/dicom
+
+# XWD - X Window Dump file.
+#   As described in /usr/X11R6/include/X11/XWDFile.h
+#   used by the xwd program.
+#   Bradford Castalia, idaeim, 1/01
+#   updated by Adam Buchbinder, 2/09
+# The following assumes version 7 of the format; the first long is the length
+# of the header, which is at least 25 4-byte longs, and the one at offset 8
+# is a constant which is always either 1 or 2. Offset 12 is the pixmap depth,
+# which is a maximum of 32.
+0	belong	>100
+>8	belong	<3
+>>12	belong	<33
+>>>4	belong	7			XWD X Window Dump image data
+!:mime	image/x-xwindowdump
+>>>>100	string	>\0			\b, "%s"
+>>>>16	belong	x			\b, %dx
+>>>>20	belong	x			\b%dx
+>>>>12	belong	x			\b%d
+
+# PDS - Planetary Data System
+#   These files use Parameter Value Language in the header section.
+#   Unfortunately, there is no certain magic, but the following
+#   strings have been found to be most likely.
+0	string	NJPL1I00		PDS (JPL) image data
+2	string	NJPL1I			PDS (JPL) image data
+0	string	CCSD3ZF			PDS (CCSD) image data
+2	string	CCSD3Z			PDS (CCSD) image data
+0	string	PDS_			PDS image data
+0	string	LBLSIZE=		PDS (VICAR) image data
+
+# pM8x: ATARI STAD compressed bitmap format
+#
+# from Oskar Schirmer <schirmer@scara.com> Feb 2, 2001
+# p M 8 5/6 xx yy zz data...
+# Atari ST STAD bitmap is always 640x400, bytewise runlength compressed.
+# bytes either run horizontally (pM85) or vertically (pM86). yy is the
+# most frequent byte, xx and zz are runlength escape codes, where xx is
+# used for runs of yy.
+#
+0	string	pM85		Atari ST STAD bitmap image data (hor)
+>5	byte	0x00		(white background)
+>5	byte	0xFF		(black background)
+0	string	pM86		Atari ST STAD bitmap image data (vert)
+>5	byte	0x00		(white background)
+>5	byte	0xFF		(black background)
+
+# Gurkan Sengun <gurkan@linuks.mine.nu>, www.linuks.mine.nu
+# http://www.atarimax.com/jindroush.atari.org/afmtatr.html
+0	leshort	0x0296		Atari ATR image
+
+# XXX:
+# This is bad magic 0x5249 == 'RI' conflicts with RIFF and other
+# magic.
+# SGI RICE image file <mpruett@sgi.com>
+#0	beshort	0x5249		RICE image
+#>2	beshort	x		v%d
+#>4	beshort	x		(%d x
+#>6	beshort	x		%d)
+#>8	beshort	0		8 bit
+#>8	beshort	1		10 bit
+#>8	beshort	2		12 bit
+#>8	beshort	3		13 bit
+#>10	beshort	0		4:2:2
+#>10	beshort	1		4:2:2:4
+#>10	beshort	2		4:4:4
+#>10	beshort	3		4:4:4:4
+#>12	beshort	1		RGB
+#>12	beshort	2		CCIR601
+#>12	beshort	3		RP175
+#>12	beshort	4		YUV
+
+# PCX image files
+# From: Dan Fandrich <dan@coneharvesters.com>
+# updated by Joerg Jenderek at Feb 2013 by http://de.wikipedia.org/wiki/PCX
+# http://web.archive.org/web/20100206055706/http://www.qzx.com/pc-gpe/pcx.txt
+# GRR: original test was still too general as it catches xbase examples T5.DBT,T6.DBT with 0xa000000
+# test for bytes 0x0a,version byte (0,2,3,4,5),compression byte flag(0,1), bit depth (>0) of PCX or T5.DBT,T6.DBT
+0	ubelong&0xffF8fe00	0x0a000000	
+# for PCX bit depth > 0 
+>3	ubyte		>0	
+# test for valid versions
+>>1	ubyte		<6	
+>>>1	ubyte		!1	PCX
+!:mime	image/x-pcx
+#!:mime	image/pcx
+>>>>1	ubyte		0	ver. 2.5 image data
+>>>>1	ubyte		2	ver. 2.8 image data, with palette
+>>>>1	ubyte		3	ver. 2.8 image data, without palette
+>>>>1	ubyte		4	for Windows image data
+>>>>1	ubyte		5	ver. 3.0 image data
+>>>>4	uleshort	x	bounding box [%d,
+>>>>6	uleshort	x	%d] -
+>>>>8	uleshort	x	[%d,
+>>>>10	uleshort	x	%d],
+>>>>65	ubyte		>1	%d planes each of
+>>>>3	ubyte		x	%d-bit
+>>>>68	byte		1	colour,
+>>>>68	byte		2	grayscale,
+# this should not happen
+>>>>68	default		x	image,
+>>>>12	leshort		>0	%d x
+>>>>>14	uleshort	x	%d dpi,
+>>>>2	byte		0	uncompressed
+>>>>2	byte		1	RLE compressed
+
+# Adobe Photoshop
+# From: Asbjoern Sloth Toennesen <asbjorn@lila.io>
+0	string		8BPS Adobe Photoshop Image
+!:mime	image/vnd.adobe.photoshop
+>4   beshort 2 (PSB)
+>18  belong  x \b, %d x
+>14  belong  x %d,
+>24  beshort 0 bitmap
+>24  beshort 1 grayscale
+>>12 beshort 2 with alpha
+>24  beshort 2 indexed
+>24  beshort 3 RGB
+>>12 beshort 4 \bA
+>24  beshort 4 CMYK
+>>12 beshort 5 \bA
+>24  beshort 7 multichannel
+>24  beshort 8 duotone
+>24  beshort 9 lab
+>12  beshort > 1
+>>12  beshort x \b, %dx
+>12  beshort 1 \b,
+>22  beshort x %d-bit channel
+>12  beshort > 1 \bs
+
+# XV thumbnail indicator (ThMO)
+0	string		P7\ 332		XV thumbnail image data
+
+# NITF is defined by United States MIL-STD-2500A
+0	string	NITF	National Imagery Transmission Format
+>25	string	>\0	dated %.14s
+
+# GEM Image: Version 1, Headerlen 8 (Wolfram Kleff)
+# Format variations from: Bernd Nuernberger <bernd.nuernberger@web.de>
+# See http://fileformats.archiveteam.org/wiki/GEM_Raster
+# For variations, also see:
+#    http://www.seasip.info/Gem/ff_img.html (Ventura) 
+#    http://www.atari-wiki.com/?title=IMG_file (XIMG, STTT)
+#    http://www.fileformat.info/format/gemraster/spec/index.htm (XIMG, STTT)
+#    http://sylvana.net/1stguide/1STGUIDE.ENG (TIMG)
+0       beshort     0x0001
+>2      beshort     0x0008      GEM Image data
+>>0     use gem_info
+>2      beshort     0x0009      GEM Image data (Ventura)
+>>0     use gem_info
+16      string      XIMG\0      GEM XIMG Image data
+>0      use gem_info
+16      string      STTT\0\x10  GEM STTT Image data 
+>0      use gem_info
+16      string      TIMG\0      GEM TIMG Image data
+>0      use gem_info
+
+0   name        gem_info
+>12	beshort		x		%d x
+>14	beshort		x		%d,
+>4	beshort		x		%d planes,
+>8	beshort		x		%d x
+>10	beshort		x		%d pixelsize
+
+# GEM Metafile (Wolfram Kleff)
+0	lelong		0x0018FFFF	GEM Metafile data
+>4	leshort		x		version %d
+
+#
+# SMJPEG. A custom Motion JPEG format used by Loki Entertainment
+# Software Torbjorn Andersson <d91tan@Update.UU.SE>.
+#
+0	string	\0\nSMJPEG	SMJPEG
+>8	belong	x		%d.x data
+# According to the specification you could find any number of _TXT
+# headers here, but I can't think of any way of handling that. None of
+# the SMJPEG files I tried it on used this feature. Even if such a
+# file is encountered the output should still be reasonable.
+>16	string	_SND		\b,
+>>24	beshort	>0		%d Hz
+>>26	byte	8		8-bit
+>>26	byte	16		16-bit
+>>28	string	NONE		uncompressed
+# >>28	string	APCM		ADPCM compressed
+>>27	byte	1		mono
+>>28	byte	2		stereo
+# Help! Isn't there any way to avoid writing this part twice?
+>>32	string	_VID		\b,
+# >>>48	string	JFIF		JPEG
+>>>40	belong	>0		%d frames
+>>>44	beshort	>0		(%d x
+>>>46	beshort	>0		%d)
+>16	string	_VID		\b,
+# >>32	string	JFIF		JPEG
+>>24	belong	>0		%d frames
+>>28	beshort	>0		(%d x
+>>30	beshort	>0		%d)
+
+0	string	Paint\ Shop\ Pro\ Image\ File	Paint Shop Pro Image File
+
+# "thumbnail file" (icon)
+# descended from "xv", but in use by other applications as well (Wolfram Kleff)
+0       string          P7\ 332         XV "thumbnail file" (icon) data
+
+# taken from fkiss: (<yav@mte.biglobe.ne.jp> ?)
+0       string          KiSS            KISS/GS
+>4      byte            16              color
+>>5     byte            x               %d bit
+>>8     leshort         x               %d colors
+>>10    leshort         x               %d groups
+>4      byte            32              cell
+>>5     byte            x               %d bit
+>>8     leshort         x               %d x
+>>10    leshort         x               %d
+>>12    leshort         x               +%d
+>>14    leshort         x               +%d
+
+# Webshots (www.webshots.com), by John Harrison
+0       string          C\253\221g\230\0\0\0 Webshots Desktop .wbz file
+
+# Hercules DASD image files
+# From Jan Jaeger <jj@septa.nl>
+0       string  CKD_P370        Hercules CKD DASD image file
+>8      long    x               \b, %d heads per cylinder
+>12     long    x               \b, track size %d bytes
+>16     byte    x               \b, device type 33%2.2X
+
+0       string  CKD_C370        Hercules compressed CKD DASD image file
+>8      long    x               \b, %d heads per cylinder
+>12     long    x               \b, track size %d bytes
+>16     byte    x               \b, device type 33%2.2X
+
+0       string  CKD_S370        Hercules CKD DASD shadow file
+>8      long    x               \b, %d heads per cylinder
+>12     long    x               \b, track size %d bytes
+>16     byte    x               \b, device type 33%2.2X
+
+# Squeak images and programs - etoffi@softhome.net
+0	string		\146\031\0\0	Squeak image data
+0	search/1	'From\040Squeak	Squeak program text
+
+# partimage: file(1) magic for PartImage files (experimental, incomplete)
+# Author: Hans-Joachim Baader <hjb@pro-linux.de>
+0		string	PaRtImAgE-VoLuMe	PartImage
+>0x0020		string	0.6.1		file version %s
+>>0x0060	lelong	>-1		volume %d
+#>>0x0064 8 byte identifier
+#>>0x007c reserved
+>>0x0200	string	>\0		type %s
+>>0x1400	string	>\0		device %s,
+>>0x1600	string	>\0		original filename %s,
+# Some fields omitted
+>>0x2744	lelong	0		not compressed
+>>0x2744	lelong	1		gzip compressed
+>>0x2744	lelong	2		bzip2 compressed
+>>0x2744	lelong	>2		compressed with unknown algorithm
+>0x0020		string	>0.6.1		file version %s
+>0x0020		string	<0.6.1		file version %s
+
+# DCX is multi-page PCX, using a simple header of up to 1024
+# offsets for the respective PCX components.
+# From: Joerg Wunsch <joerg_wunsch@uriah.heep.sax.de>
+0	lelong	987654321	DCX multi-page PCX image data
+
+# Simon Walton <simonw@matteworld.com>
+# Kodak Cineon format for scanned negatives
+# http://www.kodak.com/US/en/motion/support/dlad/
+0	lelong  0xd75f2a80	Cineon image data
+>200	belong  >0		\b, %d x
+>204	belong  >0		%d
+
+
+# Bio-Rad .PIC is an image format used by microscope control systems
+# and related image processing software used by biologists.
+# From: Vebjorn Ljosa <vebjorn@ljosa.com>
+# BOOL values are two-byte integers; use them to rule out false positives.
+# http://web.archive.org/web/20050317223257/www.cs.ubc.ca/spider/ladic/text/biorad.txt
+# Samples: http://www.loci.wisc.edu/software/sample-data
+14	leshort <2
+>62	leshort <2
+>>54	leshort 12345		Bio-Rad .PIC Image File
+>>>0	leshort >0		%d x
+>>>2	leshort >0		%d,
+>>>4	leshort =1		1 image in file
+>>>4	leshort >1		%d images in file
+
+# From Jan "Yenya" Kasprzak <kas@fi.muni.cz>
+# The description of *.mrw format can be found at
+# http://www.dalibor.cz/minolta/raw_file_format.htm
+0	string	\000MRM			Minolta Dimage camera raw image data
+
+# Summary: DjVu image / document
+# Extension: .djvu
+# Reference: http://djvu.org/docs/DjVu3Spec.djvu
+# Submitted by: Stephane Loeuillet <stephane.loeuillet@tiscali.fr>
+# Modified by (1): Abel Cheung <abelcheung@gmail.com>
+0	string	AT&TFORM
+>12	string	DJVM		DjVu multiple page document
+!:mime	image/vnd.djvu
+>12	string	DJVU		DjVu image or single page document
+!:mime	image/vnd.djvu
+>12	string	DJVI		DjVu shared document
+!:mime	image/vnd.djvu
+>12	string	THUM		DjVu page thumbnails
+!:mime	image/vnd.djvu
+
+# Originally by Marc Espie
+# Modified by Robert Minsk <robertminsk at yahoo.com>
+# http://www.openexr.com/openexrfilelayout.pdf
+0	lelong		20000630	OpenEXR image data,
+!:mime image/x-exr
+>4	lelong&0x000000ff x		version %d,
+>4	lelong		^0x00000200	storage: scanline
+>4	lelong		&0x00000200	storage: tiled
+>8	search/0x1000	compression\0	\b, compression:
+>>&16	byte		0		none
+>>&16	byte		1		rle
+>>&16	byte		2		zips
+>>&16	byte		3		zip
+>>&16	byte		4		piz
+>>&16	byte		5		pxr24
+>>&16	byte		6		b44
+>>&16	byte		7		b44a
+>>&16	byte		>7		unknown
+>8	 search/0x1000	dataWindow\0	\b, dataWindow:
+>>&10	lelong		x		(%d
+>>&14	lelong		x		%d)-
+>>&18	lelong		x		\b(%d
+>>&22	lelong		x		%d)
+>8	search/0x1000	displayWindow\0	\b, displayWindow:
+>>&10	lelong		x		(%d
+>>&14	lelong		x		%d)-
+>>&18	lelong		x		\b(%d
+>>&22	lelong		x		%d)
+>8	search/0x1000	lineOrder\0	 \b, lineOrder:
+>>&14	byte		0		increasing y
+>>&14	byte		1		decreasing y
+>>&14	byte		2		random y
+>>&14	byte		>2		unknown
+
+# SMPTE Digital Picture Exchange Format, SMPTE DPX
+#
+# ANSI/SMPTE 268M-1994, SMPTE Standard for File Format for Digital
+# Moving-Picture Exchange (DPX), v1.0, 18 February 1994
+# Robert Minsk <robertminsk at yahoo.com>
+0	string		SDPX	DPX image data, big-endian,
+!:mime image/x-dpx
+>768	beshort		<4
+>>772	belong		x	%dx
+>>776	belong		x	\b%d,
+>768	beshort		>3
+>>776	belong		x	%dx
+>>772	belong		x	\b%d,
+>768	beshort		0	left to right/top to bottom
+>768	beshort		1	right to left/top to bottom
+>768	beshort		2	left to right/bottom to top
+>768	beshort		3	right to left/bottom to top
+>768	beshort		4	top to bottom/left to right
+>768	beshort		5	top to bottom/right to left
+>768	leshort		6	bottom to top/left to right
+>768	leshort		7	bottom to top/right to left
+
+# From: Tom Hilinski <tom.hilinski@comcast.net>
+# http://www.unidata.ucar.edu/packages/netcdf/
+0	string	CDF\001			NetCDF Data Format data
+
+#-----------------------------------------------------------------------
+# Hierarchical Data Format, used to facilitate scientific data exchange
+# specifications at http://hdf.ncsa.uiuc.edu/
+0	belong	0x0e031301	Hierarchical Data Format (version 4) data
+!:mime	application/x-hdf
+0	string	\211HDF\r\n\032\n	Hierarchical Data Format (version 5) data
+!:mime	application/x-hdf
+512	string	\211HDF\r\n\032\n	Hierarchical Data Format (version 5) with 512 bytes user block
+!:mime	application/x-hdf
+1024	string	\211HDF\r\n\032\n	Hierarchical Data Format (version 5) with 1k user block
+!:mime	application/x-hdf
+2048	string	\211HDF\r\n\032\n	Hierarchical Data Format (version 5) with 2k user block
+!:mime	application/x-hdf
+4096	string	\211HDF\r\n\032\n	Hierarchical Data Format (version 5) with 4k user block
+!:mime	application/x-hdf
+
+
+# From: Tobias Burnus <burnus@net-b.de>
+# Xara (for a while: Corel Xara) is a graphic package, see
+# http://www.xara.com/ for Windows and as GPL application for Linux
+0	string	XARA\243\243	Xara graphics file
+
+# http://www.cartesianinc.com/Tech/
+0	string	CPC\262		Cartesian Perceptual Compression image
+!:mime	image/x-cpi
+
+# From Albert Cahalan <acahalan@gmail.com>
+# puredigital used it for the CVS disposable camcorder
+#8       lelong  4       ZBM bitmap image data
+#>4      leshort x       %u x
+#>6      leshort x       %u
+
+# From Albert Cahalan <acahalan@gmail.com>
+# uncompressed 5:6:5 HighColor image for OLPC XO firmware icons
+0       string C565     OLPC firmware icon image data
+>4      leshort x       %u x
+>6      leshort x       %u
+
+# Applied Images - Image files from Cytovision
+# Gustavo Junior Alves <gjalves@gjalves.com.br>
+0	string	\xce\xda\xde\xfa	Cytovision Metaphases file
+0	string	\xed\xad\xef\xac	Cytovision Karyotype file
+0	string	\x0b\x00\x03\x00	Cytovision FISH Probe file
+0	string	\xed\xfe\xda\xbe	Cytovision FLEX file
+0	string	\xed\xab\xed\xfe	Cytovision FLEX file
+0	string	\xad\xfd\xea\xad	Cytovision RATS file
+
+# Wavelet Scalar Quantization format used in gray-scale fingerprint images
+# From Tano M Fotang <mfotang@quanteq.com>
+0	string	\xff\xa0\xff\xa8\x00	Wavelet Scalar Quantization image data
+
+# Type:		PCO B16 image files
+# URL:		http://www.pco.de/fileadmin/user_upload/db/download/MA_CWDCOPIE_0412b.pdf
+# From:		Florian Philipp <florian.philipp@binarywings.net>
+# Extension:	.b16
+# Description:	Pixel image format produced by PCO Camware, typically used
+#		together with PCO cameras.
+# Note:		Different versions exist for e.g. 8 bit and 16 bit images.
+#		Documentation is incomplete.
+0	string/b	PCO-	PCO B16 image data
+>12	lelong		x	\b, %dx
+>16	lelong		x	\b%d
+>20	lelong		0	\b, short header
+>20	lelong		-1	\b, extended header
+>>24	lelong		0	\b, grayscale
+>>>36	lelong		0	linear LUT
+>>>36	lelong		1	logarithmic LUT
+>>>28	lelong		x	[%d
+>>>32	lelong		x	\b,%d]
+>>24	lelong		1	\b, color
+>>>64	lelong		0	linear LUT
+>>>64	lelong		1	logarithmic LUT
+>>>40	lelong		x	r[%d
+>>>44	lelong		x	\b,%d]
+>>>48	lelong		x	g[%d
+>>>52	lelong		x	\b,%d]
+>>>56	lelong		x	b[%d
+>>>60	lelong		x	\b,%d]
+
+# Polar Monitor Bitmap (.pmb) used as logo for Polar Electro watches
+# From: Markus Heidelberg <markus.heidelberg at web.de>
+0	string/t	[BitmapInfo2]	Polar Monitor Bitmap text
+!:mime	image/x-polar-monitor-bitmap
+
+# From: Rick Richardson <rickrich@gmail.com>
+0	string	GARMIN\ BITMAP\ 01	Garmin Bitmap file
+
+# Type:	Ulead Photo Explorer5 (.pe5)
+# URL:	http://www.jisyo.com/cgibin/view.cgi?EXT=pe5 (Japanese)
+# From:	Simon Horman <horms@debian.org>
+0	string	IIO2H			Ulead Photo Explorer5
+
+# Type:	X11 cursor
+# URL:	http://webcvs.freedesktop.org/mime/shared-mime-info/freedesktop.org.xml.in?view=markup
+# From:	Mathias Brodala <info@noctus.net>
+0	string	Xcur			X11 cursor
+
+# Type:	Olympus ORF raw images.
+# URL:	http://libopenraw.freedesktop.org/wiki/Olympus_ORF
+# From:	Adam Buchbinder <adam.buchbinder@gmail.com>
+0	string		MMOR		Olympus ORF raw image data, big-endian
+!:mime	image/x-olympus-orf
+0	string		IIRO		Olympus ORF raw image data, little-endian
+!:mime	image/x-olympus-orf
+0	string		IIRS		Olympus ORF raw image data, little-endian
+!:mime	image/x-olympus-orf
+
+# Type: files used in modern AVCHD camcoders to store clip information
+# Extension: .cpi
+# From: Alexander Danilov <alexander.a.danilov@gmail.com>
+0	string	HDMV0100	AVCHD Clip Information
+
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# URL: http://local.wasp.uwa.edu.au/~pbourke/dataformats/pic/
+# Radiance HDR; usually has .pic or .hdr extension.
+0	string	#?RADIANCE\n	Radiance HDR image data
+#!mime	image/vnd.radiance
+
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# URL: http://www.mpi-inf.mpg.de/resources/pfstools/pfs_format_spec.pdf
+# Used by the pfstools packages. The regex matches for the image size could
+# probably use some work. The MIME type is made up; if there's one in
+# actual common use, it should replace the one below.
+0	string	PFS1\x0a	PFS HDR image data
+#!mime	image/x-pfs
+>1	regex	[0-9]*\ 		\b, %s
+>>1	regex	\ [0-9]{4}		\bx%s
+
+# Type: Foveon X3F
+# URL:  http://www.photofo.com/downloads/x3f-raw-format.pdf
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# Note that the MIME type isn't defined anywhere that I can find; if
+# there's a canonical type for this format, it should replace this one.
+0	string	FOVb	Foveon X3F raw image data
+!:mime	image/x-x3f
+>6	leshort	x	\b, version %d.
+>4	leshort	x	\b%d
+>28	lelong	x	\b, %dx
+>32	lelong	x	\b%d
+
+# Paint.NET file
+# From Adam Buchbinder <adam.buchbinder@gmail.com>
+0	string	PDN3	Paint.NET image data
+!:mime	image/x-paintnet
+
+# Not really an image.
+# From: "Tano M. Fotang" <mfotang@quanteq.com>
+0	string	\x46\x4d\x52\x00	ISO/IEC 19794-2 Format Minutiae Record (FMR)
+
+# doc: http://www.shikino.co.jp/eng/products/images/FLOWER.jpg.zip
+# example: http://www.shikino.co.jp/eng/products/images/FLOWER.wdp.zip
+90	bequad		0x574D50484F544F00	JPEG-XR Image
+>98	byte&0x08	=0x08			\b, hard tiling
+>99	byte&0x80	=0x80			\b, tiling present
+>99	byte&0x40	=0x40			\b, codestream present
+>99	byte&0x38	x			\b, spatial xform=
+>99	byte&0x38	0x00			\bTL
+>99	byte&0x38	0x08			\bBL
+>99	byte&0x38	0x10			\bTR
+>99	byte&0x38	0x18			\bBR
+>99	byte&0x38	0x20			\bBT
+>99	byte&0x38	0x28			\bRB
+>99	byte&0x38	0x30			\bLT
+>99	byte&0x38	0x38			\bLB
+>100	byte&0x80	=0x80			\b, short header
+>>102	beshort+1	x			\b, %d
+>>104	beshort+1	x			\bx%d
+>100	byte&0x80	=0x00			\b, long header
+>>102	belong+1	x			\b, %x
+>>106	belong+1	x			\bx%x
+>101	beshort&0xf	x			\b, bitdepth=
+>>101	beshort&0xf	0x0			\b1-WHITE=1
+>>101	beshort&0xf	0x1			\b8
+>>101	beshort&0xf	0x2			\b16
+>>101	beshort&0xf	0x3			\b16-SIGNED
+>>101	beshort&0xf	0x4			\b16-FLOAT
+>>101	beshort&0xf	0x5			\b(reserved 5)
+>>101	beshort&0xf	0x6			\b32-SIGNED
+>>101	beshort&0xf	0x7			\b32-FLOAT
+>>101	beshort&0xf	0x8			\b5
+>>101	beshort&0xf	0x9			\b10
+>>101	beshort&0xf	0xa			\b5-6-5
+>>101	beshort&0xf	0xb			\b(reserved %d)
+>>101	beshort&0xf	0xc			\b(reserved %d)
+>>101	beshort&0xf	0xd			\b(reserved %d)
+>>101	beshort&0xf	0xe			\b(reserved %d)
+>>101	beshort&0xf	0xf			\b1-BLACK=1
+>101	beshort&0xf0	x			\b, colorfmt=
+>>101	beshort&0xf0	0x00			\bYONLY
+>>101	beshort&0xf0	0x10			\bYUV240
+>>101	beshort&0xf0	0x20			\bYWV422
+>>101	beshort&0xf0	0x30			\bYWV444
+>>101	beshort&0xf0	0x40			\bCMYK
+>>101	beshort&0xf0	0x50			\bCMYKDIRECT
+>>101	beshort&0xf0	0x60			\bNCOMPONENT
+>>101	beshort&0xf0	0x70			\bRGB
+>>101	beshort&0xf0	0x80			\bRGBE
+>>101	beshort&0xf0	>0x80			\b(reserved 0x%x)
+
+# From: Johan van der Knijff <johan.vanderknijff@kb.nl>
+#
+# BPG (Better Portable Graphics) format
+# http://bellard.org/bpg/
+# http://fileformats.archiveteam.org/wiki/BPG
+#
+0	string	\x42\x50\x47\xFB	BPG (Better Portable Graphics)
+!:mime  image/bpg
+
+#------------------------------------------------------------------------------
+# $File$
+# inform:  file(1) magic for Inform interactive fiction language
+
+# URL:  http://www.inform-fiction.org/
+# From: Reuben Thomas <rrt@sc3d.org>
+
+0	search/100/cW	constant\ story		Inform source text
+
+#------------------------------------------------------------------------------
+# $File: intel,v 1.11 2013/02/06 14:18:52 christos Exp $
+# intel:  file(1) magic for x86 Unix
+#
+# Various flavors of x86 UNIX executable/object (other than Xenix, which
+# is in "microsoft").  DOS is in "msdos"; the ambitious soul can do
+# Windows as well.
+#
+# Windows NT belongs elsewhere, as you need x86 and MIPS and Alpha and
+# whatever comes next (HP-PA Hummingbird?).  OS/2 may also go elsewhere
+# as well, if, as, and when IBM makes it portable.
+#
+# The `versions' should be un-commented if they work for you.
+# (Was the problem just one of endianness?)
+#
+0	leshort		0502		basic-16 executable
+>12	lelong		>0		not stripped
+#>22	leshort		>0		- version %d
+0	leshort		0503		basic-16 executable (TV)
+>12	lelong		>0		not stripped
+#>22	leshort		>0		- version %d
+0	leshort		0510		x86 executable
+>12	lelong		>0		not stripped
+0	leshort		0511		x86 executable (TV)
+>12	lelong		>0		not stripped
+0	leshort		=0512		iAPX 286 executable small model (COFF)
+>12	lelong		>0		not stripped
+#>22	leshort		>0		- version %d
+0	leshort		=0522		iAPX 286 executable large model (COFF)
+>12	lelong		>0		not stripped
+#>22	leshort		>0		- version %d
+# SGI labeled the next entry as "iAPX 386 executable" --Dan Quinlan
+0	leshort		=0514		80386 COFF executable
+>12	lelong		>0		not stripped
+>22	leshort		>0		- version %d
+
+# rom: file(1) magic for BIOS ROM Extensions found in intel machines
+#      mapped into memory between 0xC0000 and 0xFFFFF
+# From Gurkan Sengun <gurkan@linuks.mine.nu>, www.linuks.mine.nu
+0        beshort         0x55AA       BIOS (ia32) ROM Ext.
+>5       string          USB          USB
+>7       string          LDR          UNDI image
+>30      string          IBM          IBM comp. Video
+>26      string          Adaptec      Adaptec
+>28      string          Adaptec      Adaptec
+>42      string          PROMISE      Promise
+>2       byte            x            (%d*512)
+
+# Flash descriptors for Intel SPI flash roms.
+# From Dr. Jesus <j@hug.gs>
+0	lelong		0x0ff0a55a	Intel serial flash for ICH/PCH ROM <= 5 or 3400 series A-step
+16	lelong		0x0ff0a55a	Intel serial flash for PCH ROM
+
+#------------------------------------------------------------------------------
+# $File$
+# interleaf:  file(1) magic for InterLeaf TPS:
+#
+0	string		=\210OPS	Interleaf saved data
+0	string		=<!OPS		Interleaf document text
+>5	string		,\ Version\ =	\b, version
+>>17	string		>\0		%.3s
+
+#------------------------------------------------------------------------------
+# $File$
+# island:  file(1) magic for IslandWite/IslandDraw, from SunOS 5.5.1
+# "/etc/magic":
+# From: guy@netapp.com (Guy Harris)
+#
+4	string		pgscriptver	IslandWrite document
+13	string		DrawFile	IslandDraw document
+
+
+#------------------------------------------------------------------------------
+# $File$
+# ispell:  file(1) magic for ispell
+#
+# Ispell 3.0 has a magic of 0x9601 and ispell 3.1 has 0x9602.  This magic
+# will match 0x9600 through 0x9603 in *both* little endian and big endian.
+# (No other current magic entries collide.)
+#
+# Updated by Daniel Quinlan (quinlan@yggdrasil.com)
+#
+0	leshort&0xFFFC	0x9600		little endian ispell
+>0	byte		0		hash file (?),
+>0	byte		1		3.0 hash file,
+>0	byte		2		3.1 hash file,
+>0	byte		3		hash file (?),
+>2	leshort		0x00		8-bit, no capitalization, 26 flags
+>2	leshort		0x01		7-bit, no capitalization, 26 flags
+>2	leshort		0x02		8-bit, capitalization, 26 flags
+>2	leshort		0x03		7-bit, capitalization, 26 flags
+>2	leshort		0x04		8-bit, no capitalization, 52 flags
+>2	leshort		0x05		7-bit, no capitalization, 52 flags
+>2	leshort		0x06		8-bit, capitalization, 52 flags
+>2	leshort		0x07		7-bit, capitalization, 52 flags
+>2	leshort		0x08		8-bit, no capitalization, 128 flags
+>2	leshort		0x09		7-bit, no capitalization, 128 flags
+>2	leshort		0x0A		8-bit, capitalization, 128 flags
+>2	leshort		0x0B		7-bit, capitalization, 128 flags
+>2	leshort		0x0C		8-bit, no capitalization, 256 flags
+>2	leshort		0x0D		7-bit, no capitalization, 256 flags
+>2	leshort		0x0E		8-bit, capitalization, 256 flags
+>2	leshort		0x0F		7-bit, capitalization, 256 flags
+>4	leshort		>0		and %d string characters
+0	beshort&0xFFFC	0x9600		big endian ispell
+>1	byte		0		hash file (?),
+>1	byte		1		3.0 hash file,
+>1	byte		2		3.1 hash file,
+>1	byte		3		hash file (?),
+>2	beshort		0x00		8-bit, no capitalization, 26 flags
+>2	beshort		0x01		7-bit, no capitalization, 26 flags
+>2	beshort		0x02		8-bit, capitalization, 26 flags
+>2	beshort		0x03		7-bit, capitalization, 26 flags
+>2	beshort		0x04		8-bit, no capitalization, 52 flags
+>2	beshort		0x05		7-bit, no capitalization, 52 flags
+>2	beshort		0x06		8-bit, capitalization, 52 flags
+>2	beshort		0x07		7-bit, capitalization, 52 flags
+>2	beshort		0x08		8-bit, no capitalization, 128 flags
+>2	beshort		0x09		7-bit, no capitalization, 128 flags
+>2	beshort		0x0A		8-bit, capitalization, 128 flags
+>2	beshort		0x0B		7-bit, capitalization, 128 flags
+>2	beshort		0x0C		8-bit, no capitalization, 256 flags
+>2	beshort		0x0D		7-bit, no capitalization, 256 flags
+>2	beshort		0x0E		8-bit, capitalization, 256 flags
+>2	beshort		0x0F		7-bit, capitalization, 256 flags
+>4	beshort		>0		and %d string characters
+# ispell 4.0 hash files  kromJx <kromJx@crosswinds.net>
+# Ispell 4.0
+0       string          ISPL            ispell
+>4      long            x               hash file version %d,
+>8      long            x               lexletters %d,
+>12     long            x               lexsize %d,
+>16     long            x               hashsize %d,
+>20     long            x               stblsize %d
+
+#------------------------------------------------------------------------------
+# $File: isz,v 1.2 2014/04/28 12:04:50 christos Exp $
+# ISO Zipped file format 
+# http://www.ezbsystems.com/isz/iszspec.txt
+0	string	IsZ!	ISO Zipped file
+>4	byte	x	\b, header size %u
+>5	byte	x	\b, version %u
+>8	lelong	x	\b, serial %u
+#12	leshort	x	\b, sector size %u
+#>16	lelong	x	\b, total sectors %u
+>17	byte	>0	\b, password protected
+#>24	lequad	x	\b, segment size %llu
+#>32	lelong	x	\b, blocks %u
+#>36	lelong	x	\b, block size %u
+
+#------------------------------------------------------------
+# $File: java,v 1.15 2013/08/14 09:10:36 christos Exp $
+# Java ByteCode and Mach-O binaries (e.g., Mac OS X) use the
+# same magic number, 0xcafebabe, so they are both handled
+# in the entry called "cafebabe".
+#------------------------------------------------------------
+# Java serialization
+# From Martin Pool (m.pool@pharos.com.au)
+0	beshort		0xaced		Java serialization data
+>2	beshort		>0x0004		\b, version %d
+
+0	belong		0xfeedfeed	Java KeyStore
+!:mime	application/x-java-keystore
+0	belong		0xcececece	Java JCE KeyStore
+!:mime	application/x-java-jce-keystore
+
+# Java source
+0	regex	^import.*;$	Java source
+!:mime	text/x-java
+
+#------------------------------------------------------------------------------
+# $File: $
+# javascript:  magic for javascript and node.js scripts.
+#
+0	search/1/w	#!/bin/node		Node.js script text executable
+!:mime application/javascript
+0	search/1/w	#!/usr/bin/node		Node.js script text executable
+!:mime application/javascript
+0	search/1/w	#!/bin/nodejs		Node.js script text executable
+!:mime application/javascript
+0	search/1/w	#!/usr/bin/nodejs	Node.js script text executable
+!:mime application/javascript
+0	search/1	#!/usr/bin/env\ node	Node.js script text executable
+!:mime application/javascript
+0	search/1	#!/usr/bin/env\ nodejs	Node.js script text executable
+!:mime application/javascript
+
+#------------------------------------------------------------------------------
+# $File: jpeg,v 1.26 2015/01/02 22:40:27 christos Exp $
+# JPEG images
+# SunOS 5.5.1 had
+#
+#	0	string		\377\330\377\340	JPEG file
+#	0	string		\377\330\377\356	JPG file
+#
+# both of which turn into "JPEG image data" here.
+#
+0	beshort		0xffd8		JPEG image data
+!:mime	image/jpeg
+!:apple	8BIMJPEG
+!:strength *3
+>6	string		JFIF		\b, JFIF standard
+# The following added by Erik Rossen <rossen@freesurf.ch> 1999-09-06
+# in a vain attempt to add image size reporting for JFIF.  Note that these
+# tests are not fool-proof since some perfectly valid JPEGs are currently
+# impossible to specify in magic(4) format.
+# First, a little JFIF version info:
+>>11	byte		x		\b %d.
+>>12	byte		x		\b%02d
+# Next, the resolution or aspect ratio of the image:
+>>13	byte		0		\b, aspect ratio
+>>13	byte		1		\b, resolution (DPI)
+>>13	byte		2		\b, resolution (DPCM)
+>>14	beshort		x		\b, density %dx
+>>16	beshort		x		\b%d
+>>4	beshort		x		\b, segment length %d
+# Next, show thumbnail info, if it exists:
+>>18	byte		!0		\b, thumbnail %dx
+>>>19	byte		x		\b%d
+>6	string		Exif		\b, Exif standard: [
+>>12	indirect/r	x
+>>12	string		x		\b]
+
+# Jump to the first segment
+>(4.S+4)	use		jpeg_segment
+
+# This uses recursion...
+0		name		jpeg_segment
+>0	beshort		0xFFFE
+# Recursion handled by FFE0
+#>>(2.S+2)	use			jpeg_segment
+>>2	pstring/HJ	x		\b, comment: "%s"
+
+>0	beshort		0xFFC0
+>>(2.S+2)	use			jpeg_segment
+>>4	byte		x		\b, baseline, precision %d
+>>7	beshort		x		\b, %dx
+>>5	beshort		x		\b%d
+>>9	byte		x		\b, frames %d
+
+>0	beshort		0xFFC1		
+>>(2.S+2)	use			jpeg_segment
+>>4	byte		x		\b, extended sequential, precision %d
+>>7	beshort		x		\b, %dx
+>>5	beshort		x		\b%d
+>>9	byte		x		\b, frames %d
+
+>0	beshort		0xFFC2		
+>>(2.S+2)	use			jpeg_segment
+>>4	byte		x		\b, progressive, precision %d
+>>7	beshort		x		\b, %dx
+>>5	beshort		x		\b%d
+>>9	byte		x		\b, frames %d
+
+# Define Huffman Tables
+>0	beshort		0xFFC4
+>>(2.S+2)	use			jpeg_segment
+
+>0	beshort		0xFFE1		
+# Recursion handled by FFE0
+#>>(2.S+2)	use			jpeg_segment
+>>4	string		Exif		\b, Exif Standard: [
+>>>10	indirect/r	x		
+>>>10	string		x		\b]
+
+# Application specific markers
+>0	beshort&0xFFE0	=0xFFE0
+>>(2.S+2)	use			jpeg_segment
+
+# DB: Define Quantization tables
+# DD: Define Restart interval [XXX: wrong here, it is 4 bytes]
+# D8: Start of image
+# D9: End of image
+# Dn: Restart
+>0	beshort&0xFFD0	=0xFFD0
+>>0	beshort&0xFFE0	!0xFFE0
+>>>(2.S+2)	use			jpeg_segment
+
+#>0	beshort		x		unknown 0x%x
+#>>(2.S+2)	use			jpeg_segment
+
+# HSI is Handmade Software's proprietary JPEG encoding scheme
+0	string		hsi1		JPEG image data, HSI proprietary
+
+# From: David Santinoli <david@santinoli.com>
+0	string		\x00\x00\x00\x0C\x6A\x50\x20\x20\x0D\x0A\x87\x0A	JPEG 2000
+# From: Johan van der Knijff <johan.vanderknijff@kb.nl>
+# Added sub-entries for JP2, JPX, JPM and MJ2 formats; added mimetypes
+# https://github.com/bitsgalore/jp2kMagic
+#
+# Now read value of 'Brand' field, which yields a few possibilities:
+>20	string		\x6a\x70\x32\x20	Part 1 (JP2)
+!:mime	image/jp2
+>20	string		\x6a\x70\x78\x20	Part 2 (JPX)
+!:mime	image/jpx
+>20	string		\x6a\x70\x6d\x20	Part 6 (JPM)
+!:mime	image/jpm
+>20	string		\x6d\x6a\x70\x32	Part 3 (MJ2)
+!:mime	video/mj2
+
+# Type: JPEG 2000 codesream
+# From: Mathieu Malaterre <mathieu.malaterre@gmail.com>
+0	belong		0xff4fff51						JPEG 2000 codestream
+45	beshort		0xff52
+
+#------------------------------------------------------------------------------
+# $File: karma,v 1.6 2009/09/19 16:28:10 christos Exp $
+# karma:  file(1) magic for Karma data files
+#
+# From <rgooch@atnf.csiro.au>
+
+0	string		KarmaRHD Version	Karma Data Structure Version
+>16	belong		x		%u
+
+#------------------------------------------------------------------------------
+# $File: kde,v 1.4 2009/09/19 16:28:10 christos Exp $
+# kde:  file(1) magic for KDE
+
+0		string/t	[KDE\ Desktop\ Entry]	KDE desktop entry
+!:mime	application/x-kdelnk
+0		string/t	#\ KDE\ Config\ File	KDE config file
+!:mime	application/x-kdelnk
+0		string/t	#\ xmcd	xmcd database file for kscd
+!:mime	text/x-xmcd
+
+#------------------------------------------------------------------------------
+# $File: kml,v 1.3 2010/11/25 15:00:12 christos Exp $
+# keepass: file(1) magic for KeePass file
+#
+# Keepass Password Safe:
+#  * original one: http://keepass.info/
+#  * *nix port:    http://www.keepassx.org/
+#  * android port: http://code.google.com/p/keepassdroid/
+
+0	lelong		0x9AA2D903	Keepass password database
+>4	lelong		0xB54BFB65	1.x KDB
+>>48	lelong		>0		\b, %d groups
+>>52	lelong		>0		\b, %d entries
+>>8	lelong&0x0f	1		\b, SHA-256
+>>8	lelong&0x0f	2		\b, AES
+>>8	lelong&0x0f	4		\b, RC4
+>>8	lelong&0x0f	8		\b, Twofish
+>>120	lelong		>0		\b, %d key transformation rounds
+>4	lelong		0xB54BFB67	2.x KDBX
+
+#------------------------------------------------------------------------------
+# $File: map,v 1.1 2014/06/03 18:22:25 christos Exp $
+# kerberos: MIT kerberos file binary formats
+#
+
+# This magic entry is for demonstration purposes and could be improved
+# if the following features were implemented in file:
+#
+# Strings inside [[ .. ]] in the descriptions have special meanings and
+# are not printed.
+#
+# 	- Provide some form of iteration in number of components
+#		[[${counter}=%d]] in the description
+#		then append
+#		[${counter}--] in the offset of the entries
+#	- Provide a way to round the next offset
+#		Add [R:4] after the offset?
+#	- Provide a way to have optional entries
+#		XXX: Syntax:
+#	- Provide a way to "save" entries to print them later.
+#		if the description is [[${name}=%s]], then nothing is
+#		printed and a subsequent entry in the same magic file
+#		can refer to ${name}
+#	- Provide a way to format strings as hex values
+#
+# http://www.gnu.org/software/shishi/manual/html_node/\
+#	The-Keytab-Binary-File-Format.html
+#
+
+0		name		keytab_entry
+#>0		beshort		x		\b, size=%d
+#>2		beshort		x		\b, components=%d
+>4		pstring/H	x		\b, realm=%s
+>>&0		pstring/H	x		\b, principal=%s/
+>>>&0		pstring/H	x		\b%s
+>>>>&0		belong		x		\b, type=%d
+>>>>>&0		bedate		x		\b, date=%s
+>>>>>>&0	byte		x		\b, kvno=%u
+#>>>>>>>&0	pstring/H	x
+#>>>>>>>>&0	belong		x	
+#>>>>>>>>>>&0	use		keytab_entry
+
+0		belong		0x05020000	Kerberos Keytab file
+>4		use		keytab_entry
+
+#------------------------------------------------------------------------------
+# $File: kml,v 1.2 2009/09/19 16:28:10 christos Exp $
+# Type: Google KML, formerly Keyhole Markup Language
+# Future development of this format has been handed
+# over to the Open Geospatial Consortium.
+# http://www.opengeospatial.org/standards/kml/
+# From: Asbjoern Sloth Toennesen <asbjorn@lila.io>
+0 string/t    \<?xml
+>20  search/400 \ xmlns= 
+>>&0 regex ['"]http://earth.google.com/kml Google KML document
+!:mime application/vnd.google-earth.kml+xml
+>>>&1 string 2.0' \b, version 2.0
+>>>&1 string 2.1' \b, version 2.1
+>>>&1 string 2.2' \b, version 2.2
+
+#------------------------------------------------------------------------------
+# Type: OpenGIS KML, formerly Keyhole Markup Language
+# This standard is maintained by the
+# Open Geospatial Consortium.
+# http://www.opengeospatial.org/standards/kml/
+# From: Asbjoern Sloth Toennesen <asbjorn@lila.io>
+>>&0 regex ['"]http://www.opengis.net/kml OpenGIS KML document
+!:mime application/vnd.google-earth.kml+xml
+>>>&1 string/t 2.2 \b, version 2.2
+
+#------------------------------------------------------------------------------
+# Type: Google KML Archive (ZIP based) 
+# http://code.google.com/apis/kml/documentation/kml_tut.html
+# From: Asbjoern Sloth Toennesen <asbjorn@lila.io>
+0 string    PK\003\004
+>4  byte    0x14
+>>30  string doc.kml Compressed Google KML Document, including resources.
+!:mime application/vnd.google-earth.kmz
+
+#------------------------------------------------------------------------------
+# $File$
+# DEC SRC Virtual Paper: Lectern files
+# Karl M. Hegbloom <karlheg@inetarena.com>
+0	string	lect	DEC SRC Virtual Paper Lectern file
+
+#------------------------------------------------------------------------------
+# $File$
+# lex:  file(1) magic for lex
+#
+#	derived empirically, your offsets may vary!
+0	search/100	yyprevious	C program text (from lex)
+>3	search/1	>\0		 for %s
+# C program text from GNU flex, from Daniel Quinlan <quinlan@yggdrasil.com>
+0	search/100	generated\ by\ flex	C program text (from flex)
+# lex description file, from Daniel Quinlan <quinlan@yggdrasil.com>
+0	search/1	%{		lex description text
+
+#------------------------------------------------------------------------------
+# $File$
+# lif:  file(1) magic for lif
+#
+# (Daniel Quinlan <quinlan@yggdrasil.com>)
+#
+0	beshort		0x8000		lif file
+
+#------------------------------------------------------------------------------
+# $File: linux,v 1.58 2014/08/04 06:21:30 christos Exp $
+# linux:  file(1) magic for Linux files
+#
+# Values for Linux/i386 binaries, from Daniel Quinlan <quinlan@yggdrasil.com>
+# The following basic Linux magic is useful for reference, but using
+# "long" magic is a better practice in order to avoid collisions.
+#
+# 2	leshort		100		Linux/i386
+# >0	leshort		0407		impure executable (OMAGIC)
+# >0	leshort		0410		pure executable (NMAGIC)
+# >0	leshort		0413		demand-paged executable (ZMAGIC)
+# >0	leshort		0314		demand-paged executable (QMAGIC)
+#
+0	lelong		0x00640107	Linux/i386 impure executable (OMAGIC)
+>16	lelong		0		\b, stripped
+0	lelong		0x00640108	Linux/i386 pure executable (NMAGIC)
+>16	lelong		0		\b, stripped
+0	lelong		0x0064010b	Linux/i386 demand-paged executable (ZMAGIC)
+>16	lelong		0		\b, stripped
+0	lelong		0x006400cc	Linux/i386 demand-paged executable (QMAGIC)
+>16	lelong		0		\b, stripped
+#
+0	string		\007\001\000	Linux/i386 object file
+>20	lelong		>0x1020		\b, DLL library
+# Linux-8086 stuff:
+0	string		\01\03\020\04	Linux-8086 impure executable
+>28	long		!0		not stripped
+0	string		\01\03\040\04	Linux-8086 executable
+>28	long		!0		not stripped
+#
+0	string		\243\206\001\0	Linux-8086 object file
+#
+0	string		\01\03\020\20	Minix-386 impure executable
+>28	long		!0		not stripped
+0	string		\01\03\040\20	Minix-386 executable
+>28	long		!0		not stripped
+0	string		\01\03\04\20	Minix-386 NSYM/GNU executable
+>28	long		!0		not stripped
+# core dump file, from Bill Reynolds <bill@goshawk.lanl.gov>
+216	lelong		0421		Linux/i386 core file
+!:strength / 2
+>220	string		>\0		of '%s'
+>200	lelong		>0		(signal %d)
+#
+# LILO boot/chain loaders, from Daniel Quinlan <quinlan@yggdrasil.com>
+# this can be overridden by the DOS executable (COM) entry
+2	string		LILO		Linux/i386 LILO boot/chain loader
+#
+# Linux make config build file, from Ole Aamot <oka@oka.no>
+# Updated by Ken Sharp
+28	string		make\ config		Linux make config build file (old)
+49	search/70	Kernel\ Configuration	Linux make config build file
+
+#
+# PSF fonts, from H. Peter Anvin <hpa@yggdrasil.com>
+# Updated by Adam Buchbinder <adam.buchbinder@gmail.com>
+# See: http://www.win.tue.nl/~aeb/linux/kbd/font-formats-1.html
+0	leshort		0x0436		Linux/i386 PC Screen Font v1 data,
+>2	byte&0x01	0		256 characters,
+>2	byte&0x01	!0		512 characters,
+>2	byte&0x02	0		no directory,
+>2	byte&0x02	!0		Unicode directory,
+>3	byte		>0		8x%d
+0	string		\x72\xb5\x4a\x86\x00\x00 Linux/i386 PC Screen Font v2 data,
+>16	lelong		x		%d characters,
+>12	lelong&0x01	0		no directory,
+>12	lelong&0x01	!0		Unicode directory,
+>24	lelong		x		%d
+>28	lelong		x		\bx%d
+
+# Linux swap file, from Daniel Quinlan <quinlan@yggdrasil.com>
+4086	string		SWAP-SPACE	Linux/i386 swap file
+# From: Jeff Bailey <jbailey@ubuntu.com>
+# Linux swap file with swsusp1 image, from Jeff Bailey <jbailey@ubuntu.com>
+4076	string		SWAPSPACE2S1SUSPEND	Linux/i386 swap file (new style) with SWSUSP1 image
+# From: James Hunt <james.hunt@ubuntu.com>
+4076    string          SWAPSPACE2LINHIB0001    Linux/i386 swap file (new style) (compressed hibernate)
+# according to man page of mkswap (8) March 1999
+# volume label and UUID Russell Coker
+# http://etbe.coker.com.au/2008/07/08/label-vs-uuid-vs-device/
+4086	string		SWAPSPACE2	Linux/i386 swap file (new style),
+>0x400	long		x		version %d (4K pages),
+>0x404	long		x		size %d pages,
+>1052	string		\0		no label,
+>1052	string		>\0		LABEL=%s,
+>0x40c	belong		x		UUID=%08x
+>0x410	beshort		x		\b-%04x
+>0x412	beshort		x		\b-%04x
+>0x414	beshort		x		\b-%04x
+>0x416	belong		x		\b-%08x
+>0x41a	beshort		x		\b%04x
+# From Daniel Novotny <dnovotny@redhat.com>
+# swap file for PowerPC
+65526	string		SWAPSPACE2	Linux/ppc swap file
+16374	string		SWAPSPACE2	Linux/ia64 swap file
+#
+# Linux kernel boot images, from Albert Cahalan <acahalan@cs.uml.edu>
+# and others such as Axel Kohlmeyer <akohlmey@rincewind.chemie.uni-ulm.de>
+# and Nicolas Lichtmaier <nick@debian.org>
+# All known start with: b8 c0 07 8e d8 b8 00 90 8e c0 b9 00 01 29 f6 29
+# Linux kernel boot images (i386 arch) (Wolfram Kleff)
+514	string		HdrS		Linux kernel
+!:strength + 55
+>510	leshort		0xAA55		x86 boot executable
+>>518	leshort		>0x1ff
+>>>529	byte		0		zImage,
+>>>529	byte		1		bzImage,
+>>>526	lelong		>0
+>>>>(526.s+0x200) string	>\0	version %s,
+>>498	leshort		1		RO-rootFS,
+>>498	leshort		0		RW-rootFS,
+>>508	leshort		>0		root_dev 0x%X,
+>>502	leshort		>0		swap_dev 0x%X,
+>>504	leshort		>0		RAMdisksize %u KB,
+>>506	leshort		0xFFFF		Normal VGA
+>>506	leshort		0xFFFE		Extended VGA
+>>506	leshort		0xFFFD		Prompt for Videomode
+>>506	leshort		>0		Video mode %d
+# This also matches new kernels, which were caught above by "HdrS".
+0		belong	0xb8c0078e	Linux kernel
+>0x1e3		string	Loading		version 1.3.79 or older
+>0x1e9		string	Loading		from prehistoric times
+
+# System.map files - Nicolas Lichtmaier <nick@debian.org>
+8	search/1	\ A\ _text	Linux kernel symbol map text
+
+# LSM entries - Nicolas Lichtmaier <nick@debian.org>
+0	search/1	Begin3	Linux Software Map entry text
+0	search/1	Begin4	Linux Software Map entry text (new format)
+
+# From Matt Zimmerman, enhanced for v3 by Matthew Palmer
+0	belong	0x4f4f4f4d	User-mode Linux COW file
+>4	belong	<3		\b, version %d
+>>8	string	>\0		\b, backing file %s
+>4	belong	>2		\b, version %d
+>>32	string	>\0		\b, backing file %s
+
+############################################################################
+# Linux kernel versions
+
+0		string		\xb8\xc0\x07\x8e\xd8\xb8\x00\x90	Linux
+>497		leshort		0		x86 boot sector
+>>514		belong		0x8e	of a kernel from the dawn of time!
+>>514		belong		0x908ed8b4	version 0.99-1.1.42
+>>514		belong		0x908ed8b8	for memtest86
+
+>497		leshort		!0		x86 kernel
+>>504		leshort		>0		RAMdisksize=%u KB
+>>502		leshort		>0		swap=0x%X
+>>508		leshort		>0		root=0x%X
+>>>498		leshort		1		\b-ro
+>>>498		leshort		0		\b-rw
+>>506		leshort		0xFFFF		vga=normal
+>>506		leshort		0xFFFE		vga=extended
+>>506		leshort		0xFFFD		vga=ask
+>>506		leshort		>0		vga=%d
+>>514		belong		0x908ed881	version 1.1.43-1.1.45
+>>514		belong		0x15b281cd
+>>>0xa8e	belong		0x55AA5a5a	version 1.1.46-1.2.13,1.3.0
+>>>0xa99	belong		0x55AA5a5a	version 1.3.1,2
+>>>0xaa3	belong		0x55AA5a5a	version 1.3.3-1.3.30
+>>>0xaa6	belong		0x55AA5a5a	version 1.3.31-1.3.41
+>>>0xb2b	belong		0x55AA5a5a	version 1.3.42-1.3.45
+>>>0xaf7	belong		0x55AA5a5a	version 1.3.46-1.3.72
+>>514		string		HdrS
+>>>518		leshort		>0x1FF
+>>>>529		byte		0		\b, zImage
+>>>>529		byte		1		\b, bzImage
+>>>>(526.s+0x200) string 	>\0		\b, version %s
+
+# Linux boot sector thefts.
+0		belong		0xb8c0078e	Linux
+>0x1e6		belong		0x454c4b53	ELKS Kernel
+>0x1e6		belong		!0x454c4b53	style boot sector
+
+############################################################################
+# Linux S390 kernel image
+# Created by: Jan Kaluza <jkaluza@redhat.com>
+8 string \x02\x00\x00\x18\x60\x00\x00\x50\x02\x00\x00\x68\x60\x00\x00\x50\x40\x40\x40\x40\x40\x40\x40\x40 Linux S390
+>0x00010000 search/b/4096 \x00\x0a\x00\x00\x8b\xad\xcc\xcc
+# 64bit
+>>&0 string \xc1\x00\xef\xe3\xf0\x68\x00\x00 Z10 64bit kernel
+>>&0 string \xc1\x00\xef\xc3\x00\x00\x00\x00 Z9-109 64bit kernel
+>>&0 string \xc0\x00\x20\x00\x00\x00\x00\x00 Z990 64bit kernel
+>>&0 string \x00\x00\x00\x00\x00\x00\x00\x00 Z900 64bit kernel
+# 32bit
+>>&0 string \x81\x00\xc8\x80\x00\x00\x00\x00 Z10 32bit kernel
+>>&0 string \x81\x00\xc8\x80\x00\x00\x00\x00 Z9-109 32bit kernel
+>>&0 string \x80\x00\x20\x00\x00\x00\x00\x00 Z990 32bit kernel
+>>&0 string \x80\x00\x00\x00\x00\x00\x00\x00 Z900 32bit kernel
+
+# Linux ARM compressed kernel image
+# From: Kevin Cernekee <cernekee@gmail.com>
+36	lelong	0x016f2818	Linux kernel ARM boot executable zImage (little-endian)
+36	belong	0x016f2818	Linux kernel ARM boot executable zImage (big-endian)
+
+############################################################################
+# Linux 8086 executable
+0	lelong&0xFF0000FF 0xC30000E9	Linux-Dev86 executable, headerless
+>5	string		.		
+>>4	string		>\0		\b, libc version %s
+
+0	lelong&0xFF00FFFF 0x4000301	Linux-8086 executable
+>2	byte&0x01	!0		\b, unmapped zero page
+>2	byte&0x20	0		\b, impure
+>2	byte&0x20	!0
+>>2	byte&0x10	!0		\b, A_EXEC
+>2	byte&0x02	!0		\b, A_PAL
+>2	byte&0x04	!0		\b, A_NSYM
+>2	byte&0x08	!0		\b, A_STAND
+>2	byte&0x40	!0		\b, A_PURE
+>2	byte&0x80	!0		\b, A_TOVLY
+>28     long            !0              \b, not stripped
+>37	string		.		
+>>36	string		>\0		\b, libc version %s
+
+# 0	lelong&0xFF00FFFF 0x10000301	ld86 I80386 executable
+# 0	lelong&0xFF00FFFF 0xB000301	ld86 M68K executable
+# 0	lelong&0xFF00FFFF 0xC000301	ld86 NS16K executable
+# 0	lelong&0xFF00FFFF 0x17000301	ld86 SPARC executable
+
+# SYSLINUX boot logo files (from 'ppmtolss16' sources)
+# http://www.syslinux.org/wiki/index.php/SYSLINUX#Display_graphic_from_filename:
+# file extension .lss .16
+0	lelong	=0x1413f33d		SYSLINUX' LSS16 image data
+# syslinux-4.05/mime/image/x-lss16.xml
+!:mime image/x-lss16
+>4	leshort	x			\b, width %d
+>6	leshort	x			\b, height %d
+
+0	string	OOOM			User-Mode-Linux's Copy-On-Write disk image
+>4	belong	x			version %d
+
+# SE Linux policy database
+# From: Mike Frysinger <vapier@gentoo.org>
+0	lelong	0xf97cff8c		SE Linux policy
+>16	lelong	x			v%d
+>20	lelong	1			MLS
+>24	lelong	x			%d symbols
+>28	lelong	x			%d ocons
+
+# Linux Logical Volume Manager (LVM) 
+# Emmanuel VARAGNAT <emmanuel.varagnat@guzu.net>
+#
+# System ID, UUID and volume group name are 128 bytes long
+# but they should never be full and initialized with zeros...
+#
+# LVM1
+#
+0x0	string	HM\001		LVM1 (Linux Logical Volume Manager), version 1
+>0x12c	string	>\0		, System ID: %s
+
+0x0	string	HM\002		LVM1 (Linux Logical Volume Manager), version 2
+>0x12c	string	>\0		, System ID: %s
+
+#  LVM2
+#
+# It seems that the label header can be in one the four first sector
+# of the disk... (from _find_labeller in lib/label/label.c of LVM2)
+#
+# 0x200 seems to be the common case
+
+0x218           string  LVM2\ 001      LVM2 PV (Linux Logical Volume Manager)
+# read the offset to add to the start of the header, and the header
+# start in 0x200
+>&(&-12.l-0x21) byte    x
+# display UUID in LVM format + display all 32 bytes (instead of max string length: 31)
+>>&0x0          string  >\x2f          \b, UUID: %.6s
+>>&0x6          string  >\x2f          \b-%.4s
+>>&0xa          string  >\x2f          \b-%.4s
+>>&0xe          string  >\x2f          \b-%.4s
+>>&0x12         string  >\x2f          \b-%.4s
+>>&0x16         string  >\x2f          \b-%.4s
+>>&0x1a         string  >\x2f          \b-%.6s
+>>&0x20         lequad  x              \b, size: %lld
+
+0x018           string  LVM2\ 001      LVM2 PV (Linux Logical Volume Manager)
+>&(&-12.l-0x21) byte    x
+# display UUID in LVM format + display all 32 bytes (instead of max string length: 31)
+>>&0x0          string  >\x2f          \b, UUID: %.6s
+>>&0x6          string  >\x2f          \b-%.4s
+>>&0xa          string  >\x2f          \b-%.4s
+>>&0xe          string  >\x2f          \b-%.4s
+>>&0x12         string  >\x2f          \b-%.4s
+>>&0x16         string  >\x2f          \b-%.4s
+>>&0x1a         string  >\x2f          \b-%.6s
+>>&0x20         lequad  x              \b, size: %lld
+
+0x418           string  LVM2\ 001      LVM2 PV (Linux Logical Volume Manager)
+>&(&-12.l-0x21) byte    x
+# display UUID in LVM format + display all 32 bytes (instead of max string length: 31)
+>>&0x0          string  >\x2f          \b, UUID: %.6s
+>>&0x6          string  >\x2f          \b-%.4s
+>>&0xa          string  >\x2f          \b-%.4s
+>>&0xe          string  >\x2f          \b-%.4s
+>>&0x12         string  >\x2f          \b-%.4s
+>>&0x16         string  >\x2f          \b-%.4s
+>>&0x1a         string  >\x2f          \b-%.6s
+>>&0x20         lequad  x              \b, size: %lld
+
+0x618           string  LVM2\ 001      LVM2 PV (Linux Logical Volume Manager)
+>&(&-12.l-0x21) byte    x              
+# display UUID in LVM format + display all 32 bytes (instead of max string length: 31)
+>>&0x0          string  >\x2f          \b, UUID: %.6s
+>>&0x6          string  >\x2f          \b-%.4s
+>>&0xa          string  >\x2f          \b-%.4s
+>>&0xe          string  >\x2f          \b-%.4s
+>>&0x12         string  >\x2f          \b-%.4s
+>>&0x16         string  >\x2f          \b-%.4s
+>>&0x1a         string  >\x2f          \b-%.6s
+>>&0x20         lequad  x              \b, size: %lld
+
+# LVM snapshot
+# from Jason Farrel
+0	string	SnAp	LVM Snapshot (CopyOnWrite store)
+>4	lelong	!0	- valid,
+>4	lelong	0	- invalid,
+>8	lelong	x	version %d,
+>12	lelong	x	chunk_size %d
+
+# SE Linux policy database
+0	lelong	0xf97cff8c		SE Linux policy
+>16	lelong	x			v%d
+>20	lelong	1			MLS
+>24	lelong	x			%d symbols
+>28	lelong	x			%d ocons
+
+# LUKS: Linux Unified Key Setup, On-Disk Format, http://luks.endorphin.org/spec
+# Anthon van der Neut (anthon@mnt.org)
+0	string	LUKS\xba\xbe	LUKS encrypted file,
+>6	beshort x		ver %d
+>8	string	x		[%s,
+>40	string	x		%s,
+>72	string	x		%s]
+>168	string	x		UUID: %s
+
+
+# Summary: Xen saved domain file
+# Created by: Radek Vokal <rvokal@redhat.com>
+0	string		LinuxGuestRecord	Xen saved domain
+>20	search/256	(name			
+>>&1	string		x			(name %s)
+
+# Type: Xen, the virtual machine monitor
+# From: Radek Vokal <rvokal@redhat.com>
+0	string		LinuxGuestRecord	Xen saved domain
+#>2	regex		\(name\ [^)]*\)		%s
+>20	search/256	(name			(name
+>>&1	string		x			%s...)
+
+# Systemd journald files
+# See http://www.freedesktop.org/wiki/Software/systemd/journal-files/.
+# From: Zbigniew Jedrzejewski-Szmek <zbyszek@in.waw.pl>
+
+# check magic
+0	string	LPKSHHRH
+# check that state is one of known values
+>16		ubyte&252	0
+# check that each half of three unique id128s is non-zero
+>>24		ubequad		>0
+>>>32		ubequad		>0
+>>>>40		ubequad		>0
+>>>>>48		ubequad		>0
+>>>>>>56	ubequad		>0
+>>>>>>>64	ubequad		>0	Journal file
+!:mime application/octet-stream
+# provide more info
+>>>>>>>>184	leqdate		0	empty
+>>>>>>>>16	ubyte		0	\b, offline
+>>>>>>>>16	ubyte		1	\b, online
+>>>>>>>>16	ubyte		2	\b, archived
+>>>>>>>>8	ulelong&1	1	\b, sealed
+>>>>>>>>12	ulelong&1	1	\b, compressed
+
+# BCache backing and cache devices
+# From: Gabriel de Perthuis <g2p.code@gmail.com>
+0x1008		lequad		8
+>0x1018		string		\xc6\x85\x73\xf6\x4e\x1a\x45\xca\x82\x65\xf5\x7f\x48\xba\x6d\x81	BCache
+>>0x1010	ulequad		0	cache device
+>>0x1010	ulequad		1	backing device
+>>0x1010	ulequad		3	cache device
+>>0x1010	ulequad		4	backing device
+>>0x1048	string		>0	\b, label "%.32s"
+>>0x1028	ubelong		x	\b, uuid %08x
+>>0x102c	ubeshort	x	\b-%04x
+>>0x102e	ubeshort	x	\b-%04x
+>>0x1030	ubeshort	x	\b-%04x
+>>0x1032	ubelong		x	\b-%08x
+>>0x1036	ubeshort	x	\b%04x
+>>0x1038	ubelong		x	\b, set uuid %08x
+>>0x103c	ubeshort	x	\b-%04x
+>>0x103e	ubeshort	x	\b-%04x
+>>0x1040	ubeshort	x	\b-%04x
+>>0x1042	ubelong		x	\b-%08x
+>>0x1046	ubeshort	x	\b%04x
+
+# Linux device tree:
+# File format description can be found in the Linux kernel sources at 
+# Documentation/devicetree/booting-without-of.txt
+# From Christoph Biedl
+0		belong		0xd00dfeed
+# structure and strings must be within blob
+>&(8.L)		byte		x
+>>&(12.L)	byte		x
+>>>20		belong		>1	Device Tree Blob version %d
+>>>>4		belong		x	\b, size=%d
+>>>>20		belong		>1
+>>>>>28		belong		x	\b, boot CPU=%d
+>>>>20		belong		>2
+>>>>>32		belong		x	\b, string block size=%d
+>>>>20		belong		>16
+>>>>>36		belong		x	\b, DT structure block size=%d
+
+# glibc locale archive as defined in glibc locale/locarchive.h
+0		lelong		0xde020109	locale archive
+>24		lelong		x		%d strings
+
+# Summary:     Database file for mlocate
+# Description: A database file as used by mlocate, a fast implementation
+#              of locate/updatedb. It uses merging to reuse the existing
+#              database and avoid rereading most of the filesystem. It's
+#              the default version of locate on Arch Linux (and others).
+# File path:   /var/lib/mlocate/mlocate.db by default (but configurable)
+# Site:        https://fedorahosted.org/mlocate/
+# Format docs: http://linux.die.net/man/5/mlocate.db
+# Type: mlocate database file
+# URL:  https://fedorahosted.org/mlocate/
+# From: Wander Nauta <info@wandernauta.nl>
+0		string		\0mlocate	mlocate database
+>12		byte		x		\b, version %d
+>13		byte		1		\b, require visibility
+>16		string		x		\b, root %s
+
+#------------------------------------------------------------------------------
+# $File$
+# lisp:  file(1) magic for lisp programs
+#
+# various lisp types, from Daniel Quinlan (quinlan@yggdrasil.com)
+
+# updated by Joerg Jenderek
+# GRR: This lot is too weak
+#0	string	;;			
+# windows INF files often begin with semicolon and use CRLF as line end
+# lisp files are mainly created on unix system with LF as line end
+#>2	search/4096	!\r		Lisp/Scheme program text
+#>2	search/4096	\r		Windows INF file
+
+0	search/4096	(setq\ 			Lisp/Scheme program text
+!:mime	text/x-lisp
+0	search/4096	(defvar\ 		Lisp/Scheme program text
+!:mime	text/x-lisp
+0	search/4096	(defparam\ 		Lisp/Scheme program text
+!:mime	text/x-lisp
+0	search/4096	(defun\  		Lisp/Scheme program text
+!:mime	text/x-lisp
+0	search/4096	(autoload\ 		Lisp/Scheme program text
+!:mime	text/x-lisp
+0	search/4096	(custom-set-variables\ 	Lisp/Scheme program text
+!:mime	text/x-lisp
+
+# Emacs 18 - this is always correct, but not very magical.
+0	string	\012(			Emacs v18 byte-compiled Lisp data
+!:mime	application/x-elc
+# Emacs 19+ - ver. recognition added by Ian Springer
+# Also applies to XEmacs 19+ .elc files; could tell them apart with regexs
+# - Chris Chittleborough <cchittleborough@yahoo.com.au>
+0	string	;ELC	
+>4	byte	>18			
+>4	byte    <32			Emacs/XEmacs v%d byte-compiled Lisp data
+!:mime	application/x-elc		
+
+# Files produced by CLISP Common Lisp From: Bruno Haible <haible@ilog.fr>
+0	string	(SYSTEM::VERSION\040'	CLISP byte-compiled Lisp program (pre 2004-03-27)
+0	string	(|SYSTEM|::|VERSION|\040'	CLISP byte-compiled Lisp program text
+
+0	long	0x70768BD2		CLISP memory image data
+0	long	0xD28B7670		CLISP memory image data, other endian
+
+#.com and .bin for MIT scheme 
+0	string	\372\372\372\372	MIT scheme (library?)
+
+# From: David Allouche <david@allouche.net>
+0	search/1	\<TeXmacs|	TeXmacs document text
+!:mime	text/texmacs
+
+#------------------------------------------------------------------------------
+# $File: llvm,v 1.7 2013/01/08 01:34:38 christos Exp $
+# llvm:  file(1) magic for LLVM byte-codes
+# URL:  http://llvm.org/docs/BitCodeFormat.html
+# From: Al Stone <ahs3@fc.hp.com>
+
+0	string	llvm	LLVM byte-codes, uncompressed
+0	string	llvc0	LLVM byte-codes, null compression
+0	string	llvc1	LLVM byte-codes, gzip compression
+0	string	llvc2	LLVM byte-codes, bzip2 compression
+
+0	lelong	0x0b17c0de	LLVM bitcode, wrapper
+# Are these Mach-O ABI values?  They appear to be.
+>16	lelong	0x01000007	x86_64
+>16	lelong	0x00000007	i386
+>16	lelong	0x00000012	ppc
+>16	lelong	0x01000012	ppc64
+>16	lelong 	0x0000000c	arm
+
+0	string	BC\xc0\xde	LLVM IR bitcode
+
+#------------------------------------------------------------------------------
+# $File: lua,v 1.5 2009/09/19 16:28:10 christos Exp $
+# lua:  file(1) magic for Lua scripting language
+# URL:  http://www.lua.org/
+# From: Reuben Thomas <rrt@sc3d.org>, Seo Sanghyeon <tinuviel@sparcs.kaist.ac.kr>
+
+# Lua scripts
+0	search/1/w	#!\ /usr/bin/lua	Lua script text executable
+!:mime	text/x-lua
+0	search/1/w	#!\ /usr/local/bin/lua	Lua script text executable
+!:mime	text/x-lua
+0	search/1	#!/usr/bin/env\ lua	Lua script text executable
+!:mime	text/x-lua
+0	search/1	#!\ /usr/bin/env\ lua	Lua script text executable
+!:mime	text/x-lua
+
+# Lua bytecode
+0	string		\033Lua			Lua bytecode,
+>4	byte		0x50			version 5.0
+>4	byte		0x51			version 5.1
+>4	byte		0x52			version 5.2
+
+#------------------------------------------------------------------------------
+# $File$
+# luks:  file(1) magic for Linux Unified Key Setup
+# URL:	http://luks.endorphin.org/spec
+# From:	Anthon van der Neut <anthon@mnt.org>
+
+0	string		LUKS\xba\xbe	LUKS encrypted file,
+>6	beshort		x		ver %d
+>8	string		x		[%s,
+>40	string		x		%s,
+>72	string		x		%s]
+>168	string		x		UUID: %s
+#------------------------------------------------------------------------------
+# $File$
+# make:  file(1) magic for M4 scripts
+#
+0	regex	\^dnl\ 		M4 macro processor script text
+!:mime	text/x-m4
+
+#------------------------------------------------------------
+# $File: mach,v 1.18 2014/03/29 15:40:34 christos Exp $
+# Mach has two magic numbers, 0xcafebabe and 0xfeedface.
+# Unfortunately the first, cafebabe, is shared with
+# Java ByteCode, so they are both handled in the file "cafebabe".
+# The "feedface" ones are handled herein.
+#------------------------------------------------------------
+# if set, it's for the 64-bit version of the architecture
+# yes, this is separate from the low-order magic number bit
+# it's also separate from the "64-bit libraries" bit in the
+# upper 8 bits of the CPU subtype
+
+0	name	mach-o-cpu
+>0	belong&0x01000000	0
+#
+# 32-bit ABIs.
+#
+#				1	vax
+>>0	belong&0x00ffffff	1
+>>>4		belong&0x00ffffff	0	vax
+>>>4		belong&0x00ffffff	1	vax11/780
+>>>4		belong&0x00ffffff	2	vax11/785
+>>>4		belong&0x00ffffff	3	vax11/750
+>>>4		belong&0x00ffffff	4	vax11/730
+>>>4		belong&0x00ffffff	5	uvaxI
+>>>4		belong&0x00ffffff	6	uvaxII
+>>>4		belong&0x00ffffff	7	vax8200
+>>>4		belong&0x00ffffff	8	vax8500
+>>>4		belong&0x00ffffff	9	vax8600
+>>>4		belong&0x00ffffff	10	vax8650
+>>>4		belong&0x00ffffff	11	vax8800
+>>>4		belong&0x00ffffff	12	uvaxIII
+>>>4		belong&0x00ffffff	>12	vax subarchitecture=%d
+>>0	belong&0x00ffffff	2	romp
+>>0	belong&0x00ffffff	3	architecture=3
+>>0	belong&0x00ffffff	4	ns32032
+>>0	belong&0x00ffffff	5	ns32332
+>>0	belong&0x00ffffff	6	m68k
+#				7	x86
+>>0	belong&0x00ffffff	7
+>>>4	belong&0x0000000f	3		i386
+>>>4	belong&0x0000000f	4		i486
+>>>>4	belong&0x00fffff0	0
+>>>>4	belong&0x00fffff0	0x80		\bsx
+>>>4	belong&0x0000000f	5		i586
+>>>4	belong&0x0000000f	6
+>>>>4	belong&0x00fffff0	0		p6
+>>>>4	belong&0x00fffff0	0x10		pentium_pro
+>>>>4	belong&0x00fffff0	0x20		pentium_2_m0x20
+>>>>4	belong&0x00fffff0	0x30		pentium_2_m3
+>>>>4	belong&0x00fffff0	0x40		pentium_2_m0x40
+>>>>4	belong&0x00fffff0	0x50		pentium_2_m5
+>>>>4	belong&0x00fffff0	>0x50		pentium_2_m0x%x
+>>>4	belong&0x0000000f	7		celeron
+>>>>4	belong&0x00fffff0	0x00		\b_m0x%x
+>>>>4	belong&0x00fffff0	0x10		\b_m0x%x
+>>>>4	belong&0x00fffff0	0x20		\b_m0x%x
+>>>>4	belong&0x00fffff0	0x30		\b_m0x%x
+>>>>4	belong&0x00fffff0	0x40		\b_m0x%x
+>>>>4	belong&0x00fffff0	0x50		\b_m0x%x
+>>>>4	belong&0x00fffff0	0x60
+>>>>4	belong&0x00fffff0	0x70		\b_mobile
+>>>>4	belong&0x00fffff0	>0x70		\b_m0x%x
+>>>4	belong&0x0000000f	8		pentium_3
+>>>>4	belong&0x00fffff0	0x00
+>>>>4	belong&0x00fffff0	0x10		\b_m
+>>>>4	belong&0x00fffff0	0x20		\b_xeon
+>>>>4	belong&0x00fffff0	>0x20		\b_m0x%x
+>>>4	belong&0x0000000f	9		pentiumM
+>>>>4	belong&0x00fffff0	0x00
+>>>>4	belong&0x00fffff0	>0x00		\b_m0x%x
+>>>4	belong&0x0000000f	10		pentium_4
+>>>>4	belong&0x00fffff0	0x00
+>>>>4	belong&0x00fffff0	0x10		\b_m
+>>>>4	belong&0x00fffff0	>0x10		\b_m0x%x
+>>>4	belong&0x0000000f	11		itanium
+>>>>4	belong&0x00fffff0	0x00
+>>>>4	belong&0x00fffff0	0x10		\b_2
+>>>>4	belong&0x00fffff0	>0x10		\b_m0x%x
+>>>4	belong&0x0000000f	12		xeon
+>>>>4	belong&0x00fffff0	0x00
+>>>>4	belong&0x00fffff0	0x10		\b_mp
+>>>>4	belong&0x00fffff0	>0x10		\b_m0x%x
+>>>4	belong&0x0000000f	>12		ia32 family=%d
+>>>>4	belong&0x00fffff0	0x00
+>>>>4	belong&0x00fffff0	>0x00		model=%x
+>>0	belong&0x00ffffff	8	mips
+>>>4		belong&0x00ffffff	1	R2300
+>>>4		belong&0x00ffffff	2	R2600
+>>>4		belong&0x00ffffff	3	R2800
+>>>4		belong&0x00ffffff	4	R2000a
+>>>4		belong&0x00ffffff	5	R2000
+>>>4		belong&0x00ffffff	6	R3000a
+>>>4		belong&0x00ffffff	7	R3000
+>>>4		belong&0x00ffffff	>7	subarchitecture=%d
+>>0	belong&0x00ffffff	9	ns32532
+>>0	belong&0x00ffffff	10	mc98000
+>>0	belong&0x00ffffff	11	hppa
+>>>4		belong&0x00ffffff	0	7100
+>>>4		belong&0x00ffffff	1	7100LC
+>>>4		belong&0x00ffffff	>1	subarchitecture=%d
+>>0	belong&0x00ffffff	12	arm
+>>>4		belong&0x00ffffff	0
+>>>4		belong&0x00ffffff	1	subarchitecture=%d
+>>>4		belong&0x00ffffff	2	subarchitecture=%d
+>>>4		belong&0x00ffffff	3	subarchitecture=%d
+>>>4		belong&0x00ffffff	4	subarchitecture=%d
+>>>4		belong&0x00ffffff	5	\b_v4t
+>>>4		belong&0x00ffffff	6	\b_v6
+>>>4		belong&0x00ffffff	7	\b_v5tej
+>>>4		belong&0x00ffffff	8	\b_xscale
+>>>4		belong&0x00ffffff	9	\b_v7
+>>>4		belong&0x00ffffff	10	\b_v7f
+>>>4		belong&0x00ffffff	11	subarchitecture=%d
+>>>4		belong&0x00ffffff	12	\b_v7k
+>>>4		belong&0x00ffffff	>12	subarchitecture=%d
+#				13	m88k
+>>0	belong&0x00ffffff	13
+>>>4		belong&0x00ffffff	0	mc88000
+>>>4		belong&0x00ffffff	1	mc88100
+>>>4		belong&0x00ffffff	2	mc88110
+>>>4		belong&0x00ffffff	>2	mc88000 subarchitecture=%d
+>>0	belong&0x00ffffff	14	SPARC
+>>0	belong&0x00ffffff	15	i860g
+>>0	belong&0x00ffffff	16	alpha
+>>0	belong&0x00ffffff	17	rs6000
+>>0	belong&0x00ffffff	18	ppc
+>>>4		belong&0x00ffffff	0
+>>>4		belong&0x00ffffff	1	\b_601
+>>>4		belong&0x00ffffff	2	\b_602
+>>>4		belong&0x00ffffff	3	\b_603
+>>>4		belong&0x00ffffff	4	\b_603e
+>>>4		belong&0x00ffffff	5	\b_603ev
+>>>4		belong&0x00ffffff	6	\b_604
+>>>4		belong&0x00ffffff	7	\b_604e
+>>>4		belong&0x00ffffff	8	\b_620
+>>>4		belong&0x00ffffff	9	\b_650
+>>>4		belong&0x00ffffff	10	\b_7400
+>>>4		belong&0x00ffffff	11	\b_7450
+>>>4		belong&0x00ffffff	100	\b_970
+>>>4		belong&0x00ffffff	>100	subarchitecture=%d
+>>0	belong&0x00ffffff	>18	architecture=%d
+>0	belong&0x01000000	0x01000000
+#
+# 64-bit ABIs.
+#
+>>0	belong&0x00ffffff	0	64-bit architecture=%d
+>>0	belong&0x00ffffff	1	64-bit architecture=%d
+>>0	belong&0x00ffffff	2	64-bit architecture=%d
+>>0	belong&0x00ffffff	3	64-bit architecture=%d
+>>0	belong&0x00ffffff	4	64-bit architecture=%d
+>>0	belong&0x00ffffff	5	64-bit architecture=%d
+>>0	belong&0x00ffffff	6	64-bit architecture=%d
+>>0	belong&0x00ffffff	7	x86_64
+>>>4		belong&0x00ffffff	0	subarchitecture=%d
+>>>4		belong&0x00ffffff	1	subarchitecture=%d
+>>>4		belong&0x00ffffff	2	subarchitecture=%d
+>>>4		belong&0x00ffffff	3
+>>>4		belong&0x00ffffff	4	\b_arch1
+>>>4		belong&0x00ffffff	>4	subarchitecture=%d
+>>0	belong&0x00ffffff	8	64-bit architecture=%d
+>>0	belong&0x00ffffff	9	64-bit architecture=%d
+>>0	belong&0x00ffffff	10	64-bit architecture=%d
+>>0	belong&0x00ffffff	11	64-bit architecture=%d
+>>0	belong&0x00ffffff	12	64-bit architecture=%d
+>>0	belong&0x00ffffff	13	64-bit architecture=%d
+>>0	belong&0x00ffffff	14	64-bit architecture=%d
+>>0	belong&0x00ffffff	15	64-bit architecture=%d
+>>0	belong&0x00ffffff	16	64-bit architecture=%d
+>>0	belong&0x00ffffff	17	64-bit architecture=%d
+>>0	belong&0x00ffffff	18	ppc64
+>>>4		belong&0x00ffffff	0
+>>>4		belong&0x00ffffff	1		\b_601
+>>>4		belong&0x00ffffff	2		\b_602
+>>>4		belong&0x00ffffff	3		\b_603
+>>>4		belong&0x00ffffff	4		\b_603e
+>>>4		belong&0x00ffffff	5		\b_603ev
+>>>4		belong&0x00ffffff	6		\b_604
+>>>4		belong&0x00ffffff	7		\b_604e
+>>>4		belong&0x00ffffff	8		\b_620
+>>>4		belong&0x00ffffff	9		\b_650
+>>>4		belong&0x00ffffff	10		\b_7400
+>>>4		belong&0x00ffffff	11		\b_7450
+>>>4		belong&0x00ffffff	100		\b_970
+>>>4		belong&0x00ffffff	>100		subarchitecture=%d
+>>0	belong&0x00ffffff	>18	64-bit architecture=%d
+
+
+0	name		mach-o-be
+>0	byte		0xcf		64-bit
+>4	use		mach-o-cpu
+>12	belong		1		object
+>12	belong		2		executable
+>12	belong		3		fixed virtual memory shared library
+>12	belong		4		core
+>12	belong		5		preload executable
+>12	belong		6		dynamically linked shared library
+>12	belong		7		dynamic linker
+>12	belong		8		bundle
+>12	belong		9		dynamically linked shared library stub
+>12	belong		10		dSYM companion file
+>12	belong		11		kext bundle
+>12	belong		>11
+>>12	belong		x		filetype=%d
+
+#
+0	lelong&0xfffffffe	0xfeedface	Mach-O
+!:strength +1
+>0	use	\^mach-o-be
+
+0	belong&0xfffffffe	0xfeedface	Mach-O
+!:strength +1
+>0	use	mach-o-be
+
+#------------------------------------------------------------------------------
+# $File: macintosh,v 1.24 2014/08/30 08:34:17 christos Exp $
+# macintosh description
+#
+# BinHex is the Macintosh ASCII-encoded file format (see also "apple")
+# Daniel Quinlan, quinlan@yggdrasil.com
+11	string	must\ be\ converted\ with\ BinHex	BinHex binary text
+!:mime	application/mac-binhex40
+>41	string	x					\b, version %.3s
+
+# Stuffit archives are the de facto standard of compression for Macintosh
+# files obtained from most archives. (franklsm@tuns.ca)
+0	string		SIT!			StuffIt Archive (data)
+!:mime	application/x-stuffit
+!:apple	SIT!SIT!
+>2	string		x			: %s
+0	string		SITD			StuffIt Deluxe (data)
+>2	string		x			: %s
+0	string		Seg			StuffIt Deluxe Segment (data)
+>2	string		x			: %s
+
+# Newer StuffIt archives (grant@netbsd.org)
+0	string		StuffIt			StuffIt Archive
+!:mime	application/x-stuffit
+!:apple	SIT!SIT!
+#>162	string		>0			: %s
+
+# Macintosh Applications and Installation binaries (franklsm@tuns.ca)
+# GRR: Too weak
+#0	string		APPL			Macintosh Application (data)
+#>2	string		x			\b: %s
+
+# Macintosh System files (franklsm@tuns.ca)
+# GRR: Too weak
+#0	string		zsys			Macintosh System File (data)
+#0	string		FNDR			Macintosh Finder (data)
+#0	string		libr			Macintosh Library (data)
+#>2	string		x			: %s
+#0	string		shlb			Macintosh Shared Library (data)
+#>2	string		x			: %s
+#0	string		cdev			Macintosh Control Panel (data)
+#>2	string		x			: %s
+#0	string		INIT			Macintosh Extension (data)
+#>2	string		x			: %s
+#0	string		FFIL			Macintosh Truetype Font (data)
+#>2	string		x			: %s
+#0	string		LWFN			Macintosh Postscript Font (data)
+#>2	string		x			: %s
+
+# Additional Macintosh Files (franklsm@tuns.ca)
+# GRR: Too weak
+#0	string		PACT			Macintosh Compact Pro Archive (data)
+#>2	string		x			: %s
+#0	string		ttro			Macintosh TeachText File (data)
+#>2	string		x			: %s
+#0	string		TEXT			Macintosh TeachText File (data)
+#>2	string		x			: %s
+#0	string		PDF			Macintosh PDF File (data)
+#>2	string		x			: %s
+
+# MacBinary format (Eric Fischer, enf@pobox.com)
+#
+# Unfortunately MacBinary doesn't really have a magic number prior
+# to the MacBinary III format.  The checksum is really the way to
+# do it, but the magic file format isn't up to the challenge.
+#
+# 0	byte		0
+# 1	byte				# filename length
+# 2	string				# filename
+# 65    string				# file type
+# 69	string				# file creator
+# 73	byte				# Finder flags
+# 74	byte		0
+# 75	beshort				# vertical posn in window
+# 77	beshort				# horiz posn in window
+# 79	beshort				# window or folder ID
+# 81    byte				# protected?
+# 82	byte		0
+# 83	belong				# length of data segment
+# 87	belong				# length of resource segment
+# 91	belong				# file creation date
+# 95	belong				# file modification date
+# 99	beshort				# length of comment after resource
+# 101	byte				# new Finder flags
+# 102	string		mBIN		# (only in MacBinary III)
+# 106	byte				# char. code of file name
+# 107	byte				# still more Finder flags
+# 116	belong				# total file length
+# 120	beshort				# length of add'l header
+# 122	byte		129		# for MacBinary II
+# 122	byte		130		# for MacBinary III
+# 123	byte		129		# minimum version that can read fmt
+# 124	beshort				# checksum
+#
+# This attempts to use the version numbers as a magic number, requiring
+# that the first one be 0x80, 0x81, 0x82, or 0x83, and that the second
+# be 0x81.  This works for the files I have, but maybe not for everyone's.
+
+# Unfortunately, this magic is quite weak - MPi
+#122	beshort&0xFCFF	0x8081		Macintosh MacBinary data
+
+# MacBinary I doesn't have the version number field at all, but MacBinary II
+# has been in use since 1987 so I hope there aren't many really old files
+# floating around that this will miss.  The original spec calls for using
+# the nulls in 0, 74, and 82 as the magic number.
+#
+# Another possibility, that would also work for MacBinary I, is to use
+# the assumption that 65-72 will all be ASCII (0x20-0x7F), that 73 will
+# have bits 1 (changed), 2 (busy), 3 (bozo), and 6 (invisible) unset,
+# and that 74 will be 0.  So something like
+# 
+# 71 	belong&0x80804EFF 0x00000000 	Macintosh MacBinary data
+# 
+# >73	byte&0x01	0x01		\b, inited
+# >73	byte&0x02	0x02		\b, changed
+# >73	byte&0x04	0x04		\b, busy
+# >73	byte&0x08	0x08		\b, bozo
+# >73	byte&0x10	0x10		\b, system
+# >73	byte&0x10	0x20		\b, bundle
+# >73	byte&0x10	0x40		\b, invisible
+# >73	byte&0x10	0x80		\b, locked
+
+#>65	string		x		\b, type "%4.4s"
+
+#>65	string		8BIM		(PhotoShop)
+#>65	string		ALB3		(PageMaker 3)
+#>65	string		ALB4		(PageMaker 4)
+#>65	string		ALT3		(PageMaker 3)
+#>65	string		APPL		(application)
+#>65	string		AWWP		(AppleWorks word processor)
+#>65	string		CIRC		(simulated circuit)
+#>65	string		DRWG		(MacDraw)
+#>65	string		EPSF		(Encapsulated PostScript)
+#>65	string		FFIL		(font suitcase)
+#>65	string		FKEY		(function key)
+#>65	string		FNDR		(Macintosh Finder)
+#>65	string		GIFf		(GIF image)
+#>65	string		Gzip		(GNU gzip)
+#>65	string		INIT		(system extension)
+#>65	string		LIB\ 		(library)
+#>65	string		LWFN		(PostScript font)
+#>65	string		MSBC		(Microsoft BASIC)
+#>65	string		PACT		(Compact Pro archive)
+#>65	string		PDF\ 		(Portable Document Format)
+#>65	string		PICT		(picture)
+#>65	string		PNTG		(MacPaint picture)
+#>65	string		PREF		(preferences)
+#>65	string		PROJ		(Think C project)
+#>65	string		QPRJ		(Think Pascal project)
+#>65	string		SCFL		(Defender scores)
+#>65	string		SCRN		(startup screen)
+#>65	string		SITD		(StuffIt Deluxe)
+#>65	string		SPn3		(SuperPaint)
+#>65	string		STAK		(HyperCard stack)
+#>65	string		Seg\ 		(StuffIt segment)
+#>65	string		TARF		(Unix tar archive)
+#>65	string		TEXT		(ASCII)
+#>65	string		TIFF		(TIFF image)
+#>65	string		TOVF		(Eudora table of contents)
+#>65	string		WDBN		(Microsoft Word word processor)
+#>65	string		WORD		(MacWrite word processor)
+#>65	string		XLS\ 		(Microsoft Excel)
+#>65	string		ZIVM		(compress (.Z))
+#>65	string		ZSYS		(Pre-System 7 system file)
+#>65	string		acf3		(Aldus FreeHand)
+#>65	string		cdev		(control panel)
+#>65	string		dfil		(Desk Accessory suitcase)
+#>65	string		libr		(library)
+#>65	string		nX^d		(WriteNow word processor)
+#>65	string		nX^w		(WriteNow dictionary)
+#>65	string		rsrc		(resource)
+#>65	string		scbk		(Scrapbook)
+#>65	string		shlb		(shared library)
+#>65	string		ttro		(SimpleText read-only)
+#>65	string		zsys		(system file)
+
+#>69	string		x		\b, creator "%4.4s"
+
+# Somewhere, Apple has a repository of registered Creator IDs.  These are
+# just the ones that I happened to have files from and was able to identify.
+
+#>69	string		8BIM		(Adobe Photoshop)
+#>69	string		ALD3		(PageMaker 3)
+#>69	string		ALD4		(PageMaker 4)
+#>69	string		ALFA		(Alpha editor)
+#>69	string		APLS		(Apple Scanner)
+#>69	string		APSC		(Apple Scanner)
+#>69	string		BRKL		(Brickles)
+#>69	string		BTFT		(BitFont)
+#>69	string		CCL2 		(Common Lisp 2)
+#>69	string		CCL\ 		(Common Lisp)
+#>69	string		CDmo		(The Talking Moose)
+#>69	string		CPCT		(Compact Pro)
+#>69	string		CSOm		(Eudora)
+#>69	string		DMOV		(Font/DA Mover)
+#>69	string		DSIM		(DigSim)
+#>69	string		EDIT		(Macintosh Edit)
+#>69	string		ERIK		(Macintosh Finder)
+#>69	string		EXTR		(self-extracting archive)
+#>69	string		Gzip		(GNU gzip)
+#>69	string		KAHL		(Think C)
+#>69	string		LWFU		(LaserWriter Utility)
+#>69	string		LZIV		(compress)
+#>69	string		MACA		(MacWrite)
+#>69	string		MACS		(Macintosh operating system)
+#>69	string		MAcK		(MacKnowledge terminal emulator)
+#>69	string		MLND		(Defender)
+#>69	string		MPNT		(MacPaint)
+#>69	string		MSBB		(Microsoft BASIC (binary))
+#>69	string		MSWD		(Microsoft Word)
+#>69	string		NCSA		(NCSA Telnet)
+#>69	string		PJMM		(Think Pascal)
+#>69	string		PSAL		(Hunt the Wumpus)
+#>69	string		PSI2		(Apple File Exchange)
+#>69	string		R*ch		(BBEdit)
+#>69	string		RMKR		(Resource Maker)
+#>69	string		RSED		(Resource Editor)
+#>69	string		Rich		(BBEdit)
+#>69	string		SIT!		(StuffIt)
+#>69	string		SPNT		(SuperPaint)
+#>69	string		Unix		(NeXT Mac filesystem)
+#>69	string		VIM!		(Vim editor)
+#>69	string		WILD		(HyperCard)
+#>69	string		XCEL		(Microsoft Excel)
+#>69	string		aCa2		(Fontographer)
+#>69	string		aca3		(Aldus FreeHand)
+#>69	string		dosa		(Macintosh MS-DOS file system)
+#>69	string		movr		(Font/DA Mover)
+#>69	string		nX^n		(WriteNow)
+#>69	string		pdos		(Apple ProDOS file system)
+#>69	string		scbk		(Scrapbook)
+#>69	string		ttxt		(SimpleText)
+#>69	string		ufox		(Foreign File Access)
+
+# Just in case...
+
+102	string		mBIN		MacBinary III data with surprising version number
+
+# sas magic from Bruce Foster (bef@nwu.edu)
+#
+#0	string		SAS		SAS
+#>8	string		x		%s
+0	string		SAS		SAS
+>24	string		DATA		data file
+>24	string		CATALOG		catalog
+>24	string		INDEX		data file index
+>24	string		VIEW		data view
+# sas 7+ magic from Reinhold Koch (reinhold.koch@roche.com)
+#
+0x54    string          SAS             SAS 7+
+>0x9C   string          DATA            data file
+>0x9C   string          CATALOG         catalog
+>0x9C   string          INDEX           data file index
+>0x9C   string          VIEW            data view
+
+# spss magic for SPSS system and portable files, 
+#	 from Bruce Foster (bef@nwu.edu).
+
+0	long		0xc1e2c3c9	SPSS Portable File
+>40	string 		x		%s
+
+0	string		$FL2		SPSS System File
+>24	string		x		%s
+
+0	string		$FL3		SPSS System File
+>24	string		x		%s
+
+# Macintosh filesystem data
+# From "Tom N Harris" <telliamed@mac.com>
+# Fixed HFS+ and Partition map magic: Ethan Benson <erbenson@alaska.net>
+# The MacOS epoch begins on 1 Jan 1904 instead of 1 Jan 1970, so these
+# entries depend on the data arithmetic added after v.35
+# There's also some Pascal strings in here, ditto...
+
+# The boot block signature, according to IM:Files, is 
+# "for HFS volumes, this field always contains the value 0x4C4B."
+# But if this is true for MFS or HFS+ volumes, I don't know.
+# Alternatively, the boot block is supposed to be zeroed if it's
+# unused, so a simply >0 should suffice.
+
+0x400	beshort			0xD2D7		Macintosh MFS data
+>0	beshort			0x4C4B		(bootable)
+>0x40a	beshort			&0x8000		(locked)
+>0x402	beldate-0x7C25B080	x		created: %s,
+>0x406	beldate-0x7C25B080	>0		last backup: %s,
+>0x414	belong			x		block size: %d,
+>0x412	beshort			x		number of blocks: %d,
+>0x424	pstring			x		volume name: %s
+
+# *.hfs updated by Joerg Jenderek
+# http://en.wikipedia.org/wiki/Hierarchical_File_System
+# "BD" gives many false positives
+0x400	beshort			0x4244		
+# ftp://ftp.mars.org/pub/hfs/hfsutils-3.2.6.tar.gz/hfsutils-3.2.6/libhfs/apple.h
+# first block of volume bit map (always 3)
+>0x40e	ubeshort		0x0003		
+# maximal length of volume name is 27
+>>0x424		ubyte			<28	Macintosh HFS data
+#!:mime	application/octet-stream
+# these mime and apple types are not sure
+!:mime	application/x-apple-diskimage
+#!:apple	hfsdINIT
+#!:apple	MACSdisk
+>>>0		beshort			0x4C4B	(bootable)
+#>>>0		beshort			0x0000	(not bootable)
+>>>0x40a	beshort			&0x8000	(locked)
+>>>0x40a	beshort			^0x0100	(mounted)
+>>>0x40a	beshort			&0x0200	(spared blocks)
+>>>0x40a	beshort			&0x0800	(unclean)
+>>>0x47C	beshort			0x482B	(Embedded HFS+ Volume)
+# http://www.epochconverter.com/
+# 0x7C245F00 seconds	~ 2082758400	~ 01 Jan 2036 00:00:00	~ 66 years to 1970
+# 0x7C25B080 seconds	~ 2082844800	~ 02 Jan 2036 00:00:00
+# construct not working
+#>>>0x402	beldate-0x7C25B080	x	created: %s,
+#>>>0x406	beldate-0x7C25B080	x	last modified: %s,
+#>>>0x440	beldate-0x7C25B080	>0	last backup: %s,
+# found block sizes 200h,1200h,2800h
+>>>0x414	belong			x	block size: %d,
+>>>0x412	beshort			x	number of blocks: %d,
+>>>0x424	pstring			x	volume name: %s
+
+0x400	beshort			0x482B		Macintosh HFS Extended
+>&0	beshort			x		version %d data
+>0	beshort			0x4C4B		(bootable)
+>0x404	belong			^0x00000100	(mounted)
+>&2	belong			&0x00000200	(spared blocks)
+>&2	belong			&0x00000800	(unclean)
+>&2	belong			&0x00008000	(locked)
+>&6	string			x		last mounted by: '%.4s',
+# really, that should be treated as a belong and we print a string
+# based on the value. TN1150 only mentions '8.10' for "MacOS 8.1"
+>&14	beldate-0x7C25B080	x		created: %s,
+# only the creation date is local time, all other timestamps in HFS+ are UTC.
+>&18	bedate-0x7C25B080	x		last modified: %s,
+>&22	bedate-0x7C25B080	>0		last backup: %s,
+>&26	bedate-0x7C25B080	>0		last checked: %s,
+>&38	belong			x		block size: %d,
+>&42	belong			x		number of blocks: %d,
+>&46	belong			x		free blocks: %d
+
+## AFAIK, only the signature is different
+# same as Apple Partition Map
+# GRR: This magic is too weak, it is just "TS"
+#0x200		beshort		0x5453		Apple Old Partition data
+#>0x2		beshort		x		block size: %d,
+#>0x230		string		x		first type: %s,
+#>0x210		string		x		name: %s,
+#>0x254		belong		x		number of blocks: %d,
+#>0x400		beshort		0x504D		
+#>>0x430		string		x		second type: %s,
+#>>0x410		string		x		name: %s,
+#>>0x454		belong		x		number of blocks: %d,
+#>>0x800		beshort		0x504D		
+#>>>0x830	string		x		third type: %s,
+#>>>0x810	string		x		name: %s,
+#>>>0x854	belong		x		number of blocks: %d,
+#>>>0xa00	beshort		0x504D		
+#>>>>0xa30	string		x		fourth type: %s,
+#>>>>0xa10	string		x		name: %s,
+#>>>>0xa54	belong		x		number of blocks: %d
+
+# From: Remi Mommsen <mommsen@slac.stanford.edu>
+0		string		BOMStore	Mac OS X bill of materials (BOM) file
+
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# URL: http://en.wikipedia.org/wiki/Datafork_TrueType
+# Derived from the 'fondu' and 'ufond' source code (fondu.sf.net). 'sfnt' is
+# TrueType; 'POST' is PostScript. 'FONT' and 'NFNT' sometimes appear, but I
+# don't know what they mean.
+0	belong	0x100
+>(0x4.L+24)	beshort	x
+>>&4	belong	0x73666e74	Mac OSX datafork font, TrueType
+>>&4	belong	0x464f4e54	Mac OSX datafork font, 'FONT'
+>>&4	belong	0x4e464e54	Mac OSX datafork font, 'NFNT'
+>>&4	belong	0x504f5354	Mac OSX datafork font, PostScript
+
+#------------------------------------------------------------------------------
+# $File: cups,v 1.2 2012/11/02 21:50:29 christos Exp $
+# MacOS files
+#
+
+0	string		book\0\0\0\0mark\0\0\0\0	MacOS Alias file
+
+#------------------------------------------------------------------------------
+# $File: magic,v 1.9 2009/09/19 16:28:10 christos Exp $
+# magic:  file(1) magic for magic files
+#
+0	string/t		#\ Magic	magic text file for file(1) cmd
+0	lelong		0xF11E041C	magic binary file for file(1) cmd
+>4	lelong		x		(version %d) (little endian)
+0	belong		0xF11E041C	magic binary file for file(1) cmd
+>4	belong		x		(version %d) (big endian)
+#------------------------------------------------------------------------------
+# $File: mail.news,v 1.21 2012/06/21 01:44:52 christos Exp $
+# mail.news:  file(1) magic for mail and news
+#
+# Unfortunately, saved netnews also has From line added in some news software.
+#0	string		From 		mail text
+0	string/t		Relay-Version: 	old news text
+!:mime	message/rfc822
+0	string/t		#!\ rnews	batched news text
+!:mime	message/rfc822
+0	string/t		N#!\ rnews	mailed, batched news text
+!:mime	message/rfc822
+0	string/t		Forward\ to 	mail forwarding text
+!:mime	message/rfc822
+0	string/t		Pipe\ to 	mail piping text
+!:mime	message/rfc822
+0	string/tc		delivered-to:	SMTP mail text
+!:mime	message/rfc822
+0	string/tc		return-path:	SMTP mail text
+!:mime	message/rfc822
+0	string/t		Path:		news text
+!:mime	message/news
+0	string/t		Xref:		news text
+!:mime	message/news
+0	string/t		From:		news or mail text
+!:mime	message/rfc822
+0	string/t		Article 	saved news text
+!:mime	message/news
+0	string/t		BABYL		Emacs RMAIL text
+0	string/t		Received:	RFC 822 mail text
+!:mime	message/rfc822
+0	string/t		MIME-Version:	MIME entity text
+#0	string/t		Content-	MIME entity text
+
+# TNEF files...
+0	lelong		0x223E9F78	Transport Neutral Encapsulation Format
+!:mime	application/vnd.ms-tnef
+
+# From: Kevin Sullivan <ksulliva@psc.edu>
+0	string		*mbx*		MBX mail folder
+
+# From: Simon Matter <simon.matter@invoca.ch>
+0	string		\241\002\213\015skiplist\ file\0\0\0	Cyrus skiplist DB
+
+# JAM(mbp) Fidonet message area databases
+# JHR file
+0	string	JAM\0			JAM message area header file
+>12	leshort >0			(%d messages)
+
+# Squish Fidonet message area databases
+# SQD file (requires at least one message in the area)
+# XXX: Weak magic
+#256	leshort	0xAFAE4453		Squish message area data file
+#>4	leshort	>0			(%d messages)
+
+#0	string		\<!--\ MHonArc		text/html; x-type=mhonarc
+
+# Cyrus: file(1) magic for compiled Cyrus sieve scripts
+# URL: http://www.cyrusimap.org/docs/cyrus-imapd/2.4.6/internal/bytecode.php
+# URL: http://git.cyrusimap.org/cyrus-imapd/tree/sieve/bytecode.h?h=master
+# From: Philipp Hahn <hahn@univention.de>
+
+# Compiled Cyrus sieve script
+0       string CyrSBytecode     Cyrus sieve bytecode data,
+>12     belong =1       version 1, big-endian
+>12     lelong =1       version 1, little-endian
+>12     belong x        version %d, network-endian
+#------------------------------------------------------------------------------
+# $File$
+# make:  file(1) magic for makefiles
+#
+0	regex	\^CFLAGS	makefile script text
+!:mime	text/x-makefile
+0	regex	\^LDFLAGS	makefile script text
+!:mime	text/x-makefile
+0	regex	\^all:	makefile script text
+!:mime	text/x-makefile
+0	regex	\^.PRECIOUS	makefile script text
+!:mime	text/x-makefile
+
+0	regex	\^SUBDIRS	automake makefile script text
+!:mime	text/x-makefile
+
+
+#------------------------------------------------------------------------------
+# $File: msdos,v 1.99 2014/06/03 01:40:24 christos Exp $
+# map:  file(1) magic for Map data
+#
+
+# Garmin .FIT files http://pub.ks-and-ks.ne.jp/cycling/edge500_fit.shtml
+8	string	.FIT		FIT Map data
+>15	byte	0
+>>35	belong	x		\b, unit id %d
+# 20 years after unix epoch
+>>39	lelong	x		\b, serial %u
+>>43	ledate/631152000 x	\b, %s
+
+>>47	leshort x		\b, manufacturer %d
+>>47	leshort	1		\b (garmin)
+>>49	leshort x		\b, product %d
+>>53	byte	x		\b, type %d
+>>53	byte	1		\b (Device)
+>>53	byte	2		\b (Settings)
+>>53	byte	3		\b (Sports/Cycling)
+>>53	byte	4		\b (Activity)
+>>53	byte	8		\b (Elevations)
+>>53	byte	10		\b (Totals)
+
+#------------------------------------------------------------------------------
+# $File: maple,v 1.6 2009/09/19 16:28:10 christos Exp $
+# maple:  file(1) magic for maple files
+# "H. Nanosecond" <aldomel@ix.netcom.com>
+# Maple V release 4, a multi-purpose math program
+#
+
+# maple library .lib
+0	string	\000MVR4\nI	MapleVr4 library
+
+# .ind
+# no magic for these :-(
+# they are compiled indexes for maple files
+
+# .hdb 
+0	string	\000\004\000\000	Maple help database
+
+# .mhp
+# this has the form <PACKAGE=name>
+0	string	\<PACKAGE=	Maple help file
+0	string	\<HELP\ NAME=	Maple help file
+0	string	\n\<HELP\ NAME=	Maple help file with extra carriage return at start (yuck)
+#0	string	#\ Newton	Maple help file, old style
+0	string	#\ daub	Maple help file, old style
+#0	string	#===========	Maple help file, old style
+
+# .mws
+0	string	\000\000\001\044\000\221	Maple worksheet
+#this is anomalous
+0	string	WriteNow\000\002\000\001\000\000\000\000\100\000\000\000\000\000	Maple worksheet, but weird
+# this has the form {VERSION 2 3 "IBM INTEL NT" "2.3" }\n
+# that is {VERSION major_version miunor_version computer_type version_string}
+0	string	{VERSION\ 	Maple worksheet
+>9	string	>\0	version %.1s.
+>>11	string	>\0	%.1s
+
+# .mps
+0	string	\0\0\001$	Maple something
+# from byte 4 it is either 'nul E' or 'soh R'
+# I think 'nul E' means a file that was saved as  a different name
+# a sort of revision marking
+# 'soh R' means new 
+>4	string	\000\105	An old revision
+>4	string	\001\122	The latest save
+
+# .mpl
+# some of these are the same as .mps above
+#0000000 000 000 001 044 000 105 same as .mps
+#0000000 000 000 001 044 001 122 same as .mps
+
+0	string	#\n##\ <SHAREFILE=	Maple something
+0	string	\n#\n##\ <SHAREFILE=	Maple something
+0	string	##\ <SHAREFILE=	Maple something
+0	string	#\r##\ <SHAREFILE=	Maple something
+0	string	\r#\r##\ <SHAREFILE=	Maple something
+0	string	#\ \r##\ <DESCRIBE>	Maple something anomalous.
+#--------------------------------------------
+# marc21: file(1) magic for MARC 21 Format
+#
+# Kevin Ford (kefo@loc.gov)
+# 
+# MARC21 formats are for the representation and communication
+# of bibliographic and related information in machine-readable
+# form.  For more info, see http://www.loc.gov/marc/
+
+
+# leader position 20-21 must be 45
+20	string	45	
+
+# leader starts with 5 digits, followed by codes specific to MARC format
+>0	regex/1l	(^[0-9]{5})[acdnp][^bhlnqsu-z]	MARC21 Bibliographic
+!:mime	application/marc
+>0	regex/1l	(^[0-9]{5})[acdnosx][z]	MARC21 Authority
+!:mime	application/marc
+>0	regex/1l	(^[0-9]{5})[cdn][uvxy]	MARC21 Holdings
+!:mime	application/marc
+0	regex/1l	(^[0-9]{5})[acdn][w]	MARC21 Classification
+!:mime	application/marc
+>0	regex/1l	(^[0-9]{5})[cdn][q]	MARC21 Community
+!:mime	application/marc
+
+# leader position 22-23, should be "00" but is it?
+>0	regex/1l	(^.{21})([^0]{2})	(non-conforming)
+!:mime	application/marc
+
+#------------------------------------------------------------------------------
+# $File$
+# mathcad:  file(1) magic for Mathcad documents
+# URL:	http://www.mathsoft.com/
+# From:	Josh Triplett <josh@freedesktop.org>
+
+0	string	.MCAD\t		Mathcad document
+
+#------------------------------------------------------------------------------
+# $File$
+# mathematica:  file(1) magic for mathematica files
+# "H. Nanosecond" <aldomel@ix.netcom.com>
+# Mathematica a multi-purpose math program
+# versions 2.2 and 3.0
+
+#mathematica .mb
+0	string	\064\024\012\000\035\000\000\000	Mathematica version 2 notebook
+0	string	\064\024\011\000\035\000\000\000	Mathematica version 2 notebook
+
+# .ma
+# multiple possibilites:
+
+0	string	(*^\n\n::[\011frontEndVersion\ =\ 	Mathematica notebook
+#>41	string	>\0	%s
+
+#0	string	(*^\n\n::[\011palette	Mathematica notebook version 2.x
+
+#0	string	(*^\n\n::[\011Information	Mathematica notebook version 2.x
+#>675	string	>\0	%s #doesn't work well
+
+# there may be 'cr' instread of 'nl' in some does this matter?
+
+# generic:
+0	string	(*^\r\r::[\011	Mathematica notebook version 2.x
+0	string	(*^\r\n\r\n::[\011	Mathematica notebook version 2.x
+0	string	(*^\015			Mathematica notebook version 2.x
+0	string	(*^\n\r\n\r::[\011	Mathematica notebook version 2.x
+0	string	(*^\r::[\011	Mathematica notebook version 2.x
+0	string	(*^\r\n::[\011	Mathematica notebook version 2.x
+0	string	(*^\n\n::[\011	Mathematica notebook version 2.x
+0	string	(*^\n::[\011	Mathematica notebook version 2.x
+
+
+# Mathematica .mx files
+
+#0	string	(*This\ is\ a\ Mathematica\ binary\ dump\ file.\ It\ can\ be\ loaded\ with\ Get.*)	Mathematica binary file
+0	string	(*This\ is\ a\ Mathematica\ binary\ 	Mathematica binary file
+#>71	string \000\010\010\010\010\000\000\000\000\000\000\010\100\010\000\000\000	
+# >71... is optional
+>88	string	>\0	from %s
+
+
+# Mathematica files PBF:
+# 115 115 101 120 102 106 000 001 000 000 000 203 000 001 000
+0	string	MMAPBF\000\001\000\000\000\203\000\001\000	Mathematica PBF (fonts I think)
+
+# .ml files  These are menu resources I think
+# these start with "[0-9][0-9][0-9]\ A~[0-9][0-9][0-9]\ 
+# how to put that into a magic rule?
+4	string	\ A~	MAthematica .ml file
+
+# .nb files
+#too long 0	string	(***********************************************************************\n\n\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ Mathematica-Compatible Notebook	Mathematica 3.0 notebook
+0	string	(***********************	Mathematica 3.0 notebook
+
+# other (* matches it is a comment start in these langs
+# GRR: Too weak; also matches other languages e.g. ML
+#0	string	(*	Mathematica, or Pascal, Modula-2 or 3 code text
+
+#########################
+# MatLab v5
+0       string  MATLAB  Matlab v5 mat-file
+>126    short   0x494d  (big endian)
+>>124   beshort x       version 0x%04x
+>126    short   0x4d49  (little endian)
+>>124   leshort x       version 0x%04x
+
+
+#------------------------------------------------------------------------------
+# $File: matroska,v 1.7 2012/08/26 10:06:15 christos Exp $
+# matroska:  file(1) magic for Matroska files
+#
+# See http://www.matroska.org/
+#
+
+# EBML id:
+0		belong		0x1a45dfa3
+# DocType id:
+>4		search/4096 	\x42\x82
+# DocType contents:
+>>&1		string		webm		WebM
+!:mime  video/webm
+>>&1		string		matroska	Matroska data
+!:mime  video/x-matroska
+
+#------------------------------------------------------------------------------
+# $File$
+# Mavroyanopoulos Nikos <nmav@hellug.gr>
+# mcrypt:   file(1) magic for mcrypt 2.2.x;
+0	string		\0m\3		mcrypt 2.5 encrypted data,
+>4	string		>\0		algorithm: %s,
+>>&1	leshort		>0		keysize: %d bytes,
+>>>&0	string		>\0		mode: %s,
+
+0	string		\0m\2		mcrypt 2.2 encrypted data,
+>3	byte		0		algorithm: blowfish-448,
+>3	byte		1		algorithm: DES,
+>3	byte		2		algorithm: 3DES,
+>3	byte		3		algorithm: 3-WAY,
+>3	byte		4		algorithm: GOST,
+>3	byte		6		algorithm: SAFER-SK64,
+>3	byte		7		algorithm: SAFER-SK128,
+>3	byte		8		algorithm: CAST-128,
+>3	byte		9		algorithm: xTEA,
+>3	byte		10		algorithm: TWOFISH-128,
+>3	byte		11		algorithm: RC2,
+>3	byte		12		algorithm: TWOFISH-192,
+>3	byte		13		algorithm: TWOFISH-256,
+>3	byte		14		algorithm: blowfish-128,
+>3	byte		15		algorithm: blowfish-192,
+>3	byte		16		algorithm: blowfish-256,
+>3	byte		100		algorithm: RC6,
+>3	byte		101		algorithm: IDEA,
+>4	byte		0		mode: CBC,
+>4	byte		1		mode: ECB,
+>4	byte		2		mode: CFB,
+>4	byte		3		mode: OFB,
+>4	byte		4		mode: nOFB,
+>5	byte		0		keymode: 8bit
+>5	byte		1		keymode: 4bit
+>5	byte		2		keymode: SHA-1 hash
+>5	byte		3		keymode: MD5 hash
+
+#------------------------------------------------------------------------------
+# $File$
+# mercurial:  file(1) magic for Mercurial changeset bundles
+# http://www.selenic.com/mercurial/wiki/
+#
+# Jesse Glick (jesse.glick@sun.com)
+#
+
+0	string		HG10		Mercurial changeset bundle
+>4	string		UN		(uncompressed)
+>4	string		GZ		(gzip compressed)
+>4	string		BZ		(bzip2 compressed)
+
+#------------------------------------------------------------------------------
+# $File: mathematica,v 1.7 2009/09/19 16:28:10 christos Exp $
+# metastore:  file(1) magic for metastore files
+# From: Thomas Wissen
+# see http://david.hardeman.nu/software.php#metastore
+0	string		MeTaSt00r3	Metastore data file, 
+>10	bequad		x		version %0llx
+
+#------------------------------------------------------------------------------
+# $File: rinex,v 1.4 2011/05/03 01:44:17 christos Exp $
+# rinex:  file(1) magic for RINEX files
+# http://igscb.jpl.nasa.gov/igscb/data/format/rinex210.txt
+# ftp://cddis.gsfc.nasa.gov/pub/reports/formats/rinex300.pdf
+# data for testing: ftp://cddis.gsfc.nasa.gov/pub/gps/data
+60	string		RINEX
+>80	search/256	XXRINEXB	RINEX Data, GEO SBAS Broadcast
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/broadcast
+>80	search/256	XXRINEXD	RINEX Data, Observation (Hatanaka comp)
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/observation
+>80	search/256	XXRINEXC	RINEX Data, Clock
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/clock
+>80	search/256	XXRINEXH	RINEX Data, GEO SBAS Navigation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXG	RINEX Data, GLONASS Navigation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXL	RINEX Data, Galileo Navigation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXM	RINEX Data, Meteorological
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/meteorological
+>80	search/256	XXRINEXN	RINEX Data, Navigation	
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXO	RINEX Data, Observation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/observation
+
+# https://en.wikipedia.org/wiki/GRIB
+0	string	GRIB
+>7	byte	=1	Gridded binary (GRIB) version 1
+>7	byte	=2	Gridded binary (GRIB) version 2
+
+#------------------------------------------------------------------------------
+# $File: mime,v 1.5 2009/09/19 16:28:10 christos Exp $
+# mime:  file(1) magic for MIME encoded files
+#
+0	string/t		Content-Type:\ 
+>14	string		>\0		%s
+0	string/t		Content-Type:
+>13	string		>\0		%s
+
+#------------------------------------------------------------------------------
+# $File: mips,v 1.9 2013/01/12 03:09:51 christos Exp $
+# mips:  file(1) magic for MIPS ECOFF and Ucode, as used in SGI IRIX
+# and DEC Ultrix
+#
+0	beshort	0x0160		MIPSEB ECOFF executable
+>20	beshort	0407		(impure)
+>20	beshort	0410		(swapped)
+>20	beshort	0413		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>22	byte	x		- version %d
+>23	byte	x		\b.%d
+#
+0	beshort	0x0162		MIPSEL-BE ECOFF executable
+>20	beshort	0407		(impure)
+>20	beshort	0410		(swapped)
+>20	beshort	0413		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+0	beshort	0x6001		MIPSEB-LE ECOFF executable
+>20	beshort	03401		(impure)
+>20	beshort	04001		(swapped)
+>20	beshort	05401		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+0	beshort	0x6201		MIPSEL ECOFF executable
+>20	beshort	03401		(impure)
+>20	beshort	04001		(swapped)
+>20	beshort	05401		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+# MIPS 2 additions
+#
+0	beshort	0x0163		MIPSEB MIPS-II ECOFF executable
+>20	beshort	0407		(impure)
+>20	beshort	0410		(swapped)
+>20	beshort	0413		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>22	byte	x		- version %d
+>23	byte	x		\b.%d
+#
+0	beshort	0x0166		MIPSEL-BE MIPS-II ECOFF executable
+>20	beshort	0407		(impure)
+>20	beshort	0410		(swapped)
+>20	beshort	0413		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>22	byte	x		- version %d
+>23	byte	x		\b.%d
+#
+0	beshort	0x6301		MIPSEB-LE MIPS-II ECOFF executable
+>20	beshort	03401		(impure)
+>20	beshort	04001		(swapped)
+>20	beshort	05401		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+0	beshort	0x6601		MIPSEL MIPS-II ECOFF executable
+>20	beshort	03401		(impure)
+>20	beshort	04001		(swapped)
+>20	beshort	05401		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+# MIPS 3 additions
+#
+0	beshort	0x0140		MIPSEB MIPS-III ECOFF executable
+>20	beshort	0407		(impure)
+>20	beshort	0410		(swapped)
+>20	beshort	0413		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>22	byte	x		- version %d
+>23	byte	x		\b.%d
+#
+0	beshort	0x0142		MIPSEL-BE MIPS-III ECOFF executable
+>20	beshort	0407		(impure)
+>20	beshort	0410		(swapped)
+>20	beshort	0413		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>22	byte	x		- version %d
+>23	byte	x		\b.%d
+#
+0	beshort	0x4001		MIPSEB-LE MIPS-III ECOFF executable
+>20	beshort	03401		(impure)
+>20	beshort	04001		(swapped)
+>20	beshort	05401		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+0	beshort	0x4201		MIPSEL MIPS-III ECOFF executable
+>20	beshort	03401		(impure)
+>20	beshort	04001		(swapped)
+>20	beshort	05401		(paged)
+>8	belong	>0		not stripped
+>8	belong	0		stripped
+>23	byte	x		- version %d
+>22	byte	x		\b.%d
+#
+0	beshort	0x180		MIPSEB Ucode
+0	beshort	0x182		MIPSEL-BE Ucode
+
+#------------------------------------------------------------------------------
+# $File$
+# mirage:  file(1) magic for Mirage executables
+#
+# XXX - byte order?
+#
+0	long	31415		Mirage Assembler m.out executable
+
+#-----------------------------------------------------------------------------
+# $File: misctools,v 1.13 2013/01/16 13:53:10 christos Exp $
+# misctools:  file(1) magic for miscellaneous UNIX tools.
+#
+0	search/1	%%!!			X-Post-It-Note text
+0	string/c	BEGIN:VCALENDAR		vCalendar calendar file
+!:mime	text/calendar
+0	string/c	BEGIN:VCARD		vCard visiting card
+!:mime	text/x-vcard
+
+# Summary: Libtool library file
+# Extension: .la
+# Submitted by: Tomasz Trojanowski <tomek@uninet.com.pl>
+0	search/80	.la\ -\ a\ libtool\ library\ file	libtool library file
+
+# Summary: Libtool object file
+# Extension: .lo
+# Submitted by: Abel Cheung <abelcheung@gmail.com>
+0	search/80	.lo\ -\ a\ libtool\ object\ file	libtool object file
+
+# From: Daniel Novotny <dnovotny@redhat.com>
+0	string		MDMP\x93\xA7				MDMP crash report data
+
+# Summary: abook addressbook file
+# Submitted by: Mark Schreiber <mark7@alumni.cmu.edu>
+0	string	#\x20abook\x20addressbook\x20file abook address book
+!:mime application/x-abook-addressbook
+
+#------------------------------------------------------------------------------
+# $File$
+# mkid:  file(1) magic for mkid(1) databases
+#
+# ID is the binary tags database produced by mkid(1).
+#
+# XXX - byte order?
+#
+0	string		\311\304	ID tags data
+>2	short		>0		version %d
+
+#------------------------------------------------------------------------------
+# $File$
+# mlssa: file(1) magic for MLSSA datafiles
+#
+0		lelong		0xffffabcd	MLSSA datafile,
+>4		leshort		x		algorithm %d,
+>10		lelong		x		%d samples
+
+#------------------------------------------------------------------------------
+# $File$
+# mmdf:  file(1) magic for MMDF mail files
+#
+0	string	\001\001\001\001	MMDF mailbox
+
+#------------------------------------------------------------------------------
+# $File: modem,v 1.5 2010/09/20 18:55:20 rrt Exp $
+# modem:  file(1) magic for modem programs
+#
+# From: Florian La Roche <florian@knorke.saar.de>
+1	string		PC\ Research,\ Inc	Digifax-G3-File
+>29	byte		1			\b, fine resolution
+>29	byte		0			\b, normal resolution
+
+0	short		0x0100		raw G3 data, byte-padded
+0	short		0x1400		raw G3 data
+#
+# Magic data for vgetty voice formats
+# (Martin Seine & Marc Eberhard)
+
+#
+# raw modem data version 1
+#
+0    string    RMD1      raw modem data
+>4   string    >\0       (%s /
+>20  short     >0        compression type 0x%04x)
+
+#
+# portable voice format 1
+#
+0    string    PVF1\n         portable voice format
+>5   string    >\0       (binary %s)
+
+#
+# portable voice format 2
+#
+0    string    PVF2\n         portable voice format
+>5   string >\0          (ascii %s)
+
+# From: Bernd Nuernberger <bernd.nuernberger@web.de>
+# Brooktrout G3 fax data incl. 128 byte header
+# Common suffixes: 3??, BRK, BRT, BTR
+0	leshort		0x01bb
+>2	leshort		0x0100		Brooktrout 301 fax image,
+>>9	leshort		x		%d x
+>>0x2d	leshort		x		%d
+>>6	leshort		200		\b, fine resolution
+>>6	leshort		100		\b, normal resolution
+>>11	byte		1		\b, G3 compression
+>>11	byte		2		\b, G32D compression
+
+#------------------------------------------------------------------------------
+# $File: motorola,v 1.10 2009/09/19 16:28:11 christos Exp $
+# motorola:  file(1) magic for Motorola 68K and 88K binaries
+#
+# 68K
+#
+0	beshort		0520		mc68k COFF
+>18	beshort		^00000020	object
+>18	beshort		&00000020	executable
+>12	belong		>0		not stripped
+>168	string		.lowmem		Apple toolbox
+>20	beshort		0407		(impure)
+>20	beshort		0410		(pure)
+>20	beshort		0413		(demand paged)
+>20	beshort		0421		(standalone)
+0	beshort		0521		mc68k executable (shared)
+>12	belong		>0		not stripped
+0	beshort		0522		mc68k executable (shared demand paged)
+>12	belong		>0		not stripped
+#
+# Motorola/UniSoft 68K Binary Compatibility Standard (BCS)
+#
+0	beshort		0554		68K BCS executable
+#
+# 88K
+#
+# Motorola/88Open BCS
+#
+0	beshort		0555		88K BCS executable
+#
+# Motorola S-Records, from Gerd Truschinski <gt@freebsd.first.gmd.de>
+0   string      S0          Motorola S-Record; binary data in text format
+
+# ATARI ST relocatable PRG
+#
+# from Oskar Schirmer <schirmer@scara.com> Feb 3, 2001
+# (according to Roland Waldi, Oct 21, 1987)
+# besides the magic 0x601a, the text segment size is checked to be
+# not larger than 1 MB (which is a lot on ST).
+# The additional 0x601b distinction I took from Doug Lee's magic.
+0	belong&0xFFFFFFF0	0x601A0000	Atari ST M68K contiguous executable
+>2	belong			x		(txt=%d,
+>6	belong			x		dat=%d,
+>10	belong			x		bss=%d,
+>14	belong			x		sym=%d)
+0	belong&0xFFFFFFF0	0x601B0000	Atari ST M68K non-contig executable
+>2	belong			x		(txt=%d,
+>6	belong			x		dat=%d,
+>10	belong			x		bss=%d,
+>14	belong			x		sym=%d)
+
+# Atari ST/TT... program format (sent by Wolfram Kleff <kleff@cs.uni-bonn.de>)
+0       beshort         0x601A          Atari 68xxx executable,
+>2      belong          x               text len %u,
+>6      belong          x               data len %u,
+>10     belong          x               BSS len %u,
+>14     belong          x               symboltab len %u,
+>18     belong          0
+>22     belong          &0x01           fastload flag,
+>22     belong          &0x02           may be loaded to alternate RAM,
+>22     belong          &0x04           malloc may be from alternate RAM,
+>22     belong          x               flags: 0x%X,
+>26     beshort         0               no relocation tab
+>26     beshort         !0              + relocation tab
+>30     string          SFX             [Self-Extracting LZH SFX archive]
+>38     string          SFX             [Self-Extracting LZH SFX archive]
+>44     string          ZIP!            [Self-Extracting ZIP SFX archive]
+
+0       beshort         0x0064          Atari 68xxx CPX file
+>8      beshort         x               (version %04x)
+
+#------------------------------------------------------------------------------
+# $File: mozilla,v 1.5 2015/01/24 15:48:42 christos Exp $
+# mozilla:  file(1) magic for Mozilla XUL fastload files 
+# (XUL.mfasl and XPC.mfasl)
+# URL:	http://www.mozilla.org/
+# From:	Josh Triplett <josh@freedesktop.org>
+
+0	string	XPCOM\nMozFASL\r\n\x1A		Mozilla XUL fastload data
+0	string	mozLz4a				Mozilla lz4 compressed bookmark data
+
+#------------------------------------------------------------------------------
+# $File: msdos,v 1.99 2014/06/03 01:40:24 christos Exp $
+# msdos:  file(1) magic for MS-DOS files
+#
+
+# .BAT files (Daniel Quinlan, quinlan@yggdrasil.com)
+# updated by Joerg Jenderek at Oct 2008,Apr 2011
+0	string/t	@			
+>1	string/cW	\ echo\ off	DOS batch file text
+!:mime	text/x-msdos-batch
+>1	string/cW	echo\ off	DOS batch file text
+!:mime	text/x-msdos-batch
+>1	string/cW	rem		DOS batch file text
+!:mime	text/x-msdos-batch
+>1	string/cW	set\ 		DOS batch file text
+!:mime	text/x-msdos-batch
+
+
+# OS/2 batch files are REXX. the second regex is a bit generic, oh well
+# the matched commands seem to be common in REXX and uncommon elsewhere
+100	search/0xffff   rxfuncadd
+>100	regex/c =^[\ \t]{0,10}call[\ \t]{1,10}rxfunc	OS/2 REXX batch file text
+100	search/0xffff   say
+>100	regex/c =^[\ \t]{0,10}say\ ['"]			OS/2 REXX batch file text
+
+0	leshort		0x14c	MS Windows COFF Intel 80386 object file
+#>4	ledate		x	stamp %s
+0	leshort		0x166	MS Windows COFF MIPS R4000 object file
+#>4	ledate		x	stamp %s
+0	leshort		0x184	MS Windows COFF Alpha object file
+#>4	ledate		x	stamp %s
+0	leshort		0x268	MS Windows COFF Motorola 68000 object file
+#>4	ledate		x	stamp %s
+0	leshort		0x1f0	MS Windows COFF PowerPC object file
+#>4	ledate		x	stamp %s
+0	leshort		0x290	MS Windows COFF PA-RISC object file
+#>4	ledate		x	stamp %s
+
+# Tests for various EXE types.
+#
+# Many of the compressed formats were extraced from IDARC 1.23 source code.
+#
+0	string/b	MZ
+# All non-DOS EXE extensions have the relocation table more than 0x40 bytes into the file.
+>0x18	leshort <0x40 MS-DOS executable
+!:mime	application/x-dosexec
+# These traditional tests usually work but not always.  When test quality support is
+# implemented these can be turned on.
+#>>0x18	leshort	0x1c	(Borland compiler)
+#>>0x18	leshort	0x1e	(MS compiler)
+
+# If the relocation table is 0x40 or more bytes into the file, it's definitely
+# not a DOS EXE.
+>0x18  leshort >0x3f
+
+# Maybe it's a PE?
+>>(0x3c.l) string PE\0\0 PE
+!:mime	application/x-dosexec
+>>>(0x3c.l+24)	leshort		0x010b	\b32 executable
+>>>(0x3c.l+24)	leshort		0x020b	\b32+ executable
+>>>(0x3c.l+24)	leshort		0x0107	ROM image
+>>>(0x3c.l+24)	default		x	Unknown PE signature
+>>>>&0 		leshort		x	0x%x
+>>>(0x3c.l+22)	leshort&0x2000	>0	(DLL)
+>>>(0x3c.l+92)	leshort		1	(native)
+>>>(0x3c.l+92)	leshort		2	(GUI)
+>>>(0x3c.l+92)	leshort		3	(console)
+>>>(0x3c.l+92)	leshort		7	(POSIX)
+>>>(0x3c.l+92)	leshort		9	(Windows CE)
+>>>(0x3c.l+92)	leshort		10	(EFI application)
+>>>(0x3c.l+92)	leshort		11	(EFI boot service driver)
+>>>(0x3c.l+92)	leshort		12	(EFI runtime driver)
+>>>(0x3c.l+92)	leshort		13	(EFI ROM)
+>>>(0x3c.l+92)	leshort		14	(XBOX)
+>>>(0x3c.l+92)	leshort		15	(Windows boot application)
+>>>(0x3c.l+92)	default		x	(Unknown subsystem
+>>>>&0		leshort		x	0x%x)
+>>>(0x3c.l+4)	leshort		0x14c	Intel 80386
+>>>(0x3c.l+4)	leshort		0x166	MIPS R4000
+>>>(0x3c.l+4)	leshort		0x168	MIPS R10000
+>>>(0x3c.l+4)	leshort		0x184	Alpha
+>>>(0x3c.l+4)	leshort		0x1a2	Hitachi SH3
+>>>(0x3c.l+4)	leshort		0x1a6	Hitachi SH4
+>>>(0x3c.l+4)	leshort		0x1c0	ARM
+>>>(0x3c.l+4)	leshort		0x1c2	ARM Thumb
+>>>(0x3c.l+4)	leshort		0x1c4	ARMv7 Thumb
+>>>(0x3c.l+4)	leshort		0x1f0	PowerPC
+>>>(0x3c.l+4)	leshort		0x200	Intel Itanium
+>>>(0x3c.l+4)	leshort		0x266	MIPS16
+>>>(0x3c.l+4)	leshort		0x268	Motorola 68000
+>>>(0x3c.l+4)	leshort		0x290	PA-RISC
+>>>(0x3c.l+4)	leshort		0x366	MIPSIV
+>>>(0x3c.l+4)	leshort		0x466	MIPS16 with FPU
+>>>(0x3c.l+4)	leshort		0xebc	EFI byte code
+>>>(0x3c.l+4)	leshort		0x8664	x86-64
+>>>(0x3c.l+4)	leshort		0xc0ee	MSIL
+>>>(0x3c.l+4)	default		x	Unknown processor type
+>>>>&0		leshort		x	0x%x
+>>>(0x3c.l+22)	leshort&0x0200	>0	(stripped to external PDB)
+>>>(0x3c.l+22)	leshort&0x1000	>0	system file
+>>>(0x3c.l+24)	leshort		0x010b
+>>>>(0x3c.l+232) lelong	>0	Mono/.Net assembly
+>>>(0x3c.l+24)	leshort		0x020b
+>>>>(0x3c.l+248) lelong	>0	Mono/.Net assembly
+
+# hooray, there's a DOS extender using the PE format, with a valid PE
+# executable inside (which just prints a message and exits if run in win)
+>>>(8.s*16)		string		32STUB	\b, 32rtm DOS extender
+>>>(8.s*16)		string		!32STUB	\b, for MS Windows
+>>>(0x3c.l+0xf8)	string		UPX0 \b, UPX compressed
+>>>(0x3c.l+0xf8)	search/0x140	PEC2 \b, PECompact2 compressed
+>>>(0x3c.l+0xf8)	search/0x140	UPX2
+>>>>(&0x10.l+(-4))	string		PK\3\4 \b, ZIP self-extracting archive (Info-Zip)
+>>>(0x3c.l+0xf8)	search/0x140	.idata
+>>>>(&0xe.l+(-4))	string		PK\3\4 \b, ZIP self-extracting archive (Info-Zip)
+>>>>(&0xe.l+(-4))	string		ZZ0 \b, ZZip self-extracting archive
+>>>>(&0xe.l+(-4))	string		ZZ1 \b, ZZip self-extracting archive
+>>>(0x3c.l+0xf8)	search/0x140	.rsrc
+>>>>(&0x0f.l+(-4))	string		a\\\4\5 \b, WinHKI self-extracting archive
+>>>>(&0x0f.l+(-4))	string		Rar! \b, RAR self-extracting archive
+>>>>(&0x0f.l+(-4))	search/0x3000	MSCF \b, InstallShield self-extracting archive
+>>>>(&0x0f.l+(-4))	search/32	Nullsoft \b, Nullsoft Installer self-extracting archive
+>>>(0x3c.l+0xf8)	search/0x140	.data
+>>>>(&0x0f.l)		string		WEXTRACT \b, MS CAB-Installer self-extracting archive
+>>>(0x3c.l+0xf8)	search/0x140	.petite\0 \b, Petite compressed
+>>>>(0x3c.l+0xf7)	byte		x
+>>>>>(&0x104.l+(-4))	string		=!sfx! \b, ACE self-extracting archive
+>>>(0x3c.l+0xf8)	search/0x140	.WISE \b, WISE installer self-extracting archive
+>>>(0x3c.l+0xf8)	search/0x140	.dz\0\0\0 \b, Dzip self-extracting archive
+>>>&(0x3c.l+0xf8)	search/0x100	_winzip_ \b, ZIP self-extracting archive (WinZip)
+>>>&(0x3c.l+0xf8)	search/0x100	SharedD \b, Microsoft Installer self-extracting archive
+>>>0x30			string		Inno \b, InnoSetup self-extracting archive
+
+# Hmm, not a PE but the relocation table is too high for a traditional DOS exe,
+# must be one of the unusual subformats.
+>>(0x3c.l) string !PE\0\0 MS-DOS executable
+!:mime	application/x-dosexec
+
+>>(0x3c.l)		string		NE \b, NE
+!:mime	application/x-dosexec
+>>>(0x3c.l+0x36)	byte		1 for OS/2 1.x
+>>>(0x3c.l+0x36)	byte		2 for MS Windows 3.x
+>>>(0x3c.l+0x36)	byte		3 for MS-DOS
+>>>(0x3c.l+0x36)	byte		4 for Windows 386
+>>>(0x3c.l+0x36)	byte		5 for Borland Operating System Services
+>>>(0x3c.l+0x36)	default		x
+>>>>(0x3c.l+0x36)	byte		x (unknown OS %x)
+>>>(0x3c.l+0x36)	byte		0x81 for MS-DOS, Phar Lap DOS extender
+>>>(0x3c.l+0x0c)	leshort&0x8003	0x8002 (DLL)
+>>>(0x3c.l+0x0c)	leshort&0x8003	0x8001 (driver)
+>>>&(&0x24.s-1)		string		ARJSFX \b, ARJ self-extracting archive
+>>>(0x3c.l+0x70)	search/0x80	WinZip(R)\ Self-Extractor \b, ZIP self-extracting archive (WinZip)
+
+>>(0x3c.l)		string		LX\0\0 \b, LX
+!:mime	application/x-dosexec
+>>>(0x3c.l+0x0a)	leshort		<1 (unknown OS)
+>>>(0x3c.l+0x0a)	leshort		1 for OS/2
+>>>(0x3c.l+0x0a)	leshort		2 for MS Windows
+>>>(0x3c.l+0x0a)	leshort		3 for DOS
+>>>(0x3c.l+0x0a)	leshort		>3 (unknown OS)
+>>>(0x3c.l+0x10)	lelong&0x28000	=0x8000 (DLL)
+>>>(0x3c.l+0x10)	lelong&0x20000	>0 (device driver)
+>>>(0x3c.l+0x10)	lelong&0x300	0x300 (GUI)
+>>>(0x3c.l+0x10)	lelong&0x28300	<0x300 (console)
+>>>(0x3c.l+0x08)	leshort		1 i80286
+>>>(0x3c.l+0x08)	leshort		2 i80386
+>>>(0x3c.l+0x08)	leshort		3 i80486
+>>>(8.s*16)		string		emx \b, emx
+>>>>&1			string		x %s
+>>>&(&0x54.l-3)		string		arjsfx \b, ARJ self-extracting archive
+
+# MS Windows system file, supposedly a collection of LE executables
+>>(0x3c.l)		string		W3 \b, W3 for MS Windows
+!:mime	application/x-dosexec
+
+>>(0x3c.l)		string		LE\0\0 \b, LE executable
+!:mime	application/x-dosexec
+>>>(0x3c.l+0x0a)	leshort		1
+# some DOS extenders use LE files with OS/2 header
+>>>>0x240		search/0x100	DOS/4G for MS-DOS, DOS4GW DOS extender
+>>>>0x240		search/0x200	WATCOM\ C/C++ for MS-DOS, DOS4GW DOS extender
+>>>>0x440		search/0x100	CauseWay\ DOS\ Extender for MS-DOS, CauseWay DOS extender
+>>>>0x40		search/0x40	PMODE/W for MS-DOS, PMODE/W DOS extender
+>>>>0x40		search/0x40	STUB/32A for MS-DOS, DOS/32A DOS extender (stub)
+>>>>0x40		search/0x80	STUB/32C for MS-DOS, DOS/32A DOS extender (configurable stub)
+>>>>0x40		search/0x80	DOS/32A for MS-DOS, DOS/32A DOS extender (embedded)
+# this is a wild guess; hopefully it is a specific signature
+>>>>&0x24		lelong		<0x50
+>>>>>(&0x4c.l)		string		\xfc\xb8WATCOM
+>>>>>>&0		search/8	3\xdbf\xb9 \b, 32Lite compressed
+# another wild guess: if real OS/2 LE executables exist, they probably have higher start EIP
+#>>>>(0x3c.l+0x1c)	lelong		>0x10000 for OS/2
+# fails with DOS-Extenders.
+>>>(0x3c.l+0x0a)	leshort		2 for MS Windows
+>>>(0x3c.l+0x0a)	leshort		3 for DOS
+>>>(0x3c.l+0x0a)	leshort		4 for MS Windows (VxD)
+>>>(&0x7c.l+0x26)	string		UPX \b, UPX compressed
+>>>&(&0x54.l-3)		string		UNACE \b, ACE self-extracting archive
+
+# looks like ASCII, probably some embedded copyright message.
+# and definitely not NE/LE/LX/PE
+>>0x3c		lelong	>0x20000000
+>>>(4.s*512)	leshort !0x014c \b, MZ for MS-DOS
+!:mime	application/x-dosexec
+# header data too small for extended executable
+>2		long	!0
+>>0x18		leshort <0x40
+>>>(4.s*512)	leshort !0x014c
+
+>>>>&(2.s-514)	string	!LE
+>>>>>&-2	string	!BW \b, MZ for MS-DOS
+!:mime	application/x-dosexec
+>>>>&(2.s-514)	string	LE \b, LE
+>>>>>0x240	search/0x100	DOS/4G for MS-DOS, DOS4GW DOS extender
+# educated guess since indirection is still not capable enough for complex offset
+# calculations (next embedded executable would be at &(&2*512+&0-2)
+# I suspect there are only LE executables in these multi-exe files
+>>>>&(2.s-514)	string	BW
+>>>>>0x240	search/0x100	DOS/4G	\b, LE for MS-DOS, DOS4GW DOS extender (embedded)
+>>>>>0x240	search/0x100	!DOS/4G	\b, BW collection for MS-DOS
+
+# This sequence skips to the first COFF segment, usually .text
+>(4.s*512)	leshort		0x014c \b, COFF
+!:mime	application/x-dosexec
+>>(8.s*16)	string		go32stub for MS-DOS, DJGPP go32 DOS extender
+>>(8.s*16)	string		emx
+>>>&1		string		x for DOS, Win or OS/2, emx %s
+>>&(&0x42.l-3)	byte		x 
+>>>&0x26	string		UPX \b, UPX compressed
+# and yet another guess: small .text, and after large .data is unusal, could be 32lite
+>>&0x2c		search/0xa0	.text
+>>>&0x0b	lelong		<0x2000
+>>>>&0		lelong		>0x6000 \b, 32lite compressed
+
+>(8.s*16) string $WdX \b, WDos/X DOS extender
+
+# By now an executable type should have been printed out.  The executable
+# may be a self-uncompressing archive, so look for evidence of that and 
+# print it out.  
+#
+# Some signatures below from Greg Roelofs, newt@uchicago.edu.
+#
+>0x35	string	\x8e\xc0\xb9\x08\x00\xf3\xa5\x4a\x75\xeb\x8e\xc3\x8e\xd8\x33\xff\xbe\x30\x00\x05 \b, aPack compressed
+>0xe7	string	LH/2\ 	Self-Extract \b, %s
+>0x1c	string	UC2X	\b, UCEXE compressed
+>0x1c	string	WWP\ 	\b, WWPACK compressed
+>0x1c	string	RJSX 	\b, ARJ self-extracting archive
+>0x1c	string	diet 	\b, diet compressed
+>0x1c	string	LZ09 	\b, LZEXE v0.90 compressed
+>0x1c	string	LZ91 	\b, LZEXE v0.91 compressed
+>0x1c	string	tz 	\b, TinyProg compressed
+>0x1e	string	Copyright\ 1989-1990\ PKWARE\ Inc.	Self-extracting PKZIP archive
+!:mime	application/zip
+# Yes, this really is "Copr", not "Corp."
+>0x1e	string	PKLITE\ Copr.	Self-extracting PKZIP archive
+!:mime	application/zip
+# winarj stores a message in the stub instead of the sig in the MZ header
+>0x20	search/0xe0	aRJsfX \b, ARJ self-extracting archive
+>0x20	string AIN
+>>0x23	string 2	\b, AIN 2.x compressed
+>>0x23	string <2	\b, AIN 1.x compressed
+>>0x23	string >2	\b, AIN 1.x compressed
+>0x24	string	LHa's\ SFX \b, LHa self-extracting archive
+!:mime	application/x-lha
+>0x24	string	LHA's\ SFX \b, LHa self-extracting archive
+!:mime	application/x-lha
+>0x24	string	\ $ARX \b, ARX self-extracting archive
+>0x24	string	\ $LHarc \b, LHarc self-extracting archive
+>0x20	string	SFX\ by\ LARC \b, LARC self-extracting archive
+>0x40	string aPKG \b, aPackage self-extracting archive
+>0x64	string	W\ Collis\0\0 \b, Compack compressed
+>0x7a	string		Windows\ self-extracting\ ZIP	\b, ZIP self-extracting archive
+>>&0xf4 search/0x140 \x0\x40\x1\x0
+>>>(&0.l+(4)) string MSCF \b, WinHKI CAB self-extracting archive
+>1638	string	-lh5- \b, LHa self-extracting archive v2.13S
+>0x17888 string Rar! \b, RAR self-extracting archive
+
+# Skip to the end of the EXE.  This will usually work fine in the PE case
+# because the MZ image is hardcoded into the toolchain and almost certainly
+# won't match any of these signatures.
+>(4.s*512)	long	x 
+>>&(2.s-517)	byte	x 
+>>>&0	string		PK\3\4 \b, ZIP self-extracting archive
+>>>&0	string		Rar! \b, RAR self-extracting archive
+>>>&0	string		=!\x11 \b, AIN 2.x self-extracting archive
+>>>&0	string		=!\x12 \b, AIN 2.x self-extracting archive
+>>>&0	string		=!\x17 \b, AIN 1.x self-extracting archive
+>>>&0	string		=!\x18 \b, AIN 1.x self-extracting archive
+>>>&7	search/400	**ACE** \b, ACE self-extracting archive
+>>>&0	search/0x480	UC2SFX\ Header \b, UC2 self-extracting archive
+
+# a few unknown ZIP sfxes, no idea if they are needed or if they are
+# already captured by the generic patterns above
+>(8.s*16)	search/0x20	PKSFX \b, ZIP self-extracting archive (PKZIP)
+# TODO: how to add this? >FileSize-34 string Windows\ Self-Installing\ Executable \b, ZIP self-extracting archive
+#
+
+# TELVOX Teleinformatica CODEC self-extractor for OS/2:
+>49801	string	\x79\xff\x80\xff\x76\xff	\b, CODEC archive v3.21
+>>49824 leshort		=1			\b, 1 file
+>>49824 leshort		>1			\b, %u files
+
+# added by Joerg Jenderek of http://www.freedos.org/software/?prog=kc
+# and http://www.freedos.org/software/?prog=kpdos
+# for FreeDOS files like KEYBOARD.SYS, KEYBRD2.SYS, KEYBRD3.SYS, *.KBD
+0	string/b	KCF		FreeDOS KEYBoard Layout collection
+# only version=0x100 found
+>3	uleshort	x		\b, version 0x%x
+# length of string containing author,info and special characters
+>6	ubyte		>0		
+#>>6	pstring		x		\b, name=%s
+>>7	string		>\0		\b, author=%-.14s
+>>7	search/254	\xff		\b, info=
+#>>>&0	string		x		\b%-s
+>>>&0	string		x		\b%-.15s
+# for FreeDOS *.KL files 
+0	string/b	KLF		FreeDOS KEYBoard Layout file
+# only version=0x100 or 0x101 found
+>3	uleshort	x		\b, version 0x%x
+# stringlength
+>5	ubyte		>0		
+>>8	string		x		\b, name=%-.2s
+0	string	\xffKEYB\ \ \ \0\0\0\0	
+>12	string	\0\0\0\0`\004\360	MS-DOS KEYBoard Layout file
+
+# .COM formats (Daniel Quinlan, quinlan@yggdrasil.com)
+# Uncommenting only the first two lines will cover about 2/3 of COM files,
+# but it isn't feasible to match all COM files since there must be at least
+# two dozen different one-byte "magics".
+# test too generic ?
+0	byte		0xe9		DOS executable (COM)
+>0x1FE leshort		0xAA55		\b, boot code
+>6	string		SFX\ of\ LHarc	(%s)
+
+# DOS device driver updated by Joerg Jenderek at May 2011
+# http://maben.homeip.net/static/S100/IBM/software/DOS/DOS%20techref/CHAPTER.009
+0	ulequad&0x07a0ffffffff		0xffffffff		DOS executable (
+>40	search/7			UPX!			\bUPX compressed 
+# DOS device driver attributes
+>4	uleshort&0x8000			0x0000			\bblock device driver
+# character device
+>4	uleshort&0x8000			0x8000			\b
+>>4	uleshort&0x0008			0x0008			\bclock 
+# fast video output by int 29h
+>>4	uleshort&0x0010			0x0010			\bfast 
+# standard input/output device
+>>4	uleshort&0x0003			>0			\bstandard 
+>>>4	uleshort&0x0001			0x0001			\binput
+>>>4	uleshort&0x0003			0x0003			\b/
+>>>4	uleshort&0x0002			0x0002			\boutput 
+>>4	uleshort&0x8000			0x8000			\bcharacter device driver
+>0	ubyte				x			
+# upx compressed device driver has garbage instead of real in name field of header
+>>40	search/7			UPX!			
+>>40	default				x			
+# leading/trailing nulls, zeros or non ASCII characters in 8-byte name field at offset 10 are skipped
+>>>12		ubyte			>0x27			\b 
+>>>>10		ubyte			>0x20			
+>>>>>10		ubyte			!0x2E			
+>>>>>>10	ubyte			!0x2A			\b%c
+>>>>11		ubyte			>0x20			
+>>>>>11		ubyte			!0x2E			\b%c
+>>>>12		ubyte			>0x20			
+>>>>>12		ubyte			!0x39			
+>>>>>>12	ubyte			!0x2E			\b%c
+>>>13		ubyte			>0x20			
+>>>>13		ubyte			!0x2E			\b%c
+>>>>14		ubyte			>0x20			
+>>>>>14		ubyte			!0x2E			\b%c
+>>>>15		ubyte			>0x20			
+>>>>>15		ubyte			!0x2E			\b%c
+>>>>16		ubyte			>0x20			
+>>>>>16		ubyte			!0x2E			
+>>>>>>16	ubyte			<0xCB			\b%c
+>>>>17		ubyte			>0x20			
+>>>>>17		ubyte			!0x2E			
+>>>>>>17	ubyte			<0x90			\b%c
+# some character device drivers like ASPICD.SYS, btcdrom.sys and Cr_atapi.sys contain only spaces or points in name field
+>>>4		uleshort&0x8000		0x8000			
+>>>>12		ubyte			<0x2F			
+# they have their real name at offset 22
+>>>>>22		string			>\0			\b%-.5s
+>4	uleshort&0x8000			0x0000			
+# 32 bit sector addressing ( > 32 MB) for block devices
+>>4	uleshort&0x0002			0x0002			\b,32-bit sector-
+# support by driver functions 13h, 17h, 18h
+>4	uleshort&0x0040			0x0040			\b,IOCTL-
+# open, close, removable media support by driver functions 0Dh, 0Eh, 0Fh
+>4	uleshort&0x0800			0x0800			\b,close media-
+# output until busy support by int 10h for character device driver
+>4	uleshort&0x8000			0x8000			
+>>4	uleshort&0x2000			0x2000			\b,until busy-
+# direct read/write support by driver functions 03h,0Ch
+>4	uleshort&0x4000			0x4000			\b,control strings-
+>4	uleshort&0x8000			0x8000			
+>>4	uleshort&0x6840			>0			\bsupport
+>4	uleshort&0x8000			0x0000			
+>>4	uleshort&0x4842			>0			\bsupport
+>0	ubyte				x			\b)
+# DOS driver cmd640x.sys has 0x12 instead of 0xffffffff for pointer field to next device header 
+# Too weak, matches files that only contain 0's
+#0	ulequad&0x000007a0ffffffed	0x0000000000000000	DOS-executable (
+#>4	uleshort&0x8000			0x8000			\bcharacter device driver
+#>>10	string				x			%-.8s
+#>4	uleshort&0x4000			0x4000			\b,control strings-support)
+
+# test too generic ?
+0	byte		0x8c		DOS executable (COM)
+# updated by Joerg Jenderek at Oct 2008
+0	ulelong		0xffff10eb	DR-DOS executable (COM)
+# byte 0xeb conflicts with "sequent" magic leshort 0xn2eb
+0	ubeshort&0xeb8d	>0xeb00		
+# DR-DOS STACKER.COM SCREATE.SYS missed
+>0	byte		0xeb
+>>0x1FE leshort		0xAA55		DOS executable (COM), boot code
+>>85	string		UPX		DOS executable (COM), UPX compressed
+>>4	string		\ $ARX		DOS executable (COM), ARX self-extracting archive
+>>4	string		\ $LHarc	DOS executable (COM), LHarc self-extracting archive
+>>0x20e string		SFX\ by\ LARC	DOS executable (COM), LARC self-extracting archive
+# updated by Joerg Jenderek at Oct 2008
+#0	byte		0xb8		COM executable
+0	uleshort&0x80ff	0x00b8		
+# modified by Joerg Jenderek
+>1	lelong		!0x21cd4cff	COM executable for DOS
+# http://syslinux.zytor.com/comboot.php
+# (32-bit COMBOOT) programs *.C32 contain 32-bit code and run in flat-memory 32-bit protected mode
+# start with assembler instructions mov eax,21cd4cffh
+0	uleshort&0xc0ff	0xc0b8		
+>1	lelong		0x21cd4cff	COM executable (32-bit COMBOOT)
+# syslinux:doc/comboot.txt
+# A COM32R program must start with the byte sequence B8 FE 4C CD 21 (mov
+# eax,21cd4cfeh) as a magic number.
+0       string/b	\xb8\xfe\x4c\xcd\x21	COM executable (COM32R)
+# start with assembler instructions mov eax,21cd4cfeh
+0	uleshort&0xc0ff	0xc0b8		
+>1	lelong		0x21cd4cfe	COM executable (32-bit COMBOOT, relocatable)
+0	string/b	\x81\xfc		
+>4	string	\x77\x02\xcd\x20\xb9	
+>>36	string	UPX!			FREE-DOS executable (COM), UPX compressed
+252	string Must\ have\ DOS\ version DR-DOS executable (COM)
+# added by Joerg Jenderek at Oct 2008
+# GRR search is not working
+#34	search/2	UPX!		FREE-DOS executable (COM), UPX compressed
+34	string	UPX!			FREE-DOS executable (COM), UPX compressed
+35	string	UPX!			FREE-DOS executable (COM), UPX compressed
+# GRR search is not working
+#2	search/28	\xcd\x21	COM executable for MS-DOS
+#WHICHFAT.cOM
+2	string	\xcd\x21		COM executable for DOS
+#DELTREE.cOM DELTREE2.cOM
+4	string	\xcd\x21		COM executable for DOS
+#IFMEMDSK.cOM ASSIGN.cOM COMP.cOM
+5	string	\xcd\x21		COM executable for DOS
+#DELTMP.COm HASFAT32.cOM
+7	string	\xcd\x21		
+>0	byte	!0xb8			COM executable for DOS
+#COMP.cOM MORE.COm
+10	string	\xcd\x21		
+>5	string	!\xcd\x21		COM executable for DOS
+#comecho.com
+13	string	\xcd\x21		COM executable for DOS
+#HELP.COm EDIT.coM
+18	string	\xcd\x21		COM executable for MS-DOS
+#NWRPLTRM.COm
+23	string	\xcd\x21		COM executable for MS-DOS
+#LOADFIX.cOm LOADFIX.cOm
+30	string	\xcd\x21		COM executable for MS-DOS
+#syslinux.com 3.11
+70	string	\xcd\x21		COM executable for DOS
+# many compressed/converted COMs start with a copy loop instead of a jump
+0x6	search/0xa	\xfc\x57\xf3\xa5\xc3	COM executable for MS-DOS
+0x6	search/0xa	\xfc\x57\xf3\xa4\xc3	COM executable for DOS
+>0x18	search/0x10	\x50\xa4\xff\xd5\x73	\b, aPack compressed
+0x3c	string		W\ Collis\0\0		COM executable for MS-DOS, Compack compressed
+# FIXME: missing diet .com compression
+
+# miscellaneous formats
+0	string/b	LZ		MS-DOS executable (built-in)
+#0	byte		0xf0		MS-DOS program library data
+#
+
+# AAF files:
+# <stuartc@rd.bbc.co.uk> Stuart Cunningham
+0	string/b	\320\317\021\340\241\261\032\341AAFB\015\000OM\006\016\053\064\001\001\001\377			AAF legacy file using MS Structured Storage
+>30	byte	9		(512B sectors)
+>30	byte	12		(4kB sectors)
+0	string/b	\320\317\021\340\241\261\032\341\001\002\001\015\000\002\000\000\006\016\053\064\003\002\001\001			AAF file using MS Structured Storage
+>30	byte	9		(512B sectors)
+>30	byte	12		(4kB sectors)
+
+# Popular applications
+2080	string	Microsoft\ Word\ 6.0\ Document	%s
+!:mime	application/msword
+2080	string	Documento\ Microsoft\ Word\ 6 Spanish Microsoft Word 6 document data
+!:mime	application/msword
+# Pawel Wiecek <coven@i17linuxb.ists.pwr.wroc.pl> (for polish Word)
+2112	string	MSWordDoc			Microsoft Word document data
+!:mime	application/msword
+#
+0	belong	0x31be0000			Microsoft Word Document
+!:mime	application/msword
+#
+0	string/b	PO^Q`				Microsoft Word 6.0 Document
+!:mime	application/msword
+#
+0	string/b	\376\067\0\043			Microsoft Office Document
+!:mime	application/msword
+0	string/b	\333\245-\0\0\0			Microsoft Office Document
+!:mime	application/msword
+512	string/b	\354\245\301			Microsoft Word Document
+!:mime	application/msword
+
+#
+0	string/b	\xDB\xA5\x2D\x00		Microsoft WinWord 2.0 Document
+!:mime application/msword
+#
+2080	string	Microsoft\ Excel\ 5.0\ Worksheet	%s
+!:mime	application/vnd.ms-excel
+#
+0	string/b	\xDB\xA5\x2D\x00		Microsoft WinWord 2.0 Document
+!:mime application/msword
+
+2080	string	Foglio\ di\ lavoro\ Microsoft\ Exce	%s
+!:mime	application/vnd.ms-excel
+#
+# Pawel Wiecek <coven@i17linuxb.ists.pwr.wroc.pl> (for polish Excel)
+2114	string	Biff5		Microsoft Excel 5.0 Worksheet
+!:mime	application/vnd.ms-excel
+# Italian MS-Excel
+2121	string	Biff5		Microsoft Excel 5.0 Worksheet
+!:mime	application/vnd.ms-excel
+0	string/b	\x09\x04\x06\x00\x00\x00\x10\x00	Microsoft Excel Worksheet
+!:mime	application/vnd.ms-excel
+#
+0	belong	0x00001a00	Lotus 1-2-3
+!:mime	application/x-123
+>4	belong	0x00100400	wk3 document data
+>4	belong	0x02100400	wk4 document data
+>4	belong	0x07800100	fm3 or fmb document data
+>4	belong	0x07800000	fm3 or fmb document data
+#
+0	belong	0x00000200	Lotus 1-2-3
+!:mime	application/x-123
+>4	belong	0x06040600	wk1 document data
+>4	belong	0x06800200	fmt document data
+0	string/b		WordPro\0	Lotus WordPro
+!:mime	application/vnd.lotus-wordpro
+0	string/b		WordPro\r\373	Lotus WordPro
+!:mime	application/vnd.lotus-wordpro
+
+
+# Summary: Script used by InstallScield to uninstall applications
+# Extension: .isu
+# Submitted by: unknown
+# Modified by (1): Abel Cheung <abelcheung@gmail.com> (replace useless entry)
+0		string		\x71\xa8\x00\x00\x01\x02
+>12		string		Stirling\ Technologies,		InstallShield Uninstall Script
+
+# Winamp .avs
+#0	string	Nullsoft\ AVS\ Preset\ \060\056\061\032 A plug in for Winamp ms-windows Freeware media player
+0	string/b	Nullsoft\ AVS\ Preset\ 	Winamp plug in
+
+# Windows Metafont .WMF
+0	string/b	\327\315\306\232	ms-windows metafont .wmf
+0	string/b	\002\000\011\000	ms-windows metafont .wmf
+0	string/b	\001\000\011\000	ms-windows metafont .wmf
+
+#tz3 files whatever that is (MS Works files)
+0	string/b	\003\001\001\004\070\001\000\000	tz3 ms-works file
+0	string/b	\003\002\001\004\070\001\000\000	tz3 ms-works file
+0	string/b	\003\003\001\004\070\001\000\000	tz3 ms-works file
+
+# PGP sig files .sig
+#0 string \211\000\077\003\005\000\063\237\127 065 to  \027\266\151\064\005\045\101\233\021\002 PGP sig
+0 string \211\000\077\003\005\000\063\237\127\065\027\266\151\064\005\045\101\233\021\002 PGP sig
+0 string \211\000\077\003\005\000\063\237\127\066\027\266\151\064\005\045\101\233\021\002 PGP sig
+0 string \211\000\077\003\005\000\063\237\127\067\027\266\151\064\005\045\101\233\021\002 PGP sig
+0 string \211\000\077\003\005\000\063\237\127\070\027\266\151\064\005\045\101\233\021\002 PGP sig
+0 string \211\000\077\003\005\000\063\237\127\071\027\266\151\064\005\045\101\233\021\002 PGP sig
+0 string \211\000\225\003\005\000\062\122\207\304\100\345\042 PGP sig
+
+# windows zips files .dmf
+0	string/b	MDIF\032\000\010\000\000\000\372\046\100\175\001\000\001\036\001\000 MS Windows special zipped file
+
+
+#ico files
+0	string/b	\102\101\050\000\000\000\056\000\000\000\000\000\000\000	Icon for MS Windows
+
+# Windows icons
+0   name    ico-dir
+# not entirely accurate, the number of icons is part of the header
+>0  byte    1   - 1 icon
+>0  ubyte   >1  - %d icons
+>2  byte    0   \b, 256x
+>2  byte    !0  \b, %dx
+>3  byte    0   \b256
+>3  byte    !0  \b%d
+>4  ubyte   !0  \b, %d colors
+
+0   belong  0x00000100
+>9  byte    0
+>>0 byte    x           MS Windows icon resource
+!:mime	image/x-icon
+>>4 use     ico-dir
+>9  ubyte   0xff
+>>0 byte    x           MS Windows icon resource
+!:mime	image/x-icon
+>>4 use     ico-dir
+
+# Windows non-animated cursors
+0   name    cur-dir
+# not entirely accurate, the number of icons is part of the header
+>0  byte        1   - 1 icon
+>0  ubyte       >1  - %d icons
+>2  byte        0   \b, 256x
+>2  byte        !0  \b, %dx
+>3  byte        0   \b256
+>3  byte        !0  \b%d
+>6  uleshort    x   \b, hotspot @%dx
+>8  uleshort    x   \b%d
+
+0   belong  0x00000200
+>9  byte    0
+>>0 byte    x           MS Windows cursor resource
+!:mime image/x-cur
+>>4 use     cur-dir
+>9  ubyte   0xff
+>>0 byte    x           MS Windows cursor resource
+!:mime image/x-cur
+>>4 use     cur-dir
+
+# .chr files
+0	string/b	PK\010\010BGI	Borland font 
+>4	string	>\0	%s
+# then there is a copyright notice
+
+
+# .bgi files
+0	string/b	pk\010\010BGI	Borland device 
+>4	string	>\0	%s
+# then there is a copyright notice
+
+
+# Windows Recycle Bin record file (named INFO2)
+# By Abel Cheung (abelcheung AT gmail dot com)
+# Version 4 always has 280 bytes (0x118) per record, version 5 has 800 bytes
+# Since Vista uses another structure, INFO2 structure probably won't change
+# anymore. Detailed analysis in:
+# http://www.cybersecurityinstitute.biz/downloads/INFO2.pdf
+0	lelong		0x00000004
+>12	lelong		0x00000118	Windows Recycle Bin INFO2 file (Win98 or below)
+
+0	lelong		0x00000005
+>12	lelong		0x00000320	Windows Recycle Bin INFO2 file (Win2k - WinXP)
+
+
+##### put in Either Magic/font or Magic/news
+# Acroread or something	 files wrongly identified as G3	 .pfm
+# these have the form \000 \001 any? \002 \000 \000
+# or \000 \001 any? \022 \000 \000
+0	belong&0xffff00ff	0x00010012	PFM data
+>4	string			\000\000
+>6	string			>\060		- %s
+
+0	belong&0xffff00ff	0x00010002	PFM data
+>4	string			\000\000
+>6	string			>\060		- %s
+#0	string	\000\001 pfm?
+#>3	string	\022\000\000Copyright\	yes
+#>3	string	\002\000\000Copyright\	yes
+#>3	string	>\0	oops, not a font file. Cancel that.
+#it clashes with ttf files so put it lower down.
+
+# From Doug Lee via a FreeBSD pr
+9	string		GERBILDOC	First Choice document
+9	string		GERBILDB	First Choice database
+9	string		GERBILCLIP	First Choice database
+0	string		GERBIL		First Choice device file
+9	string		RABBITGRAPH	RabbitGraph file
+0	string		DCU1		Borland Delphi .DCU file
+0	string		=!<spell>	MKS Spell hash list (old format)
+0	string		=!<spell2>	MKS Spell hash list
+# Too simple - MPi
+#0	string		AH		Halo(TM) bitmapped font file
+0	lelong		0x08086b70	TurboC BGI file
+0	lelong		0x08084b50	TurboC Font file
+
+# Debian#712046: The magic below identifies "Delphi compiled form data". 
+# An additional source of information is available at:
+# http://www.woodmann.com/fravia/dafix_t1.htm
+0	string		TPF0
+>4	pstring		>\0		Delphi compiled form '%s'
+
+# tests for DBase files moved, updated and merged to database
+
+0	string		PMCC		Windows 3.x .GRP file
+1	string		RDC-meg		MegaDots 
+>8	byte		>0x2F		version %c
+>9	byte		>0x2F		\b.%c file
+0	lelong		0x4C
+>4	lelong		0x00021401	Windows shortcut file
+
+# .PIF files added by Joerg Jenderek from http://smsoft.ru/en/pifdoc.htm
+# only for windows versions equal or greater 3.0
+0x171	string	MICROSOFT\ PIFEX\0	Windows Program Information File
+!:mime	application/x-dosexec
+#>2	string	 	>\0		\b, Title:%.30s
+>0x24	string		>\0		\b for %.63s
+>0x65	string		>\0		\b, directory=%.64s
+>0xA5	string		>\0		\b, parameters=%.64s
+#>0x181	leshort	x	\b, offset %x
+#>0x183	leshort	x	\b, offsetdata %x
+#>0x185	leshort	x	\b, section length %x
+>0x187	search/0xB55	WINDOWS\ VMM\ 4.0\0	
+>>&0x5e		ubyte	>0			
+>>>&-1		string	<PIFMGR.DLL		\b, icon=%s
+#>>>&-1		string	PIFMGR.DLL		\b, icon=%s
+>>>&-1		string	>PIFMGR.DLL		\b, icon=%s
+>>&0xF0		ubyte	>0			
+>>>&-1		string	<Terminal		\b, font=%.32s
+#>>>&-1		string	=Terminal		\b, font=%.32s
+>>>&-1		string	>Terminal		\b, font=%.32s
+>>&0x110	ubyte	>0			
+>>>&-1		string	<Lucida\ Console	\b, TrueTypeFont=%.32s
+#>>>&-1		string	=Lucida\ Console	\b, TrueTypeFont=%.32s
+>>>&-1		string	>Lucida\ Console	\b, TrueTypeFont=%.32s
+#>0x187	search/0xB55	WINDOWS\ 286\ 3.0\0	\b, Windows 3.X standard mode-style
+#>0x187	search/0xB55	WINDOWS\ 386\ 3.0\0	\b, Windows 3.X enhanced mode-style
+>0x187	search/0xB55	WINDOWS\ NT\ \ 3.1\0	\b, Windows NT-style
+#>0x187	search/0xB55	WINDOWS\ NT\ \ 4.0\0	\b, Windows NT-style
+>0x187	search/0xB55	CONFIG\ \ SYS\ 4.0\0	\b +CONFIG.SYS
+#>>&06		string	x			\b:%s
+>0x187	search/0xB55	AUTOEXECBAT\ 4.0\0	\b +AUTOEXEC.BAT
+#>>&06		string	x			\b:%s
+
+# DOS EPS Binary File Header
+# From: Ed Sznyter <ews@Black.Market.NET>
+0	belong		0xC5D0D3C6	DOS EPS Binary File
+>4	long		>0		Postscript starts at byte %d
+>>8	long		>0		length %d
+>>>12	long		>0		Metafile starts at byte %d
+>>>>16	long		>0		length %d
+>>>20	long		>0		TIFF starts at byte %d
+>>>>24	long		>0		length %d
+
+# TNEF magic From "Joomy" <joomy@se-ed.net> 
+# Microsoft Outlook's Transport Neutral Encapsulation Format (TNEF)
+0	leshort		0x223e9f78	TNEF
+!:mime	application/vnd.ms-tnef
+
+# Norton Guide (.NG , .HLP) files added by Joerg Jenderek from source NG2HTML.C
+# of http://www.davep.org/norton-guides/ng2h-105.tgz
+# http://en.wikipedia.org/wiki/Norton_Guides
+0	string		NG\0\001	
+# only value 0x100 found at offset 2
+>2	ulelong		0x00000100	Norton Guide
+# Title[40]
+>>8	string		>\0		"%-.40s"
+#>>6	uleshort	x		\b, MenuCount=%u
+# szCredits[5][66]
+>>48	string		>\0		\b, %-.66s
+>>114	string		>\0		%-.66s
+
+# 4DOS help (.HLP) files added by Joerg Jenderek from source TPHELP.PAS 
+# of http://www.4dos.info/
+# pointer,HelpID[8]=4DHnnnmm
+0	ulelong	0x48443408		4DOS help file
+>4	string	x			\b, version %-4.4s
+
+# old binary Microsoft (.HLP) files added by Joerg Jenderek from http://file-extension.net/seeker/file_extension_hlp
+0	ulequad	0x3a000000024e4c	MS Advisor help file
+
+# HtmlHelp files (.chm)
+0	string/b	ITSF\003\000\000\000\x60\000\000\000\001\000\000\000	MS Windows HtmlHelp Data
+
+# GFA-BASIC (Wolfram Kleff)
+2	string/b	GFA-BASIC3	GFA-BASIC 3 data
+
+#------------------------------------------------------------------------------
+# From Stuart Caie <kyzer@4u.net> (developer of cabextract)
+# Microsoft Cabinet files
+0	string/b	MSCF\0\0\0\0	Microsoft Cabinet archive data
+!:mime application/vnd.ms-cab-compressed
+>8	lelong		x		\b, %u bytes
+>28	leshort		1		\b, 1 file
+>28	leshort		>1		\b, %u files
+
+# InstallShield Cabinet files
+0	string/b	ISc(		InstallShield Cabinet archive data
+>5	byte&0xf0	=0x60		version 6,
+>5	byte&0xf0	!0x60		version 4/5,
+>(12.l+40)	lelong	x		%u files
+
+# Windows CE package files
+0	string/b	MSCE\0\0\0\0	Microsoft WinCE install header
+>20	lelong		0		\b, architecture-independent
+>20	lelong		103		\b, Hitachi SH3
+>20	lelong		104		\b, Hitachi SH4
+>20	lelong		0xA11		\b, StrongARM
+>20	lelong		4000		\b, MIPS R4000
+>20	lelong		10003		\b, Hitachi SH3
+>20	lelong		10004		\b, Hitachi SH3E
+>20	lelong		10005		\b, Hitachi SH4
+>20	lelong		70001		\b, ARM 7TDMI
+>52	leshort		1		\b, 1 file
+>52	leshort		>1		\b, %u files
+>56	leshort		1		\b, 1 registry entry
+>56	leshort		>1		\b, %u registry entries
+
+
+# Windows Enhanced Metafile (EMF)
+# See msdn.microsoft.com/archive/en-us/dnargdi/html/msdn_enhmeta.asp 
+# for further information.
+0	ulelong 1
+>40	string	\ EMF		Windows Enhanced Metafile (EMF) image data
+>>44	ulelong x		version 0x%x
+
+# from http://filext.com by Derek M Jones <derek@knosof.co.uk>
+# False positive with PPT (also currently this string is too long)
+#0	string/b	\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3E\x00\x03\x00\xFE\xFF\x09\x00\x06	Microsoft Installer
+0	string/b	\320\317\021\340\241\261\032\341	Microsoft Office Document
+#>48	byte	0x1B					Excel Document
+#!:mime application/vnd.ms-excel
+>546	string	bjbj			Microsoft Word Document
+!:mime	application/msword
+>546	string	jbjb			Microsoft Word Document
+!:mime	application/msword
+
+0	string/b	\224\246\056		Microsoft Word Document
+!:mime	application/msword
+
+512	string	R\0o\0o\0t\0\ \0E\0n\0t\0r\0y	Microsoft Word Document
+!:mime	application/msword
+
+# From: "Nelson A. de Oliveira" <naoliv@gmail.com>
+# Magic type for Dell's BIOS .hdr files
+# Dell's .hdr
+0	string/b $RBU
+>23	string Dell			%s system BIOS
+>5	byte   2
+>>48	byte   x			version %d.
+>>49	byte   x			\b%d.
+>>50	byte   x			\b%d
+>5	byte   <2
+>>48	string x			version %.3s
+
+# Type: Microsoft DirectDraw Surface
+# URL:	http://msdn.microsoft.com/library/default.asp?url=/library/en-us/directx9_c/directx/graphics/reference/DDSFileReference/ddsfileformat.asp
+# From: Morten Hustveit <morten@debian.org>
+0	string/b	DDS\040\174\000\000\000 Microsoft DirectDraw Surface (DDS),
+>16	lelong	>0			%d x
+>12	lelong	>0			%d,
+>84	string	x			%.4s
+
+# Type: Microsoft Document Imaging Format (.mdi)
+# URL:	http://en.wikipedia.org/wiki/Microsoft_Document_Imaging_Format
+# From: Daniele Sempione <scrows@oziosi.org>
+0	short	0x5045			Microsoft Document Imaging Format
+
+# MS eBook format (.lit)
+0	string/b	ITOLITLS		Microsoft Reader eBook Data
+>8	lelong	x			\b, version %u
+!:mime					application/x-ms-reader
+
+# Windows CE Binary Image Data Format
+# From: Dr. Jesus <j@hug.gs>
+0	string/b	B000FF\n	Windows Embedded CE binary image
+
+# Windows Imaging (WIM) Image
+0	string/b	MSWIM\000\000\000	Windows imaging (WIM) image
+
+# The second byte of these signatures is a file version; I don't know what, 
+# if anything, produced files with version numbers 0-2.
+# From: John Elliott <johne@seasip.demon.co.uk>
+0	string	\xfc\x03\x00	Mallard BASIC program data (v1.11)
+0	string	\xfc\x04\x00	Mallard BASIC program data (v1.29+)
+0	string	\xfc\x03\x01	Mallard BASIC protected program data (v1.11)
+0	string	\xfc\x04\x01	Mallard BASIC protected program data (v1.29+)
+
+0	string	MIOPEN		Mallard BASIC Jetsam data
+0	string	Jetsam0		Mallard BASIC Jetsam index data
+
+
+#------------------------------------------------------------------------------
+# $File: msooxml,v 1.4 2014/01/06 18:16:24 rrt Exp $
+# msooxml:  file(1) magic for Microsoft Office XML
+# From: Ralf Brown <ralf.brown@gmail.com>
+
+# .docx, .pptx, and .xlsx are XML plus other files inside a ZIP
+#   archive.  The first member file is normally "[Content_Types].xml".
+#   but some libreoffice generated files put this later. Perhaps skip
+#   the "[Content_Types].xml" test?
+# Since MSOOXML doesn't have anything like the uncompressed "mimetype"
+#   file of ePub or OpenDocument, we'll have to scan for a filename
+#   which can distinguish between the three types
+
+# start by checking for ZIP local file header signature
+0		string		PK\003\004
+!:strength +10
+# make sure the first file is correct
+>0x1E		regex		\\[Content_Types\\]\\.xml|_rels/\\.rels
+# skip to the second local file header
+# since some documents include a 520-byte extra field following the file
+# header, we need to scan for the next header
+>>(18.l+49)	search/2000	PK\003\004
+# now skip to the *third* local file header; again, we need to scan due to a
+# 520-byte extra field following the file header
+>>>&26		search/1000	PK\003\004
+# and check the subdirectory name to determine which type of OOXML
+# file we have.  Correct the mimetype with the registered ones:
+# http://technet.microsoft.com/en-us/library/cc179224.aspx
+>>>>&26		string		word/		Microsoft Word 2007+
+!:mime application/vnd.openxmlformats-officedocument.wordprocessingml.document
+>>>>&26		string		ppt/		Microsoft PowerPoint 2007+
+!:mime application/vnd.openxmlformats-officedocument.presentationml.presentation
+>>>>&26		string		xl/		Microsoft Excel 2007+
+!:mime application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+>>>>&26		default		x		Microsoft OOXML
+
+#------------------------------------------------------------------------------
+# $File$
+# msvc:  file(1) magic for msvc
+# "H. Nanosecond" <aldomel@ix.netcom.com>
+# Microsoft visual C
+# 
+# I have version 1.0
+
+# .aps
+0	string	HWB\000\377\001\000\000\000	Microsoft Visual C .APS file
+
+# .ide
+#too long 0	string	\102\157\162\154\141\156\144\040\103\053\053\040\120\162\157\152\145\143\164\040\106\151\154\145\012\000\032\000\002\000\262\000\272\276\372\316	MSVC .ide
+0	string	\102\157\162\154\141\156\144\040\103\053\053\040\120\162\157	MSVC .ide
+
+# .res
+0	string	\000\000\000\000\040\000\000\000\377	MSVC .res
+0	string	\377\003\000\377\001\000\020\020\350	MSVC .res
+0	string	\377\003\000\377\001\000\060\020\350	MSVC .res
+
+#.lib
+0	string	\360\015\000\000	Microsoft Visual C library
+0	string	\360\075\000\000	Microsoft Visual C library
+0	string	\360\175\000\000	Microsoft Visual C library
+
+#.pch
+0	string	DTJPCH0\000\022\103\006\200	Microsoft Visual C .pch
+
+# .pdb
+# too long 0	string	Microsoft\ C/C++\ program\ database\ 
+0	string	Microsoft\ C/C++\ 	MSVC program database
+>18	string	program\ database\ 	
+>33	string	>\0	ver %s
+
+#.sbr
+0	string	\000\002\000\007\000	MSVC .sbr
+>5	string 	>\0	%s
+
+#.bsc
+0	string	\002\000\002\001	MSVC .bsc
+
+#.wsp
+0	string	1.00\ .0000.0000\000\003	MSVC .wsp version 1.0000.0000
+# these seem to start with the version and contain menus
+
+#------------------------------------------------------------------------------
+# msx:  file(1) magic for the MSX Home Computer
+# v1.1
+# Fabio R. Schmidlin <sd-snatcher@users.sourceforge.net>
+
+############## MSX Music file formats ##############
+
+# Gigamix MGSDRV music file
+0	string		MGS	MSX Gigamix MGSDRV3 music file, 
+>6	ubeshort	0x0D0A
+>>3	byte		x	\bv%c
+>>4	byte		x	\b.%c
+>>5	byte		x	\b%c
+>>8	string		>\0	\b, title: %s
+
+1	string		mgs2\ 	MSX Gigamix MGSDRV2 music file
+>6	uleshort	0x80
+>>0x2E	uleshort	0
+>>>0x30	string		>\0	\b, title: %s
+
+# KSS music file
+0	string		KSCC	KSS music file v1.03
+>0xE	byte		0
+>>0xF	byte&0x02	0	\b, soundchips: AY-3-8910, SCC(+)
+>>0xF	byte&0x02	2	\b, soundchip(s): SN76489
+>>>0xF	byte&0x04	4	stereo
+>>0xF	byte&0x01	1	\b, YM2413
+>>0xF	byte&0x08	8	\b, Y8950
+
+0	string		KSSX	KSS music file v1.20
+>0xE	byte&0xEF	0
+>>0xF	byte&0x40	0x00	\b, 60Hz
+>>0xF	byte&0x40	0x40	\b, 50Hz
+>>0xF	byte&0x02	0	\b, soundchips: AY-3-8910, SCC(+)
+>>0xF	byte&0x02	0x02	\b, soundchips: SN76489
+>>>0xF	byte&0x04	0x04	stereo
+>>0xF	byte&0x01	0x01	\b, 
+>>>0xF	byte&0x18	0x00	\bYM2413
+>>>0xF	byte&0x18	0x08	\bYM2413, Y8950
+>>>0xF	byte&0x18	0x18	\bYM2413+Y8950 pseudostereo
+>>0xF	byte&0x18	0x10	\b, Majyutsushi DAC
+
+# Moonblaster for Moonsound
+0	string		MBMS
+>4	byte		0x10	MSX Moonblaster for MoonSound music
+
+# Music Player K-kaz
+0	string		MPK	MSX Music Player K-kaz song
+>6	ubeshort	0x0D0A
+>>3	byte		x	v%c
+>>4	byte		x	\b.%c
+>>5	byte		x	\b%c
+
+# I don't know why these don't work
+#0	search/0xFFFF	\r\n.FM9
+#>0	search/0xFFFF	\r\n#FORMAT	MSX Music Player K-kaz source MML file
+#0	search/0xFFFF	\r\nFM1\ \=
+#>0	search/0xFFFF	\r\nPSG1\=
+#>>0	search/0xFFFF	\r\nSCC1\=		MSX MuSiCa MML source file
+
+# OPX Music file
+0x35	beshort		0x0d0a
+>0x7B	beshort		0x0d0a
+>>0x7D	byte		0x1a
+>>>0x87	uleshort	0		MSX OPX Music file
+>>>>0x86	byte		0		v1.5
+>>>>>0	string		>\32		\b, title: %s
+>>>>0x86	byte		1		v2.4
+>>>>>0	string		>\32		\b, title: %s
+
+# SCMD music file
+0x8B	string		SCMD
+>0xCE	uleshort	0	MSX SCMD Music file
+#>>-2	uleshort	0x6a71	; The file must end with this value. How to code this here?
+>>0x8F	string		>\0		\b, title: %s
+
+0	search/0xFFFF	\r\n@title
+>&0	search/0xFFFF	\r\n@m=[	MSX SCMD source MML file
+
+
+############## MSX image file formats ##############
+
+# MSX raw VRAM dump
+0	ubyte		0xFE
+>1	uleshort	0
+>>5	uleshort	0
+>>>3	uleshort	0x37FF		MSX SC2/GRP raw image
+>>>3	uleshort	0x6A00		MSX Graph Saurus SR5 raw image
+>>>3	uleshort	>0x769E
+>>>>3	uleshort	<0x8000		MSX GE5/GE6 raw image
+>>>>>3	uleshort	0x7FFF		\b, with sprite patterns
+>>>3	uleshort	0xD3FF		MSX screen 7-12 raw image
+>>>3	uleshort	0xD400		MSX Graph Saurus SR7/SR8/SRS raw image
+
+# Graph Saurus compressed images
+0	ubyte		0xFD
+>1	uleshort	0
+>>5	uleshort	0
+>>>3	uleshort	>0x013D		MSX Graph Saurus compressed image
+
+# Maki-chan Graphic format
+0	string		MAKI02\ \ 	Maki-chan image,
+>8	byte		x		system ID: %c
+>9	byte		x		\b%c
+>10	byte		x		\b%c
+>11	byte		x		\b%c,
+>13	search/0x200	\x1A
+# >>&3	ubyte		0		, video mode: PC-98 400 lines, 16 analog colors
+# >>&3	ubyte		1		, video mode: MSX SC7, 16 analog colors
+# >>&3	ubyte		2		, video mode: VM-98 400 lines, 8 analog colors
+# >>&3	ubyte		3		, video mode: PC-88 analog, 200 lines, 8 analog colors
+# >>&3	ubyte		4		, video mode: 400 lines, 16 digital colors
+# >>&3	ubyte		5		, video mode: 200 lines, 16 digital colors
+# >>&3	ubyte		6		, video mode: old PC-98 digital 400 lines, 8 colors
+# >>&3	ubyte		7		, video mode: PC-88 400 lines, 8 digital colors
+>>&8	uleshort+1	x		%dx
+>>&10	uleshort+1	x		\b%d,
+>>&3	ubyte&0x82	0x80		256 colors
+>>&3	ubyte&0x82	0x00		16 colors
+>>&3	ubyte&0x82	0x01		8 colors
+>>&3	ubyte&0x04	4		digital
+>>&3	ubyte&0x04	0		analog
+>>&3	ubyte&0x01	1		\b, 2:1 dot aspect ratio
+
+# Japanese PIC file
+0	string		PIC\x1A
+>4	lelong		0		Japanese PIC image file
+
+# MSX G9B image file
+0	string		G9B
+>1	uleshort	11
+>>3	uleshort	>10
+>>>5	ubyte		>0		MSX G9B image, depth=%d
+>>>>8	uleshort	x		\b, %dx
+>>>>10	uleshort	x		\b%d
+>>>>5	ubyte		<9
+>>>>>6	ubyte		0
+>>>>>>7	ubyte		x		\b, codec=%d RGB color palettes
+>>>>>6	ubyte		64		\b, codec=RGB fixed color
+>>>>>6	ubyte		128		\b, codec=YJK
+>>>>>6	ubyte		192		\b, codec=YUV
+>>>>5	ubyte		>8		codec=RGB fixed color
+>>>>12	ubyte		0		\b, raw
+>>>>12	ubyte		1		\b, bitbuster compression
+
+############## Other MSX file formats ##############
+
+# MSX ROMs
+0	string		AB
+>2	uleshort	0x0010			MSX ROM
+>>2	uleshort	x			\b, init=0x%4x
+>>4	uleshort	>0			\b, stat=0x%4x
+>>6	uleshort	>0			\b, dev=0x%4x
+>>8	uleshort	>0			\b, bas=0x%4x
+>2	uleshort	0x4010			MSX ROM
+>>2	uleshort	x			\b, init=0x%04x
+>>4	uleshort	>0			\b, stat=0x%04x
+>>6	uleshort	>0			\b, dev=0x%04x
+>>8	uleshort	>0			\b, bas=0x%04x
+>2	uleshort	0x8010			MSX ROM
+>>2	uleshort	x			\b, init=0x%04x
+>>4	uleshort	>0			\b, stat=0x%04x
+>>6	uleshort	>0			\b, dev=0x%04x
+>>8	uleshort	>0			\b, bas=0x%04x
+
+0	string		AB
+#>2	string		5JSuperLAYDOCK		MSX Super Laydock ROM
+#>3	string		@HYDLIDE3MSX		MSX Hydlide-3 ROM
+#>3	string		@3\x80IA862		Golvellius MSX1 ROM
+>2	uleshort	>10
+>>10	string		\0\0\0\0\0\0		MSX ROM
+>>>0x10	string		YZ\0\0\0\0		Konami Game Master 2 MSX ROM
+>>>0x10	string		CD			\b, Konami RC-
+>>>>0x12	ubyte		x			\b%d
+>>>>0x13	ubyte/16	x			\b%d
+>>>>0x13	ubyte&0xF	x			\b%d
+>>>0x10	string		EF			\b, Konami RC-
+>>>>0x12	ubyte		x			\b%d
+>>>>0x13	ubyte/16	x			\b%d
+>>>>0x13	ubyte&0xF	x			\b%d
+>>>2	uleshort	x			\b, init=0x%04x
+>>>4	uleshort	>0			\b, stat=0x%04x
+>>>6	uleshort	>0			\b, dev=0x%04x
+>>>8	uleshort	>0			\b, bas=0x%04x
+>2	uleshort	0
+>>4	uleshort	0
+>>>6	uleshort	0
+>>>>8	uleshort	>0			MSX BASIC program in ROM, bas=0x%04x
+
+0x4000	string		AB
+>0x4002	uleshort	>0x4010
+>>0x400A	string		\0\0\0\0\0\0	MSX MegaROM with nonstandard page order
+>>0x4002	uleshort	x			\b, init=0x%04x
+>>0x4004	uleshort	>0			\b, stat=0x%04x
+>>0x4006	uleshort	>0			\b, dev=0x%04x
+>>0x4008	uleshort	>0			\b, bas=0x%04x
+
+0x8000	string		AB
+>0x8002	uleshort	>0x4010
+>>0x800A	string		\0\0\0\0\0\0	MSX MegaROM with nonstandard page order
+>>0x8002	uleshort	x			\b, init=0x%04x
+>>0x8004	uleshort	>0			\b, stat=0x%04x
+>>0x8006	uleshort	>0			\b, dev=0x%04x
+>>0x8008	uleshort	>0			\b, bas=0x%04x
+
+
+0x3C000	string		AB
+>0x3C008	string		\0\0\0\0\0\0\0\0	MSX MegaROM with nonstandard page order
+>>0x3C002	uleshort	x			\b, init=0x%04x
+>>0x3C004	uleshort	>0			\b, stat=0x%04x
+>>0x3C006	uleshort	>0			\b, dev=0x%04x
+>>0x3C008	uleshort	>0			\b, bas=0x%04x
+
+# MSX BIN file
+#0	byte		0xFE
+#>1	uleshort	>0x8000
+#>>3	uleshort	>0x8004
+#>>>5	uleshort	>0x8000			MSX BIN file
+
+# MSX-BASIC file
+0	byte		0xFF
+>3	uleshort	0x000A
+>>1	uleshort	>0x8000			MSX-BASIC program
+
+# MSX .CAS file
+0	string	\x1F\xA6\xDE\xBA\xCC\x13\x7D\x74	MSX cassette archive
+
+# Mega-Assembler file
+0	byte		0xFE
+>1	uleshort	0x0001
+>>5	uleshort	0xffff
+>>>6	byte		0x0A		MSX Mega-Assembler source
+
+# Execrom Patchfile
+0	string		ExecROM\ patchfile\x1A	MSX ExecROM patchfile
+>0x12	ubyte/16	x		v%d
+>0x12	ubyte&0xF	x		\b.%d
+>0x13	ubyte		x		\b, contains %d patches
+
+# Konami's King's Valley-2 custom stage (ELG file)
+4	uleshort	0x0900
+>0xF	byte		1
+>>0x14	byte		0
+>>>0x1E	string		\ \ \ 
+>>>>0x23	byte	1
+>>>>>0x25	byte	0
+>>>>>>0x15	string	>\x30
+>>>>>>>0x15	string	<\x5A		Konami King's Valley-2 custom stage, title: "%-8.8s"
+>>>>>>>>0x1D	byte	<32	\b, theme: %d
+
+# Metal Gear 1 savegame
+#0x4F	string	\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF
+#>>0x60	string	\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF
+#>>>0x7B	string	\0x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00	Metal Gear 1 savegame
+
+# ------------------------------------------------------------------------
+# $File$
+# mup: file(1) magic for Mup (Music Publisher) input file.
+#
+# From: Abel Cheung <abel (@) oaka.org>
+#
+# NOTE: This header is mainly proposed in the Arkkra mailing list,
+# and is not a mandatory header because of old mup input file
+# compatibility. Noteedit also use mup format, but is not forcing
+# user to use any header as well.
+#
+0		search/1	//!Mup		Mup music publication program input text
+>6		string		-Arkkra		(Arkkra)
+>>13		string		-		
+>>>16		string		.		
+>>>>14		string		x		\b, need V%.4s
+>>>15		string		.		
+>>>>14		string		x		\b, need V%.3s
+>6		string		-		
+>>9		string		.		
+>>>7		string		x		\b, need V%.4s
+>>8		string		.		
+>>>7		string		x		\b, need V%.3s
+#------------------------------------------------------------------------------
+# $File: cracklib,v 1.7 2009/09/19 16:28:08 christos Exp $
+# music:  file (1) magic for music formats
+
+# BWW format used by Bagpipe Music Writer Gold by Robert MacNeil Musicworks
+# and Bagpipe Writer by Doug Wickstrom
+#
+0	string		Bagpipe		Bagpipe
+>8	string		Reader		Reader
+>>15	string		>\0		(version %.3s)
+>8	string		Music\ Writer	Music Writer
+>>20	string		:
+>>>21	string		>\0		(version %.3s)
+>>21	string		Gold		Gold
+>>>25	string		:
+>>>>26	string		>\0		(version %.3s)
+
+
+#-----------------------------------------------------------------------------
+# $File: natinst,v 1.5 2013/02/06 14:18:52 christos Exp $
+# natinst:  file(1) magic for National Instruments Code Files
+
+#
+# From <egamez@fcfm.buap.mx> Enrique Gamez-Flores
+# version 1
+# Many formats still missing, we use, for the moment LabVIEW
+# We guess VXI format file. VISA, LabWindowsCVI, BridgeVIEW, etc, are missing
+#
+0       string          RSRC            National Instruments,
+# Check if it's a LabVIEW File
+>8      string          LV              LabVIEW File,
+# Check which kind of file it is
+>>10    string          SB              Code Resource File, data
+>>10    string          IN              Virtual Instrument Program, data
+>>10    string          AR              VI Library, data
+# This is for Menu Libraries
+>8      string          LMNULBVW        Portable File Names, data
+# This is for General Resources
+>8      string          rsc             Resources File, data
+# This is for VXI Package
+0       string          VMAP            National Instruments, VXI File, data
+
+#------------------------------------------------------------------------------
+# $File: ncr,v 1.7 2009/09/19 16:28:11 christos Exp $
+# ncr:  file(1) magic for NCR Tower objects
+#
+# contributed by
+# Michael R. Wayne  ***  TMC & Associates  ***  INTERNET: wayne@ford-vax.arpa
+# uucp: {philabs | pyramid} !fmsrl7!wayne   OR   wayne@fmsrl7.UUCP
+#
+0	beshort		000610	Tower/XP rel 2 object
+>12	   belong		>0	not stripped
+>20	   beshort		0407	executable
+>20	   beshort		0410	pure executable
+>22	   beshort		>0	- version %d
+0	beshort		000615	Tower/XP rel 2 object
+>12	   belong		>0	not stripped
+>20	   beshort		0407	executable
+>20	   beshort		0410	pure executable
+>22	   beshort		>0	- version %d
+0	beshort		000620	Tower/XP rel 3 object
+>12	   belong		>0	not stripped
+>20	   beshort		0407	executable
+>20	   beshort		0410	pure executable
+>22	   beshort		>0	- version %d
+0	beshort		000625	Tower/XP rel 3 object
+>12	   belong		>0	not stripped
+>20	   beshort		0407	executable
+>20	   beshort		0410	pure executable
+>22	   beshort		>0	- version %d
+0	beshort		000630	Tower32/600/400 68020 object
+>12	   belong		>0	not stripped
+>20	   beshort		0407	executable
+>20	   beshort		0410	pure executable
+>22	   beshort		>0	- version %d
+0	beshort		000640	Tower32/800 68020
+>18	   beshort		&020000	w/68881 object
+>18	   beshort		&040000	compatible object
+>18	   beshort		&060000	object
+>20	   beshort		0407	executable
+>20	   beshort		0413	pure executable
+>12	   belong		>0	not stripped
+>22	   beshort		>0	- version %d
+0	beshort		000645	Tower32/800 68010
+>18	   beshort		&040000	compatible object
+>18	   beshort		&060000 object
+>20	   beshort		0407	executable
+>20	   beshort		0413	pure executable
+>12	   belong		>0	not stripped
+>22	   beshort		>0	- version %d
+
+#------------------------------------------------------------
+# $File: java,v 1.12 2009/09/19 16:28:10 christos Exp $
+
+# From: Mikhail Gusarov <dottedmag@dottedmag.net>
+# NekoVM (http://nekovm.org/) bytecode
+0	string		NEKO	NekoVM bytecode
+>4	lelong		x	(%d global symbols,
+>8	lelong		x	%d global fields,
+>12	lelong		x	%d bytecode ops)
+!:mime	application/x-nekovm-bytecode
+
+
+#------------------------------------------------------------------------------
+# $File: netbsd,v 1.21 2014/03/29 15:40:34 christos Exp $
+# netbsd:  file(1) magic for NetBSD objects
+#
+# All new-style magic numbers are in network byte order.
+# The old-style magic numbers are indistinguishable from the same magic
+# numbers used in other systems, and are handled, for all those systems,
+# in aout.
+#
+
+0	belong&0377777777	041400413	a.out NetBSD/i386 demand paged
+>0	byte			&0x80		
+>>20	lelong			<4096		shared library
+>>20	lelong			=4096		dynamically linked executable
+>>20	lelong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	041400410	a.out NetBSD/i386 pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	041400407	a.out NetBSD/i386
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	lelong			!0		executable
+>>20	lelong			=0		object file
+>16	lelong			>0		not stripped
+0	belong&0377777777	041400507	a.out NetBSD/i386 core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+0	belong&0377777777	041600413	a.out NetBSD/m68k demand paged
+>0	byte			&0x80		
+>>20	belong			<8192		shared library
+>>20	belong			=8192		dynamically linked executable
+>>20	belong			>8192		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	041600410	a.out NetBSD/m68k pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	041600407	a.out NetBSD/m68k
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	belong			!0		executable
+>>20	belong			=0		object file
+>16	belong			>0		not stripped
+0	belong&0377777777	041600507	a.out NetBSD/m68k core
+>12	string			>\0		from '%s'
+>32	belong			!0		(signal %d)
+
+0	belong&0377777777	042000413	a.out NetBSD/m68k4k demand paged
+>0	byte			&0x80		
+>>20	belong			<4096		shared library
+>>20	belong			=4096		dynamically linked executable
+>>20	belong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	042000410	a.out NetBSD/m68k4k pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	042000407	a.out NetBSD/m68k4k
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	belong			!0		executable
+>>20	belong			=0		object file
+>16	belong			>0		not stripped
+0	belong&0377777777	042000507	a.out NetBSD/m68k4k core
+>12	string			>\0		from '%s'
+>32	belong			!0		(signal %d)
+
+0	belong&0377777777	042200413	a.out NetBSD/ns32532 demand paged
+>0	byte			&0x80		
+>>20	lelong			<4096		shared library
+>>20	lelong			=4096		dynamically linked executable
+>>20	lelong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	042200410	a.out NetBSD/ns32532 pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	042200407	a.out NetBSD/ns32532
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	lelong			!0		executable
+>>20	lelong			=0		object file
+>16	lelong			>0		not stripped
+0	belong&0377777777	042200507	a.out NetBSD/ns32532 core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+0	belong&0377777777	045200507	a.out NetBSD/powerpc core
+>12	string			>\0		from '%s'
+
+0	belong&0377777777	042400413	a.out NetBSD/SPARC demand paged
+>0	byte			&0x80		
+>>20	belong			<8192		shared library
+>>20	belong			=8192		dynamically linked executable
+>>20	belong			>8192		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	042400410	a.out NetBSD/SPARC pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	042400407	a.out NetBSD/SPARC
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	belong			!0		executable
+>>20	belong			=0		object file
+>16	belong			>0		not stripped
+0	belong&0377777777	042400507	a.out NetBSD/SPARC core
+>12	string			>\0		from '%s'
+>32	belong			!0		(signal %d)
+
+0	belong&0377777777	042600413	a.out NetBSD/pmax demand paged
+>0	byte			&0x80		
+>>20	lelong			<4096		shared library
+>>20	lelong			=4096		dynamically linked executable
+>>20	lelong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	042600410	a.out NetBSD/pmax pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	042600407	a.out NetBSD/pmax
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	lelong			!0		executable
+>>20	lelong			=0		object file
+>16	lelong			>0		not stripped
+0	belong&0377777777	042600507	a.out NetBSD/pmax core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+0	belong&0377777777	043000413	a.out NetBSD/vax 1k demand paged
+>0	byte			&0x80		
+>>20	lelong			<4096		shared library
+>>20	lelong			=4096		dynamically linked executable
+>>20	lelong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	043000410	a.out NetBSD/vax 1k pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	043000407	a.out NetBSD/vax 1k
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	lelong			!0		executable
+>>20	lelong			=0		object file
+>16	lelong			>0		not stripped
+0	belong&0377777777	043000507	a.out NetBSD/vax 1k core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+0	belong&0377777777	045400413	a.out NetBSD/vax 4k demand paged
+>0	byte			&0x80		
+>>20	lelong			<4096		shared library
+>>20	lelong			=4096		dynamically linked executable
+>>20	lelong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	045400410	a.out NetBSD/vax 4k pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	045400407	a.out NetBSD/vax 4k
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	lelong			!0		executable
+>>20	lelong			=0		object file
+>16	lelong			>0		not stripped
+0	belong&0377777777	045400507	a.out NetBSD/vax 4k core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+# NetBSD/alpha does not support (and has never supported) a.out objects,
+# so no rules are provided for them.  NetBSD/alpha ELF objects are 
+# dealt with in "elf".
+0	lelong		0x00070185		ECOFF NetBSD/alpha binary
+>10	leshort		0x0001			not stripped
+>10	leshort		0x0000			stripped
+0	belong&0377777777	043200507	a.out NetBSD/alpha core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+0	belong&0377777777	043400413	a.out NetBSD/mips demand paged
+>0	byte			&0x80		
+>>20	belong			<8192		shared library
+>>20	belong			=8192		dynamically linked executable
+>>20	belong			>8192		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	043400410	a.out NetBSD/mips pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	belong			>0		not stripped
+0	belong&0377777777	043400407	a.out NetBSD/mips
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	belong			!0		executable
+>>20	belong			=0		object file
+>16	belong			>0		not stripped
+0	belong&0377777777	043400507	a.out NetBSD/mips core
+>12	string			>\0		from '%s'
+>32	belong			!0		(signal %d)
+
+0	belong&0377777777	043600413	a.out NetBSD/arm32 demand paged
+>0	byte			&0x80
+>>20	lelong			<4096		shared library
+>>20	lelong			=4096		dynamically linked executable
+>>20	lelong			>4096		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	043600410	a.out NetBSD/arm32 pure
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80		executable
+>16	lelong			>0		not stripped
+0	belong&0377777777	043600407	a.out NetBSD/arm32
+>0	byte			&0x80		dynamically linked executable
+>0	byte			^0x80
+>>0	byte			&0x40		position independent
+>>20	lelong			!0		executable
+>>20	lelong			=0		object file
+>16	lelong			>0		not stripped
+# NetBSD/arm26 has always used ELF objects, but it shares a core file
+# format with NetBSD/arm32.
+0	belong&0377777777	043600507	a.out NetBSD/arm core
+>12	string			>\0		from '%s'
+>32	lelong			!0		(signal %d)
+
+# Kernel core dump format
+0	belong&0x0000ffff 0x00008fca	NetBSD kernel core file
+>0	belong&0x03ff0000 0x00000000	\b, Unknown
+>0	belong&0x03ff0000 0x00010000	\b, sun 68010/68020
+>0	belong&0x03ff0000 0x00020000	\b, sun 68020
+>0	belong&0x03ff0000 0x00640000	\b, 386 PC
+>0	belong&0x03ff0000 0x00860000	\b, i386 BSD
+>0	belong&0x03ff0000 0x00870000	\b, m68k BSD (8K pages)
+>0	belong&0x03ff0000 0x00880000	\b, m68k BSD (4K pages)
+>0	belong&0x03ff0000 0x00890000	\b, ns32532 BSD
+>0	belong&0x03ff0000 0x008a0000	\b, SPARC/32 BSD
+>0	belong&0x03ff0000 0x008b0000	\b, pmax BSD
+>0	belong&0x03ff0000 0x008c0000	\b, vax BSD (1K pages)
+>0	belong&0x03ff0000 0x008d0000	\b, alpha BSD
+>0	belong&0x03ff0000 0x008e0000	\b, mips BSD (Big Endian)
+>0	belong&0x03ff0000 0x008f0000	\b, arm6 BSD
+>0	belong&0x03ff0000 0x00900000	\b, m68k BSD (2K pages)
+>0	belong&0x03ff0000 0x00910000	\b, sh3 BSD
+>0	belong&0x03ff0000 0x00950000	\b, ppc BSD (Big Endian)
+>0	belong&0x03ff0000 0x00960000	\b, vax BSD (4K pages)
+>0	belong&0x03ff0000 0x00970000	\b, mips1 BSD
+>0	belong&0x03ff0000 0x00980000	\b, mips2 BSD
+>0	belong&0x03ff0000 0x00990000	\b, m88k BSD
+>0	belong&0x03ff0000 0x00920000	\b, parisc BSD
+>0	belong&0x03ff0000 0x009b0000	\b, sh5/64 BSD
+>0	belong&0x03ff0000 0x009c0000	\b, SPARC/64 BSD
+>0	belong&0x03ff0000 0x009d0000	\b, amd64 BSD
+>0	belong&0x03ff0000 0x009e0000	\b, sh5/32 BSD
+>0	belong&0x03ff0000 0x009f0000	\b, ia64 BSD
+>0	belong&0x03ff0000 0x00b70000	\b, aarch64 BSD
+>0	belong&0x03ff0000 0x00b80000	\b, or1k BSD
+>0	belong&0x03ff0000 0x00b90000	\b, Risk-V BSD
+>0	belong&0x03ff0000 0x00c80000	\b, hp200 BSD
+>0	belong&0x03ff0000 0x012c0000	\b, hp300 BSD
+>0	belong&0x03ff0000 0x020b0000	\b, hp800 HP-UX
+>0	belong&0x03ff0000 0x020c0000	\b, hp200/hp300 HP-UX
+>0	belong&0xfc000000 0x04000000	\b, CPU
+>0	belong&0xfc000000 0x08000000	\b, DATA
+>0	belong&0xfc000000 0x10000000	\b, STACK
+>4	leshort	x			\b, (headersize = %d
+>6	leshort	x			\b, segmentsize = %d
+>6	lelong	x			\b, segments = %d)
+
+#------------------------------------------------------------------------------
+# $File$
+# netscape:  file(1) magic for Netscape files
+# "H. Nanosecond" <aldomel@ix.netcom.com>
+# version 3 and 4 I think
+#
+
+# Netscape Address book  .nab
+0	string \000\017\102\104\000\000\000\000\000\000\001\000\000\000\000\002\000\000\000\002\000\000\004\000 Netscape Address book
+
+# Netscape Communicator address book
+0   string   \000\017\102\111 Netscape Communicator address book
+
+# .snm Caches
+0	string		#\ Netscape\ folder\ cache	Netscape folder cache
+0	string	\000\036\204\220\000	Netscape folder cache
+# .n2p 
+# Net 2 Phone 
+#0	string	123\130\071\066\061\071\071\071\060\070\061\060\061\063\060
+0	string	SX961999	Net2phone
+
+#
+#This is files ending in .art, FIXME add more rules
+0       string          JG\004\016\0\0\0\0      ART
+
+#------------------------------------------------------------------------------
+# $File$
+# netware:  file(1) magic for NetWare Loadable Modules (NLMs)
+# From: Mads Martin Joergensen <mmj@suse.de>
+
+0	string	NetWare\ Loadable\ Module	NetWare Loadable Module
+
+#------------------------------------------------------------------------------
+# $File$
+# news:  file(1) magic for SunOS NeWS fonts (not "news" as in "netnews")
+#
+0	string		StartFontMetrics	ASCII font metrics
+0	string		StartFont	ASCII font bits
+0	belong		0x137A2944	NeWS bitmap font
+0	belong		0x137A2947	NeWS font family
+0	belong		0x137A2950	scalable OpenFont binary
+0	belong		0x137A2951	encrypted scalable OpenFont binary
+8	belong		0x137A2B45	X11/NeWS bitmap font
+8	belong		0x137A2B48	X11/NeWS font family
+
+#------------------------------------------------------------------------------
+# $File: nitpicker,v 1.5 2014/04/28 12:04:50 christos Exp $
+# nitpicker:  file(1) magic for Flowfiles.
+# From: Christian Jachmann <C.Jachmann@gmx.net> http://www.nitpicker.de
+0	string	NPFF	NItpicker Flow File 
+>4	byte	x	V%d.
+>5	byte	x	%d
+>6	bedate	x	started: %s
+>10	bedate	x	stopped: %s
+>14	belong	x	Bytes: %u
+>18	belong	x	Bytes1: %u
+>22	belong	x	Flows: %u
+>26	belong	x	Pkts: %u
+
+#------------------------------------------------------------------------------
+# $File: oasis,v 1.1 2011/03/15 02:09:38 christos Exp $
+# OASIS
+# Summary: OASIS stream file
+# Long description: Open Artwork System Interchange Standard
+# File extension: .oas
+# Full name:	Ben Cowley (bcowley@broadcom.com)
+#		Philip Dixon (pdixon@broadcom.com)
+# Reference: http://www.wrcad.com/oasis/oasis-3626-042303-draft.pdf
+#		(see page 3)
+0	string	%SEMI-OASIS\r\n		OASIS Stream file
+
+#------------------------------------------------------------------------------
+# $File: ocaml,v 1.4 2009/09/19 16:28:11 christos Exp $
+# ocaml: file(1) magic for Objective Caml files.
+0	string	Caml1999	OCaml
+>8	string	X		exec file
+>8	string	I		interface file (.cmi)
+>8	string	O		object file (.cmo)
+>8	string	A		library file (.cma)
+>8	string	Y		native object file (.cmx)
+>8	string	Z		native library file (.cmxa)
+>8	string	M		abstract syntax tree implementation file
+>8	string	N		abstract syntax tree interface file
+>9	string	>\0		(Version %3.3s)
+
+#------------------------------------------------------------------------------
+# $File$
+# octave binary data file(1) magic, from Dirk Eddelbuettel <edd@debian.org>
+0	string		Octave-1-L	Octave binary data (little endian)
+0	string		Octave-1-B	Octave binary data (big endian)
+
+#------------------------------------------------------------------------------
+# $File$
+# Microsoft OLE 2 Compound Documents : file(1) magic for Microsoft Structured
+# storage (http://en.wikipedia.org/wiki/Structured_Storage)
+# Additional tests for OLE 2 Compound Documents should be under this recipe.
+
+0   string  \320\317\021\340\241\261\032\341      OLE 2 Compound Document
+# - Microstation V8 DGN files (www.bentley.com)
+#   Last update on 10/23/2006 by Lester Hightower
+> 0x480  string  D\000g\000n\000~\000H                : Microstation V8 DGN
+# - Visio documents
+#   Last update on 10/23/2006 by Lester Hightower
+> 0x480  string  V\000i\000s\000i\000o\000D\000o\000c : Visio Document
+
+#------------------------------------------------------------------------------
+# $File$
+# olf:  file(1) magic for OLF executables
+#
+# We have to check the byte order flag to see what byte order all the
+# other stuff in the header is in.
+#
+# MIPS R3000 may also be for MIPS R2000.
+# What're the correct byte orders for the nCUBE and the Fujitsu VPP500?
+#
+# Created by Erik Theisen <etheisen@openbsd.org>
+# Based on elf from Daniel Quinlan <quinlan@yggdrasil.com>
+0	string		\177OLF		OLF
+>4	byte		0		invalid class
+>4	byte		1		32-bit
+>4	byte		2		64-bit
+>7	byte		0		invalid os
+>7	byte		1		OpenBSD
+>7	byte		2		NetBSD
+>7	byte		3		FreeBSD
+>7	byte		4		4.4BSD
+>7	byte		5		Linux
+>7	byte		6		SVR4
+>7	byte		7		esix
+>7	byte		8		Solaris
+>7	byte		9		Irix
+>7	byte		10		SCO
+>7	byte		11		Dell
+>7	byte		12		NCR
+>5	byte		0		invalid byte order
+>5	byte		1		LSB
+>>16	leshort		0		no file type,
+>>16	leshort		1		relocatable,
+>>16	leshort		2		executable,
+>>16	leshort		3		shared object,
+# Core handling from Peter Tobias <tobias@server.et-inf.fho-emden.de>
+# corrections by Christian 'Dr. Disk' Hechelmann <drdisk@ds9.au.s.shuttle.de>
+>>16	leshort		4		core file
+>>>(0x38+0xcc) string	>\0		of '%s'
+>>>(0x38+0x10) lelong	>0		(signal %d),
+>>16	leshort		&0xff00		processor-specific,
+>>18	leshort		0		no machine,
+>>18	leshort		1		AT&T WE32100 - invalid byte order,
+>>18	leshort		2		SPARC - invalid byte order,
+>>18	leshort		3		Intel 80386,
+>>18	leshort		4		Motorola 68000 - invalid byte order,
+>>18	leshort		5		Motorola 88000 - invalid byte order,
+>>18	leshort		6		Intel 80486,
+>>18	leshort		7		Intel 80860,
+>>18	leshort		8		MIPS R3000_BE - invalid byte order,
+>>18	leshort		9		Amdahl - invalid byte order,
+>>18	leshort		10		MIPS R3000_LE,
+>>18	leshort		11		RS6000 - invalid byte order,
+>>18	leshort		15		PA-RISC - invalid byte order,
+>>18	leshort		16		nCUBE,
+>>18	leshort		17		VPP500,
+>>18	leshort		18		SPARC32PLUS,
+>>18	leshort		20		PowerPC,
+>>18	leshort		0x9026		Alpha,
+>>20	lelong		0		invalid version
+>>20	lelong		1		version 1
+>>36	lelong		1		MathCoPro/FPU/MAU Required
+>8	string		>\0		(%s)
+>5	byte		2		MSB
+>>16	beshort		0		no file type,
+>>16	beshort		1		relocatable,
+>>16	beshort		2		executable,
+>>16	beshort		3		shared object,
+>>16	beshort		4		core file,
+>>>(0x38+0xcc) string	>\0		of '%s'
+>>>(0x38+0x10) belong	>0		(signal %d),
+>>16	beshort		&0xff00		processor-specific,
+>>18	beshort		0		no machine,
+>>18	beshort		1		AT&T WE32100,
+>>18	beshort		2		SPARC,
+>>18	beshort		3		Intel 80386 - invalid byte order,
+>>18	beshort		4		Motorola 68000,
+>>18	beshort		5		Motorola 88000,
+>>18	beshort		6		Intel 80486 - invalid byte order,
+>>18	beshort		7		Intel 80860,
+>>18	beshort		8		MIPS R3000_BE,
+>>18	beshort		9		Amdahl,
+>>18	beshort		10		MIPS R3000_LE - invalid byte order,
+>>18	beshort		11		RS6000,
+>>18	beshort		15		PA-RISC,
+>>18	beshort		16		nCUBE,
+>>18	beshort		17		VPP500,
+>>18	beshort		18		SPARC32PLUS,
+>>18	beshort		20		PowerPC or cisco 4500,
+>>18	beshort		21		cisco 7500,
+>>18	beshort		24		cisco SVIP,
+>>18	beshort		25		cisco 7200,
+>>18	beshort		36		cisco 12000,
+>>18	beshort		0x9026		Alpha,
+>>20	belong		0		invalid version
+>>20	belong		1		version 1
+>>36	belong		1		MathCoPro/FPU/MAU Required
+
+#------------------------------------------------------------------------------
+# $File: os2,v 1.7 2009/09/19 16:28:11 christos Exp $
+# os2:  file(1) magic for OS/2 files
+#
+
+# Provided 1998/08/22 by
+# David Mediavilla <davidme.news@REMOVEIFNOTSPAMusa.net>
+1	search/1	InternetShortcut	MS Windows 95 Internet shortcut text
+>17	search/100	URL= 			(URL=<
+>>&0	string		x			\b%s>)
+
+# OS/2 URL objects
+# Provided 1998/08/22 by
+# David Mediavilla <davidme.news@REMOVEIFNOTSPAMusa.net>
+#0	string	http:			OS/2 URL object text
+#>5	string	>\			(WWW) <http:%s>
+#0	string	mailto:			OS/2 URL object text
+#>7	string	>\			(email) <%s>
+#0	string	news:			OS/2 URL object text
+#>5	string	>\			(Usenet) <%s>
+#0	string	ftp:			OS/2 URL object text
+#>4	string	>\			(FTP) <ftp:%s>
+#0	string	file:			OS/2 URL object text
+#>5	string	>\			(Local file) <%s>
+
+# >>>>> OS/2 INF/HLP <<<<<  (source: Daniel Dissett ddissett@netcom.com)
+# Carl Hauser (chauser.parc@xerox.com) and 
+# Marcus Groeber (marcusg@ph-cip.uni-koeln.de)
+# list the following header format in inf02a.doc:
+#
+#  int16 ID;           // ID magic word (5348h = "HS")
+#  int8  unknown1;     // unknown purpose, could be third letter of ID
+#  int8  flags;        // probably a flag word...
+#                      //  bit 0: set if INF style file
+#                      //  bit 4: set if HLP style file
+#                      // patching this byte allows reading HLP files
+#                      // using the VIEW command, while help files 
+#                      // seem to work with INF settings here as well.
+#  int16 hdrsize;      // total size of header
+#  int16 unknown2;     // unknown purpose
+# 
+0   string  HSP\x01\x9b\x00 OS/2 INF
+>107 string >0                      (%s)
+0   string  HSP\x10\x9b\x00     OS/2 HLP
+>107 string >0                      (%s)
+
+# OS/2 INI (this is a guess)
+0  string   \xff\xff\xff\xff\x14\0\0\0  OS/2 INI
+
+#------------------------------------------------------------------------------
+# $File$
+# os400:  file(1) magic for IBM OS/400 files
+#
+# IBM OS/400 (i5/OS) Save file (SAVF) - gerardo.cacciari@gmail.com
+# In spite of its quite variable format (due to internal memory page
+# length differences between CISC and RISC versions of the OS) the
+# SAVF structure hasn't suitable offsets to identify the catalog
+# header in the first descriptor where there are some useful infos,
+# so we must search in a somewhat large area for a particular string
+# that represents the EBCDIC encoding of 'QSRDSSPC' (save/restore
+# descriptor space) preceded by a two byte constant.
+#
+1090	 search/7393	\x19\xDB\xD8\xE2\xD9\xC4\xE2\xE2\xD7\xC3 IBM OS/400 save file data
+>&212	 byte		0x01			 \b, created with SAVOBJ
+>&212	 byte		0x02			 \b, created with SAVLIB
+>&212	 byte		0x07			 \b, created with SAVCFG
+>&212	 byte		0x08			 \b, created with SAVSECDTA
+>&212	 byte		0x0A			 \b, created with SAVSECDTA
+>&212	 byte		0x0B			 \b, created with SAVDLO
+>&212	 byte		0x0D			 \b, created with SAVLICPGM
+>&212	 byte		0x11			 \b, created with SAVCHGOBJ
+>&213	 byte		0x44			 \b, at least V5R4 to open
+>&213	 byte		0x43			 \b, at least V5R3 to open
+>&213	 byte		0x42			 \b, at least V5R2 to open
+>&213	 byte		0x41			 \b, at least V5R1 to open
+>&213	 byte		0x40			 \b, at least V4R5 to open
+>&213	 byte		0x3F			 \b, at least V4R4 to open
+>&213	 byte		0x3E			 \b, at least V4R3 to open
+>&213	 byte		0x3C			 \b, at least V4R2 to open
+>&213	 byte		0x3D			 \b, at least V4R1M4 to open
+>&213	 byte		0x3B			 \b, at least V4R1 to open
+>&213	 byte		0x3A			 \b, at least V3R7 to open
+>&213	 byte		0x35			 \b, at least V3R6 to open
+>&213	 byte		0x36			 \b, at least V3R2 to open
+>&213	 byte		0x34			 \b, at least V3R1 to open
+>&213	 byte		0x31			 \b, at least V3R0M5 to open
+>&213	 byte		0x30			 \b, at least V2R3 to open
+
+#------------------------------------------------------------------------------
+# $File: os9,v 1.6 2009/09/19 16:28:11 christos Exp $
+#
+# Copyright (c) 1996 Ignatios Souvatzis. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+#
+# OS9/6809 module descriptions:
+#
+0	beshort		0x87CD	OS9/6809 module:
+#
+>6	byte&0x0f	0x00	non-executable
+>6	byte&0x0f	0x01	machine language
+>6	byte&0x0f	0x02	BASIC I-code
+>6	byte&0x0f	0x03	Pascal P-code
+>6	byte&0x0f	0x04	C I-code
+>6	byte&0x0f	0x05	COBOL I-code
+>6	byte&0x0f	0x06	Fortran I-code
+#
+>6	byte&0xf0	0x10	program executable
+>6	byte&0xf0	0x20	subroutine
+>6	byte&0xf0	0x30	multi-module
+>6	byte&0xf0	0x40	data module
+#
+>6	byte&0xf0	0xC0	system module
+>6	byte&0xf0	0xD0	file manager
+>6	byte&0xf0	0xE0	device driver
+>6	byte&0xf0	0xF0	device descriptor
+#
+# OS9/m68k stuff (to be continued)
+#
+0	beshort		0x4AFC	OS9/68K module:
+#
+# attr
+>0x14	byte&0x80	0x80	re-entrant
+>0x14	byte&0x40	0x40	ghost
+>0x14	byte&0x20	0x20	system-state
+#
+# lang:
+#
+>0x13	byte		1	machine language
+>0x13	byte		2	BASIC I-code
+>0x13	byte		3	Pascal P-code
+>0x13	byte		4	C I-code
+>0x13	byte		5	COBOL I-code
+>0x13	byte		6	Fortran I-code
+#
+#
+# type:
+#
+>0x12	byte		1	program executable
+>0x12	byte		2	subroutine
+>0x12	byte		3	multi-module
+>0x12	byte		4	data module
+>0x12	byte		11	trap library
+>0x12	byte		12	system module
+>0x12	byte		13	file manager
+>0x12	byte		14	device driver
+>0x12	byte		15	device descriptor
+
+#------------------------------------------------------------------------------
+# $File$
+#
+# Mach magic number info
+#
+0	long		0xefbe	OSF/Rose object
+# I386 magic number info
+#
+0	short		0565	i386 COFF object
+
+#------------------------------------------------------------------------------
+# $File: palm,v 1.12 2014/03/28 19:11:40 christos Exp $
+# palm:	 file(1) magic for PalmOS {.prc,.pdb}: applications, docfiles, and hacks
+#
+# Brian Lalor <blalor@hcirisc.cs.binghamton.edu>
+
+# These are weak, byte 59 is not guaranteed to be 0 and there are
+# 8 character identifiers at byte 60, one I found for appl is BIGb.
+# What are the possibilities and where is this documented?
+
+# The common header format for PalmOS .pdb/.prc files is
+# {
+#         char            name[ 32 ];
+#         Word            attributes;
+#         Word            version;
+#         DWord           creationDate;
+#         DWord           modificationDate;
+#         DWord           lastBackupDate;
+#         DWord           modificationNumber;
+#         DWord           appInfoID;
+#         DWord           sortInfoID;
+#         char            type[4];
+#         char            creator[4];
+#         DWord           uniqueIDSeed;
+#         RecordListType  recordList;
+# };
+#
+# Datestamps are unsigned seconds since the MacOS epoch (Jan 1, 1904),
+# or Unix/POSIX time + 2082844800.
+
+0		name		aportisdoc
+# date is supposed to be big-endian seconds since 1 Jan 1904, but many
+# files contain the timestamp in little-endian or a completely
+# nonsensical value...
+#>36		bedate-2082844800	>0	\b, created %s
+# compression: 1=uncomp, 2=orig, 0x4448=HuffDic
+>(78.L)		beshort		=1		\b, uncompressed
+# compressed
+>(78.L)		beshort		>1
+>>(78.L+4)	belong		x		\b, %d bytes uncompressed
+
+# appl
+#60		string		appl		PalmOS application
+#>0		string		>\0		"%s"
+
+# HACK
+#60		string		HACK		HackMaster hack
+#>0		string		>\0		"%s"
+
+# iSiloX e-book
+60		string		SDocSilX	iSiloX E-book
+>0		string		>\0		"%s"
+
+# Mobipocket (www.mobipocket.com), donated by Carl Witty
+# expanded by Ralf Brown
+60		string	 	BOOKMOBI	Mobipocket E-book
+# MobiPocket stores a full title, pointed at by the belong at offset
+# 0x54 in its header at (78.L), with length given by the belong at
+# offset 0x58.
+# there's no guarantee that the title string is null-terminated, but
+# we currently can't specify a variable-length string where the length
+# field is not at the start of the string; in practice, the data
+# following the string always seems to start with a zero byte
+>(78.L)		belong		x
+>>&(&0x50.L-4)	string		>\0		"%s"
+>0		use		aportisdoc
+>>(78.L+0x68)	belong		>0		\b, version %d
+>>(78.L+0x1C)	belong		!0		\b, codepage %d
+>>(78.L+0x0C)	beshort	 	>0		\b, encrypted (type %d)
+
+# AportisDoc/PalmDOC
+60		string		TEXtREAd	AportisDoc/PalmDOC E-book
+>0		string		>\0		"%s"
+>0		use		aportisdoc
+
+# Variety of PalmOS document types
+# Michael-John Turner <mj@debian.org>
+# Thanks to Hasan Umit Ezerce <humit@tr-net.net.tr> for his DocType
+60	string			BVokBDIC	BDicty PalmOS document
+>0	string			>\0		"%s"
+60	string			DB99DBOS	DB PalmOS document
+>0	string			>\0		"%s"
+60	string			vIMGView	FireViewer/ImageViewer PalmOS document
+>0	string			>\0		"%s"
+60	string			PmDBPmDB	HanDBase PalmOS document
+>0	string			>\0		"%s"
+60	string			InfoINDB	InfoView PalmOS document
+>0	string			>\0		"%s"
+60	string			ToGoToGo	iSilo PalmOS document
+>0	string			>\0		"%s"
+60	string			JfDbJBas	JFile PalmOS document
+>0	string			>\0		"%s"
+60	string			JfDbJFil	JFile Pro PalmOS document
+>0	string			>\0		"%s"
+60	string			DATALSdb	List PalmOS document
+>0	string			>\0		"%s"
+60	string			Mdb1Mdb1	MobileDB PalmOS document
+>0	string			>\0		"%s"
+60	string			PNRdPPrs	PeanutPress PalmOS document
+>0	string			>\0		"%s"
+60	string			DataPlkr	Plucker PalmOS document
+>0	string			>\0		"%s"
+60	string			DataSprd	QuickSheet PalmOS document
+>0	string			>\0		"%s"
+60	string			SM01SMem	SuperMemo PalmOS document
+>0	string			>\0		"%s"
+60	string			TEXtTlDc	TealDoc PalmOS document
+>0	string			>\0		"%s"
+60	string			InfoTlIf	TealInfo PalmOS document
+>0	string			>\0		"%s"
+60	string			DataTlMl	TealMeal PalmOS document
+>0	string			>\0		"%s"
+60	string			DataTlPt	TealPaint PalmOS document
+>0	string			>\0		"%s"
+60	string			dataTDBP	ThinkDB PalmOS document
+>0	string			>\0		"%s"
+60	string			TdatTide	Tides PalmOS document
+>0	string			>\0		"%s"
+60	string			ToRaTRPW	TomeRaider PalmOS document
+>0	string			>\0		"%s"
+
+# A GutenPalm zTXT etext for use on Palm Pilots (http://gutenpalm.sf.net)
+# For version 1.xx zTXTs, outputs version and numbers of bookmarks and
+#   annotations.
+# For other versions, just outputs version.
+#
+60		string		zTXT		A GutenPalm zTXT e-book
+>0		string		>\0		"%s"
+>(0x4E.L)	byte		0
+>>(0x4E.L+1)	byte		x		(v0.%02d)
+>(0x4E.L)	byte		1
+>>(0x4E.L+1)	byte		x		(v1.%02d)
+>>>(0x4E.L+10)	beshort		>0
+>>>>(0x4E.L+10) beshort		<2		- 1 bookmark
+>>>>(0x4E.L+10) beshort		>1		- %d bookmarks
+>>>(0x4E.L+14)	beshort		>0
+>>>>(0x4E.L+14) beshort		<2		- 1 annotation
+>>>>(0x4E.L+14) beshort		>1		- %d annotations
+>(0x4E.L)	byte		>1		(v%d.
+>>(0x4E.L+1)	byte		x		%02d)
+
+# Palm OS .prc file types
+60		string		libr
+# flags, only bit 0 or bit 6
+# http://en.wikipedia.org/wiki/PRC_%28Palm_OS%29
+# http://web.mit.edu/tytso/www/pilot/prc-format.html
+>0x20		beshort&0xffbe	0
+>>0		string		>\0		Palm OS dynamic library data "%s"
+60		string		ptch		Palm OS operating system patch data
+>0		string		>\0		"%s"
+
+# Mobipocket (www.mobipocket.com), donated by Carl Witty
+60	string			BOOKMOBI	Mobipocket E-book
+>0	string			>\0		"%s"
+
+#------------------------------------------------------------------------------
+# $File$
+#
+# Parix COFF executables
+# From: Ignatios Souvatzis <ignatios@cs.uni-bonn.de>
+#
+0	beshort&0xfff	0xACE	PARIX
+>0	byte&0xf0	0x80	T800
+>0	byte&0xf0	0x90	T9000
+>19	byte&0x02	0x02	executable
+>19	byte&0x02	0x00	object
+>19	byte&0x0c	0x00	not stripped
+#------------------------------------------------------------------------------
+# $File$
+# parrot: file(1) magic for Parrot Virtual Machine
+# URL:	http://www.lua.org/
+# From: Lubomir Rintel <lkundrak@v3.sk>
+
+# Compiled Parrot byte code
+0	string	\376PBC\r\n\032\n	Parrot bytecode
+>64	byte	x			%d.
+>72	byte	x			\b%d,
+>8	byte	>0			%d byte words,
+>16	byte	0			little-endian,
+>16	byte	1			big-endian,
+>32	byte	0			IEEE-754 8 byte double floats,
+>32	byte	1			x86 12 byte long double floats,
+>32	byte	2			IEEE-754 16 byte long double floats,
+>32	byte	3			MIPS 16 byte long double floats,
+>32	byte	4			AIX 16 byte long double floats,
+>32	byte	5			4-byte floats,
+>40	byte	x			Parrot %d.
+>48	byte	x			\b%d.
+>56	byte	x			\b%d
+#------------------------------------------------------------------------------
+# $File: pascal,v 1.1 2011/12/08 12:12:46 rrt Exp $
+# pascal:  file(1) magic for Pascal source
+#
+0	search/8192	(input,		Pascal source text
+!:mime	text/x-pascal
+#0	regex		\^program	Pascal source text
+#!:mime	text/x-pascal
+#0	regex           	\^record		Pascal source text
+#!:mime	text/x-pascal
+
+#------------------------------------------------------------------------------
+# $File: cubemap,v 1.1 2012/06/06 13:03:20 christos Exp $
+# file(1) magic(5) data for OpenStreetMap
+
+# OpenStreetMap Protocolbuffer Binary Format (.osm.pbf)
+# http://wiki.openstreetmap.org/wiki/PBF_Format
+# From: Markus Heidelberg <markus.heidelberg@web.de>
+0	belong		0x0000000D
+>4	beshort		0x0A09
+>>6	string		OSMHeader	OpenStreetMap Protocolbuffer Binary Format
+
+#------------------------------------------------------------------------------
+# $File$
+# pbm:  file(1) magic for Portable Bitmap files
+#
+# XXX - byte order?
+#
+0	short	0x2a17	"compact bitmap" format (Poskanzer)
+
+#------------------------------------------------------------------------------
+# $File: pdf,v 1.7 2013/08/22 07:47:26 christos Exp $
+# pdf:  file(1) magic for Portable Document Format
+#
+
+0	string		%PDF-		PDF document
+!:mime	application/pdf
+>5	byte		x		\b, version %c
+>7	byte		x		\b.%c
+
+0	string		\012%PDF-	PDF document
+!:mime	application/pdf
+>6	byte		x		\b, version %c
+>8	byte		x		\b.%c
+
+# From: Nick Schmalenberger <nick@schmalenberger.us>
+# Forms Data Format
+0       string          %FDF-           FDF document
+!:mime application/vnd.fdf
+>5      byte            x               \b, version %c
+>7      byte            x               \b.%c
+
+#------------------------------------------------------------------------------
+# $File: pdp,v 1.9 2013/04/19 20:11:43 christos Exp $
+# pdp:  file(1) magic for PDP-11 executable/object and APL workspace
+#
+0	lelong		0101555		PDP-11 single precision APL workspace
+0	lelong		0101554		PDP-11 double precision APL workspace
+#
+# PDP-11 a.out
+#
+0	leshort		0407		PDP-11 executable
+>8	leshort		>0		not stripped
+>15	byte		>0		- version %d
+
+# updated by Joerg Jenderek at Mar 2013
+# GRR: line below too general as it catches also Windows precompiled setup information *.PNF
+0	leshort		0401		
+# skip *.PNF with WinDirPathOffset 58h 
+>68	ulelong		!0x00000058	PDP-11 UNIX/RT ldp
+# skip *.PNF with high byte of InfVersionDatumCount zero
+#>>15	byte		!0		PDP-11 UNIX/RT ldp
+0	leshort		0405		PDP-11 old overlay
+
+0	leshort		0410		PDP-11 pure executable
+>8	leshort		>0		not stripped
+>15	byte		>0		- version %d
+
+0	leshort		0411		PDP-11 separate I&D executable
+>8	leshort		>0		not stripped
+>15	byte		>0		- version %d
+
+0	leshort		0437		PDP-11 kernel overlay
+
+# These last three are derived from 2.11BSD file(1)
+0	leshort		0413		PDP-11 demand-paged pure executable
+>8	leshort		>0		not stripped
+
+0	leshort		0430		PDP-11 overlaid pure executable
+>8	leshort		>0		not stripped
+
+0	leshort		0431		PDP-11 overlaid separate executable
+>8	leshort		>0		not stripped
+#------------------------------------------------------------------------------
+# $File: perl,v 1.22 2014/04/28 12:04:35 christos Exp $
+# perl:  file(1) magic for Larry Wall's perl language.
+#
+# The `eval' lines recognizes an outrageously clever hack.
+# Keith Waclena <keith@cerberus.uchicago.edu>
+# Send additions to <perl5-porters@perl.org>
+0	search/1	eval\ "exec\ /bin/perl		Perl script text
+!:mime	text/x-perl
+0	search/1	eval\ "exec\ /usr/bin/perl	Perl script text
+!:mime	text/x-perl
+0	search/1	eval\ "exec\ /usr/local/bin/perl	Perl script text
+!:mime	text/x-perl
+0	search/1	eval\ '(exit\ $?0)'\ &&\ eval\ 'exec	Perl script text
+!:mime	text/x-perl
+0	search/1	#!/usr/bin/env\ perl	Perl script text executable
+!:mime	text/x-perl
+0	search/1	#!\ /usr/bin/env\ perl	Perl script text executable
+!:mime	text/x-perl
+0	search/1	#!
+>0	regex	\^#!.*/bin/perl([[:space:]].*)*$	Perl script text executable
+!:mime	text/x-perl
+
+# by Dmitry V. Levin and Alexey Tourbin
+# check the first line
+0	search/1	package
+>0	regex		\^package[\ \t]+[0-9A-Za-z_:]+\ *;	Perl5 module source text
+!:strength + 10
+# not 'p', check other lines
+0	search/1	!p
+>0	regex		\^package[\ \t]+[0-9A-Za-z_:]+\ *;
+>>0	regex		\^1\ *;|\^(use|sub|my)\ .*[(;{=]	Perl5 module source text
+!:strength + 10
+
+# Perl POD documents
+# From: Tom Hukins <tom@eborcom.com>
+0	search/1/W	\=pod\n		Perl POD document text
+0	search/1/W	\n\=pod\n	Perl POD document text
+0	search/1/W	\=head1\ 	Perl POD document text
+0	search/1/W	\n\=head1\ 	Perl POD document text
+0	search/1/W	\=head2\ 	Perl POD document text
+0	search/1/W	\n\=head2\ 	Perl POD document text
+0	search/1/W	\=encoding\ 	Perl POD document text
+0	search/1/W	\n\=encoding\ 	Perl POD document text
+
+
+# Perl Storable data files.
+0	string	perl-store	perl Storable (v0.6) data
+>4	byte	>0	(net-order %d)
+>>4	byte	&01	(network-ordered)
+>>4	byte	=3	(major 1)
+>>4	byte	=2	(major 1)
+
+0	string	pst0	perl Storable (v0.7) data
+>4	byte	>0
+>>4	byte	&01	(network-ordered)
+>>4	byte	=5	(major 2)
+>>4	byte	=4	(major 2)
+>>5	byte	>0	(minor %d)
+
+# This is Debian #742949 by Zefram <zefram@fysh.org>:
+# -----------------------------------------------------------
+# The Perl module Hash::SharedMem
+# <https://metacpan.org/release/Hash-SharedMem> defines a file format
+# for a key/value store.  Details of the file format are in the "DESIGN"
+# file in the module distribution.  Magic:
+0	bequad	=0xa58afd185cbf5af7	Hash::SharedMem master file, big-endian
+>8	bequad	<0x1000000
+>>15	byte	>2	\b, line size 2^%d byte
+>>14	byte	>2	\b, page size 2^%d byte
+>>13	byte	&1
+>>>13	byte	>1	\b, max fanout %d
+0	lequad	=0xa58afd185cbf5af7	Hash::SharedMem master file, little-endian
+>8	lequad	<0x1000000
+>>8	byte	>2	\b, line size 2^%d byte
+>>9	byte	>2	\b, page size 2^%d byte
+>>10	byte	&1
+>>>10	byte	>1	\b, max fanout %d
+0	bequad	=0xc693dac5ed5e47c2	Hash::SharedMem data file, big-endian
+>8	bequad	<0x1000000
+>>15	byte	>2	\b, line size 2^%d byte
+>>14	byte	>2	\b, page size 2^%d byte
+>>13	byte	&1
+>>>13	byte	>1	\b, max fanout %d
+0	lequad	=0xc693dac5ed5e47c2	Hash::SharedMem data file, little-endian
+>8	lequad	<0x1000000
+>>8	byte	>2	\b, line size 2^%d byte
+>>9	byte	>2	\b, page size 2^%d byte
+>>10	byte	&1
+>>>10	byte	>1	\b, max fanout %d
+
+#------------------------------------------------------------------------------
+# $File: matroska,v 1.8 2013/02/08 17:25:16 christos Exp $
+# pgf: file(1) magic for Progressive Graphics File (PGF)
+#
+# <http://www.libpgf.org/uploads/media/PGF_Details_01.pdf>
+# 2013 by Philipp Hahn <pmhahn debian org>
+0 string PGF Progressive Graphics image data,
+!:mime image/x-pgf
+>3	string	2	version %s,
+>3	string	4	version %s,
+>3	string	5	version %s,
+>3	string	6	version %s,
+#	PGFPreHeader
+#>>4	lelong	x	header size %d,
+#	PGFHeader
+>>8	lelong	x	%d x
+>>12	lelong	x	%d,
+>>16	byte	x	%d levels,
+>>17	byte	x	compression level %d,
+>>18	byte	x	%d bpp,
+>>19	byte	x	%d channels,
+>>20	clear	x
+>>20	byte	0	bitmap,
+>>20	byte	1	gray scale,
+>>20	byte	2	indexed color,
+>>20	byte	3	RGB color,
+>>20	byte	4	CYMK color,
+>>20	byte	5	HSL color,
+>>20	byte	6	HSB color,
+>>20	byte	7	multi-channel,
+>>20	byte	8	duo tone,
+>>20	byte	9	LAB color,
+>>20	byte	10	gray scale 16,
+>>20	byte	11	RGB color 48,
+>>20	byte	12	LAB color 48,
+>>20	byte	13	CYMK color 64,
+>>20	byte	14	deep multi-channel,
+>>20	byte	15	duo tone 16,
+>>20	byte	17	RGBA color,
+>>20	byte	18	gray scale 32,
+>>20	byte	19	RGB color 12,
+>>20	byte	20	RGB color 16,
+>>20	byte	255	unknown format,
+>>20	default	x	format 
+>>>20	byte	x	\b %d,
+>>21	byte	x	%d bpc
+#	PGFPostHeader
+#	Level-Sizes
+#>>(4.l+4)	lelong x level 0 size: %d
+#>>(4.l+8)	lelong x level 1 size: %d
+#>>(4.l+12)	lelong x level 2 size: %d
+
+#------------------------------------------------------------------------------
+# $File: pgp,v 1.10 2014/10/14 16:50:37 christos Exp $
+# pgp:  file(1) magic for Pretty Good Privacy
+# see http://lists.gnupg.org/pipermail/gnupg-devel/1999-September/016052.html
+#
+0       beshort         0x9900                  PGP key public ring
+!:mime	application/x-pgp-keyring
+0       beshort         0x9501                  PGP key security ring
+!:mime	application/x-pgp-keyring
+0       beshort         0x9500                  PGP key security ring
+!:mime	application/x-pgp-keyring
+0	beshort		0xa600			PGP encrypted data
+#!:mime	application/pgp-encrypted
+#0	string		-----BEGIN\040PGP	text/PGP armored data
+!:mime	text/PGP # encoding: armored data
+#>15	string	PUBLIC\040KEY\040BLOCK-	public key block
+#>15	string	MESSAGE-		message
+#>15	string	SIGNED\040MESSAGE-	signed message
+#>15	string	PGP\040SIGNATURE-	signature
+
+2	string	---BEGIN\ PGP\ PUBLIC\ KEY\ BLOCK-	PGP public key block
+!:mime	application/pgp-keys
+>10	search/100	\n\n
+>>&0	use		pgp
+0	string	-----BEGIN\040PGP\40MESSAGE-		PGP message
+!:mime	application/pgp
+>10	search/100	\n\n
+>>&0	use		pgp
+0	string	-----BEGIN\040PGP\40SIGNATURE-		PGP signature
+!:mime	application/pgp-signature
+>10	search/100	\n\n
+>>&0	use		pgp
+
+# Decode the type of the packet based on it's base64 encoding.
+# Idea from Mark Martinec
+# The specification is in RFC 4880, section 4.2 and 4.3:
+# http://tools.ietf.org/html/rfc4880#section-4.2
+
+0	name		pgp
+>0	byte		0x67		Reserved (old)
+>0	byte		0x68		Public-Key Encrypted Session Key (old)
+>0	byte		0x69		Signature (old)
+>0	byte		0x6a		Symmetric-Key Encrypted Session Key (old)
+>0	byte		0x6b		One-Pass Signature (old)
+>0	byte		0x6c		Secret-Key (old)
+>0	byte		0x6d		Public-Key (old)
+>0	byte		0x6e		Secret-Subkey (old)
+>0	byte		0x6f		Compressed Data (old)
+>0	byte		0x70		Symmetrically Encrypted Data (old)
+>0	byte		0x71		Marker (old)
+>0	byte		0x72		Literal Data (old)
+>0	byte		0x73		Trust (old)
+>0	byte		0x74		User ID (old)
+>0	byte		0x75		Public-Subkey (old)
+>0	byte		0x76		Unused (old)
+>0	byte		0x77
+>>1	byte&0xc0	0x00		Reserved
+>>1	byte&0xc0	0x40		Public-Key Encrypted Session Key
+>>1	byte&0xc0	0x80		Signature
+>>1	byte&0xc0	0xc0		Symmetric-Key Encrypted Session Key
+>0	byte		0x78
+>>1	byte&0xc0	0x00		One-Pass Signature
+>>1	byte&0xc0	0x40		Secret-Key
+>>1	byte&0xc0	0x80		Public-Key
+>>1	byte&0xc0	0xc0		Secret-Subkey
+>0	byte		0x79
+>>1	byte&0xc0	0x00		Compressed Data
+>>1	byte&0xc0	0x40		Symmetrically Encrypted Data
+>>1	byte&0xc0	0x80		Marker
+>>1	byte&0xc0	0xc0		Literal Data
+>0	byte		0x7a
+>>1	byte&0xc0	0x00		Trust
+>>1	byte&0xc0	0x40		User ID
+>>1	byte&0xc0	0x80		Public-Subkey
+>>1	byte&0xc0	0xc0		Unused [z%x]
+>0	byte		0x30
+>>1	byte&0xc0	0x00		Unused [0%x]
+>>1	byte&0xc0	0x40		User Attribute
+>>1	byte&0xc0	0x80		Sym. Encrypted and Integrity Protected Data 
+>>1	byte&0xc0	0xc0		Modification Detection Code
+
+# magic signatures to detect PGP crypto material (from stef)
+# detects and extracts metadata from:
+#  - symmetric encrypted packet header
+#  - RSA (e=65537) secret (sub-)keys
+
+# 1024b RSA encrypted data
+
+0	string	\x84\x8c\x03		PGP RSA encrypted session key -
+>3	lelong	x			keyid: %X
+>7	lelong	x			%X
+>11	byte	0x01			RSA (Encrypt or Sign) 1024b
+>11	byte	0x02			RSA Encrypt-Only 1024b
+>12	string	\x04\x00
+>12	string	\x03\xff
+>12	string	\x03\xfe
+>12	string	\x03\xfd
+>12	string	\x03\xfc
+>12	string	\x03\xfb
+>12	string	\x03\xfa
+>12	string	\x03\xf9
+>142	byte	0xd2			.
+
+# 2048b RSA encrypted data
+
+0	string	\x85\x01\x0c\x03	PGP RSA encrypted session key -
+>4	lelong	x			keyid: %X
+>8	lelong	x			%X
+>12	byte	0x01			RSA (Encrypt or Sign) 2048b
+>12	byte	0x02			RSA Encrypt-Only 2048b
+>13	string	\x08\x00
+>13	string	\x07\xff
+>13	string	\x07\xfe
+>13	string	\x07\xfd
+>13	string	\x07\xfc
+>13	string	\x07\xfb
+>13	string	\x07\xfa
+>13	string	\x07\xf9
+>271	byte	0xd2			.
+
+# 3072b RSA encrypted data
+
+0	string	\x85\x01\x8c\x03	PGP RSA encrypted session key -
+>4	lelong	x			keyid: %X
+>8	lelong	x			%X
+>12	byte	0x01			RSA (Encrypt or Sign) 3072b
+>12	byte	0x02			RSA Encrypt-Only 3072b
+>13	string	\x0c\x00
+>13	string	\x0b\xff
+>13	string	\x0b\xfe
+>13	string	\x0b\xfd
+>13	string	\x0b\xfc
+>13	string	\x0b\xfb
+>13	string	\x0b\xfa
+>13	string	\x0b\xf9
+>399	byte	0xd2			.
+
+# 3072b RSA encrypted data
+
+0	string	\x85\x02\x0c\x03	PGP RSA encrypted session key -
+>4	lelong	x			keyid: %X
+>8	lelong	x			%X
+>12	byte	0x01			RSA (Encrypt or Sign) 4096b
+>12	byte	0x02			RSA Encrypt-Only 4096b
+>13	string	\x10\x00
+>13	string	\x0f\xff
+>13	string	\x0f\xfe
+>13	string	\x0f\xfd
+>13	string	\x0f\xfc
+>13	string	\x0f\xfb
+>13	string	\x0f\xfa
+>13	string	\x0f\xf9
+>527	byte	0xd2			.
+
+# 4096b RSA encrypted data
+
+0	string	\x85\x04\x0c\x03	PGP RSA encrypted session key -
+>4	lelong	x			keyid: %X
+>8	lelong	x			%X
+>12	byte	0x01			RSA (Encrypt or Sign) 8129b
+>12	byte	0x02			RSA Encrypt-Only 8129b
+>13	string	\x20\x00
+>13	string	\x1f\xff
+>13	string	\x1f\xfe
+>13	string	\x1f\xfd
+>13	string	\x1f\xfc
+>13	string	\x1f\xfb
+>13	string	\x1f\xfa
+>13	string	\x1f\xf9
+>1039	byte	0xd2			.
+
+# crypto algo mapper
+
+0	name	crypto
+>0	byte	0x00			Plaintext or unencrypted data
+>0	byte	0x01			IDEA
+>0	byte	0x02			TripleDES
+>0	byte	0x03			CAST5 (128 bit key)
+>0	byte	0x04			Blowfish (128 bit key, 16 rounds)
+>0	byte	0x07			AES with 128-bit key
+>0	byte	0x08			AES with 192-bit key
+>0	byte	0x09			AES with 256-bit key
+>0	byte	0x0a			Twofish with 256-bit key
+
+# hash algo mapper
+
+0	name	hash
+>0	byte	0x01			MD5
+>0	byte	0x02			SHA-1
+>0	byte	0x03			RIPE-MD/160
+>0	byte	0x08			SHA256
+>0	byte	0x09			SHA384
+>0	byte	0x0a			SHA512
+>0	byte	0x0b			SHA224
+
+# pgp symmetric encrypted data
+
+0	byte	0x8c			PGP symmetric key encrypted data -
+>1	byte	0x0d
+>1	byte	0x0c
+>2	byte	0x04
+>3	use	crypto
+>4	byte	0x01			salted -
+>>5	use	hash
+>>14	byte	0xd2			.
+>>14	byte	0xc9			.
+>4	byte	0x03			salted & iterated -
+>>5	use	hash
+>>15	byte	0xd2			.
+>>15	byte	0xc9			.
+
+# encrypted keymaterial needs s2k & can be checksummed/hashed
+
+0	name	chkcrypto
+>0	use	crypto
+>1	byte	0x00			Simple S2K
+>1	byte	0x01			Salted S2K
+>1	byte	0x03			Salted&Iterated S2K
+>2	use	hash
+
+# all PGP keys start with this prolog
+# containing version, creation date, and purpose
+
+0	name	keyprolog
+>0	byte	0x04
+>1	beldate	x			created on %s -
+>5	byte	0x01			RSA (Encrypt or Sign)
+>5	byte	0x02			RSA Encrypt-Only
+
+# end of secret keys known signature
+# contains e=65537 and the prolog to
+# the encrypted parameters
+
+0	name	keyend
+>0	string	\x00\x11\x01\x00\x01	e=65537
+>5	use	crypto
+>5	byte	0xff			checksummed
+>>6	use	chkcrypto
+>5	byte	0xfe			hashed
+>>6	use	chkcrypto
+
+# PGP secret keys contain also the public parts
+# these vary by bitsize of the key
+
+0	name	x1024
+>0	use	keyprolog
+>6	string	\x03\xfe
+>6	string	\x03\xff
+>6	string	\x04\x00
+>136	use	keyend
+
+0	name	x2048
+>0	use	keyprolog
+>6	string	\x80\x00
+>6	string	\x07\xfe
+>6	string	\x07\xff
+>264	use	keyend
+
+0	name	x3072
+>0	use	keyprolog
+>6	string	\x0b\xfe
+>6	string	\x0b\xff
+>6	string	\x0c\x00
+>392	use	keyend
+
+0	name	x4096
+>0	use	keyprolog
+>6	string	\x10\x00
+>6	string	\x0f\xfe
+>6	string	\x0f\xff
+>520	use	keyend
+
+# \x00|\x1f[\xfe\xff]).{1024})'
+0	name	x8192
+>0	use	keyprolog
+>6	string	\x20\x00
+>6	string	\x1f\xfe
+>6	string	\x1f\xff
+>1032	use	keyend
+
+# depending on the size of the pkt
+# we branch into the proper key size
+# signatures defined as x{keysize}
+
+>0	name	pgpkey
+>0	string	\x01\xd8	1024b
+>>2	use	x1024
+>0	string	\x01\xeb	1024b
+>>2	use	x1024
+>0	string	\x01\xfb	1024b
+>>2	use	x1024
+>0	string	\x01\xfd	1024b
+>>2	use	x1024
+>0	string	\x01\xf3	1024b
+>>2	use	x1024
+>0	string	\x01\xee	1024b
+>>2	use	x1024
+>0	string	\x01\xfe	1024b
+>>2	use	x1024
+>0	string	\x01\xf4	1024b
+>>2	use	x1024
+>0	string	\x02\x0d	1024b
+>>2	use	x1024
+>0	string	\x02\x03	1024b
+>>2	use	x1024
+>0	string	\x02\x05	1024b
+>>2	use	x1024
+>0	string	\x02\x15	1024b
+>>2	use	x1024
+>0	string	\x02\x00	1024b
+>>2	use	x1024
+>0	string	\x02\x10	1024b
+>>2	use	x1024
+>0	string	\x02\x04	1024b
+>>2	use	x1024
+>0	string	\x02\x06	1024b
+>>2	use	x1024
+>0	string	\x02\x16	1024b
+>>2	use	x1024
+>0	string	\x03\x98	2048b
+>>2	use	x2048
+>0	string	\x03\xab	2048b
+>>2	use	x2048
+>0	string	\x03\xbb	2048b
+>>2	use	x2048
+>0	string	\x03\xbd	2048b
+>>2	use	x2048
+>0	string	\x03\xcd	2048b
+>>2	use	x2048
+>0	string	\x03\xb3	2048b
+>>2	use	x2048
+>0	string	\x03\xc3	2048b
+>>2	use	x2048
+>0	string	\x03\xc5	2048b
+>>2	use	x2048
+>0	string	\x03\xd5	2048b
+>>2	use	x2048
+>0	string	\x03\xae	2048b
+>>2	use	x2048
+>0	string	\x03\xbe	2048b
+>>2	use	x2048
+>0	string	\x03\xc0	2048b
+>>2	use	x2048
+>0	string	\x03\xd0	2048b
+>>2	use	x2048
+>0	string	\x03\xb4	2048b
+>>2	use	x2048
+>0	string	\x03\xc4	2048b
+>>2	use	x2048
+>0	string	\x03\xc6	2048b
+>>2	use	x2048
+>0	string	\x03\xd6	2048b
+>>2	use	x2048
+>0	string	\x05X		3072b
+>>2	use	x3072
+>0	string	\x05k		3072b
+>>2	use	x3072
+>0	string	\x05{		3072b
+>>2	use	x3072
+>0	string	\x05}		3072b
+>>2	use	x3072
+>0	string	\x05\x8d	3072b
+>>2	use	x3072
+>0	string	\x05s		3072b
+>>2	use	x3072
+>0	string	\x05\x83	3072b
+>>2	use	x3072
+>0	string	\x05\x85	3072b
+>>2	use	x3072
+>0	string	\x05\x95	3072b
+>>2	use	x3072
+>0	string	\x05n		3072b
+>>2	use	x3072
+>0	string	\x05\x7e	3072b
+>>2	use	x3072
+>0	string	\x05\x80	3072b
+>>2	use	x3072
+>0	string	\x05\x90	3072b
+>>2	use	x3072
+>0	string	\x05t		3072b
+>>2	use	x3072
+>0	string	\x05\x84	3072b
+>>2	use	x3072
+>0	string	\x05\x86	3072b
+>>2	use	x3072
+>0	string	\x05\x96	3072b
+>>2	use	x3072
+>0	string	\x07[		4096b
+>>2	use	x4096
+>0	string	\x07\x18	4096b
+>>2	use	x4096
+>0	string	\x07+		4096b
+>>2	use	x4096
+>0	string	\x07;		4096b
+>>2	use	x4096
+>0	string	\x07=		4096b
+>>2	use	x4096
+>0	string	\x07M		4096b
+>>2	use	x4096
+>0	string	\x073		4096b
+>>2	use	x4096
+>0	string	\x07C		4096b
+>>2	use	x4096
+>0	string	\x07E		4096b
+>>2	use	x4096
+>0	string	\x07U		4096b
+>>2	use	x4096
+>0	string	\x07.		4096b
+>>2	use	x4096
+>0	string	\x07>		4096b
+>>2	use	x4096
+>0	string	\x07@		4096b
+>>2	use	x4096
+>0	string	\x07P		4096b
+>>2	use	x4096
+>0	string	\x074		4096b
+>>2	use	x4096
+>0	string	\x07D		4096b
+>>2	use	x4096
+>0	string	\x07F		4096b
+>>2	use	x4096
+>0	string	\x07V		4096b
+>>2	use	x4096
+>0	string	\x0e[		8192b
+>>2	use	x8192
+>0	string	\x0e\x18	8192b
+>>2	use	x8192
+>0	string	\x0e+		8192b
+>>2	use	x8192
+>0	string	\x0e;		8192b
+>>2	use	x8192
+>0	string	\x0e=		8192b
+>>2	use	x8192
+>0	string	\x0eM		8192b
+>>2	use	x8192
+>0	string	\x0e3		8192b
+>>2	use	x8192
+>0	string	\x0eC		8192b
+>>2	use	x8192
+>0	string	\x0eE		8192b
+>>2	use	x8192
+>0	string	\x0eU		8192b
+>>2	use	x8192
+>0	string	\x0e.		8192b
+>>2	use	x8192
+>0	string	\x0e>		8192b
+>>2	use	x8192
+>0	string	\x0e@		8192b
+>>2	use	x8192
+>0	string	\x0eP		8192b
+>>2	use	x8192
+>0	string	\x0e4		8192b
+>>2	use	x8192
+>0	string	\x0eD		8192b
+>>2	use	x8192
+>0	string	\x0eF		8192b
+>>2	use	x8192
+>0	string	\x0eV		8192b
+>>2	use	x8192
+
+# PGP RSA (e=65537) secret (sub-)key header
+
+0	byte	0x95			PGP	Secret Key -
+>1	use	pgpkey
+0	byte	0x97			PGP	Secret Sub-key -
+>1	use	pgpkey
+0	byte	0x9d			PGP	Secret Sub-key -
+>1	use	pgpkey
+
+#------------------------------------------------------------------------------
+# $File$
+# pkgadd:  file(1) magic for SysV R4 PKG Datastreams
+#
+0       string          #\ PaCkAgE\ DaTaStReAm  pkg Datastream (SVR4)
+!:mime	application/x-svr4-package
+
+#------------------------------------------------------------------------------
+# $File$
+# plan9:  file(1) magic for AT&T Bell Labs' Plan 9 executables
+# From: "Stefan A. Haubenthal" <polluks@web.de>
+#
+0	belong		0x00000107	Plan 9 executable, Motorola 68k
+0	belong		0x000001EB	Plan 9 executable, Intel 386
+0	belong		0x00000247	Plan 9 executable, Intel 960
+0	belong		0x000002AB	Plan 9 executable, SPARC
+0	belong		0x00000407	Plan 9 executable, MIPS R3000
+0	belong		0x0000048B	Plan 9 executable, AT&T DSP 3210
+0	belong		0x00000517	Plan 9 executable, MIPS R4000 BE
+0	belong		0x000005AB	Plan 9 executable, AMD 29000
+0	belong		0x00000647	Plan 9 executable, ARM 7-something
+0	belong		0x000006EB	Plan 9 executable, PowerPC
+0	belong		0x00000797	Plan 9 executable, MIPS R4000 LE
+0	belong		0x0000084B	Plan 9 executable, DEC Alpha
+
+#------------------------------------------------------------------------------
+# $File$
+# plus5:  file(1) magic for Plus Five's UNIX MUMPS
+#
+# XXX - byte order?  Paging Hokey....
+#
+0	short		0x259		mumps avl global
+>2	byte		>0		(V%d)
+>6	byte		>0		with %d byte name
+>7	byte		>0		and %d byte data cells
+0	short		0x25a		mumps blt global
+>2	byte		>0		(V%d)
+>8	short		>0		- %d byte blocks
+>15	byte		0x00		- P/D format
+>15	byte		0x01		- P/K/D format
+>15	byte		0x02		- K/D format
+>15	byte		>0x02		- Bad Flags
+
+#------------------------------------------------------------------------------
+# $File: printer,v 1.25 2011/05/20 23:31:46 christos Exp $
+# printer:  file(1) magic for printer-formatted files
+#
+
+# PostScript, updated by Daniel Quinlan (quinlan@yggdrasil.com)
+0	string		%!		PostScript document text
+!:mime	application/postscript
+!:apple	ASPSTEXT
+>2	string		PS-Adobe-	conforming
+>>11	string		>\0		DSC level %.3s
+>>>15	string		EPS		\b, type %s
+>>>15	string		Query		\b, type %s
+>>>15	string		ExitServer	\b, type %s
+>>>15   search/1000		%%LanguageLevel:\ 
+>>>>&0	string		>\0		\b, Level %s
+# Some PCs have the annoying habit of adding a ^D as a document separator
+0	string		\004%!		PostScript document text
+!:mime	application/postscript
+!:apple	ASPSTEXT
+>3	string		PS-Adobe-	conforming
+>>12	string		>\0		DSC level %.3s
+>>>16	string		EPS		\b, type %s
+>>>16	string		Query		\b, type %s
+>>>16	string		ExitServer	\b, type %s
+>>>16   search/1000		%%LanguageLevel:\ 
+>>>>&0	string		>\0		\b, Level %s
+0	string		\033%-12345X%!PS	PostScript document
+
+# DOS EPS Binary File Header
+# From: Ed Sznyter <ews@Black.Market.NET>
+0       belong          0xC5D0D3C6      DOS EPS Binary File
+>4      long            >0              Postscript starts at byte %d
+>>8     long            >0              length %d
+>>>12   long            >0              Metafile starts at byte %d
+>>>>16  long            >0              length %d
+>>>20   long            >0              TIFF starts at byte %d
+>>>>24  long            >0              length %d
+
+# Summary: Adobe's PostScript Printer Description File
+# Extension: .ppd
+# Reference: http://partners.adobe.com/public/developer/en/ps/5003.PPD_Spec_v4.3.pdf, Section 3.8
+# Submitted by: Yves Arrouye <arrouye@marin.fdn.fr>
+#
+0	string		*PPD-Adobe:\x20	PPD file
+>&0	string		x		\b, version %s
+
+# HP Printer Job Language
+0	string		\033%-12345X@PJL	HP Printer Job Language data
+# HP Printer Job Language
+# The header found on Win95 HP plot files is the "Silliest Thing possible" 
+# (TM)
+# Every driver puts the language at some random position, with random case
+# (LANGUAGE and Language)
+# For example the LaserJet 5L driver puts the "PJL ENTER LANGUAGE" in line 10
+# From: Uwe Bonnes <bon@elektron.ikp.physik.th-darmstadt.de>
+# 
+0	string		\033%-12345X@PJL	HP Printer Job Language data
+>&0	string		>\0			%s			
+>>&0	string		>\0			%s			
+>>>&0	string		>\0			%s		
+>>>>&0	string		>\0			%s		
+#>15	string		\ ENTER\ LANGUAGE\ =
+#>31	string		PostScript		PostScript
+
+# From: Stefan Thurner <thurners@nicsys.de>
+0	string		\033%-12345X@PJL
+>&0	search/10000	%!			PJL encapsulated PostScript document text
+
+# Rick Richardson <rickrich@gmail.com>
+
+# For Fuji-Xerox Printers - HBPL stands for Host Based Printer Language
+# For Oki Data Printers - HIPERC
+# For Konica Minolta Printers - LAVAFLOW
+# For Samsung Printers - QPDL
+# For HP Printers - ZJS stands for Zenographics ZJStream
+0	string		\033%-12345X@PJL	HP Printer Job Language data
+>0	search/10000	@PJL\ ENTER\ LANGUAGE=HBPL	- HBPL
+>0	search/10000	@PJL\ ENTER\ LANGUAGE=HIPERC	- Oki Data HIPERC
+>0	search/10000	@PJL\ ENTER\ LANGUAGE=LAVAFLOW	- Konica Minolta LAVAFLOW
+>0	search/10000	@PJL\ ENTER\ LANGUAGE=QPDL	- Samsung QPDL
+>0	search/10000	@PJL\ ENTER\ LANGUAGE\ =\ QPDL	- Samsung QPDL
+>0	search/10000	@PJL\ ENTER\ LANGUAGE=ZJS	- HP ZJS
+
+
+# HP Printer Control Language, Daniel Quinlan (quinlan@yggdrasil.com)
+0	string		\033E\033	HP PCL printer data
+>3	string		\&l0A		- default page size
+>3	string		\&l1A		- US executive page size
+>3	string		\&l2A		- US letter page size
+>3	string		\&l3A		- US legal page size
+>3	string		\&l26A		- A4 page size
+>3	string		\&l80A		- Monarch envelope size
+>3	string		\&l81A		- No. 10 envelope size
+>3	string		\&l90A		- Intl. DL envelope size
+>3	string		\&l91A		- Intl. C5 envelope size
+>3	string		\&l100A		- Intl. B5 envelope size
+>3	string		\&l-81A		- No. 10 envelope size (landscape)
+>3	string		\&l-90A		- Intl. DL envelope size (landscape)
+
+# IMAGEN printer-ready files:
+0	string	@document(		Imagen printer
+# this only works if "language xxx" is first item in Imagen header.
+>10	string	language\ impress	(imPRESS data)
+>10	string	language\ daisy		(daisywheel text)
+>10	string	language\ diablo	(daisywheel text)
+>10	string	language\ printer	(line printer emulation)
+>10	string	language\ tektronix	(Tektronix 4014 emulation)
+# Add any other languages that your Imagen uses - remember
+# to keep the word `text' if the file is human-readable.
+# [GRR 950115:  missing "postscript" or "ultrascript" (whatever it was called)]
+#
+# Now magic for IMAGEN font files...
+0	string		Rast		RST-format raster font data
+>45	string		>0		face %s
+# From Jukka Ukkonen
+0	string		\033[K\002\0\0\017\033(a\001\0\001\033(g	Canon Bubble Jet BJC formatted data
+
+# From <mike@flyn.org>
+# These are the /etc/magic entries to decode data sent to an Epson printer.
+0       string          \x1B\x40\x1B\x28\x52\x08\x00\x00REMOTE1P        Epson Stylus Color 460 data
+
+
+#------------------------------------------------------------------------------
+# zenographics:  file(1) magic for Zenographics ZjStream printer data
+# Rick Richardson <rickrich@gmail.com>
+0	string		JZJZ
+>0x12	string		ZZ		Zenographics ZjStream printer data (big-endian)
+0	string		ZJZJ
+>0x12	string		ZZ		Zenographics ZjStream printer data (little-endian)
+
+
+#------------------------------------------------------------------------------
+# Oak Technologies printer stream
+# Rick Richardson <rickrich@gmail.com>
+0       string          OAK
+>0x07	byte		0
+>0x0b	byte		0	Oak Technologies printer stream
+
+# This would otherwise be recognized as PostScript - nick@debian.org
+0	string		%!VMF 		SunClock's Vector Map Format data
+
+#------------------------------------------------------------------------------
+# HP LaserJet 1000 series downloadable firmware file
+0	string	\xbe\xefABCDEFGH	HP LaserJet 1000 series downloadable firmware   
+
+# From: Paolo <oopla@users.sf.net>
+# Epson ESC/Page, ESC/PageColor 
+0	string	\x1b\x01@EJL	Epson ESC/Page language printer data
+
+#------------------------------------------------------------------------------
+# $File$
+# project:  file(1) magic for Project management
+# 
+# Magic strings for ftnchek project files. Alexander Mai
+0	string	FTNCHEK_\ P	project file for ftnchek
+>10	string	1		version 2.7
+>10	string	2		version 2.8 to 2.10
+>10	string	3		version 2.11 or later
+
+#------------------------------------------------------------------------------
+# $File$
+# psdbms:  file(1) magic for psdatabase
+#
+0	belong&0xff00ffff	0x56000000	ps database
+>1	string	>\0	version %s
+>4	string	>\0	from kernel %s
+
+#------------------------------------------------------------------------------
+# $File$
+# pulsar:  file(1) magic for Pulsar POP3 daemon binary files
+#
+# http://pulsar.sourceforge.net
+# mailto:rok.papez@lugos.si
+#
+
+0	belong	0x1ee7f11e	Pulsar POP3 daemon mailbox cache file.
+>4	ubelong	x		Version: %d.
+>8	ubelong	x		\b%d
+
+
+#------------------------------------------------------------------------------
+# $File: vax,v 1.7 2009/09/19 16:28:13 christos Exp $
+# pwsafe: file(1) magic for passwordsafe file
+#
+# Password Safe
+# http://passwordsafe.sourceforge.net/
+# file format specs
+# http://passwordsafe.svn.sourceforge.net/viewvc/passwordsafe/trunk/pwsafe/pwsafe/docs/formatV3.txt
+# V2 http://passwordsafe.svn.sourceforge.net/viewvc/passwordsafe/trunk/pwsafe/pwsafe/docs/formatV2.txt
+# V1 http://passwordsafe.svn.sourceforge.net/viewvc/passwordsafe/trunk/pwsafe/pwsafe/docs/notes.txt
+# V2 and V1 have no easy identifier that I can find
+# .psafe3
+0	string	PWS3	Password Safe V3 database
+
+#------------------------------------------------------------------------------
+# $File$
+# pyramid:  file(1) magic for Pyramids
+#
+# XXX - byte order?
+#
+0	long		0x50900107	Pyramid 90x family executable
+0	long		0x50900108	Pyramid 90x family pure executable
+>16	long		>0		not stripped
+0	long		0x5090010b	Pyramid 90x family demand paged pure executable
+>16	long		>0		not stripped
+
+#------------------------------------------------------------------------------
+# $File: python,v 1.25 2014/05/06 16:08:32 christos Exp $
+# python:  file(1) magic for python
+#
+# Outlook puts """ too for urgent messages
+# From: David Necas <yeti@physics.muni.cz>
+# often the module starts with a multiline string
+0	string/t	"""	Python script text executable
+# MAGIC as specified in Python/import.c (1.5 to 2.7a0 and 3.1a0, assuming
+# that Py_UnicodeFlag is off for Python 2)
+# 20121  ( YEAR - 1995 ) + MONTH  + DAY (little endian followed by "\r\n"
+0	belong		0x994e0d0a	python 1.5/1.6 byte-compiled
+0	belong		0x87c60d0a	python 2.0 byte-compiled
+0	belong		0x2aeb0d0a	python 2.1 byte-compiled
+0	belong		0x2ded0d0a	python 2.2 byte-compiled
+0	belong		0x3bf20d0a	python 2.3 byte-compiled
+0	belong		0x6df20d0a	python 2.4 byte-compiled
+0	belong		0xb3f20d0a	python 2.5 byte-compiled
+0	belong		0xd1f20d0a	python 2.6 byte-compiled
+0	belong		0x03f30d0a	python 2.7 byte-compiled
+0	belong		0x3b0c0d0a	python 3.0 byte-compiled
+0	belong		0x4f0c0d0a	python 3.1 byte-compiled
+0	belong		0x6c0c0d0a	python 3.2 byte-compiled
+0	belong		0x9e0c0d0a	python 3.3 byte-compiled
+0	belong		0xee0c0d0a	python 3.4 byte-compiled
+
+0	search/1/w	#!\ /usr/bin/python	Python script text executable
+!:mime text/x-python
+0	search/1/w	#!\ /usr/local/bin/python	Python script text executable
+!:mime text/x-python
+0	search/1	#!/usr/bin/env\ python	Python script text executable
+!:mime text/x-python
+0	search/1	#!\ /usr/bin/env\ python	Python script text executable
+!:mime text/x-python
+
+
+# from module.submodule import func1, func2
+0	regex	\^from\\s+(\\w|\\.)+\\s+import.*$	Python script text executable
+!:mime text/x-python
+
+# def __init__ (self, ...):
+0	search/4096	def\ __init__
+>&0	search/64 self	Python script text executable
+!:mime text/x-python
+
+# comments
+#0	search/4096	'''
+#>&0	regex	.*'''$	Python script text executable
+#!:mime text/x-python
+
+#0	search/4096	"""
+#>&0	regex	.*"""$	Python script text executable
+#!:mime text/x-python
+
+# try:
+# except: or finally:
+# block
+0	search/4096	try:
+>&0	regex	\^\\s*except.*:	Python script text executable
+!:mime text/x-python
+>&0	search/4096	finally:	Python script text executable
+!:mime text/x-python
+
+# def name(args, args):
+0	regex	 \^(\ |\\t){0,50}def\ {1,50}[a-zA-Z]{1,100}
+>&0	regex	\ {0,50}\\(([a-zA-Z]|,|\ ){1,255}\\):$ Python script text executable
+!:mime text/x-python
+
+#------------------------------------------------------------------------------
+# $File: qt,v 1.1 2014/12/12 16:48:39 christos Exp $
+# qt:  file(1) magic for Qt
+
+# http://doc.qt.io/qt-5/resources.html
+0	string		\<!DOCTYPE\040RCC\>	Qt Resource Collection file
+
+# https://qt.gitorious.org/qt/qtbase/source/\
+# 5367fa356233da4c0f28172a8f817791525f5457:\
+# src/tools/rcc/rcc.cpp#L840
+0	string		qres\0\0		Qt Binary Resource file
+0	search/1024	The\040Resource\040Compiler\040for\040Qt	Qt C-code resource file
+
+# https://qt.gitorious.org/qt/qtbase/source/\
+# 5367fa356233da4c0f28172a8f817791525f5457:\
+# src/corelib/kernel/qtranslator.cpp#L62
+0	string		\x3c\xb8\x64\x18\xca\xef\x9c\x95
+>8	string		\xcd\x21\x1c\xbf\x60\xa1\xbd\xdd	Qt Translation file
+
+#------------------------------------------------------------------------------
+# $File: revision,v 1.8 2010/11/25 15:00:12 christos Exp $
+# file(1) magic for revision control files
+# From Hendrik Scholz <hendrik@scholz.net>
+0	string/t	/1\ :pserver:	cvs password text file
+
+# Conary changesets
+# From: Jonathan Smith <smithj@rpath.com>
+0	belong	0xea3f81bb	Conary changeset data
+
+# Type: Git bundles (git-bundle)
+# From: Josh Triplett <josh@freedesktop.org>
+0	string	#\ v2\ git\ bundle\n	Git bundle
+
+# Type: Git pack
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+# The actual magic is 'PACK', but that clashes with Doom/Quake packs. However,
+# those have a little-endian offset immediately following the magic 'PACK',
+# the first byte of which is never 0, while the first byte of the Git pack
+# version, since it's a tiny number stored in big-endian format, is always 0.
+0	string	PACK\0		Git pack
+>4	belong	>0		\b, version %d
+>>8	belong	>0		\b, %d objects
+
+# Type: Git pack index
+# From: Adam Buchbinder <adam.buchbinder@gmail.com>
+0	string	\377tOc		Git pack index
+>4	belong	=2		\b, version 2
+
+# Type: Git index file
+# From: Frederic Briare <fbriere@fbriere.net>
+0	string	DIRC		Git index
+>4	belong	>0		\b, version %d
+>>8	belong	>0		\b, %d entries
+
+# Type:	Mercurial bundles
+# From:	Seo Sanghyeon <tinuviel@sparcs.kaist.ac.kr>
+0	string	HG10		Mercurial bundle,
+>4	string	UN		uncompressed
+>4	string	BZ		bzip2 compressed
+
+# Type:	Subversion (SVN) dumps
+# From:	Uwe Zeisberger <zeisberg@informatik.uni-freiburg.de>
+0	string	SVN-fs-dump-format-version:	Subversion dumpfile
+>28	string	>\0				(version: %s)
+
+# Type:	Bazaar revision bundles and merge requests
+# URL:	http://www.bazaar-vcs.org/
+# From:	Jelmer Vernooij <jelmer@samba.org>
+0	string	#\ Bazaar\ revision\ bundle\ v Bazaar Bundle
+0	string	#\ Bazaar\ merge\ directive\ format Bazaar merge directive
+
+#------------------------------------------------------------------------------
+# $File: riff,v 1.30 2014/09/23 17:02:12 christos Exp $
+# riff:  file(1) magic for RIFF format
+# See
+#
+#	http://www.seanet.com/users/matts/riffmci/riffmci.htm
+#
+
+# audio format tag. Assume limits: max 1024 bit, 128 channels, 1 MHz
+0   name    riff-wave
+>0	leshort		1		\b, Microsoft PCM
+>>14	leshort		>0
+>>>14	leshort		<1024	\b, %d bit
+>0	leshort		2		\b, Microsoft ADPCM
+>0	leshort		6		\b, ITU G.711 A-law
+>0	leshort		7		\b, ITU G.711 mu-law
+>0	leshort		8		\b, Microsoft DTS
+>0	leshort		17		\b, IMA ADPCM
+>0	leshort		20		\b, ITU G.723 ADPCM (Yamaha)
+>0	leshort		49		\b, GSM 6.10
+>0	leshort		64		\b, ITU G.721 ADPCM
+>0	leshort		80		\b, MPEG
+>0	leshort		85		\b, MPEG Layer 3
+>0	leshort		0x2001		\b, DTS
+>2	leshort		=1		\b, mono
+>2	leshort		=2		\b, stereo
+>2	leshort		>2
+>>2	leshort		<128	\b, %d channels
+>4	lelong		>0
+>>4	lelong		<1000000	%d Hz
+
+# try to find "fmt "
+0   name    riff-walk
+>0  string  fmt\x20
+>>4 lelong  <0x80
+>>>8 use    riff-wave
+>0  string  LIST
+>>&(4.l+4)  use riff-walk
+>0  string  DISP
+>>&(4.l+4)  use riff-walk
+>0  string  bext
+>>&(4.l+4)  use riff-walk
+>0  string  Fake
+>>&(4.l+4)  use riff-walk
+>0  string  fact
+>>&(4.l+4)  use riff-walk
+>0  string  VP8
+>>11		byte		0x9d
+>>>12		byte		0x01
+>>>>13		byte		0x2a	\b, VP8 encoding
+>>>>>14		leshort&0x3fff	x	\b, %d
+>>>>>16		leshort&0x3fff	x	\bx%d, Scaling:
+>>>>>14		leshort&0xc000	0x0000	\b [none]
+>>>>>14		leshort&0xc000	0x1000	\b [5/4]
+>>>>>14		leshort&0xc000	0x2000	\b [5/3]
+>>>>>14		leshort&0xc000	0x3000	\b [2]
+>>>>>14		leshort&0xc000	0x0000	\bx[none]
+>>>>>14		leshort&0xc000	0x1000	\bx[5/4]
+>>>>>14		leshort&0xc000	0x2000	\bx[5/3]
+>>>>>14		leshort&0xc000	0x3000	\bx[2]
+>>>>>15		byte&0x80	=0x00	\b, YUV color
+>>>>>15		byte&0x80	=0x80	\b, bad color specification
+>>>>>15		byte&0x40	=0x40	\b, no clamping required
+>>>>>15		byte&0x40	=0x00	\b, decoders should clamp
+#>0  string  x		we got %s
+#>>&(4.l+4)  use riff-walk
+
+# AVI section extended by Patrik Radman <patrik+file-magic@iki.fi>
+#
+0	string		RIFF		RIFF (little-endian) data
+# RIFF Palette format
+>8	string		PAL		\b, palette
+>>16	leshort		x		\b, version %d
+>>18	leshort		x		\b, %d entries
+# RIFF Device Independent Bitmap format
+>8	string		RDIB		\b, device-independent bitmap
+>>16	string		BM		
+>>>30	leshort		12		\b, OS/2 1.x format
+>>>>34	leshort		x		\b, %d x
+>>>>36	leshort		x		%d
+>>>30	leshort		64		\b, OS/2 2.x format
+>>>>34	leshort		x		\b, %d x
+>>>>36	leshort		x		%d
+>>>30	leshort		40		\b, Windows 3.x format
+>>>>34	lelong		x		\b, %d x
+>>>>38	lelong		x		%d x
+>>>>44	leshort		x		%d
+# RIFF MIDI format
+>8	string		RMID		\b, MIDI
+# RIFF Multimedia Movie File format
+>8	string		RMMP		\b, multimedia movie
+# RIFF wrapper for MP3
+>8	string		RMP3		\b, MPEG Layer 3 audio
+# Microsoft WAVE format (*.wav)
+>8	string		WAVE		\b, WAVE audio
+!:mime	audio/x-wav
+>>12    string  >\0
+>>>12   use     riff-walk
+# Corel Draw Picture
+>8	string		CDRA		\b, Corel Draw Picture
+!:mime	image/x-coreldraw
+>8	string		CDR6		\b, Corel Draw Picture, version 6
+!:mime	image/x-coreldraw
+>8	string		NUNDROOT	\b, Steinberg CuBase
+# AVI == Audio Video Interleave
+>8	string		AVI\040		\b, AVI
+!:mime	video/x-msvideo
+>>12    string          LIST
+>>>20   string          hdrlavih
+>>>>&36 lelong          x               \b, %u x
+>>>>&40 lelong          x               %u,
+>>>>&4  lelong          >1000000        <1 fps,
+>>>>&4  lelong          1000000         1.00 fps,
+>>>>&4  lelong          500000          2.00 fps,
+>>>>&4  lelong          333333          3.00 fps,
+>>>>&4  lelong          250000          4.00 fps,
+>>>>&4  lelong          200000          5.00 fps,
+>>>>&4  lelong          166667          6.00 fps,
+>>>>&4  lelong          142857          7.00 fps,
+>>>>&4  lelong          125000          8.00 fps,
+>>>>&4  lelong          111111          9.00 fps,
+>>>>&4  lelong          100000          10.00 fps,
+# ]9.9,10.1[
+>>>>&4  lelong          <101010
+>>>>>&-4        lelong  >99010
+>>>>>>&-4       lelong  !100000         ~10 fps,
+>>>>&4  lelong          83333           12.00 fps,
+# ]11.9,12.1[
+>>>>&4  lelong          <84034
+>>>>>&-4        lelong  >82645
+>>>>>>&-4       lelong  !83333          ~12 fps,
+>>>>&4  lelong          66667           15.00 fps,
+# ]14.9,15.1[
+>>>>&4  lelong          <67114
+>>>>>&-4        lelong  >66225
+>>>>>>&-4       lelong  !66667          ~15 fps,
+>>>>&4  lelong          50000           20.00 fps,
+>>>>&4  lelong          41708           23.98 fps,
+>>>>&4  lelong          41667           24.00 fps,
+# ]23.9,24.1[
+>>>>&4  lelong          <41841
+>>>>>&-4        lelong  >41494
+>>>>>>&-4       lelong  !41708
+>>>>>>>&-4      lelong  !41667          ~24 fps,
+>>>>&4  lelong          40000           25.00 fps,
+# ]24.9,25.1[
+>>>>&4  lelong          <40161
+>>>>>&-4        lelong  >39841
+>>>>>>&-4       lelong  !40000          ~25 fps,
+>>>>&4  lelong          33367           29.97 fps,
+>>>>&4  lelong          33333           30.00 fps,
+# ]29.9,30.1[
+>>>>&4  lelong          <33445
+>>>>>&-4        lelong  >33223
+>>>>>>&-4       lelong  !33367
+>>>>>>>&-4      lelong  !33333          ~30 fps,
+>>>>&4  lelong          <32224          >30 fps,
+##>>>>&4  lelong          x               (%lu)
+##>>>>&20 lelong          x               %lu frames,
+# Note: The tests below assume that the AVI has 1 or 2 streams,
+#       "vids" optionally followed by "auds".
+#       (Should cover 99.9% of all AVIs.)
+# assuming avih length = 56
+>>>88   string  LIST
+>>>>96  string  strlstrh
+>>>>>108        string  vids    video:
+>>>>>>&0        lelong  0               uncompressed
+# skip past vids strh
+>>>>>>(104.l+108)       string  strf
+>>>>>>>(104.l+132)      lelong          1       RLE 8bpp
+>>>>>>>(104.l+132)      string/c        cvid    Cinepak
+>>>>>>>(104.l+132)      string/c        i263    Intel I.263
+>>>>>>>(104.l+132)      string/c        iv32    Indeo 3.2
+>>>>>>>(104.l+132)      string/c        iv41    Indeo 4.1
+>>>>>>>(104.l+132)      string/c        iv50    Indeo 5.0
+>>>>>>>(104.l+132)      string/c        mp42    Microsoft MPEG-4 v2
+>>>>>>>(104.l+132)      string/c        mp43    Microsoft MPEG-4 v3
+>>>>>>>(104.l+132)      string/c        fmp4    FFMpeg MPEG-4
+>>>>>>>(104.l+132)      string/c        mjpg    Motion JPEG
+>>>>>>>(104.l+132)      string/c        div3    DivX 3
+>>>>>>>>112             string/c        div3    Low-Motion
+>>>>>>>>112             string/c        div4    Fast-Motion
+>>>>>>>(104.l+132)      string/c        divx    DivX 4
+>>>>>>>(104.l+132)      string/c        dx50    DivX 5
+>>>>>>>(104.l+132)      string/c        xvid    XviD
+>>>>>>>(104.l+132)	string/c	h264	H.264
+>>>>>>>(104.l+132)      string/c        wmv3    Windows Media Video 9
+>>>>>>>(104.l+132)      string/c        h264    X.264 or H.264
+>>>>>>>(104.l+132)      lelong  0
+##>>>>>>>(104.l+132)      string  x       (%.4s)
+# skip past first (video) LIST
+>>>>(92.l+96)   string  LIST
+>>>>>(92.l+104) string  strlstrh
+>>>>>>(92.l+116)        string          auds    \b, audio:
+# auds strh length = 56:
+>>>>>>>(92.l+172)       string          strf
+>>>>>>>>(92.l+180)      leshort 0x0001  uncompressed PCM
+>>>>>>>>(92.l+180)      leshort 0x0002  ADPCM
+>>>>>>>>(92.l+180)      leshort 0x0006  aLaw
+>>>>>>>>(92.l+180)      leshort 0x0007  uLaw
+>>>>>>>>(92.l+180)      leshort 0x0050  MPEG-1 Layer 1 or 2
+>>>>>>>>(92.l+180)      leshort 0x0055  MPEG-1 Layer 3
+>>>>>>>>(92.l+180)      leshort 0x2000  Dolby AC3
+>>>>>>>>(92.l+180)      leshort 0x0161  DivX
+##>>>>>>>>(92.l+180)      leshort x       (0x%.4x)
+>>>>>>>>(92.l+182)      leshort 1       (mono,
+>>>>>>>>(92.l+182)      leshort 2       (stereo,
+>>>>>>>>(92.l+182)      leshort >2      (%d channels,
+>>>>>>>>(92.l+184)      lelong  x       %d Hz)
+# auds strh length = 64:
+>>>>>>>(92.l+180)       string          strf
+>>>>>>>>(92.l+188)      leshort 0x0001  uncompressed PCM
+>>>>>>>>(92.l+188)      leshort 0x0002  ADPCM
+>>>>>>>>(92.l+188)      leshort 0x0055  MPEG-1 Layer 3
+>>>>>>>>(92.l+188)      leshort 0x2000  Dolby AC3
+>>>>>>>>(92.l+188)      leshort 0x0161  DivX
+##>>>>>>>>(92.l+188)      leshort x       (0x%.4x)
+>>>>>>>>(92.l+190)      leshort 1       (mono,
+>>>>>>>>(92.l+190)      leshort 2       (stereo,
+>>>>>>>>(92.l+190)      leshort >2      (%d channels,
+>>>>>>>>(92.l+192)      lelong  x       %d Hz)
+# Animated Cursor format
+>8	string		ACON		\b, animated cursor
+# SoundFont 2 <mpruett@sgi.com>
+>8	string		sfbk		SoundFont/Bank
+# MPEG-1 wrapped in a RIFF, apparently
+>8      string          CDXA            \b, wrapped MPEG-1 (CDXA)
+>8	string		4XMV		\b, 4X Movie file 
+# AMV-type AVI file: http://wiki.multimedia.cx/index.php?title=AMV
+>8	string		AMV\040		\b, AMV 
+>8      string          WEBP            \b, Web/P image
+!:mime	image/webp
+>>12	use		riff-walk
+
+#
+# XXX - some of the below may only appear in little-endian form.
+#
+# Also "MV93" appears to be for one form of Macromedia Director
+# files, and "GDMF" appears to be another multimedia format.
+#
+0	string		RIFX		RIFF (big-endian) data
+# RIFF Palette format
+>8	string		PAL		\b, palette
+>>16	beshort		x		\b, version %d
+>>18	beshort		x		\b, %d entries
+# RIFF Device Independent Bitmap format
+>8	string		RDIB		\b, device-independent bitmap
+>>16	string		BM		
+>>>30	beshort		12		\b, OS/2 1.x format
+>>>>34	beshort		x		\b, %d x
+>>>>36	beshort		x		%d
+>>>30	beshort		64		\b, OS/2 2.x format
+>>>>34	beshort		x		\b, %d x
+>>>>36	beshort		x		%d
+>>>30	beshort		40		\b, Windows 3.x format
+>>>>34	belong		x		\b, %d x
+>>>>38	belong		x		%d x
+>>>>44	beshort		x		%d
+# RIFF MIDI format
+>8	string		RMID		\b, MIDI
+# RIFF Multimedia Movie File format
+>8	string		RMMP		\b, multimedia movie
+# Microsoft WAVE format (*.wav)
+>8	string		WAVE		\b, WAVE audio
+>>20	leshort		1		\b, Microsoft PCM
+>>>34	leshort		>0		\b, %d bit
+>>22	beshort		=1		\b, mono
+>>22	beshort		=2		\b, stereo
+>>22	beshort		>2		\b, %d channels
+>>24	belong		>0		%d Hz
+# Corel Draw Picture
+>8	string		CDRA		\b, Corel Draw Picture
+>8	string		CDR6		\b, Corel Draw Picture, version 6
+# AVI == Audio Video Interleave
+>8	string		AVI\040		\b, AVI
+# Animated Cursor format
+>8	string		ACON		\b, animated cursor
+# Notation Interchange File Format (big-endian only)
+>8	string		NIFF		\b, Notation Interchange File Format
+# SoundFont 2 <mpruett@sgi.com>
+>8	string		sfbk		SoundFont/Bank
+
+#------------------------------------------------------------------------------
+# Sony Wave64
+# see http://www.vcs.de/fileadmin/user_upload/MBS/PDF/Whitepaper/Informations_about_Sony_Wave64.pdf
+# 128 bit RIFF-GUID { 66666972-912E-11CF-A5D6-28DB04C10000 } in little-endian 
+0	string	riff\x2E\x91\xCF\x11\xA5\xD6\x28\xDB\x04\xC1\x00\x00		Sony Wave64 RIFF data
+# 128 bit + total file size (64 bits) so 24 bytes
+# then WAVE-GUID { 65766177-ACF3-11D3-8CD1-00C04F8EDB8A }
+>24	string		wave\xF3\xAC\xD3\x11\x8C\xD1\x00\xC0\x4F\x8E\xDB\x8A		\b, WAVE 64 audio
+!:mime	audio/x-w64
+# FMT-GUID { 20746D66-ACF3-11D3-8CD1-00C04F8EDB8A }
+>>40	search/256	fmt\x20\xF3\xAC\xD3\x11\x8C\xD1\x00\xC0\x4F\x8E\xDB\x8A		\b
+>>>&10	leshort		=1		\b, mono
+>>>&10	leshort		=2		\b, stereo
+>>>&10	leshort		>2		\b, %d channels
+>>>&12	lelong		>0		%d Hz
+
+#------------------------------------------------------------------------------
+# MBWF/RF64
+# see EBU TECH 3306 http://tech.ebu.ch/docs/tech/tech3306-2009.pdf
+0	string	RF64\xff\xff\xff\xffWAVEds64		MBWF/RF64 audio
+!:mime	audio/x-wav
+>40	search/256	fmt\x20		\b
+>>&6	leshort		=1		\b, mono
+>>&6	leshort		=2		\b, stereo
+>>&6	leshort		>2		\b, %d channels
+>>&8	lelong		>0		%d Hz
+
+#------------------------------------------------------------------------------
+# $File: rinex,v 1.3 2011/04/04 21:12:03 christos Exp $
+# rinex:  file(1) magic for RINEX files
+# http://igscb.jpl.nasa.gov/igscb/data/format/rinex210.txt
+# ftp://cddis.gsfc.nasa.gov/pub/reports/formats/rinex300.pdf
+# data for testing: ftp://cddis.gsfc.nasa.gov/pub/gps/data
+60	string		RINEX
+>80	search/256	XXRINEXB	RINEX Data, GEO SBAS Broadcast
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/broadcast
+>80	search/256	XXRINEXD	RINEX Data, Observation (Hatanaka comp)
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/observation
+>80	search/256	XXRINEXC	RINEX Data, Clock
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/clock
+>80	search/256	XXRINEXH	RINEX Data, GEO SBAS Navigation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXG	RINEX Data, GLONASS Navigation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXL	RINEX Data, Galileo Navigation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXM	RINEX Data, Meteorological
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/meteorological
+>80	search/256	XXRINEXN	RINEX Data, Navigation	
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/navigation
+>80	search/256	XXRINEXO	RINEX Data, Observation
+>>&32	string		x		\b, date %15.15s
+>>5	string		x		\b, version %6.6s
+!:mime	rinex/observation
+
+#------------------------------------------------------------------------------
+# $File: rpm,v 1.11 2011/06/14 12:47:41 christos Exp $
+#
+# RPM: file(1) magic for Red Hat Packages   Erik Troan (ewt@redhat.com)
+#
+0	belong		0xedabeedb	RPM
+!:mime	application/x-rpm
+>4	byte		x		v%d
+>5	byte		x		\b.%d
+>6	beshort		1		src
+>6	beshort		0		bin
+>>8	beshort		1		i386/x86_64
+>>8	beshort		2		Alpha/Sparc64
+>>8	beshort		3		Sparc
+>>8	beshort		4		MIPS
+>>8	beshort		5		PowerPC
+>>8	beshort		6		68000
+>>8	beshort		7		SGI
+>>8	beshort		8		RS6000
+>>8	beshort		9		IA64
+>>8	beshort		10		Sparc64
+>>8	beshort		11		MIPSel
+>>8	beshort		12		ARM
+>>8	beshort		13		MiNT
+>>8	beshort		14		S/390
+>>8	beshort		15		S/390x
+>>8	beshort		16		PowerPC64
+>>8	beshort		17		SuperH
+>>8	beshort		18		Xtensa
+>>8	beshort		255		noarch
+
+#delta RPM    Daniel Novotny (dnovotny@redhat.com)
+0	string		drpm		Delta RPM
+!:mime  application/x-rpm
+>12	string 	x	%s
+>>8	beshort		11		MIPSel
+>>8	beshort		12		ARM
+>>8	beshort		13		MiNT
+>>8	beshort		14		S/390
+>>8	beshort		15		S/390x
+>>8	beshort		16		PowerPC64
+>>8	beshort		17		SuperH
+>>8	beshort		18		Xtensa
+>>10	string		x		%s
+
+#------------------------------------------------------------------------------
+# $File$
+# rtf:	file(1) magic for Rich Text Format (RTF)
+#
+# Duncan P. Simpson, D.P.Simpson@dcs.warwick.ac.uk
+#
+0	string		{\\rtf		Rich Text Format data,
+!:mime	text/rtf
+>5	string		1		version 1,
+>>6	string		\\ansi		ANSI
+>>6	string		\\mac		Apple Macintosh
+>>6	string		\\pc		IBM PC, code page 437
+>>6	string		\\pca		IBM PS/2, code page 850
+>>6	default		x		unknown character set
+>5	default		x		unknown version
+
+#------------------------------------------------------------------------------
+# $File: ruby,v 1.4 2010/07/08 20:24:13 christos Exp $
+# ruby:  file(1) magic for Ruby scripting language
+# URL:  http://www.ruby-lang.org/
+# From: Reuben Thomas <rrt@sc3d.org>
+
+# Ruby scripts
+0	search/1/w	#!\ /usr/bin/ruby	Ruby script text executable
+!:mime text/x-ruby
+0	search/1/w	#!\ /usr/local/bin/ruby	Ruby script text executable
+!:mime text/x-ruby
+0	search/1	#!/usr/bin/env\ ruby	Ruby script text executable
+!:mime text/x-ruby
+0	search/1	#!\ /usr/bin/env\ ruby	Ruby script text executable
+!:mime text/x-ruby
+
+# What looks like ruby, but does not have a shebang
+# (modules and such)
+# From: Lubomir Rintel <lkundrak@v3.sk>
+0	regex		\^[\ \t]*require[\ \t]'[A-Za-z_/]+'
+>0	regex		include\ [A-Z]|def\ [a-z]|\ do$
+>>0	regex		\^[\ \t]*end([\ \t]*[;#].*)?$		Ruby script text
+!:mime	text/x-ruby
+0	regex		\^[\ \t]*(class|module)[\ \t][A-Z]
+>0	regex		(modul|includ)e\ [A-Z]|def\ [a-z]
+>>0	regex		\^[\ \t]*end([\ \t]*[;#].*)?$		Ruby module source text
+!:mime	text/x-ruby
+
+#------------------------------------------------------------------------------
+# $File$
+# sc:  file(1) magic for "sc" spreadsheet
+#
+38	string		Spreadsheet	sc spreadsheet file
+!:mime	application/x-sc
+
+#------------------------------------------------------------------------------
+# $File$
+# sccs:  file(1) magic for SCCS archives
+#
+# SCCS archive structure:
+# \001h01207
+# \001s 00276/00000/00000
+# \001d D 1.1 87/09/23 08:09:20 ian 1 0
+# \001c date and time created 87/09/23 08:09:20 by ian
+# \001e
+# \001u
+# \001U
+# ... etc.
+# Now '\001h' happens to be the same as the 3B20's a.out magic number (0550).
+# *Sigh*. And these both came from various parts of the USG.
+# Maybe we should just switch everybody from SCCS to RCS!
+# Further, you can't just say '\001h0', because the five-digit number
+# is a checksum that could (presumably) have any leading digit,
+# and we don't have regular expression matching yet. 
+# Hence the following official kludge:
+8	string		\001s\ 			SCCS archive data
+
+#------------------------------------------------------------------------------
+# $File: scientific,v 1.8 2014/01/06 17:46:23 rrt Exp $
+# scientific:  file(1) magic for scientific formats 
+#
+# From: Joe Krahn <krahn@niehs.nih.gov>
+
+########################################################
+# CCP4 data and plot files:
+0	string		MTZ\040		MTZ reflection file
+
+92	string		PLOT%%84	Plot84 plotting file
+>52	byte		1		, Little-endian
+>55	byte		1		, Big-endian
+
+########################################################
+# Electron density MAP/MASK formats
+
+0	string		EZD_MAP	NEWEZD Electron Density Map
+109	string		MAP\040(  Old EZD Electron Density Map
+
+0	string/c	:-)\040Origin	BRIX Electron Density Map
+>170	string		>0	, Sigma:%.12s
+#>4	string		>0	%.178s
+#>4	addr		x	%.178s
+
+7	string		18\040!NTITLE	XPLOR ASCII Electron Density Map
+9	string		\040!NTITLE\012\040REMARK	CNS ASCII electron density map
+
+208	string		MAP\040	CCP4 Electron Density Map
+# Assumes same stamp for float and double (normal case)
+>212	byte		17	\b, Big-endian
+>212	byte		34	\b, VAX format
+>212	byte		68	\b, Little-endian
+>212	byte		85	\b, Convex native
+
+############################################################
+# X-Ray Area Detector images
+0	string	R-AXIS4\ \ \ 	R-Axis Area Detector Image:
+>796	lelong	<20		Little-endian, IP #%d,
+>>768	lelong	>0		Size=%dx
+>>772	lelong	>0		\b%d
+>796	belong	<20		Big-endian, IP #%d,
+>>768	belong	>0		Size=%dx
+>>772	belong	>0		\b%d
+
+0	string	RAXIS\ \ \ \ \ 	R-Axis Area Detector Image, Win32:
+>796	lelong	<20		Little-endian, IP #%d,
+>>768	lelong	>0		Size=%dx
+>>772	lelong	>0		\b%d
+>796	belong	<20		Big-endian, IP #%d,
+>>768	belong	>0		Size=%dx
+>>772	belong	>0		\b%d
+
+
+1028	string	MMX\000\000\000\000\000\000\000\000\000\000\000\000\000	MAR Area Detector Image,
+>1072	ulong	>1		Compressed(%d),
+>1100	ulong	>1		%d headers,
+>1104	ulong	>0		%d x
+>1108	ulong	>0		%d,
+>1120	ulong	>0		%d bits/pixel
+
+# Type: GEDCOM genealogical (family history) data
+# From: Giuseppe Bilotta
+0       search/1/c	0\ HEAD         GEDCOM genealogy text
+>&0     search		1\ GEDC
+>>&0    search		2\ VERS         version
+>>>&1   string		>\0		%s
+# From: Phil Endecott <phil05@chezphil.org>
+0	string	\000\060\000\040\000\110\000\105\000\101\000\104		GEDCOM data
+0	string	\060\000\040\000\110\000\105\000\101\000\104\000		GEDCOM data
+0	string	\376\377\000\060\000\040\000\110\000\105\000\101\000\104	GEDCOM data
+0	string	\377\376\060\000\040\000\110\000\105\000\101\000\104\000	GEDCOM data
+
+# PDB: Protein Data Bank files
+# Adam Buchbinder <adam.buchbinder@gmail.com>
+#
+# http://www.wwpdb.org/documentation/format32/sect2.html
+# http://www.ch.ic.ac.uk/chemime/
+#
+# The PDB file format is fixed-field, 80 columns. From the spec:
+#
+# COLS        DATA
+#  1 -  6      "HEADER"
+#  11 - 50     String(40)
+#  51 - 59     Date
+#  63 - 66     IDcode
+#
+# Thus, positions 7-10, 60-62 and 67-80 are spaces. The Date must be in the
+# format DD-MMM-YY, e.g., 01-JAN-70, and the IDcode consists of numbers and
+# uppercase letters. However, examples have been seen without the date string,
+# e.g., the example on the chemime site.
+0	string	HEADER\ \ \ \ 
+>&0	regex/1l	\^.{40}
+>>&0	regex/1l	[0-9]{2}-[A-Z]{3}-[0-9]{2}\ {3}
+>>>&0	regex/1ls	[A-Z0-9]{4}.{14}$
+>>>>&0	regex/1l	[A-Z0-9]{4}	Protein Data Bank data, ID Code %s
+!:mime	chemical/x-pdb
+>>>>0	regex/1l	[0-9]{2}-[A-Z]{3}-[0-9]{2}	\b, %s
+
+# Type:	GDSII Stream file
+0	belong	0x00060002	GDSII Stream file
+>4	byte	0x00
+>>5	byte	x		version %d.0
+>4	byte	>0x00		version %d
+>>5	byte	x		\b.%d
+
+#------------------------------------------------------------------------------
+# $File$
+0	search/1		-----BEGIN\ CERTIFICATE------	RFC1421 Security Certificate text
+0	search/1		-----BEGIN\ NEW\ CERTIFICATE	RFC1421 Security Certificate Signing Request text
+0	belong	0xedfeedfe	Sun 'jks' Java Keystore File data
+# Type:	SE Linux policy modules *.pp reference policy
+#	for Fedora 5 to 9, RHEL5, and Debian Etch and Lenny.
+# URL:	http://doc.coker.com.au/computers/selinux-magic
+# From:	Russell Coker <russell@coker.com.au>
+
+0		lelong	0xf97cff8f	SE Linux modular policy
+>4		lelong	x		version %d,
+>8		lelong	x		%d sections,
+>>(12.l)	lelong	0xf97cff8d
+>>>(12.l+27)	lelong	x		mod version %d,
+>>>(12.l+31)	lelong	0		Not MLS,
+>>>(12.l+31)	lelong	1		MLS,
+>>>(12.l+23)	lelong	2
+>>>>(12.l+47)	string	>\0		module name %s
+>>>(12.l+23)	lelong	1		base
+
+1	string	policy_module(	SE Linux policy module source
+2	string	policy_module(	SE Linux policy module source
+
+0	string	##\ <summary>	SE Linux policy interface source
+
+#0	search	gen_context(	SE Linux policy file contexts
+
+#0	search	gen_sens(	SE Linux policy MLS constraints source
+
+#------------------------------------------------------------------------------
+# $File$
+# sendmail:  file(1) magic for sendmail config files
+#
+# XXX - byte order?
+#
+0	byte	046	  Sendmail frozen configuration 
+>16	string	>\0	  - version %s
+0	short	0x271c	  Sendmail frozen configuration
+>16	string	>\0	  - version %s
+
+#------------------------------------------------------------------------------
+# sendmail:  file(1) magic for sendmail m4(1) files
+#
+# From Hendrik Scholz <hendrik@scholz.net>
+# i.e. files in /usr/share/sendmail/cf/
+#
+0   string  divert(-1)\n    sendmail m4 text file
+
+
+#------------------------------------------------------------------------------
+# $File: sequent,v 1.11 2014/06/02 19:27:54 christos Exp $
+# sequent:  file(1) magic for Sequent machines
+#
+# Sequent information updated by Don Dwiggins <atsun!dwiggins>.
+# For Sequent's multiprocessor systems (incomplete).
+0	lelong	0x00ea        	BALANCE NS32000 .o
+>16	lelong	>0		not stripped
+>124	lelong	>0		version %d
+0	lelong	0x10ea        	BALANCE NS32000 executable (0 @ 0)
+>16	lelong  >0            	not stripped
+>124	lelong	>0		version %d
+0	lelong	0x20ea        	BALANCE NS32000 executable (invalid @ 0)
+>16	lelong  >0            	not stripped
+>124	lelong	>0		version %d
+0	lelong	0x30ea        	BALANCE NS32000 standalone executable
+>16	lelong  >0          	not stripped
+>124	lelong	>0		version %d
+#
+# Symmetry information added by Jason Merrill <jason@jarthur.claremont.edu>.
+# Symmetry magic nums will not be reached if DOS COM comes before them;
+# byte 0xeb is matched before these get a chance.
+0	leshort	0x12eb		SYMMETRY i386 .o
+>16	lelong	>0		not stripped
+>124	lelong	>0		version %d
+0	leshort	0x22eb		SYMMETRY i386 executable (0 @ 0)
+>16	lelong	>0		not stripped
+>124	lelong	>0		version %d
+0	leshort	0x32eb		SYMMETRY i386 executable (invalid @ 0)
+>16	lelong	>0		not stripped
+>124	lelong	>0		version %d
+# http://en.wikipedia.org/wiki/Sequent_Computer_Systems
+# below test line conflicts with MS-DOS 2.11 floppies and Acronis loader
+#0	leshort	0x42eb		SYMMETRY i386 standalone executable
+0	leshort	0x42eb		
+# skip unlike negative version
+>124	lelong	>-1		
+# assuming version 28867614 is very low probable
+>>124	lelong	!28867614	SYMMETRY i386 standalone executable
+>>>16	lelong	>0		not stripped
+>>>124	lelong	>0		version %d
+
+#------------------------------------------------------------------------------
+# $File: sereal,v 1.2 2014/11/11 20:10:49 christos Exp $
+# sereal: file(1) magic the Sereal binary serialization format
+#
+# From: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
+#
+# See the specification of the format at
+# https://github.com/Sereal/Sereal/blob/master/sereal_spec.pod#document-header-format
+#
+# I'd have liked to do the byte&0xF0 matching against 0, 1, 2 ... by
+# doing (byte&0xF0)>>4 here, but unfortunately that's not
+# supported. So when we print out a message about an unknown format
+# we'll print out e.g. 0x30 instead of the more human-readable
+# 0x30>>4.
+#
+# See https://github.com/Sereal/Sereal/commit/35372ae01d in the
+# Sereal.git repository for test Sereal data.
+0	name		sereal
+>4	byte&0x0F	x		(version %d,
+>4	byte&0xF0	0x00		uncompressed)
+>4	byte&0xF0	0x10		compressed with non-incremental Snappy)
+>4	byte&0xF0	0x20		compressed with incremental Snappy)
+>4	byte&0xF0	>0x20		unknown subformat, flag: %d>>4)
+
+0	string/b	\=srl		Sereal data packet
+!:mime application/sereal
+>&0	use		sereal
+0	string/b	\=\xF3rl	Sereal data packet
+!:mime application/sereal
+>&0	use		sereal
+0	string/b	\=\xC3\xB3rl	Sereal data packet, UTF-8 encoded
+!:mime application/sereal
+>&0	use		sereal
+
+
+#------------------------------------------------------------------------------
+# $File: sgi,v 1.20 2014/03/10 00:53:38 christos Exp $
+# sgi:  file(1) magic for Silicon Graphics operating systems and applications
+#
+# Executable images are handled either in aout (for old-style a.out
+# files for 68K; they are indistinguishable from other big-endian 32-bit
+# a.out files) or in mips (for MIPS ECOFF and Ucode files)
+#
+
+# kbd file definitions
+0	string	kbd!map		kbd map file
+>8	byte	>0		Ver %d:
+>10	short	>0		with %d table(s)
+
+0	beshort	0x8765		disk quotas file
+
+0	beshort	0x0506		IRIS Showcase file
+>2	byte	0x49		-
+>3	byte	x		- version %d
+0	beshort	0x0226		IRIS Showcase template
+>2	byte	0x63		-
+>3	byte	x		- version %d
+0	belong	0x5343464d	IRIS Showcase file
+>4	byte	x		- version %d
+0	belong	0x5443464d	IRIS Showcase template
+>4	byte	x		- version %d
+0	belong	0xdeadbabe	IRIX Parallel Arena
+>8	belong	>0		- version %d
+
+# core files
+#
+# 32bit core file
+0	belong	0xdeadadb0	IRIX core dump
+>4	belong	1		of
+>16	string	>\0		'%s'
+# 64bit core file
+0	belong	0xdeadad40	IRIX 64-bit core dump
+>4	belong	1		of
+>16	string	>\0		'%s'
+# N32bit core file
+0       belong	0xbabec0bb	IRIX N32 core dump
+>4      belong	1               of
+>16     string	>\0             '%s'
+# New style crash dump file
+0	string	\x43\x72\x73\x68\x44\x75\x6d\x70	IRIX vmcore dump of
+>36	string	>\0					'%s'
+
+# Trusted IRIX info
+0	string	SGIAUDIT	SGI Audit file
+>8	byte	x		- version %d
+>9	byte	x		\b.%d
+#
+0	string	WNGZWZSC	Wingz compiled script
+0	string	WNGZWZSS	Wingz spreadsheet
+0	string	WNGZWZHP	Wingz help file
+#
+0	string	#Inventor V	IRIS Inventor 1.0 file
+0	string	#Inventor V2	Open Inventor 2.0 file
+# GLF is OpenGL stream encoding
+0	string	glfHeadMagic();		GLF_TEXT
+4	belong	0x7d000000		GLF_BINARY_LSB_FIRST
+!:strength -30
+4	belong	0x0000007d		GLF_BINARY_MSB_FIRST
+!:strength -30
+# GLS is OpenGL stream encoding; GLS is the successor of GLF
+0	string	glsBeginGLS(		GLS_TEXT
+4	belong	0x10000000		GLS_BINARY_LSB_FIRST
+!:strength -30
+4	belong	0x00000010		GLS_BINARY_MSB_FIRST
+!:strength -30
+
+#
+#
+# Performance Co-Pilot file types
+0	string	PmNs				PCP compiled namespace (V.0)
+0	string	PmN				PCP compiled namespace
+>3	string	>\0				(V.%1.1s)
+#3	lelong	0x84500526			PCP archive
+3	belong	0x84500526			PCP archive
+>7	byte	x				(V.%d)
+#>20	lelong	-2				temporal index
+#>20	lelong	-1				metadata
+#>20	lelong	0				log volume #0
+#>20	lelong	>0				log volume #%d
+>20	belong	-2				temporal index
+>20	belong	-1				metadata
+>20	belong	0				log volume #0
+>20	belong	>0				log volume #%d
+>24	string	>\0				host: %s
+0	string	PCPFolio			PCP
+>9	string	Version:			Archive Folio
+>18	string	>\0				(V.%s)
+0	string	#pmchart			PCP pmchart view
+>9	string	Version
+>17	string	>\0				(V%-3.3s)
+0	string	#kmchart			PCP kmchart view
+>9	string	Version
+>17	string	>\0				(V.%s)
+0	string	pmview				PCP pmview config
+>7	string	Version
+>15	string	>\0				(V%-3.3s)
+0	string	#pmlogger			PCP pmlogger config
+>10	string	Version
+>18	string	>\0				(V%1.1s)
+0	string	#pmdahotproc			PCP pmdahotproc config
+>13	string	Version
+>21	string	>\0				(V%-3.3s)
+0	string	PcPh				PCP Help
+>4	string	1				Index
+>4	string	2				Text
+>5	string	>\0				(V.%1.1s)
+0	string	#pmieconf-rules			PCP pmieconf rules
+>16	string	>\0				(V.%1.1s)
+3	string	pmieconf-pmie			PCP pmie config
+>17	string	>\0				(V.%1.1s)
+
+# SpeedShop data files
+0	lelong	0x13130303			SpeedShop data file
+
+# mdbm files
+0	lelong	0x01023962			mdbm file, version 0 (obsolete)
+0	string	mdbm				mdbm file,
+>5	byte	x				version %d,
+>6	byte	x				2^%d pages,
+>7	byte	x				pagesize 2^%d,
+>17	byte	x				hash %d,
+>11	byte	x				dataformat %d
+
+# Alias Maya files
+0	string/t	//Maya\040ASCII	Alias Maya Ascii File,
+>13	string	>\0	version %s
+8	string	MAYAFOR4	Alias Maya Binary File,
+>32	string	>\0	version %s scene
+8	string	MayaFOR4	Alias Maya Binary File,
+>32	string	>\0	version %s scene
+8	string	CIMG		Alias Maya Image File
+8	string	DEEP		Alias Maya Image File
+#------------------------------------------------------------------------------
+# $File: sgml,v 1.29 2012/08/26 10:25:41 christos Exp $
+# Type:	SVG Vectorial Graphics
+# From:	Noel Torres <tecnico@ejerciciosresueltos.com>
+0	string		\<?xml\ version="
+>15	string		>\0
+>>19	search/4096	\<svg			SVG Scalable Vector Graphics image
+!:mime	image/svg+xml
+>>19	search/4096	\<gnc-v2		GnuCash file
+!:mime	application/x-gnucash
+
+# Sitemap file
+0	string/t		\<?xml\ version="
+>15	string		>\0
+>>19	search/4096	\<urlset		XML Sitemap document text
+!:mime	application/xml-sitemap
+
+# OpenStreetMap XML (.osm)
+# http://wiki.openstreetmap.org/wiki/OSM_XML
+# From: Markus Heidelberg <markus.heidelberg@web.de>
+0	string		\<?xml\ version="
+>15	string		>\0
+>>19	search/4096	\<osm			OpenStreetMap XML data
+
+# xhtml
+0	string/t		\<?xml\ version="
+>15	string		>\0
+>>19	search/4096/cWbt	\<!doctype\ html	XHTML document text
+!:mime	text/html
+0	string/t		\<?xml\ version='
+>15	string		>\0
+>>19	search/4096/cWbt	\<!doctype\ html	XHTML document text
+!:mime	text/html
+0	string/t		\<?xml\ version="
+>15	string		>\0
+>>19	search/4096/cWbt	\<html	broken XHTML document text
+!:mime	text/html
+
+#------------------------------------------------------------------------------
+# sgml:  file(1) magic for Standard Generalized Markup Language
+# HyperText Markup Language (HTML) is an SGML document type,
+# from Daniel Quinlan (quinlan@yggdrasil.com)
+# adapted to string extenstions by Anthon van der Neut <anthon@mnt.org)
+0	search/4096/cWt	\<!doctype\ html	HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<head			HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<title			HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<html			HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<script 		HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<style 		HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<table			HTML document text
+!:mime	text/html
+!:strength + 5
+0	search/4096/cwt	\<a\ href=		HTML document text
+!:mime	text/html
+!:strength + 5
+
+# Extensible markup language (XML), a subset of SGML
+# from Marc Prud'hommeaux (marc@apocalypse.org)
+0	search/1/cwt	\<?xml			XML document text
+!:mime	application/xml
+!:strength + 5
+0	string/t		\<?xml\ version\ "	XML
+!:mime	application/xml
+!:strength + 5
+0	string/t		\<?xml\ version="	XML
+!:mime	application/xml
+!:strength + 5
+>15	string/t	>\0			%.3s document text
+>>23	search/1	\<xsl:stylesheet	(XSL stylesheet)
+>>24	search/1	\<xsl:stylesheet	(XSL stylesheet)
+0	string		\<?xml\ version='	XML
+!:mime	application/xml
+!:strength + 5
+>15	string/t	>\0			%.3s document text
+>>23	search/1	\<xsl:stylesheet	(XSL stylesheet)
+>>24	search/1	\<xsl:stylesheet	(XSL stylesheet)
+0	search/1/wbt	\<?xml			XML document text
+!:mime	application/xml
+!:strength - 10
+0	search/1/wt	\<?XML			broken XML document text
+!:mime	application/xml
+!:strength - 10
+
+
+# SGML, mostly from rph@sq
+0	search/4096/cwt	\<!doctype		exported SGML document text
+0	search/4096/cwt	\<!subdoc		exported SGML subdocument text
+0	search/4096/cwt	\<!--			exported SGML document text
+!:strength - 10
+
+# Web browser cookie files
+# (Mozilla, Galeon, Netscape 4, Konqueror..)
+# Ulf Harnhammar <ulfh@update.uu.se>
+0	search/1	#\ HTTP\ Cookie\ File	Web browser cookie text
+0	search/1	#\ Netscape\ HTTP\ Cookie\ File	Netscape cookie text
+0	search/1	#\ KDE\ Cookie\ File	Konqueror cookie text
+
+#------------------------------------------------------------------------
+# $File: sharc,v 1.6 2009/09/19 16:28:12 christos Exp $
+# file(1) magic for sharc files
+#
+# SHARC DSP, MIDI SysEx and RiscOS filetype definitions added by 
+# FutureGroove Music (dsp@futuregroove.de)
+
+#------------------------------------------------------------------------
+#0	string			Draw		RiscOS Drawfile
+#0	string			PACK		RiscOS PackdDir archive
+
+#------------------------------------------------------------------------
+# SHARC DSP stuff (based on the FGM SHARC DSP SDK)
+
+#0	string			=!		Assembler source
+#0	string			Analog		ADi asm listing file
+0	string			.SYSTEM		SHARC architecture file
+0	string			.system		SHARC architecture file
+
+0	leshort			0x521C		SHARC COFF binary
+>2	leshort			>1		, %d sections
+>>12	lelong			>0		, not stripped
+
+#------------------------------------------------------------------------------
+# $File$
+# sinclair:  file(1) sinclair QL
+
+# additions to /etc/magic by Thomas M. Ott (ThMO)
+
+# Sinclair QL floppy disk formats (ThMO)
+0	string	=QL5		QL disk dump data,
+>3	string	=A		720 KB,
+>3	string	=B		1.44 MB,
+>3	string	=C		3.2 MB,
+>4	string	>\0		label:%.10s
+
+# Sinclair QL OS dump (ThMO)
+# (NOTE: if `file' would be able to use indirect references in a endian format
+#	 differing from the natural host format, this could be written more
+#	 reliably and faster...)
+#
+# we *can't* lookup QL OS code dumps, because `file' is UNABLE to read more
+# than the first 8K of a file... #-(
+#
+#0		belong	=0x30000
+#>49124		belong	<47104
+#>>49128		belong	<47104
+#>>>49132	belong	<47104
+#>>>>49136	belong	<47104	QL OS dump data,
+#>>>>>49148	string	>\0	type %.3s,
+#>>>>>49142	string	>\0	version %.4s
+
+# Sinclair QL firmware executables (ThMO)
+0	string	NqNqNq`\004	QL firmware executable (BCPL)
+
+# Sinclair QL libraries (was ThMO)
+0	beshort	0xFB01		QDOS object
+>2	pstring	x		'%s'
+
+# Sinclair QL executables (was ThMO)
+4	belong	0x4AFB		QDOS executable
+>9	pstring	x		'%s'
+
+# Sinclair QL ROM (ThMO)
+0	belong	=0x4AFB0001	QL plugin-ROM data,
+>9	pstring	=\0		un-named
+>9	pstring	>\0		named: %s
+# Type: SiSU Markup Language
+# URL:  http://www.sisudoc.org/
+# From: Ralph Amissah <ralph.amissah@gmail.com>
+
+0	regex	\^%?[\ \t]*SiSU[\ \t]+insert	SiSU text insert
+>5	regex	[0-9.]+				%s
+
+0	regex	\^%[\ \t]+SiSU[\ \t]+master	SiSU text master
+>5	regex	[0-9.]+				%s
+
+0	regex	\^%?[\ \t]*SiSU[\ \t]+text	SiSU text
+>5	regex	[0-9.]+				%s
+
+0	regex	\^%?[\ \t]*SiSU[\ \t][0-9.]+	SiSU text
+>5	regex	[0-9.]+				%s
+
+0	regex	\^%*[\ \t]*sisu-[0-9.]+		SiSU text
+>5	regex	[0-9.]+				%s
+
+#------------------------------------------------------------------------------
+# $File$
+# Sketch Drawings: http://sketch.sourceforge.net/ 
+# From: Edwin Mons <e@ik.nu>
+0	search/1	##Sketch	Sketch document text
+
+#-----------------------------------------------
+# $File$
+# GNU Smalltalk image, starting at version 1.6.2
+# From: catull_us@yahoo.com
+#
+0	string	GSTIm\0\0	GNU SmallTalk
+# little-endian
+>7	byte&1	=0		LE image version
+>>10	byte	x		%d.
+>>9	byte	x		\b%d.
+>>8	byte	x		\b%d
+#>>12	lelong	x		, data: %ld
+#>>16	lelong	x		, table: %ld
+#>>20	lelong	x		, memory: %ld
+# big-endian
+>7	byte&1	=1		BE image version
+>>8	byte	x		%d.
+>>9	byte	x		\b%d.
+>>10	byte	x		\b%d
+#>>12	belong	x		, data: %ld
+#>>16	belong	x		, table: %ld
+#>>20	belong	x		, memory: %ld
+
+
+
+#------------------------------------------------------------------------------
+# $File$
+# smile:  file(1) magic for Smile serialization
+#
+# The Smile serialization format uses a 4-byte header:
+#
+#   Constant byte #0: 0x3A (ASCII ':')
+#   Constant byte #1: 0x29 (ASCII ')')
+#   Constant byte #2: 0x0A (ASCII linefeed, '\n')
+#   Variable byte #3, consisting of bits:
+#     Bits 4-7 (4 MSB): 4-bit version number
+#     Bits 3: Reserved
+#     Bit 2 (mask 0x04): Whether raw binary (unescaped 8-bit) values may be present in content
+#     Bit 1 (mask 0x02): Whether shared String value checking was enabled during encoding, default false
+#     Bit 0 (mask 0x01): Whether shared property name checking was enabled during encoding, default true
+#
+# Reference: http://wiki.fasterxml.com/SmileFormatSpec
+# Created by: Pierre-Alexandre Meyer <pierre@mouraf.org>
+
+# Detection
+0	string		:)\n	Smile binary data
+
+# Versioning
+>3	byte&0xF0	x		version %d:
+
+# Properties
+>3	byte&0x04	0x04		binary raw,
+>3	byte&0x04	0x00		binary encoded,
+>3	byte&0x02	0x02		shared String values enabled,
+>3	byte&0x02	0x00		shared String values disabled,
+>3	byte&0x01	0x01		shared field names enabled
+>3	byte&0x01	0x00		shared field names disabled
+
+
+#------------------------------------------------------------------------------
+# $File: sniffer,v 1.18 2011/08/08 08:49:27 christos Exp $
+# sniffer:  file(1) magic for packet capture files
+#
+# From: guy@alum.mit.edu (Guy Harris)
+#
+
+#
+# Microsoft Network Monitor 1.x capture files.
+#
+0	string		RTSS		NetMon capture file
+>5	byte		x		- version %d
+>4	byte		x		\b.%d
+>6	leshort		0		(Unknown)
+>6	leshort		1		(Ethernet)
+>6	leshort		2		(Token Ring)
+>6	leshort		3		(FDDI)
+>6	leshort		4		(ATM)
+>6	leshort		>4		(type %d)
+
+#
+# Microsoft Network Monitor 2.x capture files.
+#
+0	string		GMBU		NetMon capture file
+>5	byte		x		- version %d
+>4	byte		x		\b.%d
+>6	leshort		0		(Unknown)
+>6	leshort		1		(Ethernet)
+>6	leshort		2		(Token Ring)
+>6	leshort		3		(FDDI)
+>6	leshort		4		(ATM)
+>6	leshort		5		(IP-over-IEEE 1394)
+>6	leshort		6		(802.11)
+>6	leshort		7		(Raw IP)
+>6	leshort		8		(Raw IP)
+>6	leshort		9		(Raw IP)
+>6	leshort		>9		(type %d)
+
+#
+# Network General Sniffer capture files.
+# Sorry, make that "Network Associates Sniffer capture files."
+# Sorry, make that "Network General old DOS Sniffer capture files."
+#
+0	string		TRSNIFF\ data\ \ \ \ \032	Sniffer capture file
+>33	byte		2		(compressed)
+>23	leshort		x		- version %d
+>25	leshort		x		\b.%d
+>32	byte		0		(Token Ring)
+>32	byte		1		(Ethernet)
+>32	byte		2		(ARCNET)
+>32	byte		3		(StarLAN)
+>32	byte		4		(PC Network broadband)
+>32	byte		5		(LocalTalk)
+>32	byte		6		(Znet)
+>32	byte		7		(Internetwork Analyzer)
+>32	byte		9		(FDDI)
+>32	byte		10		(ATM)
+
+#
+# Cinco Networks NetXRay capture files.
+# Sorry, make that "Network General Sniffer Basic capture files."
+# Sorry, make that "Network Associates Sniffer Basic capture files."
+# Sorry, make that "Network Associates Sniffer Basic, and Windows
+# Sniffer Pro", capture files."
+# Sorry, make that "Network General Sniffer capture files."
+# Sorry, make that "NetScout Sniffer capture files."
+#
+0	string		XCP\0		NetXRay capture file
+>4	string		>\0		- version %s
+>44	leshort		0		(Ethernet)
+>44	leshort		1		(Token Ring)
+>44	leshort		2		(FDDI)
+>44	leshort		3		(WAN)
+>44	leshort		8		(ATM)
+>44	leshort		9		(802.11)
+
+#
+# "libpcap" capture files.
+# (We call them "tcpdump capture file(s)" for now, as "tcpdump" is
+# the main program that uses that format, but there are other programs
+# that use "libpcap", or that use the same capture file format.)
+#
+0	name		pcap-be
+>4	beshort		x		- version %d
+>6	beshort		x		\b.%d
+>20	belong		0		(No link-layer encapsulation
+>20	belong		1		(Ethernet
+>20	belong		2		(3Mb Ethernet
+>20	belong		3		(AX.25
+>20	belong		4		(ProNET
+>20	belong		5		(CHAOS
+>20	belong		6		(Token Ring
+>20	belong		7		(BSD ARCNET
+>20	belong		8		(SLIP
+>20	belong		9		(PPP
+>20	belong		10		(FDDI
+>20	belong		11		(RFC 1483 ATM
+>20	belong		12		(raw IP
+>20	belong		13		(BSD/OS SLIP
+>20	belong		14		(BSD/OS PPP
+>20	belong		19		(Linux ATM Classical IP
+>20	belong		50		(PPP or Cisco HDLC
+>20	belong		51		(PPP-over-Ethernet
+>20	belong		99		(Symantec Enterprise Firewall
+>20	belong		100		(RFC 1483 ATM
+>20	belong		101		(raw IP
+>20	belong		102		(BSD/OS SLIP
+>20	belong		103		(BSD/OS PPP
+>20	belong		104		(BSD/OS Cisco HDLC
+>20	belong		105		(802.11
+>20	belong		106		(Linux Classical IP over ATM
+>20	belong		107		(Frame Relay
+>20	belong		108		(OpenBSD loopback
+>20	belong		109		(OpenBSD IPsec encrypted
+>20	belong		112		(Cisco HDLC
+>20	belong		113		(Linux "cooked"
+>20	belong		114		(LocalTalk
+>20	belong		117		(OpenBSD PFLOG
+>20	belong		119		(802.11 with Prism header
+>20	belong		122		(RFC 2625 IP over Fibre Channel
+>20	belong		123		(SunATM
+>20	belong		127		(802.11 with radiotap header
+>20	belong		129		(Linux ARCNET
+>20	belong		138		(Apple IP over IEEE 1394
+>20	belong		139		(MTP2 with pseudo-header
+>20	belong		140		(MTP2
+>20	belong		141		(MTP3
+>20	belong		142		(SCCP
+>20	belong		143		(DOCSIS
+>20	belong		144		(IrDA
+>20	belong		147		(Private use 0
+>20	belong		148		(Private use 1
+>20	belong		149		(Private use 2
+>20	belong		150		(Private use 3
+>20	belong		151		(Private use 4
+>20	belong		152		(Private use 5
+>20	belong		153		(Private use 6
+>20	belong		154		(Private use 7
+>20	belong		155		(Private use 8
+>20	belong		156		(Private use 9
+>20	belong		157		(Private use 10
+>20	belong		158		(Private use 11
+>20	belong		159		(Private use 12
+>20	belong		160		(Private use 13
+>20	belong		161		(Private use 14
+>20	belong		162		(Private use 15
+>20	belong		163		(802.11 with AVS header
+>20	belong		165		(BACnet MS/TP
+>20	belong		166		(PPPD
+>20	belong		169		(GPRS LLC
+>20	belong		177		(Linux LAPD
+>20	belong		187		(Bluetooth HCI H4
+>20	belong		189		(Linux USB
+>20	belong		192		(PPI
+>20	belong		195		(802.15.4
+>20	belong		196		(SITA
+>20	belong		197		(Endace ERF
+>20	belong		201		(Bluetooth HCI H4 with pseudo-header
+>20	belong		202		(AX.25 with KISS header
+>20	belong		203		(LAPD
+>20	belong		204		(PPP with direction pseudo-header
+>20	belong		205		(Cisco HDLC with direction pseudo-header
+>20	belong		206		(Frame Relay with direction pseudo-header
+>20	belong		209		(Linux IPMB
+>20	belong		215		(802.15.4 with non-ASK PHY header
+>20	belong		220		(Memory-mapped Linux USB
+>20	belong		224		(Fibre Channel FC-2
+>20	belong		225		(Fibre Channel FC-2 with frame delimiters
+>20	belong		226		(Solaris IPNET
+>20	belong		227		(SocketCAN
+>20	belong		228		(Raw IPv4
+>20	belong		229		(Raw IPv6
+>20	belong		230		(802.15.4 without FCS
+>20	belong		231		(D-Bus messages
+>20	belong		235		(DVB-CI
+>20	belong		236		(MUX27010
+>20	belong		237		(STANAG 5066 D_PDUs
+>20	belong		239		(Linux netlink NFLOG messages
+>20	belong		240		(Hilscher netAnalyzer
+>20	belong		241		(Hilscher netAnalyzer with delimiters
+>20	belong		242		(IP-over-Infiniband
+>20	belong		243		(MPEG-2 Transport Stream packets
+>20	belong		244		(ng4t ng40
+>20	belong		245		(NFC LLCP
+>20	belong		247		(Infiniband
+>20	belong		248		(SCTP
+>16	belong		x		\b, capture length %d)
+
+0	ubelong		0xa1b2c3d4	tcpdump capture file (big-endian)
+!:mime	application/vnd.tcpdump.pcap
+>0	use	pcap-be
+0	ulelong		0xa1b2c3d4	tcpdump capture file (little-endian)
+!:mime	application/vnd.tcpdump.pcap
+>0	use	\^pcap-be
+
+#
+# "libpcap"-with-Alexey-Kuznetsov's-patches capture files.
+# (We call them "tcpdump capture file(s)" for now, as "tcpdump" is
+# the main program that uses that format, but there are other programs
+# that use "libpcap", or that use the same capture file format.)
+#
+0	ubelong		0xa1b2cd34	extended tcpdump capture file (big-endian)
+>0	use	pcap-be
+0	ulelong		0xa1b2cd34	extended tcpdump capture file (little-endian)
+>0	use	\^pcap-be
+
+#
+# "pcap-ng" capture files.
+# http://www.winpcap.org/ntar/draft/PCAP-DumpFileFormat.html
+# Pcap-ng files can contain multiple sections. Printing the endianness,
+# snaplen, or other information from the first SHB may be misleading.
+#
+0	ubelong		0x0a0d0d0a
+>8	ubelong		0x1a2b3c4d	pcap-ng capture file
+>>12	beshort		x		- version %d
+>>14	beshort		x		\b.%d
+0	ulelong		0x0a0d0d0a
+>8	ulelong		0x1a2b3c4d	pcap-ng capture file
+>>12	leshort		x		- version %d
+>>14	leshort		x		\b.%d
+
+#
+# AIX "iptrace" capture files.
+#
+0	string		iptrace\ 1.0	"iptrace" capture file
+0	string		iptrace\ 2.0	"iptrace" capture file
+
+#
+# Novell LANalyzer capture files.
+#
+0	leshort		0x1001		LANalyzer capture file
+0	leshort		0x1007		LANalyzer capture file
+
+#
+# HP-UX "nettl" capture files.
+#
+0	string		\x54\x52\x00\x64\x00	"nettl" capture file
+
+#
+# RADCOM WAN/LAN Analyzer capture files.
+#
+0	string		\x42\xd2\x00\x34\x12\x66\x22\x88	RADCOM WAN/LAN Analyzer capture file
+
+#
+# NetStumbler log files.  Not really packets, per se, but about as
+# close as you can get.  These are log files from NetStumbler, a
+# Windows program, that scans for 802.11b networks.
+#
+0	string		NetS		NetStumbler log file
+>8	lelong		x		\b, %d stations found
+
+#
+# *Peek tagged capture files.
+#
+0	string		\177ver		EtherPeek/AiroPeek/OmniPeek capture file
+
+#
+# Visual Networks traffic capture files.
+#
+0	string		\x05VNF		Visual Networks traffic capture file
+
+#
+# Network Instruments Observer capture files.
+#
+0	string		ObserverPktBuffe	Network Instruments Observer capture file
+
+#
+# Files from Accellent Group's 5View products.
+#
+0	string		\xaa\xaa\xaa\xaa	5View capture file
+
+#------------------------------------------------------------------------------
+# $File$
+# softquad:  file(1) magic for SoftQuad Publishing Software
+#
+# Author/Editor and RulesBuilder
+#
+# XXX - byte order?
+#
+0	string		\<!SQ\ DTD>	Compiled SGML rules file
+>9	string		>\0		 Type %s
+0	string		\<!SQ\ A/E>	A/E SGML Document binary
+>9	string		>\0		 Type %s
+0	string		\<!SQ\ STS>	A/E SGML binary styles file
+>9	string		>\0		 Type %s
+0	short		0xc0de		Compiled PSI (v1) data
+0	short		0xc0da		Compiled PSI (v2) data
+>3	string		>\0		(%s)
+# Binary sqtroff font/desc files...
+0	short		0125252		SoftQuad DESC or font file binary
+>2	short		>0		- version %d
+# Bitmaps...
+0	search/1	SQ\ BITMAP1	SoftQuad Raster Format text
+#0	string		SQ\ BITMAP2	SoftQuad Raster Format data
+# sqtroff intermediate language (replacement for ditroff int. lang.)
+0	string		X\ 		SoftQuad troff Context intermediate
+>2	string		495		for AT&T 495 laser printer
+>2	string		hp		for Hewlett-Packard LaserJet
+>2	string		impr		for IMAGEN imPRESS
+>2	string		ps		for PostScript
+
+# From: Michael Piefel <piefel@debian.org>
+# sqtroff intermediate language (replacement for ditroff int. lang.)
+0	string		X\ 495		SoftQuad troff Context intermediate for AT&T 495 laser printer
+0	string		X\ hp		SoftQuad troff Context intermediate for HP LaserJet
+0	string		X\ impr		SoftQuad troff Context intermediate for IMAGEN imPRESS
+0	string		X\ ps		SoftQuad troff Context intermediate for PostScript
+
+#------------------------------------------------------------------------------
+# $File$
+# spec:  file(1) magic for SPEC raw results (*.raw, *.rsf)
+#
+# Cloyce D. Spradling <cloyce@headgear.org>
+
+0	string	spec			SPEC
+>4	string	.cpu			CPU
+>>8	string	<:			\b%.4s
+>>12	string	.			raw result text
+
+17	string	version=SPECjbb		SPECjbb
+>32	string	<:			\b%.4s
+>>37	string	<:			v%.4s raw result text
+
+0	string	BEGIN\040SPECWEB	SPECweb
+>13	string	<:			\b%.2s
+>>15	string	_SSL			\b_SSL
+>>>20	string	<:			v%.4s raw result text
+>>16	string	<:			v%.4s raw result text
+
+#------------------------------------------------------------------------------
+# $File: spectrum,v 1.6 2009/09/19 16:28:12 christos Exp $
+# spectrum:  file(1) magic for Spectrum emulator files.
+#
+# John Elliott <jce@seasip.demon.co.uk>
+
+#
+# Spectrum +3DOS header
+#
+0       string          PLUS3DOS\032    Spectrum +3 data
+>15     byte            0               - BASIC program
+>15     byte            1               - number array
+>15     byte            2               - character array
+>15     byte            3               - memory block
+>>16    belong          0x001B0040      (screen)
+>15     byte            4               - Tasword document
+>15     string          TAPEFILE        - ZXT tapefile
+#
+# Tape file. This assumes the .TAP starts with a Spectrum-format header,
+# which nearly all will.
+#
+# Update: Sanity-check string contents to be printable.
+#  -Adam Buchbinder <adam.buchbinder@gmail.com>
+#
+0       string          \023\000\000
+>4      string          >\0
+>>4     string          <\177           Spectrum .TAP data "%-10.10s"
+>>>3    byte            0               - BASIC program
+>>>3    byte            1               - number array
+>>>3    byte            2               - character array
+>>>3    byte            3               - memory block
+>>>>14  belong          0x001B0040      (screen)
+
+# The following three blocks are from pak21-spectrum@srcf.ucam.org
+# TZX tape images
+0      string          ZXTape!\x1a     Spectrum .TZX data
+>8     byte            x               version %d
+>9     byte            x               \b.%d
+
+# RZX input recording files
+0      string          RZX!            Spectrum .RZX data
+>4     byte            x               version %d
+>5     byte            x               \b.%d
+
+# Floppy disk images
+0      string          MV\ -\ CPCEMU\ Disk-Fil Amstrad/Spectrum .DSK data
+0      string          MV\ -\ CPC\ format\ Dis Amstrad/Spectrum DU54 .DSK data
+0      string          EXTENDED\ CPC\ DSK\ Fil Amstrad/Spectrum Extended .DSK data
+0      string          SINCLAIR        Spectrum .SCL Betadisk image
+
+# Hard disk images
+0      string          RS-IDE\x1a      Spectrum .HDF hard disk image
+>7     byte            x               \b, version 0x%02x
+
+#------------------------------------------------------------------------------
+# $File: sql,v 1.14 2014/04/28 12:04:50 christos Exp $
+# sql:  file(1) magic for SQL files
+#
+# From: "Marty Leisner" <mleisner@eng.mc.xerox.com>
+# Recognize some MySQL files.
+# Elan Ruusamae <glen@delfi.ee>, added MariaDB signatures
+# from https://bazaar.launchpad.net/~maria-captains/maria/5.5/view/head:/support-files/magic
+#
+0	beshort			0xfe01		MySQL table definition file
+>2	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0700	MySQL MyISAM index file
+>3	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0800	MySQL MyISAM compressed data file
+>3	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0900	MySQL Maria index file
+>3	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0A00	MySQL Maria compressed data file
+>3	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0500	MySQL ISAM index file
+>3	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0600	MySQL ISAM compressed data file
+>3	byte			x		Version %d
+0	string			\376bin		MySQL replication log
+0	belong&0xffffff00	0xfefe0b00
+>4	string			MARIALOG	MySQL Maria transaction log file
+>>3	byte			x		Version %d
+0	belong&0xffffff00	0xfefe0c00
+>4	string			MACF		MySQL Maria control file
+>>3	byte			x		Version %d
+
+#------------------------------------------------------------------------------
+# iRiver H Series database file 
+# From Ken Guest <ken@linux.ie>
+# As observed from iRivNavi.iDB and unencoded firmware
+#
+0   string		iRivDB	iRiver Database file
+>11  string	>\0	Version %s
+>39  string		iHP-100	[H Series]
+
+#------------------------------------------------------------------------------
+# SQLite database files
+# Ken Guest <ken@linux.ie>, Ty Sarna, Zack Weinberg
+#
+# Version 1 used GDBM internally; its files cannot be distinguished
+# from other GDBM files.
+#
+# Version 2 used this format:
+0	string	**\ This\ file\ contains\ an\ SQLite  SQLite 2.x database
+
+# Version 3 of SQLite allows applications to embed their own "user version"
+# number in the database at offset 60.  Later, SQLite added an "application id"
+# at offset 68 that is preferred over "user version" for indicating the
+# associated application.
+#
+0   string  SQLite\ format\ 3
+>60 belong  =0x5f4d544e  Monotone source repository - SQLite3 database
+>68 belong  =0x0f055112  Fossil checkout - SQLite3 database
+>68 belong  =0x0f055113  Fossil global configuration - SQLite3 database
+>68 belong  =0x0f055111  Fossil repository - SQLite3 database
+>68 belong  =0x42654462  Bentley Systems BeSQLite Database - SQLite3 database
+>68 belong  =0x42654c6e  Bentley Systems Localization File - SQLite3 database
+>68 belong  =0x47504b47  OGC GeoPackage file - SQLite3 database
+>68 default x            SQLite 3.x database
+>>68 belong  !0          \b, application id %u
+>>60 belong  !0          \b, user version %d
+
+# SQLite Write-Ahead Log from SQLite version >= 3.7.0
+# http://www.sqlite.org/fileformat.html#walformat
+0	belong&0xfffffffe	0x377f0682	SQLite Write-Ahead Log,
+>4	belong	x	version %d
+
+# SQLite Rollback Journal
+# http://www.sqlite.org/fileformat.html#rollbackjournal
+0	string	\xd9\xd5\x05\xf9\x20\xa1\x63\xd7	SQLite Rollback Journal
+
+# Panasonic channel list database svl.bin or svl.db added by Joerg Jenderek
+# http://www.ullrich.es/job/service-menue/panasonic/panasonic-sendersortierung-sat-am-pc/
+# pceditor_V2003.jar
+0	string		PSDB\0			Panasonic channel list database
+>126	string		SQLite\ format\ 3	
+>>&-15	indirect	x			\b; contains 
+# Type:	OpenSSH key files
+# From:	Nicolas Collignon <tsointsoin@gmail.com>
+
+0	string	SSH\ PRIVATE\ KEY	OpenSSH RSA1 private key,
+>28	string	>\0			version %s
+0	string	-----BEGIN\ OPENSSH\ PRIVATE\ KEY-----	OpenSSH private key
+
+0	string	ssh-dss\ 		OpenSSH DSA public key
+0	string	ssh-rsa\ 		OpenSSH RSA public key
+0	string	ecdsa-sha2-nistp256	OpenSSH ECDSA public key
+0	string	ecdsa-sha2-nistp384	OpenSSH ECDSA public key
+0	string	ecdsa-sha2-nistp521	OpenSSH ECDSA public key
+0	string	ssh-ed25519		OpenSSH ED25519 public key
+# Type: OpenSSL certificates/key files
+# From: Nicolas Collignon <tsointsoin@gmail.com>
+
+0	string	-----BEGIN\ CERTIFICATE-----	PEM certificate
+0	string	-----BEGIN\ CERTIFICATE\ REQ	PEM certificate request
+0	string	-----BEGIN\ RSA\ PRIVATE	PEM RSA private key
+0	string	-----BEGIN\ DSA\ PRIVATE	PEM DSA private key
+0	string	-----BEGIN\ EC\ PRIVATE	PEM EC private key
+
+#------------------------------------------------------------------------------
+# $File: sun,v 1.26 2014/03/29 15:40:34 christos Exp $
+# sun:  file(1) magic for Sun machines
+#
+# Values for big-endian Sun (MC680x0, SPARC) binaries on pre-5.x
+# releases.  (5.x uses ELF.)  Entries for executables without an
+# architecture type, used before the 68020-based Sun-3's came out,
+# are in aout, as they're indistinguishable from other big-endian
+# 32-bit a.out files.
+#
+0	belong&077777777	0600413		a.out SunOS SPARC demand paged
+>0	byte		&0x80
+>>20	belong		<4096		shared library
+>>20	belong		=4096		dynamically linked executable
+>>20	belong		>4096		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0600410		a.out SunOS SPARC pure
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0600407		a.out SunOS SPARC
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0400413		a.out SunOS mc68020 demand paged
+>0	byte		&0x80
+>>20	belong		<4096		shared library
+>>20	belong		=4096		dynamically linked executable
+>>20	belong		>4096		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0400410		a.out SunOS mc68020 pure
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0400407		a.out SunOS mc68020
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0200413		a.out SunOS mc68010 demand paged
+>0	byte		&0x80
+>>20	belong		<4096		shared library
+>>20	belong		=4096		dynamically linked executable
+>>20	belong		>4096		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0200410		a.out SunOS mc68010 pure
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+0	belong&077777777	0200407		a.out SunOS mc68010
+>0	byte		&0x80		dynamically linked executable
+>0	byte		^0x80		executable
+>16	belong		>0		not stripped
+
+#
+# Core files.  "SPARC 4.x BCP" means "core file from a SunOS 4.x SPARC
+# binary executed in compatibility mode under SunOS 5.x".
+#
+0	belong		0x080456	SunOS core file
+>4	belong		432		(SPARC)
+>>132	string		>\0		from '%s'
+>>116	belong		=3		(quit)
+>>116	belong		=4		(illegal instruction)
+>>116	belong		=5		(trace trap)
+>>116	belong		=6		(abort)
+>>116	belong		=7		(emulator trap)
+>>116	belong		=8		(arithmetic exception)
+>>116	belong		=9		(kill)
+>>116	belong		=10		(bus error)
+>>116	belong		=11		(segmentation violation)
+>>116	belong		=12		(bad argument to system call)
+>>116	belong		=29		(resource lost)
+>>120	belong		x		(T=%dK,
+>>124	belong		x		D=%dK,
+>>128	belong		x		S=%dK)
+>4	belong		826		(68K)
+>>128	string		>\0		from '%s'
+>4	belong		456		(SPARC 4.x BCP)
+>>152	string		>\0		from '%s'
+# Sun SunPC
+0	long		0xfa33c08e	SunPC 4.0 Hard Disk
+0	string		#SUNPC_CONFIG	SunPC 4.0 Properties Values
+# Sun snoop (see RFC 1761, which describes the capture file format,
+# RFC 3827, which describes some additional datalink types, and
+# http://www.iana.org/assignments/snoop-datalink-types/snoop-datalink-types.xml,
+# which is the IANA registry of Snoop datalink types)
+#
+0	string		snoop		Snoop capture file
+>8	belong		>0		- version %d
+>12	belong		0		(IEEE 802.3)
+>12	belong		1		(IEEE 802.4)
+>12	belong		2		(IEEE 802.5)
+>12	belong		3		(IEEE 802.6)
+>12	belong		4		(Ethernet)
+>12	belong		5		(HDLC)
+>12	belong		6		(Character synchronous)
+>12	belong		7		(IBM channel-to-channel adapter)
+>12	belong		8		(FDDI)
+>12	belong		9		(Other)
+>12	belong		10		(type %d)
+>12	belong		11		(type %d)
+>12	belong		12		(type %d)
+>12	belong		13		(type %d)
+>12	belong		14		(type %d)
+>12	belong		15		(type %d)
+>12	belong		16		(Fibre Channel)
+>12	belong		17		(ATM)
+>12	belong		18		(ATM Classical IP)
+>12	belong		19		(type %d)
+>12	belong		20		(type %d)
+>12	belong		21		(type %d)
+>12	belong		22		(type %d)
+>12	belong		23		(type %d)
+>12	belong		24		(type %d)
+>12	belong		25		(type %d)
+>12	belong		26		(IP over Infiniband)
+>12	belong		>26		(type %d)
+
+#---------------------------------------------------------------------------
+# The following entries have been tested by Duncan Laurie <duncan@sun.com> (a
+# lead Sun/Cobalt developer) who agrees that they are good and worthy of
+# inclusion.
+
+# Boot ROM images for Sun/Cobalt Linux server appliances
+0       string  Cobalt\ Networks\ Inc.\nFirmware\ v     Paged COBALT boot rom
+>38     string x        V%.4s
+
+# New format for Sun/Cobalt boot ROMs is annoying, it stores the version code
+# at the very end where file(1) can't get it.
+0       string CRfs     COBALT boot rom data (Flat boot rom or file system)
+
+#------------------------------------------------------------------------------
+# msx:  file(1) magic for the SymbOS operating system
+# http://www.symbos.de
+# Fabio R. Schmidlin <frs@pop.com.br>
+
+# SymbOS EXE file
+0x30	string		SymExe		SymbOS executable
+>0x36	ubyte		x		v%c
+>0x37	ubyte		x		\b.%c
+>0xF	string		x		\b, name: %s
+
+# SymbOS DOX document
+0	string		INFOq\0		SymbOS DOX document
+
+# Symbos driver
+0	string		SMD1		SymbOS driver
+>19	byte		x		\b, name: %c
+>20	byte		x		\b%c
+>21	byte		x		\b%c
+>22	byte		x		\b%c
+>23	byte		x		\b%c
+>24	byte		x		\b%c
+>25	byte		x		\b%c
+>26	byte		x		\b%c
+>27	byte		x		\b%c
+>28	byte		x		\b%c
+>29	byte		x		\b%c
+>30	byte		x		\b%c
+>31	byte		x		\b%c
+
+# Symbos video
+0	string		SymVid		SymbOS video
+>6	ubyte		x		v%c
+>7	ubyte		x		\b.%c
+
+# Soundtrakker 128 ST2 music
+0	byte		0
+>0xC	string		\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x40\x00	Soundtrakker 128 ST2 music,
+>>1	string		x		name: %s
+
+
+
+#------------------------------------------------------------------------
+# $File: sysex,v 1.7 2013/09/16 15:12:42 christos Exp $
+# sysex: file(1) magic for MIDI sysex files
+#
+# GRR: original 1 byte test at offset was too general as it catches also many FATs of DOS filesystems
+# where real SYStem EXclusive messages at offset 1 are limited to seven bits
+# http://en.wikipedia.org/wiki/MIDI
+0	ubeshort&0xFF80		0xF000		SysEx File -
+
+# North American Group
+>1	byte			0x01		Sequential
+>1	byte			0x02		IDP
+>1	byte			0x03		OctavePlateau
+>1	byte			0x04		Moog
+>1	byte			0x05		Passport
+>1	byte			0x06		Lexicon
+>1	byte			0x07		Kurzweil/Future Retro
+>>3	byte			0x77		777
+>>4	byte			0x00		Bank
+>>4	byte			0x01		Song
+>>5	byte			0x0f		16
+>>5	byte			0x0e		15
+>>5	byte			0x0d		14
+>>5	byte			0x0c		13
+>>5	byte			0x0b		12
+>>5	byte			0x0a		11
+>>5	byte			0x09		10
+>>5	byte			0x08		9
+>>5	byte			0x07		8
+>>5	byte			0x06		7
+>>5	byte			0x05		6
+>>5	byte			0x04		5
+>>5	byte			0x03		4
+>>5	byte			0x02		3
+>>5	byte			0x01		2
+>>5	byte			0x00		1
+>>5	byte			0x10		(ALL)
+>>2	byte			x			\b, Channel %d
+>1	byte			0x08		Fender
+>1	byte			0x09		Gulbransen
+>1	byte			0x0a		AKG
+>1	byte			0x0b		Voyce
+>1	byte			0x0c		Waveframe
+>1	byte			0x0d		ADA
+>1	byte			0x0e		Garfield
+>1	byte			0x0f		Ensoniq
+>1	byte			0x10		Oberheim
+>>2	byte			0x06		Matrix 6 series
+>>3	byte			0x0A		Dump (All)
+>>3	byte			0x01		Dump (Bank)
+>>4 belong			0x0002040E		Matrix 1000
+>>>11 byte			<2			User bank %d
+>>>11 byte			>1			Preset bank %d
+>1	byte			0x11		Apple
+>1	byte			0x12		GreyMatter
+>1	byte			0x14		PalmTree
+>1	byte			0x15		JLCooper
+>1	byte			0x16		Lowrey
+>1	byte			0x17		AdamsSmith
+>1	byte			0x18		E-mu
+>1	byte			0x19		Harmony
+>1	byte			0x1a		ART
+>1	byte			0x1b		Baldwin
+>1	byte			0x1c		Eventide
+>1	byte			0x1d		Inventronics
+>1	byte			0x1f		Clarity
+
+# European Group
+>1	byte			0x21		SIEL
+>1	byte			0x22		Synthaxe
+>1	byte			0x24		Hohner
+>1	byte			0x25		Twister
+>1	byte			0x26		Solton
+>1	byte			0x27		Jellinghaus
+>1	byte			0x28		Southworth
+>1	byte			0x29		PPG
+>1	byte			0x2a		JEN
+>1	byte			0x2b		SSL
+>1	byte			0x2c		AudioVertrieb
+
+>1	byte			0x2f		ELKA
+>>3	byte			0x09		EK-44
+
+>1	byte			0x30		Dynacord
+>1	byte			0x31		Jomox
+>1	byte			0x33		Clavia
+>1	byte			0x39		Soundcraft
+# Some Waldorf info from http://Stromeko.Synth.net/Downloads#WaldorfDocs
+>1	byte			0x3e		Waldorf
+>>2	byte			0x00		microWave
+>>2	byte			0x0E		microwave2 / XT
+>>2	byte			0x0F		Q / Q+
+>>3	byte			=0			(default id)
+>>3 byte			>0			(
+>>>3 byte			<0x7F		\bdevice %d)
+>>>3 byte			=0x7F		\bbroadcast id)
+>>3	byte			0x7f		Microwave I
+>>>4	byte			0x00		SNDR (Sound Request)
+>>>4	byte			0x10		SNDD (Sound Dump)
+>>>4	byte			0x20		SNDP (Sound Parameter Change)
+>>>4	byte			0x30		SNDQ (Sound Parameter Inquiry)
+>>>4	byte			0x70		BOOT (Sound Reserved)
+>>>4	byte			0x01		MULR (Multi Request)
+>>>4	byte			0x11		MULD (Multi Dump)
+>>>4	byte			0x21		MULP (Multi Parameter Change)
+>>>4	byte			0x31		MULQ (Multi Parameter Inquiry)
+>>>4	byte			0x71		OS (Multi Reserved)
+>>>4	byte			0x02		DRMR (Drum Map Request)
+>>>4	byte			0x12		DRMD (Drum Map Dump)
+>>>4	byte			0x22		DRMP (Drum Map Parameter Change)
+>>>4	byte			0x32		DRMQ (Drum Map Parameter Inquiry)
+>>>4	byte			0x72		BIN (Drum Map Reserved)
+>>>4	byte			0x03		PATR (Sequencer Pattern Request)
+>>>4	byte			0x13		PATD (Sequencer Pattern Dump)
+>>>4	byte			0x23		PATP (Sequencer Pattern Parameter Change)
+>>>4	byte			0x33		PATQ (Sequencer Pattern Parameter Inquiry)
+>>>4	byte			0x73		AFM (Sequencer Pattern Reserved)
+>>>4	byte			0x04		GLBR (Global Parameter Request)
+>>>4	byte			0x14		GLBD (Global Parameter Dump)
+>>>4	byte			0x24		GLBP (Global Parameter Parameter Change)
+>>>4	byte			0x34		GLBQ (Global Parameter Parameter Inquiry)
+>>>4	byte			0x07		MODR (Mode Parameter Request)
+>>>4	byte			0x17		MODD (Mode Parameter Dump)
+>>>4	byte			0x27		MODP (Mode Parameter Parameter Change)
+>>>4	byte			0x37		MODQ (Mode Parameter Parameter Inquiry)
+>>2	byte			0x10		microQ
+>>>4	byte			0x00		SNDR (Sound Request)
+>>>4	byte			0x10		SNDD (Sound Dump)
+>>>4	byte			0x20		SNDP (Sound Parameter Change)
+>>>4	byte			0x30		SNDQ (Sound Parameter Inquiry)
+>>>4	byte			0x70		(Sound Reserved)
+>>>4	byte			0x01		MULR (Multi Request)
+>>>4	byte			0x11		MULD (Multi Dump)
+>>>4	byte			0x21		MULP (Multi Parameter Change)
+>>>4	byte			0x31		MULQ (Multi Parameter Inquiry)
+>>>4	byte			0x71		OS (Multi Reserved)
+>>>4	byte			0x02		DRMR (Drum Map Request)
+>>>4	byte			0x12		DRMD (Drum Map Dump)
+>>>4	byte			0x22		DRMP (Drum Map Parameter Change)
+>>>4	byte			0x32		DRMQ (Drum Map Parameter Inquiry)
+>>>4	byte			0x72		BIN (Drum Map Reserved)
+>>>4	byte			0x04		GLBR (Global Parameter Request)
+>>>4	byte			0x14		GLBD (Global Parameter Dump)
+>>>4	byte			0x24		GLBP (Global Parameter Parameter Change)
+>>>4	byte			0x34		GLBQ (Global Parameter Parameter Inquiry)
+>>2	byte			0x11		rackAttack
+>>>4	byte			0x00		SNDR (Sound Parameter Request)
+>>>4	byte			0x10		SNDD (Sound Parameter Dump)
+>>>4	byte			0x20		SNDP (Sound Parameter Parameter Change)
+>>>4	byte			0x30		SNDQ (Sound Parameter Parameter Inquiry)
+>>>4	byte			0x01		PRGR (Program Parameter Request)
+>>>4	byte			0x11		PRGD (Program Parameter Dump)
+>>>4	byte			0x21		PRGP (Program Parameter Parameter Change)
+>>>4	byte			0x31		PRGQ (Program Parameter Parameter Inquiry)
+>>>4	byte			0x71		OS (Program Parameter Reserved)
+>>>4	byte			0x03		PATR (Pattern Parameter Request)
+>>>4	byte			0x13		PATD (Pattern Parameter Dump)
+>>>4	byte			0x23		PATP (Pattern Parameter Parameter Change)
+>>>4	byte			0x33		PATQ (Pattern Parameter Parameter Inquiry)
+>>>4	byte			0x04		GLBR (Global Parameter Request)
+>>>4	byte			0x14		GLBD (Global Parameter Dump)
+>>>4	byte			0x24		GLBP (Global Parameter Parameter Change)
+>>>4	byte			0x34		GLBQ (Global Parameter Parameter Inquiry)
+>>>4	byte			0x05		EFXR (FX Parameter Request)
+>>>4	byte			0x15		EFXD (FX Parameter Dump)
+>>>4	byte			0x25		EFXP (FX Parameter Parameter Change)
+>>>4	byte			0x35		EFXQ (FX Parameter Parameter Inquiry)
+>>>4	byte			0x07		MODR (Mode Command Request)
+>>>4	byte			0x17		MODD (Mode Command Dump)
+>>>4	byte			0x27		MODP (Mode Command Parameter Change)
+>>>4	byte			0x37		MODQ (Mode Command Parameter Inquiry)
+>>2	byte			0x03		Wave
+>>>4	byte			0x00		SBPR (Soundprogram)
+>>>4	byte			0x01		SAPR (Performance)
+>>>4	byte			0x02		SWAVE (Wave)
+>>>4	byte			0x03		SWTBL (Wave control table)
+>>>4	byte			0x04		SVT (Velocity Curve)
+>>>4	byte			0x05		STT (Tuning Table)
+>>>4	byte			0x06		SGLB (Global Parameters)
+>>>4	byte			0x07		SARRMAP (Performance Program Change Map)
+>>>4	byte			0x08		SBPRMAP (Sound Program Change Map)
+>>>4	byte			0x09		SBPRPAR (Sound Parameter)
+>>>4	byte			0x0A		SARRPAR (Performance Parameter)
+>>>4	byte			0x0B		SINSPAR (Instrument/External Parameter)
+>>>4	byte			0x0F		SBULK (Bulk Switch on/off)
+
+# Japanese Group
+>1	byte			0x40		Kawai
+>>3	byte			0x20		K1
+>>3	byte			0x22		K4
+
+>1	byte			0x41		Roland
+>>3	byte			0x14		D-50
+>>3	byte			0x2b		U-220
+>>3	byte			0x02		TR-707
+
+>1	byte			0x42		Korg
+>>3	byte			0x19		M1
+
+>1	byte			0x43		Yamaha
+>1	byte			0x44		Casio
+>1	byte			0x46		Kamiya
+>1	byte			0x47		Akai
+>1	byte			0x48		Victor
+>1	byte			0x49		Mesosha
+>1	byte			0x4b		Fujitsu
+>1	byte			0x4c		Sony
+>1	byte			0x4e		Teac
+>1	byte			0x50		Matsushita
+>1	byte			0x51		Fostex
+>1	byte			0x52		Zoom
+>1	byte			0x54		Matsushita
+>1	byte			0x57		Acoustic tech. lab.
+# http://www.midi.org/techspecs/manid.php
+>1	belong&0xffffff00	0x00007400	Ta Horng
+>1	belong&0xffffff00	0x00007500	e-Tek
+>1	belong&0xffffff00	0x00007600	E-Voice
+>1	belong&0xffffff00	0x00007700	Midisoft
+>1	belong&0xffffff00	0x00007800	Q-Sound
+>1	belong&0xffffff00	0x00007900	Westrex
+>1	belong&0xffffff00	0x00007a00	Nvidia*
+>1	belong&0xffffff00	0x00007b00	ESS
+>1	belong&0xffffff00	0x00007c00	Mediatrix
+>1	belong&0xffffff00	0x00007d00	Brooktree
+>1	belong&0xffffff00	0x00007e00	Otari
+>1	belong&0xffffff00	0x00007f00	Key Electronics
+>1	belong&0xffffff00	0x00010000	Shure
+>1	belong&0xffffff00	0x00010100	AuraSound
+>1	belong&0xffffff00	0x00010200	Crystal
+>1	belong&0xffffff00	0x00010300	Rockwell
+>1	belong&0xffffff00	0x00010400	Silicon Graphics
+>1	belong&0xffffff00	0x00010500	Midiman
+>1	belong&0xffffff00	0x00010600	PreSonus
+>1	belong&0xffffff00	0x00010800	Topaz
+>1	belong&0xffffff00	0x00010900	Cast Lightning
+>1	belong&0xffffff00	0x00010a00	Microsoft
+>1	belong&0xffffff00	0x00010b00	Sonic Foundry
+>1	belong&0xffffff00	0x00010c00	Line 6
+>1	belong&0xffffff00	0x00010d00	Beatnik Inc.
+>1	belong&0xffffff00	0x00010e00	Van Koerving
+>1	belong&0xffffff00	0x00010f00	Altech Systems
+>1	belong&0xffffff00	0x00011000	S & S Research
+>1	belong&0xffffff00	0x00011100	VLSI Technology
+>1	belong&0xffffff00	0x00011200	Chromatic
+>1	belong&0xffffff00	0x00011300	Sapphire
+>1	belong&0xffffff00	0x00011400	IDRC
+>1	belong&0xffffff00	0x00011500	Justonic Tuning
+>1	belong&0xffffff00	0x00011600	TorComp
+>1	belong&0xffffff00	0x00011700	Newtek Inc.
+>1	belong&0xffffff00	0x00011800	Sound Sculpture
+>1	belong&0xffffff00	0x00011900	Walker Technical
+>1	belong&0xffffff00	0x00011a00	Digital Harmony
+>1	belong&0xffffff00	0x00011b00	InVision
+>1	belong&0xffffff00	0x00011c00	T-Square
+>1	belong&0xffffff00	0x00011d00	Nemesys
+>1	belong&0xffffff00	0x00011e00	DBX
+>1	belong&0xffffff00	0x00011f00	Syndyne
+>1	belong&0xffffff00	0x00012000	Bitheadz	
+>1	belong&0xffffff00	0x00012100	Cakewalk
+>1	belong&0xffffff00	0x00012200	Staccato
+>1	belong&0xffffff00	0x00012300	National Semicon.
+>1	belong&0xffffff00	0x00012400	Boom Theory
+>1	belong&0xffffff00	0x00012500	Virtual DSP Corp
+>1	belong&0xffffff00	0x00012600	Antares
+>1	belong&0xffffff00	0x00012700	Angel Software
+>1	belong&0xffffff00	0x00012800	St Louis Music
+>1	belong&0xffffff00	0x00012900	Lyrrus dba G-VOX
+>1	belong&0xffffff00	0x00012a00	Ashley Audio
+>1	belong&0xffffff00	0x00012b00	Vari-Lite
+>1	belong&0xffffff00	0x00012c00	Summit Audio
+>1	belong&0xffffff00	0x00012d00	Aureal Semicon.
+>1	belong&0xffffff00	0x00012e00	SeaSound
+>1	belong&0xffffff00	0x00012f00	U.S. Robotics
+>1	belong&0xffffff00	0x00013000	Aurisis
+>1	belong&0xffffff00	0x00013100	Nearfield Multimedia
+>1	belong&0xffffff00	0x00013200	FM7 Inc.
+>1	belong&0xffffff00	0x00013300	Swivel Systems
+>1	belong&0xffffff00	0x00013400	Hyperactive
+>1	belong&0xffffff00	0x00013500	MidiLite
+>1	belong&0xffffff00	0x00013600	Radical
+>1	belong&0xffffff00	0x00013700	Roger Linn
+>1	belong&0xffffff00	0x00013800	Helicon
+>1	belong&0xffffff00	0x00013900	Event
+>1	belong&0xffffff00	0x00013a00	Sonic Network
+>1	belong&0xffffff00	0x00013b00	Realtime Music
+>1	belong&0xffffff00	0x00013c00	Apogee Digital
+
+>1	belong&0xffffff00	0x00202b00	Medeli Electronics
+>1	belong&0xffffff00	0x00202c00	Charlie Lab
+>1	belong&0xffffff00	0x00202d00	Blue Chip Music
+>1	belong&0xffffff00	0x00202e00	BEE OH Corp
+>1	belong&0xffffff00	0x00202f00	LG Semicon America
+>1	belong&0xffffff00	0x00203000	TESI
+>1	belong&0xffffff00	0x00203100	EMAGIC
+>1	belong&0xffffff00	0x00203200	Behringer
+>1	belong&0xffffff00	0x00203300	Access Music
+>1	belong&0xffffff00	0x00203400	Synoptic
+>1	belong&0xffffff00	0x00203500	Hanmesoft Corp
+>1	belong&0xffffff00	0x00203600	Terratec
+>1	belong&0xffffff00	0x00203700	Proel SpA
+>1	belong&0xffffff00	0x00203800	IBK MIDI
+>1	belong&0xffffff00	0x00203900	IRCAM
+>1	belong&0xffffff00	0x00203a00	Propellerhead Software
+>1	belong&0xffffff00	0x00203b00	Red Sound Systems
+>1	belong&0xffffff00	0x00203c00	Electron ESI AB
+>1	belong&0xffffff00	0x00203d00	Sintefex Audio
+>1	belong&0xffffff00	0x00203e00	Music and More
+>1	belong&0xffffff00	0x00203f00	Amsaro
+>1	belong&0xffffff00	0x00204000	CDS Advanced Technology
+>1	belong&0xffffff00	0x00204100	Touched by Sound
+>1	belong&0xffffff00	0x00204200	DSP Arts
+>1	belong&0xffffff00	0x00204300	Phil Rees Music
+>1	belong&0xffffff00	0x00204400	Stamer Musikanlagen GmbH
+>1	belong&0xffffff00	0x00204500	Soundart
+>1	belong&0xffffff00	0x00204600	C-Mexx Software
+>1	belong&0xffffff00	0x00204700	Klavis Tech.
+>1	belong&0xffffff00	0x00204800	Noteheads AB
+
+0	string			T707		Roland TR-707 Data
+#------------------------------------------------------------------------------
+# file:  file(1) magic for Tcl scripting language
+# URL:  http://www.tcl.tk/
+# From: gustaf neumann
+
+# Tcl scripts
+0	search/1/w	#!\ /usr/bin/tcl	Tcl script text executable
+!:mime	text/x-tcl
+0	search/1/w	#!\ /usr/local/bin/tcl	Tcl script text executable
+!:mime	text/x-tcl
+0	search/1	#!/usr/bin/env\ tcl	Tcl script text executable
+!:mime	text/x-tcl
+0	search/1	#!\ /usr/bin/env\ tcl	Tcl script text executable
+!:mime	text/x-tcl
+0	search/1/w	#!\ /usr/bin/wish	Tcl/Tk script text executable
+!:mime	text/x-tcl
+0	search/1/w	#!\ /usr/local/bin/wish	Tcl/Tk script text executable
+!:mime	text/x-tcl
+0	search/1	#!/usr/bin/env\ wish	Tcl/Tk script text executable
+!:mime	text/x-tcl
+0	search/1	#!\ /usr/bin/env\ wish	Tcl/Tk script text executable
+!:mime	text/x-tcl
+
+# check the first line
+0	search/1	package\ req
+>0	regex		\^package[\ \t]+req	Tcl script
+# not 'p', check other lines
+0	search/1	!p
+>0	regex		\^package[\ \t]+req	Tcl script
+
+#------------------------------------------------------------------------------
+# $File$
+# teapot:  file(1) magic for "teapot" spreadsheet
+#
+0       string          #!teapot\012xdr      teapot work sheet (XDR format)
+
+#------------------------------------------------------------------------------
+# $File$
+# terminfo:  file(1) magic for terminfo
+#
+# XXX - byte order for screen images?
+#
+0	string		\032\001	Compiled terminfo entry
+0	short		0433		Curses screen image
+0	short		0434		Curses screen image
+
+#------------------------------------------------------------------------------
+# $File: tex,v 1.19 2013/09/17 17:39:16 christos Exp $
+# tex:  file(1) magic for TeX files
+#
+# XXX - needs byte-endian stuff (big-endian and little-endian DVI?)
+#
+# From <conklin@talisman.kaleida.com>
+
+# Although we may know the offset of certain text fields in TeX DVI
+# and font files, we can't use them reliably because they are not
+# zero terminated. [but we do anyway, christos]
+0	string		\367\002	TeX DVI file
+!:mime	application/x-dvi
+>16	string		>\0		(%s)
+0	string		\367\203	TeX generic font data
+0	string		\367\131	TeX packed font data
+>3	string		>\0		(%s)
+0	string		\367\312	TeX virtual font data
+0	search/1	This\ is\ TeX,	TeX transcript text
+0	search/1	This\ is\ METAFONT,	METAFONT transcript text
+
+# There is no way to detect TeX Font Metric (*.tfm) files without
+# breaking them apart and reading the data.  The following patterns
+# match most *.tfm files generated by METAFONT or afm2tfm.
+2	string		\000\021	TeX font metric data
+!:mime	application/x-tex-tfm
+>33	string		>\0		(%s)
+2	string		\000\022	TeX font metric data
+!:mime	application/x-tex-tfm
+>33	string		>\0		(%s)
+
+# Texinfo and GNU Info, from Daniel Quinlan (quinlan@yggdrasil.com)
+0	search/1	\\input\ texinfo	Texinfo source text
+!:mime	text/x-texinfo
+0	search/1	This\ is\ Info\ file	GNU Info text
+!:mime	text/x-info
+
+# TeX documents, from Daniel Quinlan (quinlan@yggdrasil.com)
+0	search/4096	\\input		TeX document text
+!:mime	text/x-tex
+!:strength + 15
+0	search/4096	\\begin		LaTeX document text
+!:mime	text/x-tex
+!:strength + 15
+0	search/4096	\\section	LaTeX document text
+!:mime	text/x-tex
+!:strength + 18
+0	search/4096	\\setlength	LaTeX document text
+!:mime	text/x-tex
+!:strength + 15
+0	search/4096	\\documentstyle	LaTeX document text
+!:mime	text/x-tex
+!:strength + 18
+0	search/4096	\\chapter	LaTeX document text
+!:mime	text/x-tex
+!:strength + 18
+0	search/4096	\\documentclass	LaTeX 2e document text
+!:mime	text/x-tex
+!:strength + 15
+0	search/4096	\\relax		LaTeX auxiliary file
+!:mime	text/x-tex
+!:strength + 15
+0	search/4096	\\contentsline	LaTeX table of contents
+!:mime	text/x-tex
+!:strength + 15
+0	search/4096	%\ -*-latex-*-	LaTeX document text
+!:mime	text/x-tex
+
+# Tex document, from Hendrik Scholz <hendrik@scholz.net>
+0   	search/1	\\ifx		TeX document text
+
+# Index and glossary files
+0	search/4096	\\indexentry	LaTeX raw index file
+0	search/4096	\\begin{theindex}	LaTeX sorted index
+0	search/4096	\\glossaryentry	LaTeX raw glossary
+0	search/4096	\\begin{theglossary}	LaTeX sorted glossary
+0	search/4096	This\ is\ makeindex	Makeindex log file
+
+# End of TeX
+
+#------------------------------------------------------------------------------
+# file(1) magic for BibTex text files
+# From Hendrik Scholz <hendrik@scholz.net>
+
+0	search/1/c	@article{	BibTeX text file
+0	search/1/c	@book{		BibTeX text file
+0	search/1/c	@inbook{	BibTeX text file
+0	search/1/c	@incollection{	BibTeX text file
+0	search/1/c	@inproceedings{	BibTeX text file
+0	search/1/c	@manual{	BibTeX text file
+0	search/1/c	@misc{		BibTeX text file
+0	search/1/c	@preamble{	BibTeX text file
+0	search/1/c	@phdthesis{	BibTeX text file
+0	search/1/c	@techreport{	BibTeX text file
+0	search/1/c	@unpublished{	BibTeX text file
+
+73	search/1	%%%\ \ 		BibTeX-file{ BibTex text file (with full header)
+
+73	search/1	%%%\ \ @BibTeX-style-file{   BibTeX style text file (with full header)
+
+0	search/1	%\ BibTeX\ standard\ bibliography\ 	BibTeX standard bibliography style text file
+
+0	search/1	%\ BibTeX\ `	BibTeX custom bibliography style text file
+
+0	search/1	@c\ @mapfile{	TeX font aliases text file
+
+0	string		#LyX		LyX document text
+
+# ConTeXt documents
+#	http://wiki.contextgarden.net/
+0	search/4096	\\setupcolors[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\definecolor[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupinteraction[	ConTeXt document text
+!:strength + 15
+0	search/4096	\\useURL[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\setuppapersize[	ConTeXt document text
+!:strength + 15
+0	search/4096	\\setuplayout[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupfooter[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupfootertexts[	ConTeXt document text
+!:strength + 15
+0	search/4096	\\setuppagenumbering[	ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupbodyfont[	ConTeXt document text
+!:strength + 15
+0	search/4096	\\setuphead[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupitemize[		ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupwhitespace[	ConTeXt document text
+!:strength + 15
+0	search/4096	\\setupindenting[	ConTeXt document text
+!:strength + 15
+
+#------------------------------------------------------------------------------
+# $File: tgif,v 1.6 2010/09/20 18:55:20 rrt Exp $
+# file(1) magic for tgif(1) files
+# From Hendrik Scholz <hendrik@scholz.net>
+0	string	%TGIF\ 			Tgif file version
+>6	string	x			%s
+
+#------------------------------------------------------------------------------
+# $File: ti-8x,v 1.6 2009/09/19 16:28:12 christos Exp $
+# ti-8x: file(1) magic for the TI-8x and TI-9x Graphing Calculators.
+#
+# From: Ryan McGuire (rmcguire@freenet.columbus.oh.us).
+#
+# Update: Romain Lievin (roms@lpg.ticalc.org).
+#
+# NOTE: This list is not complete.
+# Files for the TI-80 and TI-81 are pretty rare. I'm not going to put the
+# program/group magic numbers in here because I cannot find any.
+0		string		**TI80**	TI-80 Graphing Calculator File.
+0		string		**TI81**	TI-81 Graphing Calculator File.
+#
+# Magic Numbers for the TI-73
+#
+0		string		**TI73**	TI-73 Graphing Calculator
+>0x00003B	byte		0x00		(real number)
+>0x00003B	byte		0x01		(list)
+>0x00003B	byte		0x02		(matrix)
+>0x00003B	byte		0x03		(equation)
+>0x00003B	byte		0x04		(string)
+>0x00003B	byte		0x05		(program)
+>0x00003B	byte		0x06		(assembly program)
+>0x00003B	byte		0x07		(picture)
+>0x00003B	byte		0x08		(gdb)
+>0x00003B	byte		0x0C		(complex number)
+>0x00003B	byte		0x0F		(window settings)
+>0x00003B	byte		0x10		(zoom)
+>0x00003B	byte		0x11		(table setup)
+>0x00003B	byte		0x13		(backup)
+
+# Magic Numbers for the TI-82
+#
+0		string		**TI82**	TI-82 Graphing Calculator
+>0x00003B	byte		0x00		(real)
+>0x00003B	byte		0x01		(list)
+>0x00003B	byte		0x02		(matrix)
+>0x00003B	byte		0x03		(Y-variable)
+>0x00003B	byte		0x05		(program)
+>0x00003B	byte		0x06		(protected prgm)
+>0x00003B	byte		0x07		(picture)
+>0x00003B	byte		0x08		(gdb)
+>0x00003B	byte		0x0B		(window settings)
+>0x00003B	byte		0x0C		(window settings)
+>0x00003B	byte		0x0D		(table setup)
+>0x00003B	byte		0x0E		(screenshot)
+>0x00003B	byte		0x0F		(backup)
+#
+# Magic Numbers for the TI-83
+#
+0		string		**TI83**	TI-83 Graphing Calculator
+>0x00003B	byte		0x00		(real)
+>0x00003B	byte		0x01		(list)
+>0x00003B	byte		0x02		(matrix)
+>0x00003B	byte		0x03		(Y-variable)
+>0x00003B	byte		0x04		(string)
+>0x00003B	byte		0x05		(program)
+>0x00003B	byte		0x06		(protected prgm)
+>0x00003B	byte		0x07		(picture)
+>0x00003B	byte		0x08		(gdb)
+>0x00003B	byte		0x0B		(window settings)
+>0x00003B	byte		0x0C		(window settings)
+>0x00003B	byte		0x0D		(table setup)
+>0x00003B	byte		0x0E		(screenshot)
+>0x00003B	byte		0x13		(backup)
+#
+# Magic Numbers for the TI-83+
+#
+0		string		**TI83F*	TI-83+ Graphing Calculator
+>0x00003B	byte		0x00		(real number)
+>0x00003B	byte		0x01		(list)
+>0x00003B	byte		0x02		(matrix)
+>0x00003B	byte		0x03		(equation)
+>0x00003B	byte		0x04		(string)
+>0x00003B	byte		0x05		(program)
+>0x00003B	byte		0x06		(assembly program)
+>0x00003B	byte		0x07		(picture)
+>0x00003B	byte		0x08		(gdb)
+>0x00003B	byte		0x0C		(complex number)
+>0x00003B	byte		0x0F		(window settings)
+>0x00003B	byte		0x10		(zoom)
+>0x00003B	byte		0x11		(table setup)
+>0x00003B	byte		0x13		(backup)
+>0x00003B	byte		0x15		(application variable)
+>0x00003B	byte		0x17		(group of variable)
+
+#
+# Magic Numbers for the TI-85
+#
+0		string		**TI85**	TI-85 Graphing Calculator
+>0x00003B	byte		0x00		(real number)
+>0x00003B	byte		0x01		(complex number)
+>0x00003B	byte		0x02		(real vector)
+>0x00003B	byte		0x03		(complex vector)
+>0x00003B	byte		0x04		(real list)
+>0x00003B	byte		0x05		(complex list)
+>0x00003B	byte		0x06		(real matrix)
+>0x00003B	byte		0x07		(complex matrix)
+>0x00003B	byte		0x08		(real constant)
+>0x00003B	byte		0x09		(complex constant)
+>0x00003B	byte		0x0A		(equation)
+>0x00003B	byte		0x0C		(string)
+>0x00003B	byte		0x0D		(function GDB)
+>0x00003B	byte		0x0E		(polar GDB)
+>0x00003B	byte		0x0F		(parametric GDB)
+>0x00003B	byte		0x10		(diffeq GDB)
+>0x00003B	byte		0x11		(picture)
+>0x00003B	byte		0x12		(program)
+>0x00003B	byte		0x13		(range)
+>0x00003B	byte		0x17		(window settings)
+>0x00003B	byte		0x18		(window settings)
+>0x00003B	byte		0x19		(window settings)
+>0x00003B	byte		0x1A		(window settings)
+>0x00003B	byte		0x1B		(zoom)
+>0x00003B	byte		0x1D		(backup)
+>0x00003B	byte		0x1E		(unknown)
+>0x00003B	byte		0x2A		(equation)
+>0x000032	string		ZS4		- ZShell Version 4 File.
+>0x000032	string		ZS3		- ZShell Version 3 File.
+#
+# Magic Numbers for the TI-86
+#
+0		string		**TI86**	TI-86 Graphing Calculator
+>0x00003B	byte		0x00		(real number)
+>0x00003B	byte		0x01		(complex number)
+>0x00003B	byte		0x02		(real vector)
+>0x00003B	byte		0x03		(complex vector)
+>0x00003B	byte		0x04		(real list)
+>0x00003B	byte		0x05		(complex list)
+>0x00003B	byte		0x06		(real matrix)
+>0x00003B	byte		0x07		(complex matrix)
+>0x00003B	byte		0x08		(real constant)
+>0x00003B	byte		0x09		(complex constant)
+>0x00003B	byte		0x0A		(equation)
+>0x00003B	byte		0x0C		(string)
+>0x00003B	byte		0x0D		(function GDB)
+>0x00003B	byte		0x0E		(polar GDB)
+>0x00003B	byte		0x0F		(parametric GDB)
+>0x00003B	byte		0x10		(diffeq GDB)
+>0x00003B	byte		0x11		(picture)
+>0x00003B	byte		0x12		(program)
+>0x00003B	byte		0x13		(range)
+>0x00003B	byte		0x17		(window settings)
+>0x00003B	byte		0x18		(window settings)
+>0x00003B	byte		0x19		(window settings)
+>0x00003B	byte		0x1A		(window settings)
+>0x00003B	byte		0x1B		(zoom)
+>0x00003B	byte		0x1D		(backup)
+>0x00003B	byte		0x1E		(unknown)
+>0x00003B	byte		0x2A		(equation)
+#
+# Magic Numbers for the TI-89
+#
+0		string		**TI89**	TI-89 Graphing Calculator
+>0x000048	byte		0x00		(expression)
+>0x000048	byte		0x04		(list)
+>0x000048	byte		0x06		(matrix)
+>0x000048	byte		0x0A		(data)
+>0x000048	byte		0x0B		(text)
+>0x000048	byte		0x0C		(string)
+>0x000048	byte		0x0D		(graphic data base)
+>0x000048	byte		0x0E		(figure)
+>0x000048	byte		0x10		(picture)
+>0x000048	byte		0x12		(program)
+>0x000048	byte		0x13		(function)
+>0x000048	byte		0x14		(macro)
+>0x000048	byte		0x1C		(zipped)
+>0x000048	byte		0x21		(assembler)
+#
+# Magic Numbers for the TI-92
+#
+0		string		**TI92**	TI-92 Graphing Calculator
+>0x000048	byte		0x00		(expression)
+>0x000048	byte		0x04		(list)
+>0x000048	byte		0x06		(matrix)
+>0x000048	byte		0x0A		(data)
+>0x000048	byte		0x0B		(text)
+>0x000048	byte		0x0C		(string)
+>0x000048	byte		0x0D		(graphic data base)
+>0x000048	byte		0x0E		(figure)
+>0x000048	byte		0x10		(picture)
+>0x000048	byte		0x12		(program)
+>0x000048	byte		0x13		(function)
+>0x000048	byte		0x14		(macro)
+>0x000048	byte		0x1D		(backup)
+#
+# Magic Numbers for the TI-92+/V200
+#
+0		string		**TI92P*	TI-92+/V200 Graphing Calculator
+>0x000048	byte		0x00		(expression)
+>0x000048	byte		0x04		(list)
+>0x000048	byte		0x06		(matrix)
+>0x000048	byte		0x0A		(data)
+>0x000048	byte		0x0B		(text)
+>0x000048	byte		0x0C		(string)
+>0x000048	byte		0x0D		(graphic data base)
+>0x000048	byte		0x0E		(figure)
+>0x000048	byte		0x10		(picture)
+>0x000048	byte		0x12		(program)
+>0x000048	byte		0x13		(function)
+>0x000048	byte		0x14		(macro)
+>0x000048	byte		0x1C		(zipped)
+>0x000048	byte		0x21		(assembler)
+#
+# Magic Numbers for the TI-73/83+/89/92+/V200 FLASH upgrades
+#
+0x0000016	string		Advanced	TI-XX Graphing Calculator (FLASH)
+0		string		**TIFL**	TI-XX Graphing Calculator (FLASH)
+>8		byte		>0		- Revision %d
+>>9 		byte		x		\b.%d,
+>12		byte		>0		Revision date %02x
+>>13		byte		x		\b/%02x
+>>14		beshort		x		\b/%04x,
+>17		string		>/0		name: '%s',
+>48		byte		0x74		device: TI-73,
+>48		byte		0x73		device: TI-83+,
+>48		byte		0x98		device: TI-89,
+>48		byte		0x88		device: TI-92+,
+>49		byte		0x23		type: OS upgrade,
+>49		byte		0x24		type: application,
+>49		byte		0x25		type: certificate,
+>49		byte		0x3e		type: license,
+>74		lelong		>0		size: %d bytes
+
+# VTi & TiEmu skins (TI Graphing Calculators).
+# From: Romain Lievin (roms@lpg.ticalc.org).
+# Magic Numbers for the VTi skins
+0               string          VTI		Virtual TI skin
+>3		string		v		- Version
+>>4		byte		>0		\b %c
+>>6		byte		x		\b.%c
+# Magic Numbers for the TiEmu skins
+0		string		TiEmu		TiEmu skin
+>6              string          v               - Version
+>>7             byte            >0              \b %c
+>>9             byte            x               \b.%c
+>>10		byte		x		\b%c
+
+#------------------------------------------------------------------------------
+# $File$
+# timezone:  file(1) magic for timezone data
+#
+# from Daniel Quinlan (quinlan@yggdrasil.com)
+# this should work on Linux, SunOS, and maybe others
+# Added new official magic number for recent versions of the Olson code
+0	string	TZif	timezone data
+>4	byte	0	\b, old version
+>4	byte	>0	\b, version %c
+>20	belong	0	\b, no gmt time flags
+>20	belong	1	\b, 1 gmt time flag
+>20	belong	>1	\b, %d gmt time flags
+>24	belong	0	\b, no std time flags
+>20	belong	1	\b, 1 std time flag
+>24	belong	>1	\b, %d std time flags
+>28	belong	0	\b, no leap seconds
+>28	belong	1	\b, 1 leap second
+>28	belong  >1	\b, %d leap seconds
+>32	belong	0	\b, no transition times
+>32	belong	1	\b, 1 transition time
+>32	belong  >1	\b, %d transition times
+>36	belong	0	\b, no abbreviation chars
+>36	belong	1	\b, 1 abbreviation char
+>36	belong	>1	\b, %d abbreviation chars
+0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1\0	old timezone data
+0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\2\0	old timezone data
+0	string  \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\3\0	old timezone data
+0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\4\0	old timezone data
+0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\5\0	old timezone data
+0	string	\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\6\0	old timezone data
+
+#------------------------------------------------------------------------------
+# $File: troff,v 1.10 2009/09/19 16:28:12 christos Exp $
+# troff:  file(1) magic for *roff
+#
+# updated by Daniel Quinlan (quinlan@yggdrasil.com)
+
+# troff input
+0	search/1	.\\"		troff or preprocessor input text
+!:mime	text/troff
+0	search/1	'\\"		troff or preprocessor input text
+!:mime	text/troff
+0	search/1	'.\\"		troff or preprocessor input text
+!:mime	text/troff
+0	search/1	\\"		troff or preprocessor input text
+!:mime	text/troff
+0	search/1	'''		troff or preprocessor input text
+!:mime	text/troff
+0	regex/20l	\^\\.[A-Za-z0-9][A-Za-z0-9][\ \t]	troff or preprocessor input text
+!:mime	text/troff
+0	regex/20l	\^\\.[A-Za-z0-9][A-Za-z0-9]$	troff or preprocessor input text
+!:mime	text/troff
+
+# ditroff intermediate output text
+0	search/1	x\ T		ditroff output text
+>4	search/1	cat		for the C/A/T phototypesetter
+>4	search/1	ps		for PostScript
+>4	search/1	dvi		for DVI
+>4	search/1	ascii		for ASCII
+>4	search/1	lj4		for LaserJet 4
+>4	search/1	latin1		for ISO 8859-1 (Latin 1)
+>4	search/1	X75		for xditview at 75dpi
+>>7	search/1	-12		(12pt)
+>4	search/1	X100		for xditview at 100dpi
+>>8	search/1	-12		(12pt)
+
+# output data formats
+0	string		\100\357	very old (C/A/T) troff output data
+
+#------------------------------------------------------------------------------
+# $File$
+# tuxedo:	file(1) magic for BEA TUXEDO data files
+#
+# from Ian Springer <ispringer@hotmail.com>
+#
+0	string		\0\0\1\236\0\0\0\0\0\0\0\0\0\0\0\0	BEA TUXEDO DES mask data
+
+#------------------------------------------------------------------------------
+# $File$
+# typeset:  file(1) magic for other typesetting
+#
+0	string		Interpress/Xerox	Xerox InterPress data
+>16	string		/			(version
+>>17	string		>\0			%s)
+
+#------------------------------------------------------------------------------
+# $File: unicode,v 1.5 2009/09/19 16:28:13 christos Exp $
+# Unicode:  BOM prefixed text files - Adrian Havill <havill@turbolinux.co.jp>
+# GRR: These types should be recognised in file_ascmagic so these
+# encodings can be treated by text patterns.
+# Missing types are already dealt with internally.
+#
+0	string	+/v8			Unicode text, UTF-7
+0	string	+/v9			Unicode text, UTF-7
+0	string	+/v+			Unicode text, UTF-7
+0	string	+/v/			Unicode text, UTF-7
+0	string	\335\163\146\163	Unicode text, UTF-8-EBCDIC
+0	string	\000\000\376\377	Unicode text, UTF-32, big-endian
+0	string	\377\376\000\000	Unicode text, UTF-32, little-endian
+0	string	\016\376\377		Unicode text, SCSU (Standard Compression Scheme for Unicode)
+
+#------------------------------------------------------------------------------
+# $File: unknown,v 1.7 2009/09/19 16:28:13 christos Exp $
+# unknown:  file(1) magic for unknown machines
+#
+# 0x107 is 0407, 0x108 is 0410, and 0x109 is 0411; those are all PDP-11
+# (executable, pure, and split I&D, respectively), but the PDP-11 version
+# doesn't have the "version %ld", which may be a bogus COFFism (I don't
+# think there was ever COFF for the PDP-11).
+#
+# 0x10B is 0413; that's VAX demand-paged, but this is a short, not a
+# long, as it would be on a VAX.  In any case, that could collide with
+# VAX demand-paged files, as the magic number is little-endian on those
+# binaries, so the first 16 bits of the file would contain 0x10B.
+#
+# Therefore, those entries are commented out.
+#
+# 0x10C is 0414 and 0x10E is 0416; those *are* unknown.
+#
+#0	short		0x107		unknown machine executable
+#>8	short		>0		not stripped
+#>15	byte		>0		- version %ld
+#0	short		0x108		unknown pure executable
+#>8	short		>0		not stripped
+#>15	byte		>0		- version %ld
+#0	short		0x109		PDP-11 separate I&D
+#>8	short		>0		not stripped
+#>15	byte		>0		- version %ld
+#0	short		0x10b		unknown pure executable
+#>8	short		>0		not stripped
+#>15	byte		>0		- version %ld
+0	long		0x10c		unknown demand paged pure executable
+>16	long		>0		not stripped
+0	long		0x10e		unknown readable demand paged pure executable
+
+#------------------------------------------------------------------------------
+# $File: uterus,v 1.2 2014/04/28 12:04:50 christos Exp $
+# file(1) magic for uterus files
+# http://freecode.com/projects/uterus
+#
+0	string		UTE+	uterus file
+>4	string		v	\b, version
+>5	byte		x	%c
+>6	string		.	\b.
+>7	byte		x	\b%c
+>8	string		\<\>	\b, big-endian
+>>16	belong		>0	\b, slut size %u
+>8	string		\>\<	\b, litte-endian
+>>16	lelong		>0	\b, slut size %u
+>10	byte		&8	\b, compressed
+
+#------------------------------------------------------------------------------
+# $File$
+# uuencode:  file(1) magic for ASCII-encoded files
+#
+
+# GRR:  the first line of xxencoded files is identical to that in uuencoded
+# files, but the first character in most subsequent lines is 'h' instead of
+# 'M'.  (xxencoding uses lowercase letters in place of most of uuencode's
+# punctuation and survives BITNET gateways better.)  If regular expressions
+# were supported, this entry could possibly be split into two with
+# "begin\040\.\*\012M" or "begin\040\.\*\012h" (where \. and \* are REs).
+0	search/1	begin\ 		uuencoded or xxencoded text
+
+# btoa(1) is an alternative to uuencode that requires less space.
+0	search/1	xbtoa\ Begin	btoa'd text
+
+# ship(1) is another, much cooler alternative to uuencode.
+# Greg Roelofs, newt@uchicago.edu
+0	search/1	$\012ship	ship'd binary text
+
+# bencode(8) is used to encode compressed news batches (Bnews/Cnews only?)
+# Greg Roelofs, newt@uchicago.edu
+0	search/1	Decode\ the\ following\ with\ bdeco	bencoded News text
+
+# BinHex is the Macintosh ASCII-encoded file format (see also "apple")
+# Daniel Quinlan, quinlan@yggdrasil.com
+11	search/1	must\ be\ converted\ with\ BinHex	BinHex binary text
+>41	search/1	x					\b, version %.3s
+
+# GRR: handle BASE64
+
+#------------------------------------------------------------------------------
+# $File: varied.out,v 1.22 2010/07/02 00:06:27 christos Exp $
+# varied.out:  file(1) magic for various USG systems
+#
+#	Herewith many of the object file formats used by USG systems.
+#	Most have been moved to files for a particular processor,
+#	and deleted if they duplicate other entries.
+#
+0	short		0610		Perkin-Elmer executable
+# AMD 29K
+0	beshort		0572		amd 29k coff noprebar executable
+0	beshort		01572		amd 29k coff prebar executable
+0	beshort		0160007		amd 29k coff archive
+# Cray
+6	beshort		0407		unicos (cray) executable
+# Ultrix 4.3
+596	string		\130\337\377\377	Ultrix core file
+>600	string		>\0		from '%s'
+# BeOS and MAcOS PEF executables
+# From: hplus@zilker.net (Jon Watte)
+0	string		Joy!peffpwpc	header for PowerPC PEF executable
+#
+# ava assembler/linker Uros Platise <uros.platise@ijs.si>
+0       string          avaobj  AVR assembler object code
+>7      string          >\0     version '%s'
+# gnu gmon magic From: Eugen Dedu <dedu@ese-metz.fr>
+0	string		gmon		GNU prof performance data
+>4	long		x		- version %d
+# From: Dave Pearson <davep@davep.org>
+# Harbour <URL:http://harbour-project.org/> HRB files.
+0	string		\xc0HRB		Harbour HRB file
+>4	leshort		x		version %d
+# Harbour HBV files
+0	string		\xc0HBV		Harbour variable dump file
+>4	leshort		x		version %d
+
+# From: Alex Beregszaszi <alex@fsn.hu>
+# 0	string		exec 		BugOS executable
+# 0	string		pack		BugOS archive
+
+# From: Jason Spence <jspence@lightconsulting.com>
+# Generated by the "examples" in STM's ST40 devkit, and derived code.
+0	lelong		0x13a9f17e	ST40 component image format
+>4	string		>\0		\b, name '%s'
+
+#------------------------------------------------------------------------------
+# $File: varied.script,v 1.9 2011/12/16 16:32:48 rrt Exp $
+# varied.script:  file(1) magic for various interpreter scripts
+
+0	string/t		#!\ /			a
+>3	string		>\0			%s script text executable
+!:strength / 2
+
+0	string/b		#!\ /			a
+>3	string		>\0			%s script executable (binary data)
+!:strength / 2
+
+0	string/t		#!\t/			a
+>3	string		>\0			%s script text executable
+!:strength / 2
+
+0	string/b		#!\t/			a
+>3	string		>\0			%s script executable (binary data)
+!:strength / 2
+
+0	string/t		#!/			a
+>2	string		>\0			%s script text executable
+!:strength / 2
+
+0	string/b		#!/			a
+>2	string		>\0			%s script executable (binary data)
+!:strength / 2
+
+0	string/t		#!\ 			script text executable
+>3	string		>\0			for %s
+!:strength / 3
+
+0	string/b		#!\ 			script executable
+>3	string		>\0			for %s (binary data)
+!:strength / 3
+
+# using env
+0	string/t	#!/usr/bin/env		a
+>15	string/t	>\0			%s script text executable
+!:strength / 10
+
+0	string/b	#!/usr/bin/env		a
+>15	string/b	>\0			%s script executable (binary data)
+!:strength / 10
+
+0	string/t	#!\ /usr/bin/env	a
+>16	string/t	>\0			%s script text executable
+!:strength / 10
+
+0	string/b	#!\ /usr/bin/env	a
+>16	string/b	>\0			%s script executable (binary data)
+!:strength / 10
+
+# From: arno <arenevier@fdn.fr>
+# mozilla xpconnect typelib
+# see http://www.mozilla.org/scriptable/typelib_file.html
+0	string 		XPCOM\nTypeLib\r\n\032		XPConnect Typelib
+>0x10  byte        x       version %d
+>>0x11 byte        x      \b.%d
+
+#------------------------------------------------------------------------------
+# $File: vax,v 1.8 2013/01/09 22:37:24 christos Exp $
+# vax:  file(1) magic for VAX executable/object and APL workspace
+#
+0	lelong		0101557		VAX single precision APL workspace
+0	lelong		0101556		VAX double precision APL workspace
+
+#
+# VAX a.out (BSD; others collide with 386 and other 32-bit little-endian
+# executables, and are handled in aout)
+#
+0	lelong		0420		a.out VAX demand paged (first page unmapped) pure executable
+>16	lelong		>0		not stripped
+
+#
+# VAX COFF
+#
+# The `versions' were commented out, but have been un-commented out.
+# (Was the problem just one of endianness?)
+#
+0	leshort		0570		VAX COFF executable
+>12	lelong		>0		not stripped
+>22	leshort		>0		- version %d
+0	leshort		0575		VAX COFF pure executable
+>12	lelong		>0		not stripped
+>22	leshort		>0		- version %d
+
+#------------------------------------------------------------------------------
+# $File$
+# vicar:  file(1) magic for VICAR files.
+#
+# From: Ossama Othman <othman@astrosun.tn.cornell.edu
+# VICAR is JPL's in-house spacecraft image processing program
+# VICAR image
+0	string	LBLSIZE=	VICAR image data
+>32	string	BYTE		\b, 8 bits  = VAX byte
+>32	string	HALF		\b, 16 bits = VAX word     = Fortran INTEGER*2
+>32	string	FULL		\b, 32 bits = VAX longword = Fortran INTEGER*4
+>32	string	REAL		\b, 32 bits = VAX longword = Fortran REAL*4
+>32	string	DOUB		\b, 64 bits = VAX quadword = Fortran REAL*8
+>32	string	COMPLEX		\b, 64 bits = VAX quadword = Fortran COMPLEX*8
+# VICAR label file
+43	string	SFDU_LABEL	VICAR label file
+
+#------------------------------------------------------------------------------
+# $File: virtual,v 1.5 2014/04/30 21:41:02 christos Exp $
+# From: James Nobis <quel@quelrod.net>
+# Microsoft hard disk images for:
+# Virtual Server
+# Virtual PC
+# http://technet.microsoft.com/en-us/virtualserver/bb676673.aspx
+# .vhd
+0	string	conectix	Microsoft Disk Image, Virtual Server or Virtual PC
+
+# libvirt
+# From: Philipp Hahn <hahn@univention.de>
+0	string	LibvirtQemudSave	Libvirt QEMU Suspend Image
+>0x10	lelong	x	\b, version %u
+>0x14	lelong	x	\b, XML length %u
+>0x18	lelong	1	\b, running
+>0x1c	lelong	1	\b, compressed
+
+0	string	LibvirtQemudPart	Libvirt QEMU partial Suspend Image
+# From: Alex Beregszaszi <alex@fsn.hu>
+0	string/b	COWD		VMWare3
+>4	byte	3		disk image
+>>32	lelong	x		(%d/
+>>36	lelong	x		\b%d/
+>>40	lelong	x		\b%d)
+>4	byte	2		undoable disk image
+>>32	string	>\0		(%s)
+
+0	string/b	VMDK		 VMware4 disk image
+0	string/b	KDMV		 VMware4 disk image
+
+#--------------------------------------------------------------------
+# Qemu Emulator Images
+# Lines written by Friedrich Schwittay (f.schwittay@yousable.de)
+# Updated by Adam Buchbinder (adam.buchbinder@gmail.com)
+# Made by reading sources, reading documentation, and doing trial and error
+# on existing QCOW files
+0	string/b	QFI\xFB	QEMU QCOW Image
+
+# Uncomment the following line to display Magic (only used for debugging
+# this magic number)
+#>0	string/b	x	, Magic: %s
+
+# There are currently 2 Versions: "1" and "2".
+# http://www.gnome.org/~markmc/qcow-image-format-version-1.html
+>4	belong	1	(v1)
+
+# Using the existence of the Backing File Offset to determine whether
+# to read Backing File Information
+>>12	belong	 >0	 \b, has backing file (
+# Note that this isn't a null-terminated string; the length is actually
+# (16.L). Assuming a null-terminated string happens to work usually, but it
+# may spew junk until it reaches a \0 in some cases.
+>>>(12.L)	 string >\0	\bpath %s
+
+# Modification time of the Backing File
+# Really useful if you want to know if your backing
+# file is still usable together with this image
+>>>>20	bedate >0	\b, mtime %s)
+>>>>20	default x	\b)
+
+# Size is stored in bytes in a big-endian u64.
+>>24	bequad	x	 \b, %lld bytes
+
+# 1 for AES encryption, 0 for none.
+>>36	belong	1	\b, AES-encrypted
+
+# http://www.gnome.org/~markmc/qcow-image-format.html
+>4	belong	2	(v2)
+# Using the existence of the Backing File Offset to determine whether
+# to read Backing File Information
+>>8	bequad  >0	 \b, has backing file
+# Note that this isn't a null-terminated string; the length is actually
+# (16.L). Assuming a null-terminated string happens to work usually, but it
+# may spew junk until it reaches a \0 in some cases. Also, since there's no
+# .Q modifier, we just use the bottom four bytes as an offset. Note that if
+# the file is over 4G, and the backing file path is stored after the first 4G,
+# the wrong filename will be printed. (This should be (8.Q), when that syntax
+# is introduced.)
+>>>(12.L)	 string >\0	(path %s)
+>>24	bequad	x	\b, %lld bytes
+>>32	belong	1	\b, AES-encrypted
+
+>4	belong	3	(v3)
+# Using the existence of the Backing File Offset to determine whether
+# to read Backing File Information
+>>8	bequad  >0	 \b, has backing file
+# Note that this isn't a null-terminated string; the length is actually
+# (16.L). Assuming a null-terminated string happens to work usually, but it
+# may spew junk until it reaches a \0 in some cases. Also, since there's no
+# .Q modifier, we just use the bottom four bytes as an offset. Note that if
+# the file is over 4G, and the backing file path is stored after the first 4G,
+# the wrong filename will be printed. (This should be (8.Q), when that syntax
+# is introduced.)
+>>>(12.L)	 string >\0	(path %s)
+>>24	bequad	x	\b, %lld bytes
+>>32	belong	1	\b, AES-encrypted
+
+>4	default x	(unknown version)
+
+0	string/b	QEVM		QEMU suspend to disk image
+
+# QEMU QED Image
+# http://wiki.qemu.org/Features/QED/Specification
+0	string/b	QED\0		QEMU QED Image
+
+# VDI Image
+# Sun xVM VirtualBox Disk Image
+# From: Richard W.M. Jones <rich@annexia.org>
+# VirtualBox Disk Image
+0x40	ulelong		0xbeda107f	VirtualBox Disk Image
+>0x44	uleshort	>0		\b, major %u
+>0x46	uleshort	>0		\b, minor %u
+>0	string		>\0		(%s)
+>368	lequad		x		 \b, %lld bytes
+
+0	string/b	Bochs\ Virtual\ HD\ Image	Bochs disk image,
+>32	string	x				type %s,
+>48	string	x				subtype %s
+
+0	lelong	0x02468ace			Bochs Sparse disk image
+
+
+#------------------------------------------------------------------------------
+# $File$
+# Virtutech Compressed Random Access File Format
+#
+# From <gustav@virtutech.com>
+0      string          \211\277\036\203        Virtutech CRAFF
+>4     belong          x               v%d
+>20    belong          0               uncompressed
+>20    belong          1               bzipp2ed
+>20    belong          2               gzipped
+>24    belong          0               not clean
+
+#------------------------------------------------------------------------------
+# $File$
+# visx:  file(1) magic for Visx format files
+#
+0	short		0x5555		VISX image file
+>2	byte		0		(zero)
+>2	byte		1		(unsigned char)
+>2	byte		2		(short integer)
+>2	byte		3		(float 32)
+>2	byte		4		(float 64)
+>2	byte		5		(signed char)
+>2	byte		6		(bit-plane)
+>2	byte		7		(classes)
+>2	byte		8		(statistics)
+>2	byte		10		(ascii text)
+>2	byte		15		(image segments)
+>2	byte		100		(image set)
+>2	byte		101		(unsigned char vector)
+>2	byte		102		(short integer vector)
+>2	byte		103		(float 32 vector)
+>2	byte		104		(float 64 vector)
+>2	byte		105		(signed char vector)
+>2	byte		106		(bit plane vector)
+>2	byte		121		(feature vector)
+>2	byte		122		(feature vector library)
+>2	byte		124		(chain code)
+>2	byte		126		(bit vector)
+>2	byte		130		(graph)
+>2	byte		131		(adjacency graph)
+>2	byte		132		(adjacency graph library)
+>2	string		.VISIX		(ascii text)
+
+#------------------------------------------------------------------------------
+# $File: vms,v 1.8 2014/08/17 12:58:54 christos Exp $
+# vms:  file(1) magic for VMS executables (experimental)
+#
+# VMS .exe formats, both VAX and AXP (Greg Roelofs, newt@uchicago.edu)
+
+# GRR 950122:  I'm just guessing on these, based on inspection of the headers
+# of three executables each for Alpha and VAX architectures.  The VAX files
+# all had headers similar to this:
+#
+#   00000  b0 00 30 00 44 00 60 00  00 00 00 00 30 32 30 35  ..0.D.`.....0205
+#   00010  01 01 00 00 ff ff ff ff  ff ff ff ff 00 00 00 00  ................
+#
+0	string	\xb0\0\x30\0	VMS VAX executable
+>44032	string	PK\003\004	\b, Info-ZIP SFX archive v5.12 w/decryption
+#
+# The AXP files all looked like this, except that the byte at offset 0x22
+# was 06 in some of them and 07 in others:
+#
+#   00000  03 00 00 00 00 00 00 00  ec 02 00 00 10 01 00 00  ................
+#   00010  68 00 00 00 98 00 00 00  b8 00 00 00 00 00 00 00  h...............
+#   00020  00 00 07 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
+#   00030  00 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00  ................
+#   00040  00 00 00 00 ff ff ff ff  ff ff ff ff 02 00 00 00  ................
+#
+# GRR this test is still too general as it catches example adressen.dbt
+0	belong	0x03000000	
+>8	ubelong	0xec020000	VMS Alpha executable
+>>75264	string	PK\003\004	\b, Info-ZIP SFX archive v5.12 w/decryption
+
+#------------------------------------------------------------------------------
+# $File$
+# VMware specific files (deducted from version 1.1 and log file entries)
+# Anthon van der Neut (anthon@mnt.org)
+0	belong	0x4d52564e	VMware nvram 
+
+#------------------------------------------------------------------------------
+# $File: vorbis,v 1.20 2014/09/23 16:35:08 christos Exp $
+# vorbis:  file(1) magic for Ogg/Vorbis files
+#
+# From Felix von Leitner <leitner@fefe.de>
+# Extended by Beni Cherniavsky <cben@crosswinds.net>
+# Further extended by Greg Wooledge <greg@wooledge.org>
+#
+# Most (everything but the number of channels and bitrate) is commented
+# out with `##' as it's not interesting to the average user.  The most
+# probable things advanced users would want to uncomment are probably
+# the number of comments and the encoder version.
+#
+# FIXME: The first match has been made a search, so that it can skip
+# over prepended ID3 tags. This will work for MIME type detection, but
+# won't work for detecting other properties of the file (they all need
+# to be made relative to the search). In any case, if the file has ID3
+# tags, the ID3 information will be printed, not the Ogg information,
+# so until that's fixed, this doesn't matter.
+# FIXME[2]: Disable the above for now, since search assumes text mode.
+#
+# --- Ogg Framing ---
+#0		search/1000	OggS		Ogg data
+0		string	OggS		Ogg data
+>4		byte		!0		UNKNOWN REVISION %u
+##>4		byte		0		revision 0
+>4		byte		0
+##>>14		lelong		x		(Serial %lX)
+# non-Vorbis content: FLAC (Free Lossless Audio Codec, http://flac.sourceforge.net)
+>>28		string		\x7fFLAC	\b, FLAC audio
+# non-Vorbis content: Theora
+!:mime		audio/ogg
+>>28		string		\x80theora	\b, Theora video
+!:mime		video/ogg
+# non-Vorbis content: Kate
+>>28		string		\x80kate\0\0\0\0	\b, Kate (Karaoke and Text)
+!:mime		application/ogg
+>>>37		ubyte		x		v%u
+>>>38		ubyte		x		\b.%u,
+>>>40		byte		0		utf8 encoding,
+>>>40		byte		!0		unknown character encoding,
+>>>60		string		>\0		language %s,
+>>>60		string		\0		no language set,
+>>>76		string		>\0		category %s
+>>>76		string		\0		no category set
+# non-Vorbis content: Skeleton
+>>28		string		fishead\0	\b, Skeleton
+!:mime		video/ogg
+>>>36		leshort		x		v%u
+>>>40		leshort		x		\b.%u
+# non-Vorbis content: Speex
+>>28		string		Speex\ \ \ 	\b, Speex audio
+!:mime		audio/ogg
+# non-Vorbis content: OGM
+>>28		string		\x01video\0\0\0	\b, OGM video
+!:mime		video/ogg
+>>>37		string/c	div3		(DivX 3)
+>>>37		string/c	divx		(DivX 4)
+>>>37		string/c	dx50		(DivX 5)
+>>>37		string/c	xvid		(XviD)
+# --- First vorbis packet - general header ---
+>>28		string		\x01vorbis	\b, Vorbis audio,
+!:mime		audio/ogg
+>>>35		lelong		!0		UNKNOWN VERSION %u,
+##>>>35		lelong		0		version 0,
+>>>35		lelong		0
+>>>>39		ubyte		1		mono,
+>>>>39		ubyte		2		stereo,
+>>>>39		ubyte		>2		%u channels,
+>>>>40		lelong		x		%u Hz
+# Minimal, nominal and maximal bitrates specified when encoding
+>>>>48		string		<\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff	\b,
+# The above tests if at least one of these is specified:
+>>>>>52		lelong		!-1
+# Vorbis RC2 has a bug which puts -1000 in the min/max bitrate fields
+# instead of -1.
+# Vorbis 1.0 uses 0 instead of -1.
+>>>>>>52	lelong		!0
+>>>>>>>52	lelong		!-1000
+>>>>>>>>52	lelong		x		<%u
+>>>>>48		lelong		!-1
+>>>>>>48	lelong		x		~%u
+>>>>>44		lelong		!-1
+>>>>>>44	lelong		!-1000
+>>>>>>>44	lelong		!0
+>>>>>>>>44	lelong		x		>%u
+>>>>>48		string		<\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff	bps
+# -- Second vorbis header packet - the comments
+# A kludge to read the vendor string.  It's a counted string, not a
+# zero-terminated one, so file(1) can't read it in a generic way.
+# libVorbis is the only one existing currently, so I detect specifically
+# it.  The interesting value is the cvs date (8 digits decimal).
+# Post-RC1 Ogg files have the second header packet (and thus the version)
+# in a different place, so we must use an indirect offset.
+>>>(84.b+85)		string		\x03vorbis
+>>>>(84.b+96)		string/c	Xiphophorus\ libVorbis\ I	\b, created by: Xiphophorus libVorbis I
+>>>>>(84.b+120)		string		>00000000	
+# Map to beta version numbers:
+>>>>>>(84.b+120)	string		<20000508	(<beta1, prepublic)
+>>>>>>(84.b+120)	string		20000508	(1.0 beta 1 or beta 2)
+>>>>>>(84.b+120)	string		>20000508
+>>>>>>>(84.b+120)	string		<20001031	(beta2-3)
+>>>>>>(84.b+120)	string		20001031	(1.0 beta 3)
+>>>>>>(84.b+120)	string		>20001031
+>>>>>>>(84.b+120)	string		<20010225	(beta3-4)
+>>>>>>(84.b+120)	string		20010225	(1.0 beta 4)
+>>>>>>(84.b+120)	string		>20010225
+>>>>>>>(84.b+120)	string		<20010615	(beta4-RC1)
+>>>>>>(84.b+120)	string		20010615	(1.0 RC1)
+>>>>>>(84.b+120)	string		20010813	(1.0 RC2)
+>>>>>>(84.b+120)	string		20010816	(RC2 - Garf tuned v1)
+>>>>>>(84.b+120)	string		20011014	(RC2 - Garf tuned v2)
+>>>>>>(84.b+120)	string		20011217	(1.0 RC3)
+>>>>>>(84.b+120)	string		20011231	(1.0 RC3)
+# Some pre-1.0 CVS snapshots still had "Xiphphorus"...
+>>>>>>(84.b+120)	string		>20011231	(pre-1.0 CVS)
+# For the 1.0 release, Xiphophorus is replaced by Xiph.Org
+>>>>(84.b+96)		string/c	Xiph.Org\ libVorbis\ I	\b, created by: Xiph.Org libVorbis I
+>>>>>(84.b+117)		string		>00000000	
+>>>>>>(84.b+117)	string		<20020717	(pre-1.0 CVS)
+>>>>>>(84.b+117)	string		20020717	(1.0)
+>>>>>>(84.b+117)	string		20030909	(1.0.1)
+>>>>>>(84.b+117)	string		20040629	(1.1.0 RC1)
+
+#------------------------------------------------------------------------------
+# $File$
+# VXL: file(1) magic for VXL binary IO data files
+#
+# from Ian Scott <scottim@sf.net>
+#
+# VXL is a collection of C++ libraries for Computer Vision.
+# See the vsl chapter in the VXL Book for more info
+# http://www.isbe.man.ac.uk/public_vxl_doc/books/vxl/book.html
+# http:/vxl.sf.net
+
+2	lelong	0x472b2c4e	VXL data file,
+>0	leshort	>0		schema version no %d
+
+#------------------------------------------------------------------------------
+# $File: warc,v 1.2 2009/09/19 16:28:13 christos Exp $
+# warc:  file(1) magic for WARC files
+
+0	string	WARC/	WARC Archive
+>5	string	x	version %.4s
+!:mime application/warc
+
+#------------------------------------------------------------------------------
+# Arc File Format from Internet Archive
+# see http://www.archive.org/web/researcher/ArcFileFormat.php
+0      string          filedesc://     Internet Archive File
+!:mime application/x-ia-arc
+>11    search/256      \x0A    \b
+>>&0   ubyte   >0      \b version %c
+
+#------------------------------------------------------------------------------
+# weak:  file(1) magic for very weak magic entries, disabled by default
+#
+# These entries are so weak that they might interfere identification of
+# other formats. Example include:
+# - Only identify for 1 or 2 bytes
+# - Match against very wide range of values
+# - Match against generic word in some spoken languages (e.g. English)
+
+# Summary: Computer Graphics Metafile
+# Extension: .cgm
+#0	beshort&0xffe0	0x0020		binary Computer Graphics Metafile
+#0	beshort		0x3020		character Computer Graphics Metafile
+
+#0	string		=!!		Bennet Yee's "face" format
+
+#------------------------------------------------------------------------------
+# $File: windows,v 1.9 2014/09/23 23:42:44 christos Exp $
+# windows:  file(1) magic for Microsoft Windows
+#
+# This file is mainly reserved for files where programs
+# using them are run almost always on MS Windows 3.x or
+# above, or files only used exclusively in Windows OS,
+# where there is no better category to allocate for.
+# For example, even though WinZIP almost run on Windows
+# only, it is better to treat them as "archive" instead.
+# For format usable in DOS, such as generic executable
+# format, please specify under "msdos" file.
+#
+
+
+# Summary: Outlook Express DBX file
+# Extension: .dbx
+# Created by: Christophe Monniez
+0	string	\xCF\xAD\x12\xFE	MS Outlook Express DBX file
+>4	byte	=0xC5			\b, message database
+>4	byte	=0xC6			\b, folder database
+>4	byte	=0xC7			\b, account information
+>4	byte	=0x30			\b, offline database
+
+
+# Summary: Windows crash dump
+# Extension: .dmp
+# Created by: Andreas Schuster (http://computer.forensikblog.de/)
+# Reference (1): http://computer.forensikblog.de/en/2008/02/64bit_magic.html
+# Modified by (1): Abel Cheung (Avoid match with first 4 bytes only)
+0	string		PAGE		
+>4	string		DUMP		MS Windows 32bit crash dump
+>>0x05c	byte            0		\b, no PAE
+>>0x05c	byte            1		\b, PAE
+>>0xf88	lelong		1		\b, full dump
+>>0xf88	lelong		2		\b, kernel dump
+>>0xf88	lelong		3		\b, small dump
+>>0x068	lelong		x		\b, %d pages
+>4	string		DU64		MS Windows 64bit crash dump
+>>0xf98	lelong		1		\b, full dump
+>>0xf98	lelong		2		\b, kernel dump
+>>0xf98	lelong		3		\b, small dump
+>>0x090	lequad		x		\b, %lld pages
+
+
+# Summary: Vista Event Log
+# Extension: .evtx
+# Created by: Andreas Schuster (http://computer.forensikblog.de/)
+# Reference (1): http://computer.forensikblog.de/en/2007/05/some_magic.html
+0	string		ElfFile\0	MS Windows Vista Event Log
+>0x2a	leshort		x		\b, %d chunks
+>>0x10	lelong		x		\b (no. %d in use)
+>0x18	lelong		>1		\b, next record no. %d
+>0x18	lelong		=1		\b, empty
+>0x78	lelong		&1		\b, DIRTY
+>0x78	lelong		&2		\b, FULL
+
+
+# Summary: Windows 3.1 group files
+# Extension: .grp
+# Created by: unknown
+0	string		\120\115\103\103	MS Windows 3.1 group files
+
+
+# Summary: Old format help files
+# Extension: .hlp
+# Created by: Dirk Jagdmann <doj@cubic.org>
+0	lelong		0x00035f3f		MS Windows 3.x help file
+
+
+# Summary: Hyper terminal
+# Extension: .ht
+# Created by: unknown
+0	string		HyperTerminal\ 
+>15	string		1.0\ --\ HyperTerminal\ data\ file	MS Windows HyperTerminal profile
+
+# http://ithreats.files.wordpress.com/2009/05/\
+# lnk_the_windows_shortcut_file_format.pdf
+# Summary: Windows shortcut
+# Extension: .lnk
+# Created by: unknown
+# 'L' + GUUID
+0	string		\114\0\0\0\001\024\002\0\0\0\0\0\300\0\0\0\0\0\0\106	MS Windows shortcut
+>20	lelong&1	1	\b, Item id list present
+>20	lelong&2	2	\b, Points to a file or directory
+>20	lelong&4	4	\b, Has Description string
+>20	lelong&8	8	\b, Has Relative path
+>20	lelong&16	16	\b, Has Working directory
+>20	lelong&32	32	\b, Has command line arguments
+>20	lelong&64	64	\b, Icon
+>>56	lelong			\b number=%d
+>24	lelong&1	1	\b, Read-Only
+>24	lelong&2	2	\b, Hidden
+>24	lelong&4	4	\b, System
+>24	lelong&8	8	\b, Volume Label
+>24	lelong&16	16	\b, Directory
+>24	lelong&32	32	\b, Archive
+>24	lelong&64	64	\b, Encrypted
+>24	lelong&128	128	\b, Normal
+>24	lelong&256	256	\b, Temporary
+>24	lelong&512	512	\b, Sparse
+>24	lelong&1024	1024	\b, Reparse point
+>24	lelong&2048	2048	\b, Compressed
+>24	lelong&4096	4096	\b, Offline
+>28	leqwdate	x	\b, ctime=%s
+>36	leqwdate	x	\b, mtime=%s
+>44	leqwdate	x	\b, atime=%s
+>52	lelong		x	\b, length=%u, window=
+>60	lelong&1	1	\bhide
+>60	lelong&2	2	\bnormal
+>60	lelong&4	4	\bshowminimized
+>60	lelong&8	8	\bshowmaximized
+>60	lelong&16	16	\bshownoactivate
+>60	lelong&32	32	\bminimize
+>60	lelong&64	64	\bshowminnoactive
+>60	lelong&128	128	\bshowna
+>60	lelong&256	256	\brestore
+>60	lelong&512	512	\bshowdefault
+#>20	lelong&1	0
+#>>20	lelong&2	2
+#>>>(72.l-64)	pstring/h	x	\b [%s]
+#>20	lelong&1	1
+#>>20	lelong&2	2
+#>>>(72.s)	leshort	x
+#>>>&75	pstring/h	x	\b [%s]
+
+# Summary: Outlook Personal Folders
+# Created by: unknown
+0	lelong		0x4E444221	Microsoft Outlook email folder
+>10	leshort		0x0e		(<=2002)
+>10	leshort		0x17		(>=2003)
+
+
+# Summary: Windows help cache
+# Created by: unknown
+0	string		\164\146\115\122\012\000\000\000\001\000\000\000	MS Windows help cache
+
+
+# Summary: IE cache file
+# Created by: Christophe Monniez
+0	string	Client\ UrlCache\ MMF 	Internet Explorer cache file
+>20	string	>\0			version %s
+
+
+# Summary: Registry files
+# Created by: unknown
+# Modified by (1): Joerg Jenderek
+0	string		regf		MS Windows registry file, NT/2000 or above
+0	string		CREG		MS Windows 95/98/ME registry file
+0	string		SHCC3		MS Windows 3.1 registry file
+
+
+# Summary: Windows Registry text
+# Extension: .reg
+# Submitted by: Abel Cheung <abelcheung@gmail.com>
+0	string		REGEDIT4\r\n\r\n	Windows Registry text (Win95 or above)
+0	string		Windows\ Registry\ Editor\ 
+>&0	string		Version\ 5.00\r\n\r\n	Windows Registry text (Win2K or above)
+
+# Windows *.INF *.INI files updated by Joerg Jenderek at Apr 2013
+# empty ,comment , section
+# PR/383: remove unicode BOM because it is not portable across regex impls
+0	regex/s		\\`(\\r\\n|;|[[])
+# left bracket in section line
+>&0	search/8192	[						
+# http://en.wikipedia.org/wiki/Autorun.inf
+# http://msdn.microsoft.com/en-us/library/windows/desktop/cc144200.aspx
+>>&0	regex/c		\^(autorun)]\r\n				
+>>>&0	ubyte		=0x5b						INItialization configuration
+!:mime application/x-wine-extension-ini
+# From: Pal Tamas <folti@balabit.hu>
+# Autorun File
+>>>&0	ubyte		!0x5b						Microsoft Windows Autorun file
+!:mime application/x-setupscript
+# http://msdn.microsoft.com/en-us/library/windows/hardware/ff549520(v=vs.85).aspx
+# version strings ASCII coded case-independent for Windows setup information script file
+>>&0	regex/c		\^(version|strings)]				Windows setup INFormation
+!:mime	application/x-setupscript
+#!:mime application/inf
+#!:mime application/x-wine-extension-inf
+>>&0	regex/c		\^(WinsockCRCList|OEMCPL)]			Windows setup INFormation
+!:mime	text/inf
+# http://www.winfaq.de/faq_html/Content/tip2500/onlinefaq.php?h=tip2653.htm
+# http://msdn.microsoft.com/en-us/library/windows/desktop/cc144102.aspx
+# .ShellClassInfo DeleteOnCopy LocalizedFileNames ASCII coded case-independent
+>>&0	regex/c	\^(\.ShellClassInfo|DeleteOnCopy|LocalizedFileNames)]	Windows desktop.ini
+!:mime application/x-wine-extension-ini
+#!:mime text/plain
+# http://support.microsoft.com/kb/84709/
+>>&0	regex/c		\^(don't\ load)]				Windows CONTROL.INI
+!:mime application/x-wine-extension-ini
+>>&0	regex/c		\^(ndishlp\\$|protman\\$|NETBEUI\\$)]		Windows PROTOCOL.INI
+!:mime application/x-wine-extension-ini
+# http://technet.microsoft.com/en-us/library/cc722567.aspx
+# http://www.winfaq.de/faq_html/Content/tip0000/onlinefaq.php?h=tip0137.htm
+>>&0	regex/c		\^(windows|Compatibility|embedding)]		Windows WIN.INI
+!:mime application/x-wine-extension-ini
+# http://en.wikipedia.org/wiki/SYSTEM.INI
+>>&0	regex/c		\^(boot|386enh|drivers)]			Windows SYSTEM.INI
+!:mime application/x-wine-extension-ini
+# http://www.mdgx.com/newtip6.htm
+>>&0	regex/c		\^(SafeList)]					Windows IOS.INI
+!:mime application/x-wine-extension-ini
+# http://en.wikipedia.org/wiki/NTLDR	Windows Boot Loader information
+>>&0	regex/c		\^(boot\x20loader)]				Windows boot.ini
+!:mime application/x-wine-extension-ini
+>>>&0	ubyte		x						
+# http://en.wikipedia.org/wiki/CONFIG.SYS
+>>&0	regex/c		\^(menu)]\r\n					MS-DOS CONFIG.SYS
+# http://support.microsoft.com/kb/118579/
+>>&0	regex/c		\^(Paths)]\r\n					MS-DOS MSDOS.SYS
+# VERS string unicoded case-independent
+>>&0	ubequad&0xFFdfFFdfFFdfFFdf	0x0056004500520053		
+# ION] string unicoded case-independent
+>>>&0	ubequad&0xFFdfFFdfFFdfFFff	0x0049004f004e005d		Windows setup INFormation 
+!:mime application/x-setupscript
+# STRI string unicoded case-independent
+>>&0	ubequad&0xFFdfFFdfFFdfFFdf	0x0053005400520049		
+# NGS] string unicoded case-independent
+>>>&0	ubequad&0xFFdfFFdfFFdfFFff	0x004e00470053005D		Windows setup INFormation 
+!:mime application/x-setupscript
+# unknown keyword after opening bracket
+>>&0	default				x				
+>>>&0	search/8192			[				
+# version Strings FileIdentification
+>>>>&0	string/c			version				Windows setup INFormation 
+!:mime application/x-setupscript
+# VERS string unicoded case-independent
+>>>>&0	ubequad&0xFFdfFFdfFFdfFFdf	0x0056004500520053		
+# ION] string unicoded case-independent
+>>>>>&0	ubequad&0xFFdfFFdfFFdfFFff	0x0049004f004e005d		Windows setup INFormation 
+!:mime application/x-setupscript
+# http://en.wikipedia.org/wiki/Initialization_file	Windows Initialization File or other
+#>>>>&0	default				x				Generic INItialization configuration
+#!:mime application/x-wine-extension-ini
+
+# Windows Precompiled INF files *.PNF added by Joerg Jenderek at Mar 2013 of _PNF_HEADER inf.h
+# http://read.pudn.com/downloads3/sourcecode/windows/248345/win2k/private/windows/setup/setupapi/inf.h__.htm
+# GRR: line below too general as it catches also PDP-11 UNIX/RT ldp
+0		leshort&0xFeFe	0x0000		
+# test for unused null bits in PNF_FLAGs
+>4	ulelong&0xFCffFe00	0x00000000	
+# only found 58h for Offset of WinDirPath immediately after _PNF_HEADER structure
+>>68		ulelong		>0x57		
+# test for zero high byte of InfValueBlockSize, followed by WinDirPath like
+# C:\WINDOWS (ASCII 0x433a5c.. , unicode 0x43003a005c..) or X:\MININT
+>>>(68.l-1)	ubelong&0xffE0C519	=0x00400018	Windows Precompiled iNF
+!:mime	application/x-pnf
+# currently only found Major Version=1 and Minor Version=1
+#>>>>0		uleshort	=0x0101		
+#>>>>>1		ubyte		x		\b, version %u
+#>>>>>0		ubyte		x		\b.%u
+>>>>0		uleshort	!0x0101		
+>>>>>1		ubyte		x		\b, version %u
+>>>>>0		ubyte		x		\b.%u
+# 1 ,2 (windows 98 SE)
+#>>>>2		uleshort	=2		\b, InfStyle %u
+>>>>2		uleshort	!2		\b, InfStyle %u
+#	PNF_FLAG_IS_UNICODE		0x00000001
+#	PNF_FLAG_HAS_STRINGS		0x00000002
+#	PNF_FLAG_SRCPATH_IS_URL		0x00000004
+#	PNF_FLAG_HAS_VOLATILE_DIRIDS	0x00000008
+#	PNF_FLAG_INF_VERIFIED		0x00000010
+#	PNF_FLAG_INF_DIGITALLY_SIGNED	0x00000020
+#	??				0x00000100
+#	??				0x01000000
+#	??				0x02000000
+>>>>4	ulelong&0x00000001	0x00000001	\b, unicoded
+>>>>4	ulelong&0x00000020	0x00000020	\b, digitally signed
+#>>>>8		ulelong		x		\b, InfSubstValueListOffset 0x%x
+# many 0, 1 lmouusb.PNF, 2 linkfx10.PNF , f webfdr16.PNF
+#>>>>12		uleshort	x		\b, InfSubstValueCount 0x%x
+# only < 9 found
+#>>>>14		uleshort	x		\b, InfVersionDatumCount 0x%x
+# only found values lower 0x0000ffff
+#>>>>16		ulelong		x		\b, InfVersionDataSize 0x%x
+# only found positive values lower 0x00ffFFff for InfVersionDataOffset
+>>>>20		ulelong		x		\b, at 0x%x
+>>>>4	ulelong&0x00000001	=0x00000001	
+# case independent: CatalogFile Class DriverVer layoutfile LayoutFile SetupClass signature Signature    
+>>>>>(20.l)	lestring16	x		"%s"
+>>>>4	ulelong&0x00000001	!0x00000001	
+>>>>>(20.l)	string		x		"%s"
+# FILETIME is number of 100-nanosecond intervals since 1 January 1601
+#>>>>24		ulequad		x		\b, InfVersionLastWriteTime %16.16llx
+# only found values lower 0x00ffFFff
+#>>>>32		ulelong		x		\b, StringTableBlockOffset 0x%x
+#>>>>36		ulelong		x		\b, StringTableBlockSize 0x%x
+#>>>>40		ulelong		x		\b, InfSectionCount 0x%x
+#>>>>44		ulelong		x		\b, InfSectionBlockOffset 0x%x
+#>>>>48		ulelong		x		\b, InfSectionBlockSize 0x%x
+#>>>>52		ulelong		x		\b, InfLineBlockOffset 0x%x
+#>>>>56		ulelong		x		\b, InfLineBlockSize 0x%x
+#>>>>60		ulelong		x		\b, InfValueBlockOffset 0x%x
+#>>>>64		ulelong		x		\b, InfValueBlockSize 0x%x
+# WinDirPathOffset
+#>>>>68		ulelong		x		\b, at 0x%x
+>>>>68		ulelong		>0x57		
+>>>>>4	ulelong&0x00000001	=0x00000001	
+>>>>>>(68.l)	ubequad		=0x43003a005c005700			
+# normally unicoded C:\Windows
+#>>>>>>>(68.l)	lestring16	x		\b, WinDirPath "%s"
+>>>>>>(68.l)	ubequad		!0x43003a005c005700			
+>>>>>>>(68.l)	lestring16	x		\b, WinDirPath "%s"
+>>>>>4	ulelong&0x00000001	!0x00000001	
+# normally ASCII C:\WINDOWS
+#>>>>>>(68.l)	string		=C:\\WINDOWS	\b, WinDirPath "%s"
+>>>>>>(68.l)	string		!C:\\WINDOWS	\b, WinDirPath "%s"
+# found OsLoaderPathOffset values often 0 , once 70h corelist.PNF, once 68h ASCII machine.PNF 
+#>>>>72		ulelong		>0		\b, at 0x%x
+>>>>72		ulelong		>0		\b,
+>>>>>4	ulelong&0x00000001	=0x00000001	
+>>>>>>(72.l)	lestring16	x		OsLoaderPath "%s"
+>>>>>4	ulelong&0x00000001	!0x00000001	
+# seldom C:\ instead empty
+>>>>>>(72.l)	string		x		OsLoaderPath "%s"
+# 1fdh
+#>>>>76		uleshort	x		\b, StringTableHashBucketCount 0x%x
+>>>>78		uleshort	!0x407		\b, LanguageId %x
+# only 407h found
+#>>>>78		uleshort	=0x407		\b, LanguageId %x
+# InfSourcePathOffset often 0
+#>>>>80		ulelong		>0		\b, at 0x%x
+>>>>80		ulelong		>0		\b,
+>>>>>4	ulelong&0x00000001	=0x00000001	
+>>>>>>(80.l)	lestring16	x		SourcePath "%s"
+>>>>>4	ulelong&0x00000001	!0x00000001	
+>>>>>>(80.l)	string		>\0		SourcePath "%s"
+# OriginalInfNameOffset often 0
+#>>>>84		ulelong		>0		\b, at 0x%x
+>>>>84		ulelong		>0		\b,
+>>>>>4	ulelong&0x00000001	=0x00000001	
+>>>>>>(84.l)	lestring16	x		InfName "%s"
+>>>>>4	ulelong&0x00000001	!0x00000001	
+>>>>>>(84.l)	string		>\0		InfName "%s"
+
+
+#------------------------------------------------------------------------------
+# $File$
+# wireless-regdb:        file(1) magic for CRDA wireless-regdb file format
+#
+0	string	RGDB	CRDA wireless regulatory database file
+>4	belong	19	(Version 1)
+
+#------------------------------------------------------------------------------
+# $File: wordprocessors,v 1.17 2013/02/06 14:18:52 christos Exp $
+# wordprocessors:  file(1) magic fo word processors.
+#
+####### PWP file format used on Smith Corona Personal Word Processors:
+2	string	\040\040\040\040\040\040\040\040\040\040\040ML4D\040'92	Smith Corona PWP
+>24	byte	2	\b, single spaced
+>24	byte	3	\b, 1.5 spaced
+>24	byte	4	\b, double spaced
+>25	byte	0x42	\b, letter
+>25	byte	0x54	\b, legal
+>26	byte	0x46	\b, A4
+
+#WordPerfect type files Version 1.6 - PLEASE DO NOT REMOVE THIS LINE
+0	string	\377WPC\020\000\000\000\022\012\001\001\000\000\000\000	(WP) loadable file
+>15	byte	0	Optimized for Intel
+>15	byte	1	Optimized for Non-Intel
+1	string	WPC	(Corel/WP)
+>8	short	257	WordPerfect macro
+>8	short	258	WordPerfect help file
+>8	short	259	WordPerfect keyboard file
+>8	short	266	WordPerfect document
+>8	short	267	WordPerfect dictionary
+>8	short	268	WordPerfect thesaurus
+>8	short	269	WordPerfect block
+>8	short	270	WordPerfect rectangular block
+>8	short	271	WordPerfect column block
+>8	short	272	WordPerfect printer data
+>8	short	275	WordPerfect printer data
+>8	short	276	WordPerfect driver resource data
+>8	short	279	WordPerfect hyphenation code
+>8	short	280	WordPerfect hyphenation data
+>8	short	281	WordPerfect macro resource data
+>8	short	283	WordPerfect hyphenation lex
+>8	short	285	WordPerfect wordlist
+>8	short	286	WordPerfect equation resource data
+>8	short	289	WordPerfect spell rules
+>8	short	290	WordPerfect dictionary rules
+>8	short	295	WordPerfect spell rules (Microlytics)
+>8	short	299	WordPerfect settings file
+>8	short	301	WordPerfect 4.2 document
+>8	short	325	WordPerfect dialog file
+>8	short	332	WordPerfect button bar
+>8	short	513	Shell macro
+>8	short	522	Shell definition
+>8	short	769	Notebook macro
+>8	short	770	Notebook help file
+>8	short	771	Notebook keyboard file
+>8	short	778	Notebook definition
+>8	short	1026	Calculator help file
+>8	short 	1538	Calendar help file
+>8	short 	1546	Calendar data file
+>8	short	1793	Editor macro
+>8	short	1794	Editor help file
+>8	short	1795	Editor keyboard file
+>8	short	1817	Editor macro resource file
+>8	short 	2049	Macro editor macro
+>8	short 	2050	Macro editor help file
+>8	short	2051	Macro editor keyboard file
+>8	short	2305	PlanPerfect macro
+>8	short	2306	PlanPerfect help file
+>8	short	2307	PlanPerfect keyboard file
+>8	short	2314	PlanPerfect worksheet
+>8	short	2319	PlanPerfect printer definition
+>8	short	2322	PlanPerfect graphic definition
+>8	short	2323	PlanPerfect data
+>8	short	2324	PlanPerfect temporary printer
+>8	short	2329	PlanPerfect macro resource data
+>8	byte	11	Mail
+>8	short	2818	help file
+>8	short	2821	distribution list
+>8	short	2826	out box
+>8	short	2827	in box
+>8	short	2836	users archived mailbox
+>8	short	2837	archived message database
+>8	short	2838	archived attachments
+>8	short	3083	Printer temporary file
+>8	short	3330	Scheduler help file
+>8	short	3338	Scheduler in file
+>8	short	3339	Scheduler out file
+>8	short	3594	GroupWise settings file
+>8	short	3601	GroupWise directory services
+>8	short	3627	GroupWise settings file
+>8	short	4362	Terminal resource data
+>8	short	4363	Terminal resource data
+>8	short	4395	Terminal resource data
+>8	short	4619	GUI loadable text
+>8	short	4620	graphics resource data
+>8	short	4621	printer settings file
+>8	short	4622	port definition file
+>8	short	4623	print queue parameters
+>8	short	4624	compressed file
+>8	short	5130	Network service msg file
+>8	short	5131	Network service msg file
+>8	short	5132	Async gateway login msg
+>8	short	5134	GroupWise message file
+>8	short	7956	GroupWise admin domain database
+>8	short	7957	GroupWise admin host database
+>8	short	7959	GroupWise admin remote host database
+>8	short	7960	GroupWise admin ADS deferment data file
+>8	short	8458	IntelliTAG (SGML) compiled DTD
+>8	long	18219264	WordPerfect graphic image (1.0)
+>8	long	18219520	WordPerfect graphic image (2.0)
+#end of WordPerfect type files Version 1.6 - PLEASE DO NOT REMOVE THIS LINE
+
+# Hangul (Korean) Word Processor File
+0	string	HWP\ Document\ File	Hangul (Korean) Word Processor File 3.0
+# From: Won-Kyu Park <wkpark@kldp.org>
+512	string		R\0o\0o\0t\0	Hangul (Korean) Word Processor File 2000
+!:mime	application/x-hwp
+
+# CosmicBook, from Benoit Rouits
+0       string  CSBK    Ted Neslson's CosmicBook hypertext file
+
+2       string  EYWR    AmigaWriter file
+
+# chi:  file(1) magic for ChiWriter files
+0       string          \\1cw\          ChiWriter file
+>5      string          >\0             version %s
+0       string          \\1cw           ChiWriter file
+
+# Quark Express from http://www.garykessler.net/library/file_sigs.html
+2	string	IIXPR3			Intel Quark Express Document (English)
+2	string	IIXPRa			Intel Quark Express Document (Korean)
+2	string	MMXPR3			Motorola Quark Express Document (English)
+!:mime	application/x-quark-xpress-3
+2	string	MMXPRa			Motorola Quark Express Document (Korean)
+
+# adobe indesign (document, whatever...) from querkan
+0	belong	0x0606edf5		Adobe InDesign
+>16	string	DOCUMENT		Document
+
+#------------------------------------------------------------------------------
+# ichitaro456: file(1) magic for Just System Word Processor Ichitaro
+#
+# Contributor kenzo-:
+# Reversed-engineered JS Ichitaro magic numbers
+#
+
+0	string		DOC
+>43	byte		0x14	Just System Word Processor Ichitaro v4
+!:mime	application/x-ichitaro4
+>144	string	JDASH		application/x-ichitaro4
+
+0	string		DOC
+>43	byte		0x15	Just System Word Processor Ichitaro v5
+!:mime	application/x-ichitaro5
+
+0	string		DOC
+>43	byte		0x16	Just System Word Processor Ichitaro v6
+!:mime	application/x-ichitaro6
+
+# Type: Freemind mindmap documents
+# From: Jamie Thompson <debian-bugs@jamie-thompson.co.uk>
+0	string/w	\<map\ version	Freemind document
+!:mime	application/x-freemind
+
+# Type: Freeplane mindmap documents
+# From: Felix Natter <fnatter@gmx.net>
+0       string/w        \<map\ version="freeplane  Freeplane document
+!:mime  application/x-freeplane
+
+# Type:        Scribus
+# From:        Werner Fink <werner@suse.de>
+0	string	\<SCRIBUSUTF8\ Version		Scribus Document
+0	string	\<SCRIBUSUTF8NEW\ Version	Scribus Document
+!:mime	application/x-scribus
+
+# help files .hlp compiled from html and used by gfxboot added by Joerg Jenderek
+# markups page=0x04,label=0x12, followed by strings like "opt" or "main" and title=0x14
+0	ulelong&0x8080FFFF	0x00001204	gfxboot compiled html help file
+
+#------------------------------------------------------------------------------
+# $File: wsdl,v 1.2 2013/02/05 15:20:47 christos Exp $
+# wsdl: PHP WSDL Cache, http://www.php.net/manual/en/book.soap.php
+# Cache format extracted from source:
+# http://svn.php.net/viewvc/php/php-src/trunk/ext/soap/php_sdl.c?revision=HEAD&view=markup
+# Requires file >= 5.05, see http://mx.gw.com/pipermail/file/2010/000683.html
+# By Elan Ruusamae <glen@delfi.ee>, Patryk Zawadzki <patrys@pld-linux.org>, 2010-2011
+0		string		wsdl		PHP WSDL cache,
+>4		byte		x		version 0x%02x
+>6		ledate		x		\b, created %s
+
+# uri
+>10		lelong		<0x7fffffff
+>>10		pstring/l	x		\b, uri: "%s"
+
+# source
+>>>&0		lelong		<0x7fffffff
+>>>>&-4		pstring/l	x		\b, source: "%s"
+
+# target_ns
+>>>>>&0		lelong		<0x7fffffff
+>>>>>>&-4	pstring/l	x		\b, target_ns: "%s"
+
+#------------------------------------------------------------------------------
+# $File: xdelta,v 1.4 2009/09/19 16:28:13 christos Exp $
+# file(1) magic(5) data for xdelta  Josh MacDonald <jmacd@CS.Berkeley.EDU>
+#
+0	string	%XDELTA%	XDelta binary patch file 0.14
+0	string	%XDZ000%	XDelta binary patch file 0.18
+0	string	%XDZ001%	XDelta binary patch file 0.20
+0	string	%XDZ002%	XDelta binary patch file 1.0
+0	string	%XDZ003%	XDelta binary patch file 1.0.4
+0	string	%XDZ004%	XDelta binary patch file 1.1
+
+0	string \xD6\xC3\xC4\x00	VCDIFF binary diff
+
+#------------------------------------------------------------------------------
+# $File$
+# xenix:  file(1) magic for Microsoft Xenix
+#
+# "Middle model" stuff, and "Xenix 8086 relocatable or 80286 small
+# model" lifted from "magic.xenix", with comment "derived empirically;
+# treat as folklore until proven"
+#
+# "small model", "large model", "huge model" stuff lifted from XXX
+#
+# XXX - "x.out" collides with PDP-11 archives
+#
+0	string		core		core file (Xenix)
+0	byte		0x80		8086 relocatable (Microsoft)
+0	leshort		0xff65		x.out
+>2	string		__.SYMDEF	 randomized
+>0	byte		x		archive
+0	leshort		0x206		Microsoft a.out
+>8	leshort		1		Middle model
+>0x1e	leshort		&0x10		overlay
+>0x1e	leshort		&0x2		separate
+>0x1e	leshort		&0x4		pure
+>0x1e	leshort		&0x800		segmented
+>0x1e	leshort		&0x400		standalone
+>0x1e	leshort		&0x8		fixed-stack
+>0x1c	byte		&0x80		byte-swapped
+>0x1c	byte		&0x40		word-swapped
+>0x10	lelong		>0		not-stripped
+>0x1e	leshort		^0xc000		pre-SysV
+>0x1e	leshort		&0x4000		V2.3
+>0x1e	leshort		&0x8000		V3.0
+>0x1c	byte		&0x4		86
+>0x1c	byte		&0xb		186
+>0x1c	byte		&0x9		286
+>0x1c	byte		&0xa		386
+>0x1f	byte		<0x040		small model
+>0x1f	byte		=0x048		large model	
+>0x1f	byte		=0x049		huge model 
+>0x1e	leshort		&0x1		executable
+>0x1e	leshort		^0x1		object file
+>0x1e	leshort		&0x40		Large Text
+>0x1e	leshort		&0x20		Large Data
+>0x1e	leshort		&0x120		Huge Objects Enabled
+>0x10	lelong		>0		not stripped
+
+0	leshort		0x140		old Microsoft 8086 x.out
+>0x3	byte		&0x4		separate
+>0x3	byte		&0x2		pure
+>0	byte		&0x1		executable
+>0	byte		^0x1		relocatable
+>0x14	lelong		>0		not stripped
+
+0	lelong		0x206		b.out
+>0x1e	leshort		&0x10		overlay
+>0x1e	leshort		&0x2		separate
+>0x1e	leshort		&0x4		pure
+>0x1e	leshort		&0x800		segmented
+>0x1e	leshort		&0x400		standalone
+>0x1e	leshort		&0x1		executable
+>0x1e	leshort		^0x1		object file
+>0x1e	leshort		&0x4000		V2.3
+>0x1e	leshort		&0x8000		V3.0
+>0x1c	byte		&0x4		86
+>0x1c	byte		&0xb		186
+>0x1c	byte		&0x9		286
+>0x1c	byte		&0x29		286
+>0x1c	byte		&0xa		386
+>0x1e	leshort		&0x4		Large Text
+>0x1e	leshort		&0x2		Large Data
+>0x1e	leshort		&0x102		Huge Objects Enabled
+
+0	leshort		0x580		XENIX 8086 relocatable or 80286 small model
+
+#------------------------------------------------------------------------------
+# $File: xilinx,v 1.6 2013/11/19 23:15:13 christos Exp $
+# This is Aaron's attempt at a MAGIC file for Xilinx .bit files.
+# Xilinx-Magic@RevRagnarok.com
+# Got the info from FPGA-FAQ 0026
+#
+# Rewritten to use pstring/H instead of hardcoded lengths by O. Freyermuth, 
+# fixes at least reading of bitfiles from Spartan 2, 3, 6. 
+# http://www.fpga-faq.com/FAQ_Pages/0026_Tell_me_about_bit_files.htm
+#
+# First there is the sync header and its length
+0	beshort 0x0009
+>2 	belong	=0x0ff00ff0
+>>&0	belong  =0x0ff00ff0
+>>>&0	byte    =0x00
+>>>&1   beshort =0x0001
+>>>&3	string	a	Xilinx BIT data
+# Next is a Pascal-style string with the NCD name. We want to capture that.
+>>>>&0	   pstring/H	x	- from %s
+# And then 'b'
+>>>>>&1    string b
+# Then the model / part number: 
+>>>>>>&0   pstring/H    x       - for %s
+# Then 'c'
+>>>>>>>&1 string c
+# Then the build-date
+>>>>>>>>&0 pstring/H    x       - built %s
+# Then 'd'
+>>>>>>>>>&1   string d
+# Then the build-time
+>>>>>>>>>>&0  pstring/H x        \b(%s)
+# Then 'e'
+>>>>>>>>>>>&1  string e
+# And length of data
+>>>>>>>>>>>>&0 belong x          - data length 0x%x
+
+# Raw bitstream files
+0      long    0xffffffff      
+>&0    belong  0xaa995566      Xilinx RAW bitstream (.BIN)
+
+#------------------------------------------------------------------------------
+# $File$
+# xo65 object files
+# From: "Ullrich von Bassewitz" <uz@cc65.org>
+#
+0	string		\x55\x7A\x6E\x61	xo65 object,
+>4	leshort		x			version %d,
+>6	leshort&0x0001 =0x0001			with debug info
+>6	leshort&0x0001 =0x0000			no debug info
+
+# xo65 library files
+0	string		\x6E\x61\x55\x7A	xo65 library,
+>4	leshort		x			version %d
+
+# o65 object files
+0	string		\x01\x00\x6F\x36\x35	o65
+>6	leshort&0x1000	=0x0000			executable,
+>6	leshort&0x1000	=0x1000			object,
+>5	byte		x			version %d,
+>6	leshort&0x8000	=0x8000			65816,
+>6	leshort&0x8000	=0x0000			6502,
+>6	leshort&0x2000	=0x2000			32 bit,
+>6	leshort&0x2000	=0x0000			16 bit,
+>6	leshort&0x4000	=0x4000			page reloc,
+>6	leshort&0x4000	=0x0000			byte reloc,
+>6	leshort&0x0003	=0x0000			alignment 1
+>6	leshort&0x0003	=0x0001			alignment 2
+>6	leshort&0x0003	=0x0002			alignment 4
+>6	leshort&0x0003	=0x0003			alignment 256
+
+#------------------------------------------------------------------------------
+# $File: xwindows,v 1.8 2013/02/08 17:25:57 christos Exp $
+# xwindows:  file(1) magic for various X/Window system file formats.
+
+# Compiled X Keymap 
+# XKM (compiled X keymap) files (including version and byte ordering)
+1	string	mkx				Compiled XKB Keymap: lsb,
+>0	byte	>0				version %d
+>0	byte	=0				obsolete
+0	string	xkm				Compiled XKB Keymap: msb,
+>3	byte	>0				version %d
+>3	byte	=0				obsolete
+
+# xfsdump archive
+0	string	xFSdump0			xfsdump archive
+>8	belong	x	(version %d)
+
+# Jaleo XFS files
+0	long	395726				Jaleo XFS file
+>4	long	x				- version %d
+>8	long	x				- [%d -
+>20	long	x				\b%dx
+>24	long	x				\b%dx
+>28	long	1008				\bYUV422]
+>28	long	1000				\bRGB24]
+
+# Xcursor data
+# X11 mouse cursor format defined in libXcursor, see
+# http://www.x.org/archive/X11R6.8.1/doc/Xcursor.3.html
+# http://cgit.freedesktop.org/xorg/lib/libXcursor/tree/include/X11/Xcursor/Xcursor.h
+0	string		Xcur		Xcursor data
+!:mime	image/x-xcursor
+>10	leshort		x		version %d
+>>8	leshort		x		\b.%d
+#------------------------------------------------------------------------------
+# zfs:	file(1) magic for ZFS dumps
+#
+# From <rea-fbsd@codelabs.ru>
+# ZFS dump header has the following structure (as per zfs_ioctl.h
+# in FreeBSD with drr_type is set to DRR_BEGIN)
+#
+#   enum {
+#	DRR_BEGIN, DRR_OBJECT, DRR_FREEOBJECTS,
+#	DRR_WRITE, DRR_FREE, DRR_END,
+#   } drr_type;
+#   uint32_t drr_pad;
+#   uint64_t drr_magic;
+#   uint64_t drr_version;
+#   uint64_t drr_creation_time;
+#   dmu_objset_type_t drr_type;
+#   uint32_t drr_pad;
+#   uint64_t drr_toguid;
+#   uint64_t drr_fromguid;
+#   char drr_toname[MAXNAMELEN];
+#
+# Backup magic is 0x00000002f5bacbac (quad word)
+# The drr_type is defined as
+#   typedef enum dmu_objset_type {
+#	  DMU_OST_NONE,
+#	  DMU_OST_META,
+#	  DMU_OST_ZFS,
+#	  DMU_OST_ZVOL,
+#	  DMU_OST_OTHER,		  /* For testing only! */
+#	  DMU_OST_ANY,			  /* Be careful! */
+#	  DMU_OST_NUMTYPES
+#  } dmu_objset_type_t;
+#
+# Almost all uint64_t fields are printed as the 32-bit ones (with high
+# 32 bits zeroed), because there is no simple way to print them as the
+# full 64-bit values.
+
+# Big-endian values
+8	string	\000\000\000\002\365\272\313\254 ZFS shapshot (big-endian machine),
+>20	belong	x	version %u,
+>32	belong	0	type: NONE,
+>32	belong	1	type: META,
+>32	belong	2	type: ZFS,
+>32	belong	3	type: ZVOL,
+>32	belong	4	type: OTHER,
+>32	belong	5	type: ANY,
+>32	belong	>5	type: UNKNOWN (%u),
+>40	byte	x	destination GUID: %02X
+>41	byte	x	%02X
+>42	byte	x	%02X
+>43	byte	x	%02X
+>44	byte	x	%02X
+>45	byte	x	%02X
+>46	byte	x	%02X
+>47	byte	x	%02X,
+>48	ulong	>0
+>>52	ulong	>0
+>>>48	byte	x	source GUID: %02X
+>>>49	byte	x	%02X
+>>>50	byte	x	%02X
+>>>51	byte	x	%02X
+>>>52	byte	x	%02X
+>>>53	byte	x	%02X
+>>>54	byte	x	%02X
+>>>55	byte	x	%02X,
+>56	string	>\0	name: '%s'
+
+# Little-endian values
+8	string	\254\313\272\365\002\000\000\000	ZFS shapshot (little-endian machine),
+>16	lelong	x	version %u,
+>32	lelong	0	type: NONE,
+>32	lelong	1	type: META,
+>32	lelong	2	type: ZFS,
+>32	lelong	3	type: ZVOL,
+>32	lelong	4	type: OTHER,
+>32	lelong	5	type: ANY,
+>32	lelong	>5	type: UNKNOWN (%u),
+>47	byte	x	destination GUID: %02X
+>46	byte	x	%02X
+>45	byte	x	%02X
+>44	byte	x	%02X
+>43	byte	x	%02X
+>42	byte	x	%02X
+>41	byte	x	%02X
+>40	byte	x	%02X,
+>48	ulong	>0
+>>52	ulong	>0
+>>>55	byte	x	source GUID: %02X
+>>>54	byte	x	%02X
+>>>53	byte	x	%02X
+>>>52	byte	x	%02X
+>>>51	byte	x	%02X
+>>>50	byte	x	%02X
+>>>49	byte	x	%02X
+>>>48	byte	x	%02X,
+>56	string	>\0	name: '%s'
+
+#------------------------------------------------------------------------------
+# $File$
+# zilog:  file(1) magic for Zilog Z8000.
+#
+# Was it big-endian or little-endian?  My Product Specification doesn't
+# say.
+#
+0	long		0xe807		object file (z8000 a.out)
+0	long		0xe808		pure object file (z8000 a.out)
+0	long		0xe809		separate object file (z8000 a.out)
+0	long		0xe805		overlay object file (z8000 a.out)
+
+#------------------------------------------------------------------------------
+# $File$
+# zyxel:  file(1) magic for ZyXEL modems
+#
+# From <rob@pe1chl.ampr.org>
+# These are the /etc/magic entries to decode datafiles as used for the
+# ZyXEL U-1496E DATA/FAX/VOICE modems.  (This header conforms to a
+# ZyXEL-defined standard)
+
+0	string		ZyXEL\002	ZyXEL voice data
+>10	byte		0		- CELP encoding
+>10	byte&0x0B	1		- ADPCM2 encoding
+>10	byte&0x0B	2		- ADPCM3 encoding
+>10	byte&0x0B	3		- ADPCM4 encoding
+>10	byte&0x0B	8		- New ADPCM3 encoding
+>10	byte&0x04	4		with resync

--- a/tests/ZendTest/XmlRpc/ClientTest.php
+++ b/tests/ZendTest/XmlRpc/ClientTest.php
@@ -40,8 +40,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->httpAdapter = new Adapter\Test();
-        $this->httpClient = new Http\Client('http://foo',
-                                    array('adapter' => $this->httpAdapter));
+        $this->httpClient = new Http\Client(
+            'http://foo',
+            array('adapter' => $this->httpAdapter)
+        );
 
         $this->xmlrpcClient = new Client('http://foo');
         $this->xmlrpcClient->setHttpClient($this->httpClient);
@@ -194,7 +196,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $params = array(
             new Value\Boolean(true),
             new Value\Integer(4),
-            new Value\String('foo')
+            new Value\Text('foo')
         );
         $expect = array(true, 4, 'foo');
 
@@ -259,7 +261,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $expects = 'date.method response';
         $this->setServerResponseTo($expects);
-        $this->assertSame($expects, $this->xmlrpcClient->call('date.method', array(AbstractValue::getXmlRpcValue(time(), AbstractValue::XMLRPC_TYPE_DATETIME), 'foo')));
+        $this->assertSame(
+            $expects,
+            $this->xmlrpcClient->call(
+                'date.method',
+                array(AbstractValue::getXmlRpcValue(time(), AbstractValue::XMLRPC_TYPE_DATETIME), 'foo')
+            )
+        );
     }
 
     public function testAllowsSkippingSystemCallForArrayStructLookup()
@@ -482,7 +490,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $i = $this->xmlrpcClient->getIntrospector();
 
-        $this->setExpectedException('Zend\XmlRpc\Client\Exception\IntrospectException', 'Bad number of signatures received from multicall');
+        $this->setExpectedException(
+            'Zend\XmlRpc\Client\Exception\IntrospectException',
+            'Bad number of signatures received from multicall'
+        );
         $i->getSignatureForEachMethodByMulticall();
     }
 
@@ -501,7 +512,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $i = $this->xmlrpcClient->getIntrospector();
 
-        $this->setExpectedException('Zend\XmlRpc\Client\Exception\IntrospectException', 'Multicall return is malformed.  Expected array, got integer');
+        $this->setExpectedException(
+            'Zend\XmlRpc\Client\Exception\IntrospectException',
+            'Multicall return is malformed.  Expected array, got integer'
+        );
         $i->getSignatureForEachMethodByMulticall();
     }
 
@@ -596,9 +610,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $introspector = new Client\ServerIntrospection(
             new TestClient('http://localhost/')
-            );
+        );
 
-        $this->setExpectedException('Zend\XmlRpc\Client\Exception\IntrospectException', 'Invalid signature for method "add"');
+        $this->setExpectedException(
+            'Zend\XmlRpc\Client\Exception\IntrospectException',
+            'Invalid signature for method "add"'
+        );
         $signature = $introspector->getMethodSignature('add');
     }
 
@@ -623,17 +640,17 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->setServerResponseTo($expectedResult);
 
         $this->assertSame(
-              $expectedResult,
-              $this->xmlrpcClient->call('get', array(array(1)))
-          );
+            $expectedResult,
+            $this->xmlrpcClient->call('get', array(array(1)))
+        );
 
         $expectedResult = 'integer';
         $this->setServerResponseTo($expectedResult);
 
         $this->assertSame(
-              $expectedResult,
-              $this->xmlrpcClient->call('get', array(1))
-          );
+            $expectedResult,
+            $this->xmlrpcClient->call('get', array(1))
+        );
     }
 
     /**
@@ -671,7 +688,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         return $response;
     }
 
-    public function makeHttpResponseFrom($data, $status=200, $message='OK')
+    public function makeHttpResponseFrom($data, $status = 200, $message = 'OK')
     {
         $headers = array("HTTP/1.1 $status $message",
                          "Status: $status",

--- a/tests/ZendTest/XmlRpc/RequestTest.php
+++ b/tests/ZendTest/XmlRpc/RequestTest.php
@@ -22,14 +22,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      * \Zend\XmlRpc\Request object
      * @var \Zend\XmlRpc\Request
      */
-    protected $_request;
+    protected $request;
 
     /**
      * Setup environment
      */
     public function setUp()
     {
-        $this->_request = new Request();
+        $this->request = new Request();
     }
 
     /**
@@ -37,7 +37,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function tearDown()
     {
-        unset($this->_request);
+        unset($this->request);
     }
 
     /**
@@ -45,15 +45,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testMethod()
     {
-        $this->assertTrue($this->_request->setMethod('testMethod'));
-        $this->assertTrue($this->_request->setMethod('testMethod9'));
-        $this->assertTrue($this->_request->setMethod('test.Method'));
-        $this->assertTrue($this->_request->setMethod('test_method'));
-        $this->assertTrue($this->_request->setMethod('test:method'));
-        $this->assertTrue($this->_request->setMethod('test/method'));
-        $this->assertFalse($this->_request->setMethod('testMethod-bogus'));
+        $this->assertTrue($this->request->setMethod('testMethod'));
+        $this->assertTrue($this->request->setMethod('testMethod9'));
+        $this->assertTrue($this->request->setMethod('test.Method'));
+        $this->assertTrue($this->request->setMethod('test_method'));
+        $this->assertTrue($this->request->setMethod('test:method'));
+        $this->assertTrue($this->request->setMethod('test/method'));
+        $this->assertFalse($this->request->setMethod('testMethod-bogus'));
 
-        $this->assertEquals('test/method', $this->_request->getMethod());
+        $this->assertEquals('test/method', $this->request->getMethod());
     }
 
 
@@ -79,19 +79,19 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddParam()
     {
-        $this->_request->addParam('string1');
-        $params = $this->_request->getParams();
+        $this->request->addParam('string1');
+        $params = $this->request->getParams();
         $this->assertEquals(1, count($params));
         $this->assertEquals('string1', $params[0]);
 
-        $this->_request->addParam('string2');
-        $params = $this->_request->getParams();
+        $this->request->addParam('string2');
+        $params = $this->request->getParams();
         $this->assertSame(2, count($params));
         $this->assertSame('string1', $params[0]);
         $this->assertSame('string2', $params[1]);
 
-        $this->_request->addParam(new Value\String('foo'));
-        $params = $this->_request->getParams();
+        $this->request->addParam(new Value\Text('foo'));
+        $params = $this->request->getParams();
         $this->assertSame(3, count($params));
         $this->assertSame('string1', $params[0]);
         $this->assertSame('string2', $params[1]);
@@ -101,9 +101,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testAddDateParamGeneratesCorrectXml()
     {
         $time = time();
-        $this->_request->addParam($time, AbstractValue::XMLRPC_TYPE_DATETIME);
-        $this->_request->setMethod('foo.bar');
-        $xml = $this->_request->saveXml();
+        $this->request->addParam($time, AbstractValue::XMLRPC_TYPE_DATETIME);
+        $this->request->setMethod('foo.bar');
+        $xml = $this->request->saveXml();
         $sxl = new \SimpleXMLElement($xml);
         $param = $sxl->params->param->value;
         $type  = 'dateTime.iso8601';
@@ -121,29 +121,29 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             true,
             array('one', 'two')
         );
-        $this->_request->setParams($params);
-        $returned = $this->_request->getParams();
+        $this->request->setParams($params);
+        $returned = $this->request->getParams();
         $this->assertSame($params, $returned);
 
         $params = array(
             'string2',
             array('two', 'one')
         );
-        $this->_request->setParams($params);
-        $returned = $this->_request->getParams();
+        $this->request->setParams($params);
+        $returned = $this->request->getParams();
         $this->assertSame($params, $returned);
 
         $params = array(array('value' => 'foobar'));
-        $this->_request->setParams($params);
-        $this->assertSame(array('foobar'), $this->_request->getParams());
-        $this->assertSame(array('string'), $this->_request->getTypes());
+        $this->request->setParams($params);
+        $this->assertSame(array('foobar'), $this->request->getParams());
+        $this->assertSame(array('string'), $this->request->getTypes());
 
         $null = new Value\Nil();
-        $this->_request->setParams('foo', 1, $null);
-        $this->assertSame(array('foo', 1, $null), $this->_request->getParams());
-        $this->assertSame(array('string', 'int', 'nil'), $this->_request->getTypes());
+        $this->request->setParams('foo', 1, $null);
+        $this->assertSame(array('foo', 1, $null), $this->request->getParams());
+        $this->assertSame(array('string', 'int', 'nil'), $this->request->getTypes());
 
-        $this->assertNull($this->_request->setParams(), 'Call without argument returns null');
+        $this->assertNull($this->request->setParams(), 'Call without argument returns null');
     }
 
     /**
@@ -167,61 +167,67 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $xml = $dom->saveXml();
 
 
-        $parsed = $this->_request->loadXml($xml);
+        $parsed = $this->request->loadXml($xml);
         $this->assertTrue($parsed, $xml);
 
-        $this->assertEquals('do.Something', $this->_request->getMethod());
+        $this->assertEquals('do.Something', $this->request->getMethod());
         $test = array('string1', true);
-        $params = $this->_request->getParams();
+        $params = $this->request->getParams();
         $this->assertSame($test, $params);
 
-        $parsed = $this->_request->loadXml('foo');
+        $parsed = $this->request->loadXml('foo');
         $this->assertFalse($parsed, 'Parsed non-XML string?');
     }
 
     public function testPassingInvalidTypeToLoadXml()
     {
-        $this->assertFalse($this->_request->loadXml(new \stdClass()));
-        $this->assertTrue($this->_request->isFault());
-        $this->assertSame(635, $this->_request->getFault()->getCode());
-        $this->assertSame('Invalid XML provided to request', $this->_request->getFault()->getMessage());
+        $this->assertFalse($this->request->loadXml(new \stdClass()));
+        $this->assertTrue($this->request->isFault());
+        $this->assertSame(635, $this->request->getFault()->getCode());
+        $this->assertSame('Invalid XML provided to request', $this->request->getFault()->getMessage());
     }
 
     public function testLoadingXmlWithoutMethodNameElement()
     {
-        $this->assertFalse($this->_request->loadXml('<empty/>'));
-        $this->assertTrue($this->_request->isFault());
-        $this->assertSame(632, $this->_request->getFault()->getCode());
-        $this->assertSame("Invalid request, no method passed; request must contain a 'methodName' tag",
-            $this->_request->getFault()->getMessage());
+        $this->assertFalse($this->request->loadXml('<empty/>'));
+        $this->assertTrue($this->request->isFault());
+        $this->assertSame(632, $this->request->getFault()->getCode());
+        $this->assertSame(
+            "Invalid request, no method passed; request must contain a 'methodName' tag",
+            $this->request->getFault()->getMessage()
+        );
     }
 
     public function testLoadingXmlWithInvalidParams()
     {
-        $this->assertFalse($this->_request->loadXml(
+        $this->assertFalse($this->request->loadXml(
             '<methodCall>'
-          . '<methodName>foo</methodName>'
-          . '<params><param/><param/><param><foo/></param></params>'
-          . '</methodCall>'));
-        $this->assertTrue($this->_request->isFault());
-        $this->assertSame(633, $this->_request->getFault()->getCode());
+            . '<methodName>foo</methodName>'
+            . '<params><param/><param/><param><foo/></param></params>'
+            . '</methodCall>'
+        ));
+        $this->assertTrue($this->request->isFault());
+        $this->assertSame(633, $this->request->getFault()->getCode());
         $this->assertSame(
             'Param must contain a value',
-            $this->_request->getFault()->getMessage());
+            $this->request->getFault()->getMessage()
+        );
     }
 
     public function testExceptionWhileLoadingXmlParamValueIsHandled()
     {
-        $this->assertFalse($this->_request->loadXml(
+        $this->assertFalse($this->request->loadXml(
             '<methodCall>'
-          . '<methodName>foo</methodName>'
-          . '<params><param><value><foo/></value></param></params>'
-          . '</methodCall>'));
-        $this->assertTrue($this->_request->isFault());
-        $this->assertSame(636, $this->_request->getFault()->getCode());
+            . '<methodName>foo</methodName>'
+            . '<params><param><value><foo/></value></param></params>'
+            . '</methodCall>'
+        ));
+        $this->assertTrue($this->request->isFault());
+        $this->assertSame(636, $this->request->getFault()->getCode());
         $this->assertSame(
             'Error creating xmlrpc value',
-            $this->_request->getFault()->getMessage());
+            $this->request->getFault()->getMessage()
+        );
     }
 
     /**
@@ -229,9 +235,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsFault()
     {
-        $this->assertFalse($this->_request->isFault());
-        $this->_request->loadXml('foo');
-        $this->assertTrue($this->_request->isFault());
+        $this->assertFalse($this->request->isFault());
+        $this->request->loadXml('foo');
+        $this->assertTrue($this->request->isFault());
     }
 
     /**
@@ -239,10 +245,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFault()
     {
-        $fault = $this->_request->getFault();
+        $fault = $this->request->getFault();
         $this->assertTrue(null === $fault);
-        $this->_request->loadXml('foo');
-        $fault = $this->_request->getFault();
+        $this->request->loadXml('foo');
+        $fault = $this->request->getFault();
         $this->assertTrue($fault instanceof \Zend\XmlRpc\Fault);
     }
 
@@ -252,7 +258,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      * @param string $xml
      * @return void
      */
-    protected function _testXmlRequest($xml, $argv)
+    protected function assertXmlRequest($xml, $argv)
     {
         $sx = new \SimpleXMLElement($xml);
 
@@ -286,22 +292,22 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testSaveXML()
     {
         $argv = array('string', true);
-        $this->_request->setMethod('do.Something');
-        $this->_request->setParams($argv);
-        $xml = $this->_request->saveXml();
-        $this->_testXmlRequest($xml, $argv);
+        $this->request->setMethod('do.Something');
+        $this->request->setParams($argv);
+        $xml = $this->request->saveXml();
+        $this->assertXmlRequest($xml, $argv);
     }
 
     /**
      * __toString() test
      */
-    public function test__toString()
+    public function testCastToString()
     {
         $argv = array('string', true);
-        $this->_request->setMethod('do.Something');
-        $this->_request->setParams($argv);
-        $xml = $this->_request->__toString();
-        $this->_testXmlRequest($xml, $argv);
+        $this->request->setMethod('do.Something');
+        $this->request->setParams($argv);
+        $xml = $this->request->__toString();
+        $this->assertXmlRequest($xml, $argv);
     }
 
     /**
@@ -309,10 +315,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetEncoding()
     {
-        $this->assertEquals('UTF-8', $this->_request->getEncoding());
+        $this->assertEquals('UTF-8', $this->request->getEncoding());
         $this->assertEquals('UTF-8', AbstractValue::getGenerator()->getEncoding());
-        $this->assertSame($this->_request, $this->_request->setEncoding('ISO-8859-1'));
-        $this->assertEquals('ISO-8859-1', $this->_request->getEncoding());
+        $this->assertSame($this->request, $this->request->setEncoding('ISO-8859-1'));
+        $this->assertEquals('ISO-8859-1', $this->request->getEncoding());
         $this->assertEquals('ISO-8859-1', AbstractValue::getGenerator()->getEncoding());
     }
 
@@ -326,8 +332,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $payload = file_get_contents(dirname(__FILE__) . '/_files/ZF12293-request.xml');
         $payload = sprintf($payload, 'file://' . realpath(dirname(__FILE__) . '/_files/ZF12293-payload.txt'));
-        $this->_request->loadXml($payload);
-        $method = $this->_request->getMethod();
+        $this->request->loadXml($payload);
+        $method = $this->request->getMethod();
         $this->assertTrue(empty($method));
         if (is_string($method)) {
             $this->assertNotContains('Local file inclusion', $method);
@@ -338,6 +344,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $payload = file_get_contents(dirname(__FILE__) . '/_files/ZF12293-request.xml');
         $payload = sprintf($payload, 'file://' . realpath(dirname(__FILE__) . '/_files/ZF12293-payload.txt'));
-        $this->assertFalse($this->_request->loadXml($payload));
+        $this->assertFalse($this->request->loadXml($payload));
     }
 }

--- a/tests/ZendTest/XmlRpc/ValueTest.php
+++ b/tests/ZendTest/XmlRpc/ValueTest.php
@@ -37,8 +37,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalBooleanFromNative()
     {
         $native = true;
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_BOOLEAN);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_BOOLEAN
+        );
 
         $this->assertXmlRpcType('boolean', $val);
         $this->assertSame($native, $val->getValue());
@@ -51,8 +53,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     {
         AbstractValue::setGenerator($generator);
         $xml = '<value><boolean>1</boolean></value>';
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('boolean', $val);
         $this->assertEquals('boolean', $val->getType());
@@ -93,8 +97,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
                       "<value><i4>$native</i4></value>");
 
         foreach ($xmls as $xml) {
-            $val = AbstractValue::getXmlRpcValue($xml,
-                                        AbstractValue::XML_STRING);
+            $val = AbstractValue::getXmlRpcValue(
+                $xml,
+                AbstractValue::XML_STRING
+            );
             $this->assertXmlRpcType('integer', $val);
             $this->assertEquals('int', $val->getType());
             $this->assertSame($native, $val->getValue());
@@ -132,8 +138,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalDoubleFromNative()
     {
         $native = 1.1;
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_DOUBLE);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_DOUBLE
+        );
 
         $this->assertXmlRpcType('double', $val);
         $this->assertSame($native, $val->getValue());
@@ -147,8 +155,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         AbstractValue::setGenerator($generator);
         $native = 1.1;
         $xml = "<value><double>$native</double></value>";
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('double', $val);
         $this->assertEquals('double', $val->getType());
@@ -203,8 +213,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalStringFromNative()
     {
         $native = 'foo';
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_STRING
+        );
 
         $this->assertXmlRpcType('string', $val);
         $this->assertSame($native, $val->getValue());
@@ -212,11 +224,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsStringAndSetsValueInArray()
     {
-        $val = AbstractValue::getXmlRpcValue('<value><array><data>'.
-            '<value><i4>8</i4></value>'.
-            '<value>a</value>'.
-            '<value>false</value>'.
-            '</data></array></value>', AbstractValue::XML_STRING
+        $val = AbstractValue::getXmlRpcValue(
+            '<value><array><data>'
+            . '<value><i4>8</i4></value>'
+            . '<value>a</value>'
+            . '<value>false</value>'
+            . '</data></array></value>',
+            AbstractValue::XML_STRING
         );
         $this->assertXmlRpcType('array', $val);
         $a = $val->getValue();
@@ -233,8 +247,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         AbstractValue::setGenerator($generator);
         $native = 'foo<>';
         $xml = "<value><string>foo&lt;&gt;</string></value>";
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('string', $val);
         $this->assertEquals('string', $val->getType());
@@ -250,8 +266,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         AbstractValue::setGenerator($generator);
         $native = 'foo<br/>bar';
         $xml = "<string>foo&lt;br/&gt;bar</string>";
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('string', $val);
         $this->assertEquals('string', $val->getType());
@@ -263,13 +281,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryAutodetectsNil()
     {
-        $val = AbstractValue::getXmlRpcValue(NULL);
+        $val = AbstractValue::getXmlRpcValue(null);
         $this->assertXmlRpcType('nil', $val);
     }
 
     public function testMarshalNilFromNative()
     {
-        $native = NULL;
+        $native = null;
         $types = array(AbstractValue::XMLRPC_TYPE_NIL,
                        AbstractValue::XMLRPC_TYPE_APACHENIL);
         foreach ($types as $type) {
@@ -290,11 +308,13 @@ class ValueTest extends \PHPUnit_Framework_TestCase
                      '<value><ex:nil xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions"/></value>');
 
         foreach ($xmls as $xml) {
-            $val = AbstractValue::getXmlRpcValue($xml,
-                                        AbstractValue::XML_STRING);
+            $val = AbstractValue::getXmlRpcValue(
+                $xml,
+                AbstractValue::XML_STRING
+            );
             $this->assertXmlRpcType('nil', $val);
             $this->assertEquals('nil', $val->getType());
-            $this->assertSame(NULL, $val->getValue());
+            $this->assertSame(null, $val->getValue());
             $this->assertEquals($this->wrapXml($xml), $val->saveXml());
         }
     }
@@ -310,8 +330,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalArrayFromNative()
     {
         $native = array(0,1);
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_ARRAY);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_ARRAY
+        );
 
         $this->assertXmlRpcType('array', $val);
         $this->assertSame($native, $val->getValue());
@@ -327,8 +349,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $xml = '<value><array><data><value><int>0</int></value>'
              . '<value><int>1</int></value></data></array></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('array', $val);
         $this->assertEquals('array', $val->getType());
@@ -345,8 +369,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $native = array();
         $xml    = '<value><array><data/></array></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('array', $val);
         $this->assertEquals('array', $val->getType());
@@ -367,9 +393,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $native = array();
         $xml    = '<value><array/></value>';
 
-        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException',
+        $this->setExpectedException(
+            'Zend\XmlRpc\Exception\ValueException',
             'Invalid XML for XML-RPC native array type: ARRAY tag must contain DATA tag'
-            );
+        );
         $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
     }
 
@@ -412,8 +439,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalStructFromNative()
     {
         $native = array('foo' => 0);
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_STRUCT);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_STRUCT
+        );
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertSame($native, $val->getValue());
@@ -430,8 +459,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
              . '</value></member><member><name>bar</name><value><string>'
              . 'foo&lt;&gt;bar</string></value></member></struct></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -474,8 +505,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
              . '<member><name>bar</name><value><int>1</int></value></member>'
              . '</struct></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -496,8 +529,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
              . '<member><name>bar</name><value><int>1</int></value></member>'
              . '</struct></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -532,8 +567,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $xml = '<value><struct><member><name>foo</name>'
              . '<value><string/></value></member></struct></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -551,8 +588,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $xmlDecl = '<?xml version="1.0" encoding="UTF-8"?>';
         $xml = '<value><struct><member><name>foo</name><value><string>ß</string></value></member></struct></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xmlDecl . $xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xmlDecl . $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('struct', $val);
         $this->assertEquals('struct', $val->getType());
@@ -569,8 +608,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalDateTimeFromNativeString()
     {
         $native = '1997-07-16T19:20+01:00';
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_DATETIME
+        );
 
         $this->assertXmlRpcType('dateTime', $val);
 
@@ -581,8 +622,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalDateTimeFromNativeStringProducesIsoOutput()
     {
         $native = '1997-07-16T19:20+01:00';
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_DATETIME
+        );
 
         $this->assertXmlRpcType('dateTime', $val);
 
@@ -593,16 +636,20 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testMarshalDateTimeFromInvalidString()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException',
-                                    "The timezone could not be found in the database");
+        $this->setExpectedException(
+            'Zend\XmlRpc\Exception\ValueException',
+            'The timezone could not be found in the database'
+        );
         AbstractValue::getXmlRpcValue('foobarbaz', AbstractValue::XMLRPC_TYPE_DATETIME);
     }
 
     public function testMarshalDateTimeFromNativeInteger()
     {
         $native = strtotime('1997-07-16T19:20+01:00');
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_DATETIME);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_DATETIME
+        );
 
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertSame($native, strtotime($val->getValue()));
@@ -628,8 +675,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $iso8601 = '1997-07-16T19:20+01:00';
         $xml = "<value><dateTime.iso8601>$iso8601</dateTime.iso8601></value>";
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('dateTime', $val);
         $this->assertEquals('dateTime.iso8601', $val->getType());
@@ -696,8 +745,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testMarshalBase64FromString()
     {
         $native = 'foo';
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_BASE64);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_BASE64
+        );
 
         $this->assertXmlRpcType('base64', $val);
         $this->assertSame($native, $val->getValue());
@@ -712,8 +763,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $native = 'foo';
         $xml = '<value><base64>' .base64_encode($native). '</base64></value>';
 
-        $val = AbstractValue::getXmlRpcValue($xml,
-                                    AbstractValue::XML_STRING);
+        $val = AbstractValue::getXmlRpcValue(
+            $xml,
+            AbstractValue::XML_STRING
+        );
 
         $this->assertXmlRpcType('base64', $val);
         $this->assertEquals('base64', $val->getType());
@@ -724,8 +777,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testXmlRpcValueBase64GeneratedXmlContainsBase64EncodedText()
     {
         $native = 'foo';
-        $val = AbstractValue::getXmlRpcValue($native,
-                                    AbstractValue::XMLRPC_TYPE_BASE64);
+        $val = AbstractValue::getXmlRpcValue(
+            $native,
+            AbstractValue::XMLRPC_TYPE_BASE64
+        );
 
         $this->assertXmlRpcType('base64', $val);
         $xml = $val->saveXml();
@@ -741,8 +796,10 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $o = new SerializableTestClass();
         $o->setProperty('foobar');
         $serialized = serialize($o);
-        $val = AbstractValue::getXmlRpcValue($serialized,
-                                    AbstractValue::XMLRPC_TYPE_BASE64);
+        $val = AbstractValue::getXmlRpcValue(
+            $serialized,
+            AbstractValue::XMLRPC_TYPE_BASE64
+        );
 
         $this->assertXmlRpcType('base64', $val);
         $o2 = unserialize($val->getValue());
@@ -766,13 +823,16 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function testFactoryThrowsWhenInvalidTypeSpecified()
     {
-        $this->setExpectedException('Zend\XmlRpc\Exception\ValueException', 'Given type is not a Zend\XmlRpc\AbstractValue constant');
+        $this->setExpectedException(
+            'Zend\XmlRpc\Exception\ValueException',
+            'Given type is not a Zend\XmlRpc\AbstractValue constant'
+        );
         AbstractValue::getXmlRpcValue('', 'bad type here');
     }
 
     public function testPassingXmlRpcObjectReturnsTheSameObject()
     {
-        $xmlRpcValue = new Value\String('foo');
+        $xmlRpcValue = new Value\Text('foo');
         $this->assertSame($xmlRpcValue, AbstractValue::getXmlRpcValue($xmlRpcValue));
     }
 
@@ -853,8 +913,16 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
     public function assertXmlRpcType($type, $object)
     {
-        if ($type == 'array') {
-            $type = 'arrayValue';
+        switch ($type) {
+            case 'array':
+                $type = 'arrayValue';
+                break;
+            case 'string':
+                $type = 'text';
+                break;
+            default:
+                // nothing to do
+                break;
         }
         $type = 'Zend\\XmlRpc\\Value\\' . ucfirst($type);
         $this->assertInstanceOf($type, $object);
@@ -868,14 +936,14 @@ class ValueTest extends \PHPUnit_Framework_TestCase
 
 class SerializableTestClass
 {
-    protected $_property;
+    protected $property;
     public function setProperty($property)
     {
-        $this->_property = $property;
+        $this->property = $property;
     }
 
     public function getProperty()
     {
-        return $this->_property;
+        return $this->property;
     }
 }


### PR DESCRIPTION
This is a version of #7270 (which was in turn a rebased version of #7263), rebased against master, to support PHP 7.

I have tested both against a nightly version from 2 weeks ago, as well as the Coercive STH patch. The latterwhich provided me with a number of issues in the ZF2 codebase with regard to passing invalid arguments to internal functions, and the bulk of the commits in this branch address those, keeping compatibility with PHP 5 versions as well as PHP 7 nightly.

There is one issue I've found in `Zend\Stdlib\ArrayUtils::filter()`: apparently, PHP 7 nightly has a regression in its `array_filter` implementation; the third argument, which indicates whether to pass values only, keys only, or both to the composed callback, is ignored, causing one test case to fail.

Otherwise, this version should be ready to merge anytime.
