### PR TITLE
Composer update to 2.4-RC3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "zendframework/zendxml": "~1.0-dev"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.0",
-        "ircmaxell/random-lib": "^1.1",
+        "doctrine/annotations": "~1.0",
+        "ircmaxell/random-lib": "~1.1",
         "mikey179/vfsStream": "~1.2",
         "fabpot/php-cs-fixer": "~1.0",
         "phpunit/PHPUnit": "~4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ffc1017f896134261b0d06fb2487f6b0",
+    "hash": "6fcd53d96a4cb0a2a7c415962b79c79d",
     "packages": [
         {
             "name": "zendframework/zendxml",


### PR DESCRIPTION
During `composer update` I get:

```
[RuntimeException]                                                                                                                                                             
  Could not load package zendframework/zendframework in http://packagist.org: [UnexpectedValueException] Could not parse version constraint ^1.0: Invalid version string "^1.0"
```

Dash is new composer feature available in master branch. In our company we use only last "stable" version (current alpha9). I think we should also define supported composer version in zf2. Currently we are not able to test RC or switch to 2.4 in future :(
