### PR TITLE
Add isGone to response

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -389,6 +389,16 @@ class Response extends AbstractMessage implements ResponseInterface
     }
 
     /**
+     * Does the status code indicate the resource is gone?
+     *
+     * @return bool
+     */
+    public function isGone()
+    {
+        return (410 === $this->getStatusCode());
+    }
+
+    /**
      * Do we have a normal, OK response?
      *
      * @return bool

--- a/tests/ZendTest/Http/ResponseTest.php
+++ b/tests/ZendTest/Http/ResponseTest.php
@@ -200,6 +200,24 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isForbidden(), 'Response is an error, but isForbidden() returned true');
         $this->assertFalse($response->isInformational(), 'Response is an error, but isInformational() returned true');
         $this->assertTrue($response->isNotFound(), 'Response is an error, but isNotFound() returned false');
+        $this->assertFalse($response->isGone(), 'Response is an error, but isGone() returned true');
+        $this->assertFalse($response->isOk(), 'Response is an error, but isOk() returned true');
+        $this->assertFalse($response->isServerError(), 'Response is an error, but isServerError() returned true');
+        $this->assertFalse($response->isRedirect(), 'Response is an error, but isRedirect() returned true');
+        $this->assertFalse($response->isSuccess(), 'Response is an error, but isSuccess() returned true');
+    }
+
+    public function test410IsGone()
+    {
+        $response_text = $this->readResponse('response_410');
+        $response = Response::fromString($response_text);
+
+        $this->assertEquals(410, $response->getStatusCode(), 'Response code is expected to be 410, but it\'s not.');
+        $this->assertTrue($response->isClientError(), 'Response is an error, but isClientError() returned false');
+        $this->assertFalse($response->isForbidden(), 'Response is an error, but isForbidden() returned true');
+        $this->assertFalse($response->isInformational(), 'Response is an error, but isInformational() returned true');
+        $this->assertFalse($response->isNotFound(), 'Response is an error, but isNotFound() returned true');
+        $this->assertTrue($response->isGone(), 'Response is an error, but isGone() returned false');
         $this->assertFalse($response->isOk(), 'Response is an error, but isOk() returned true');
         $this->assertFalse($response->isServerError(), 'Response is an error, but isServerError() returned true');
         $this->assertFalse($response->isRedirect(), 'Response is an error, but isRedirect() returned true');
@@ -216,6 +234,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isForbidden(), 'Response is an error, but isForbidden() returned true');
         $this->assertFalse($response->isInformational(), 'Response is an error, but isInformational() returned true');
         $this->assertFalse($response->isNotFound(), 'Response is an error, but isNotFound() returned true');
+        $this->assertFalse($response->isGone(), 'Response is an error, but isGone() returned true');
         $this->assertFalse($response->isOk(), 'Response is an error, but isOk() returned true');
         $this->assertTrue($response->isServerError(), 'Response is an error, but isServerError() returned false');
         $this->assertFalse($response->isRedirect(), 'Response is an error, but isRedirect() returned true');
@@ -245,6 +264,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isForbidden(), 'Response is an error, but isForbidden() returned true');
         $this->assertFalse($response->isInformational(), 'Response is an error, but isInformational() returned true');
         $this->assertFalse($response->isNotFound(), 'Response is an error, but isNotFound() returned true');
+        $this->assertFalse($response->isGone(), 'Response is an error, but isGone() returned true');
         $this->assertFalse($response->isOk(), 'Response is an error, but isOk() returned true');
         $this->assertFalse($response->isServerError(), 'Response is an error, but isServerError() returned true');
         $this->assertTrue($response->isRedirect(), 'Response is an error, but isRedirect() returned false');
@@ -260,6 +280,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isForbidden(), 'Response is an error, but isForbidden() returned true');
         $this->assertFalse($response->isInformational(), 'Response is an error, but isInformational() returned true');
         $this->assertFalse($response->isNotFound(), 'Response is an error, but isNotFound() returned true');
+        $this->assertFalse($response->isGone(), 'Response is an error, but isGone() returned true');
         $this->assertTrue($response->isOk(), 'Response is an error, but isOk() returned false');
         $this->assertFalse($response->isServerError(), 'Response is an error, but isServerError() returned true');
         $this->assertFalse($response->isRedirect(), 'Response is an error, but isRedirect() returned true');
@@ -283,6 +304,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response->isForbidden(), 'Response is an error, but isForbidden() returned false');
         $this->assertFalse($response->isInformational(), 'Response is an error, but isInformational() returned true');
         $this->assertFalse($response->isNotFound(), 'Response is an error, but isNotFound() returned true');
+        $this->assertFalse($response->isGone(), 'Response is an error, but isGone() returned true');
         $this->assertFalse($response->isOk(), 'Response is an error, but isOk() returned true');
         $this->assertFalse($response->isServerError(), 'Response is an error, but isServerError() returned true');
         $this->assertFalse($response->isRedirect(), 'Response is an error, but isRedirect() returned true');

--- a/tests/ZendTest/Http/_files/response_410
+++ b/tests/ZendTest/Http/_files/response_410
@@ -1,0 +1,19 @@
+HTTP/1.1 410 Gone
+Date: Fri, 17 Nov 2006 22:22:40 GMT
+Server: Apache
+Content-Length: 272
+Keep-Alive: timeout=15, max=100
+Connection: Keep-Alive
+Content-Type: text/html; charset=iso-8859-1
+
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>410 Gone</title>
+</head><body>
+<h1>Gone</h1>
+<p>The requested resource /some/wrong/path is no longer available on
+this server and there is no forwarding address. Please remove all
+references to this resource.</p>
+<hr>
+<address>Apache Server at localhost Port 80</address>
+</body></html>


### PR DESCRIPTION
As per the discussion in zendframework/zf2#7368 this change adds a new
method `\Zend\Http\Response->isGone()` to determine if the status code is
a "410 Gone". This works exactly the same as the similar methods like
`isNotFound` simply by checking the status code.

This change takes the opinion that a 410 Gone should not be included in
the `isNotFound()` method. Further discussion can be seen in the issue.
