### PR TITLE
Zend\Mail, Zend\Mime: parsing rework

### DIFF
--- a/library/Zend/Mail/Address.php
+++ b/library/Zend/Mail/Address.php
@@ -30,6 +30,19 @@ class Address implements Address\AddressInterface
         if (null !== $name && !is_string($name)) {
             throw new Exception\InvalidArgumentException('Name must be a string');
         }
+        if (strlen($email) > 254) {
+            // see http://www.rfc-editor.org/errata_search.php?eid=1690
+            throw new Exception\InvalidArgumentException('Email max size is 254 chars');
+        }
+        $arr = explode('@', $email);
+        if (isset($arr[0]) && strlen($arr[0]) > 64) {
+            // http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
+            throw new Exception\InvalidArgumentException('Email local part max size is 64 chars');
+        }
+        if (isset($arr[1]) && strlen($arr[1]) > 255) {
+            // http://tools.ietf.org/html/rfc5321#section-4.5.3.1.2
+            throw new Exception\InvalidArgumentException('Email domain part max size is 255 chars');
+        }
 
         $this->email = $email;
         $this->name  = $name;

--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -87,14 +87,12 @@ abstract class AbstractAddressList implements HeaderInterface
             if (empty($name)) {
                 $emails[] = $email;
             } else {
-                if (false !== strstr($name, ',')) {
-                    $name = sprintf('"%s"', $name);
-                }
-
                 if ($format == HeaderInterface::FORMAT_ENCODED
                     && 'ASCII' !== $encoding
                 ) {
                     $name = HeaderWrap::mimeEncodeValue($name, $encoding);
+                } elseif (false !== strpos($name, ',')) {
+                    $name = sprintf('"%s"', $name);
                 }
                 $emails[] = sprintf('%s <%s>', $name, $email);
             }

--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -41,9 +41,7 @@ abstract class AbstractAddressList implements HeaderInterface
 
     public static function fromString($headerLine)
     {
-        $decodedLine = iconv_mime_decode($headerLine, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-        // split into name/value
-        list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($decodedLine);
+        list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);
 
         if (strtolower($fieldName) !== static::$type) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -52,22 +50,24 @@ abstract class AbstractAddressList implements HeaderInterface
             ));
         }
         $header = new static();
-        if ($decodedLine != $headerLine) {
-            $header->setEncoding('UTF-8');
-        }
-        // split value on ","
+
+        //TODO: haven't we already unfolded the string when we get here?
         $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
+        // split value on ","
         $values     = str_getcsv($fieldValue, ',');
-        array_walk(
-            $values,
-            function (&$value) {
-                $value = trim($value);
-            }
-        );
 
         $addressList = $header->getAddressList();
         foreach ($values as $address) {
-            $addressList->addFromString($address);
+            $address = trim($address);
+            //we should not error when we have an empty header like 'Reply-To: '
+            if (empty($address)) {
+                continue;
+            }
+            $decoded = iconv_mime_decode($address, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
+            if ($decoded != $address) {
+                $header->setEncoding('UTF-8');
+            }
+            $addressList->addFromString($decoded);
         }
         return $header;
     }

--- a/library/Zend/Mail/Header/AbstractAddressList.php
+++ b/library/Zend/Mail/Header/AbstractAddressList.php
@@ -43,7 +43,7 @@ abstract class AbstractAddressList implements HeaderInterface
     {
         list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);
 
-        if (strtolower($fieldName) !== static::$type) {
+        if (strtolower(str_replace('_', '-', $fieldName)) !== static::$type) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid header line for "%s" string',
                 __CLASS__

--- a/library/Zend/Mail/Header/ContentTransferEncoding.php
+++ b/library/Zend/Mail/Header/ContentTransferEncoding.php
@@ -44,7 +44,7 @@ class ContentTransferEncoding implements HeaderInterface
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-transfer-encoding') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'contenttransferencoding') {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Transfer-Encoding string');
         }
 

--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -29,7 +29,7 @@ class ContentType implements HeaderInterface
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-type') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'contenttype') {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Type string');
         }
 

--- a/library/Zend/Mail/Header/GenericHeader.php
+++ b/library/Zend/Mail/Header/GenericHeader.php
@@ -88,15 +88,15 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
             throw new Exception\InvalidArgumentException('Header name must be a string');
         }
 
-        // Pre-filter to normalize valid characters, change underscore to dash
-        $fieldName = str_replace(' ', '-', ucwords(str_replace(array('_', '-'), ' ', $fieldName)));
-
         // Validate what we have
-        if (!preg_match('/^[\x21-\x39\x3B-\x7E]*$/', $fieldName)) {
+        if (!preg_match('/^[!-9;-~]+$/', $fieldName)) {
             throw new Exception\InvalidArgumentException(
                 'Header name must be composed of printable US-ASCII characters, except colon.'
             );
         }
+
+        // change underscore to dash
+        $fieldName = ucwords(str_replace('_', '-', $fieldName));
 
         $this->fieldName = $fieldName;
         return $this;

--- a/library/Zend/Mail/Header/HeaderWrap.php
+++ b/library/Zend/Mail/Header/HeaderWrap.php
@@ -90,6 +90,6 @@ abstract class HeaderWrap
      */
     public static function mimeEncodeValue($value, $encoding, $lineLength = 998)
     {
-        return Mime::encodeQuotedPrintableHeader($value, $encoding, $lineLength, Headers::EOL);
+        return Mime::encodeBase64Header($value, $encoding, $lineLength, Headers::EOL);
     }
 }

--- a/library/Zend/Mail/Header/MessageId.php
+++ b/library/Zend/Mail/Header/MessageId.php
@@ -21,7 +21,7 @@ class MessageId implements HeaderInterface
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'message-id') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'messageid') {
             throw new Exception\InvalidArgumentException('Invalid header line for Message-ID string');
         }
 

--- a/library/Zend/Mail/Header/MimeVersion.php
+++ b/library/Zend/Mail/Header/MimeVersion.php
@@ -21,7 +21,7 @@ class MimeVersion implements HeaderInterface
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'mime-version') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'mimeversion') {
             throw new Exception\InvalidArgumentException('Invalid header line for MIME-Version string');
         }
 

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -198,7 +198,7 @@ class Headers implements Countable, Iterator
     {
         if (!is_string($headerFieldNameOrLine)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects its first argument to be a string; received "%s"',
+                'addHeaderLine expects its first argument to be a string; received "%s"',
                 (is_object($headerFieldNameOrLine) ? get_class($headerFieldNameOrLine) : gettype($headerFieldNameOrLine))
             ));
         }

--- a/library/Zend/Mail/Headers.php
+++ b/library/Zend/Mail/Headers.php
@@ -58,25 +58,24 @@ class Headers implements Countable, Iterator
      * will be lazy loaded)
      *
      * @param  string $string
-     * @param  string $EOL EOL string; defaults to {@link EOL}
      * @throws Exception\RuntimeException
      * @return Headers
      */
-    public static function fromString($string, $EOL = self::EOL)
+    public static function fromString($string)
     {
         $headers     = new static();
         $currentLine = '';
 
         // iterate the header lines, some might be continuations
-        foreach (explode($EOL, $string) as $line) {
+        foreach (preg_split('/\R/', $string) as $line) {
             // check if a header name is present
-            if (preg_match('/^[\x21-\x39\x3B-\x7E]+:.*$/', $line)) {
+            if (preg_match('/^[!-9;-~]+:/', $line)) {
                 if ($currentLine) {
                     // a header name was present, then store the current complete line
                     $headers->addHeaderLine($currentLine);
                 }
                 $currentLine = trim($line);
-            } elseif (preg_match('/^\s+.*$/', $line)) {
+            } elseif (preg_match('/^\s+[^\s]/', $line)) {
                 // continuation: append to current line
                 // recover the whitespace that break the line (unfolding, rfc2822#section-2.2.3)
                 $currentLine .= ' ' . trim($line);

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -83,7 +83,6 @@ class Message
     public function setHeaders(Headers $headers)
     {
         $this->headers = $headers;
-        $headers->setEncoding($this->getEncoding());
         return $this;
     }
 

--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -475,6 +475,19 @@ class Message
     protected function getAddressListFromHeader($headerName, $headerClass)
     {
         $header = $this->getHeaderByName($headerName, $headerClass);
+        if ($header instanceof \ArrayIterator) {
+            //Merge address list
+            $arr = $header->getArrayCopy();
+            /* @var $header Header\AbstractAddressList */
+            $header = array_shift($arr);
+            $adl = $header->getAddressList();
+            /* @var $h Header\AbstractAddressList */
+            foreach ($arr as $h) {
+                $adl->merge($h->getAddressList());
+            }
+            $this->getHeaders()->removeHeader($headerName);
+            $this->getHeaders()->addHeader($header);
+        }
         if (!$header instanceof Header\AbstractAddressList) {
             throw new Exception\DomainException(sprintf(
                 'Cannot grab address list from header of type "%s"; not an AbstractAddressList implementation',

--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -273,10 +273,7 @@ class Smtp extends AbstractProtocol
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
-        // Ensure newlines are CRLF (\r\n)
-        $data = str_replace("\n", "\r\n", str_replace("\r", '', $data));
-
-        foreach (explode(self::EOL, $data) as $line) {
+        foreach (preg_split('/\R/', $data) as $line) {
             if (strpos($line, '.') === 0) {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;

--- a/library/Zend/Mime/Decode.php
+++ b/library/Zend/Mime/Decode.php
@@ -10,7 +10,6 @@
 namespace Zend\Mime;
 
 use Zend\Mail\Headers;
-use Zend\Stdlib\ErrorHandler;
 
 class Decode
 {
@@ -102,43 +101,31 @@ class Decode
     public static function splitMessage($message, &$headers, &$body, $EOL = Mime::LINEEND, $strict = false)
     {
         if ($message instanceof Headers) {
-            $message = $message->toString();
-        }
-        // check for valid header at first line
-        $firstline = strtok($message, "\n");
-        if (!preg_match('%^[^\s]+[^:]*:%', $firstline)) {
-            $headers = array();
-            // TODO: we're ignoring \r for now - is this function fast enough and is it safe to assume noone needs \r?
-            $body = str_replace(array("\r", "\n"), array('', $EOL), $message);
+            $headers = $message;
+            $body = null;
             return;
         }
 
-        // see @ZF2-372, pops the first line off a message if it doesn't contain a header
-        if (!$strict) {
-            $parts = explode(':', $firstline, 2);
-            if (count($parts) != 2) {
-                $message = substr($message, strpos($message, $EOL)+1);
+        // check for valid header at first line
+        if (!preg_match('%^[!-9;-~]+:%', $message)) {
+            //check for valid header at second line for @ZF2-372
+            if (!$strict && preg_match('%^.*\R[!-9;-~]+:%', $message)) {
+                //drop first line for @ZF2-372
+                $message = substr($message, strpos($message, "\n")+1);
+            } else {
+                //There is no headers
+                $headers = new Headers();
+                $body = $message;
+                return;
             }
         }
 
-        // find an empty line between headers and body
-        // default is set new line
-        if (strpos($message, $EOL . $EOL)) {
-            list($headers, $body) = explode($EOL . $EOL, $message, 2);
-        // next is the standard new line
-        } elseif ($EOL != "\r\n" && strpos($message, "\r\n\r\n")) {
-            list($headers, $body) = explode("\r\n\r\n", $message, 2);
-        // next is the other "standard" new line
-        } elseif ($EOL != "\n" && strpos($message, "\n\n")) {
-            list($headers, $body) = explode("\n\n", $message, 2);
-        // at last resort find anything that looks like a new line
-        } else {
-            ErrorHandler::start(E_NOTICE|E_WARNING);
-            list($headers, $body) = preg_split("%([\r\n]+)\\1%U", $message, 2);
-            ErrorHandler::stop();
+        $arr = preg_split("%\R\R%", $message, 2);
+        unset($message);
+        $headers = Headers::fromString(array_shift($arr));
+        if (isset($arr[0])) {
+            $body = $arr[0];
         }
-
-        $headers = Headers::fromString($headers, $EOL);
     }
 
     /**

--- a/library/Zend/Mime/Mime.php
+++ b/library/Zend/Mime/Mime.php
@@ -268,6 +268,7 @@ class Mime
         $lineLength = self::LINELENGTH,
         $lineEnd = self::LINEEND)
     {
+        $lineLength = $lineLength - ($lineLength % 4);
         return rtrim(chunk_split(base64_encode($str), $lineLength, $lineEnd));
     }
 

--- a/tests/ZendTest/Mail/Header/HeaderWrapTest.php
+++ b/tests/ZendTest/Mail/Header/HeaderWrapTest.php
@@ -39,8 +39,8 @@ class HeaderWrapTest extends \PHPUnit_Framework_TestCase
         $header->expects($this->any())
             ->method('getEncoding')
             ->will($this->returnValue('UTF-8'));
-        $expected = "=?UTF-8?Q?foobarblahblahblah=20baz=20batfoobarblahblahblah=20baz=20?=\r\n"
-                    . " =?UTF-8?Q?batfoobarblahblahblah=20baz=20bat?=";
+        $expected = "=?UTF-8?B?Zm9vYmFyYmxhaGJsYWhibGFoIGJheiBiYXRmb29iYXJibGFoYmxhaGJsYWggYmF6?=\r\n"
+                    . " =?UTF-8?B?IGJhdGZvb2JhcmJsYWhibGFoYmxhaCBiYXogYmF0?=";
 
         $test = HeaderWrap::wrap($string, $header);
         $this->assertEquals($expected, $test);
@@ -53,7 +53,7 @@ class HeaderWrapTest extends \PHPUnit_Framework_TestCase
     public function testMimeEncoding()
     {
         $string   = 'Umlauts: ä';
-        $expected = '=?UTF-8?Q?Umlauts:=20=C3=A4?=';
+        $expected = '=?UTF-8?B?VW1sYXV0czogw6Q=?=';
 
         $test = HeaderWrap::mimeEncodeValue($string, 'UTF-8', 78);
         $this->assertEquals($expected, $test);

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -637,23 +637,23 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $test = $this->message->getHeaders()->toString();
 
-        $expected = '=?UTF-8?Q?ZF=20DevTeam?=';
+        $expected = '=?UTF-8?B?WkYgRGV2VGVhbQ==?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-devteam@example.com>', $test);
 
-        $expected = "=?UTF-8?Q?Matthew=20Weier=20O'Phinney?=";
+        $expected = "=?UTF-8?B?TWF0dGhldyBXZWllciBPJ1BoaW5uZXk=?=";
         $this->assertContains($expected, $test, $test);
         $this->assertContains('<matthew@example.com>', $test);
 
-        $expected = '=?UTF-8?Q?ZF=20Contributors=20List?=';
+        $expected = '=?UTF-8?B?WkYgQ29udHJpYnV0b3JzIExpc3Q=?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-contributors@example.com>', $test);
 
-        $expected = '=?UTF-8?Q?ZF=20CR=20Team?=';
+        $expected = '=?UTF-8?B?WkYgQ1IgVGVhbQ==?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-crteam@example.com>', $test);
 
-        $expected = 'Subject: =?UTF-8?Q?This=20is=20a=20subject?=';
+        $expected = 'Subject: =?UTF-8?B?VGhpcyBpcyBhIHN1YmplY3Q=?=';
         $this->assertContains($expected, $test);
     }
 

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -695,4 +695,21 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setBody($mimeMessage);
         $this->assertEquals('', $this->message->getBodyText());
     }
+
+    public function testParseUglyHeaderMail()
+    {
+        $message1 = Message::fromString(file_get_contents(__DIR__ . '/_files/mail2.txt'));
+        $this->assertEquals(3, $message1->getTo()->count(), "There is 3 email addresses in the two 'To' headers");
+        $this->assertEquals(0, $message1->getCc()->count(), "There is no email address in the empty 'Cc' header");
+        $this->assertEquals("text/plain", $message1->getHeaders()->get('Content-Type')->getFieldValue());
+    }
+
+    public function testStableParsing()
+    {
+        $message1 = Message::fromString(file_get_contents(__DIR__ . '/_files/mail2.txt'));
+        $raw1 = $message1->toString();
+        $message2 = Message::fromString($raw1);
+        $raw2 = $message2->toString();
+        $this->assertEquals($raw1, $raw2, "Parsing isn't stable, we should be able to parse Message->toString() output and get same result");
+    }
 }

--- a/tests/ZendTest/Mail/Storage/MessageTest.php
+++ b/tests/ZendTest/Mail/Storage/MessageTest.php
@@ -57,7 +57,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = new Message(array('file' => $this->_file));
 
-        $this->assertEquals('Peter Müller <peter-mueller@example.com>', $message->from);
+        $this->assertEquals('"Peter Müller" <peter-mueller@example.com>', $message->from);
     }
 
     public function testGetHeaderAsArray()

--- a/tests/ZendTest/Mail/Storage/MessageTest.php
+++ b/tests/ZendTest/Mail/Storage/MessageTest.php
@@ -222,7 +222,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $header = 'Test: test';
         $body   = 'body';
-        $newlines = array("\r\n", "\n\r", "\n", "\r");
+        $newlines = array("\r\n", "\n", "\r");
 
         $decoded_body    = null; // "Declare" variable before first "read" usage to avoid IDEs warning
         $decoded_headers = null; // "Declare" variable before first "read" usage to avoid IDEs warning

--- a/tests/ZendTest/Mail/Storage/MessageTest.php
+++ b/tests/ZendTest/Mail/Storage/MessageTest.php
@@ -422,10 +422,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testStrictParseMessage()
     {
-        $this->setExpectedException('Zend\\Mail\\Exception\\RuntimeException');
-
+        //when doing strict parsing, if first line isn't an header,
+        //we consider that it's only a body
         $raw = file_get_contents($this->_file);
         $raw = "From foo@example.com  Sun Jan 01 00:00:00 2000\n" . $raw;
         $message = new Message(array('raw' => $raw, 'strict' => true));
+        $this->assertEquals($raw, $message->getContent());
     }
 }

--- a/tests/ZendTest/Mail/Transport/SendmailTest.php
+++ b/tests/ZendTest/Mail/Transport/SendmailTest.php
@@ -126,6 +126,6 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
         $message = $this->getMessage();
         $message->setEncoding('UTF-8');
         $this->transport->send($message);
-        $this->assertEquals('=?UTF-8?Q?Testing=20Zend\Mail\Transport\Sendmail?=', $this->subject);
+        $this->assertEquals('=?UTF-8?B?VGVzdGluZyBaZW5kXE1haWxcVHJhbnNwb3J0XFNlbmRtYWls?=', $this->subject);
     }
 }

--- a/tests/ZendTest/Mail/_files/mail2.txt
+++ b/tests/ZendTest/Mail/_files/mail2.txt
@@ -1,0 +1,16 @@
+To: =?utf-8?B?QUFBLCB0ZXN0IHdpdGggw6nDoCTDuQ==?= <aaaa@bbbb.com>,,
+ foo@example.com,
+To: bar@example.com
+Cc: 
+Subject: ugly headers
+Date: Sun, 01 Jan 2000 00:00:00 +0000
+From: baz@example.com
+ContENTtype: text/plain
+Message-ID: <aaaaa@mail.example.com>
+
+We should support:
+Duplicated mail headers (see To)
+Too many commas in headers (see To)
+Comma in encoded word (see To)
+Empty mail headers (see Cc)
+Malformatted headers (see ContENTtype)


### PR DESCRIPTION
Hi,

I've ran ~100000 mails through Zend\Mail\Message::fromString(), and send them to an smtp server (postfix), and here are some fixes.

I really think that we should kill the whole encoding thing and use mb_detect_encoding (don't know if mb dependency is ok)

Please start to review/comment.
