### PR TITLE
Adjust ContentType regex to allow quoted strings and equals

### DIFF
--- a/library/Zend/Http/Header/ContentType.php
+++ b/library/Zend/Http/Header/ContentType.php
@@ -55,7 +55,7 @@ class ContentType implements HeaderInterface
             $parameters = array();
             foreach ($parts as $parameter) {
                 $parameter = trim($parameter);
-                if (!preg_match('/^(?P<key>[^\s\=]+)\=(?P<value>[^\s\=]*)$/', $parameter, $matches)) {
+                if (!preg_match('/^(?P<key>[^\s\=]+)\="?(?P<value>[^\s\"]*)"?$/', $parameter, $matches)) {
                     continue;
                 }
                 $parameters[$matches['key']] = $matches['value'];

--- a/tests/ZendTest/Http/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Http/Header/ContentTypeTest.php
@@ -117,4 +117,27 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $result = $header->match($criteria);
         $this->assertEquals('application/vnd.*+json', $result);
     }
+
+    public function contentTypeParameterExamples()
+    {
+        return array(
+            'no-quotes' => array('Content-Type: foo/bar; param=baz', 'baz'),
+            'with-quotes' => array('Content-Type: foo/bar; param="baz"', 'baz'),
+            'with-equals' => array('Content-Type: foo/bar; param=baz=bat', 'baz=bat'),
+            'with-equals-and-quotes' => array('Content-Type: foo/bar; param="baz=bat"', 'baz=bat'),
+        );
+    }
+
+    /**
+     * @dataProvider contentTypeParameterExamples
+     */
+    public function testContentTypeParsesParametersCorrectly($headerString, $expectedParameterValue)
+    {
+        $contentTypeHeader = ContentType::fromString($headerString);
+
+        $parameters = $contentTypeHeader->getParameters();
+
+        $this->assertArrayHasKey('param', $parameters);
+        $this->assertSame($expectedParameterValue, $parameters['param']);
+    }
 }


### PR DESCRIPTION
This change modifies the regular expression in `ContentType::fromString()`
to allow parameters to contain the equals (`=`) character, and be
optionally enclosed in double quotes. For example the following header
is perfectly valid, but does not get currently parsed by `ContentType`:

```
Content-type: text/plain; charset="us-ascii"
```

Whilst allowing the parameter to be enclosed in double quotes, it should
not be included in the value itself, so these are outside the capture
group in the regular expression.

This change should resolve issue #7076.
