### PR TITLE
Add ValidatorServiceInterface for session validators

### DIFF
--- a/library/Zend/Session/AbstractManager.php
+++ b/library/Zend/Session/AbstractManager.php
@@ -54,19 +54,26 @@ abstract class AbstractManager implements Manager
     protected $validators;
 
     /**
+     * @var array
+     */
+    protected $validatorServices;
+
+    /**
      * Constructor
      *
      * @param  Config|null      $config
      * @param  Storage|null     $storage
      * @param  SaveHandler|null $saveHandler
      * @param  array            $validators
+     * @param  array            $validatorServices
      * @throws Exception\RuntimeException
      */
     public function __construct(
         Config $config = null,
         Storage $storage = null,
         SaveHandler $saveHandler = null,
-        array $validators = array()
+        array $validators = array(),
+        array $validatorServices = array()
     ) {
         // init config
         if ($config === null) {
@@ -118,6 +125,7 @@ abstract class AbstractManager implements Manager
         }
 
         $this->validators = $validators;
+        $this->validatorServices = $validatorServices;
     }
 
     /**

--- a/library/Zend/Session/Validator/ValidatorServiceInterface.php
+++ b/library/Zend/Session/Validator/ValidatorServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Session\Validator;
+
+/**
+ * Session validator interface created by factory
+ */
+interface ValidatorServiceInterface extends ValidatorInterface
+{
+	public function setData($data);
+}

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -100,6 +100,16 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($validators, 'validators', $manager);
     }
 
+    public function testCanPassValidatorServicesToConstructor()
+    {
+        $validators = array(
+            $this->getMock('Zend\Session\Validator\ValidatorServiceInterface'),
+            $this->getMock('Zend\Session\Validator\ValidatorServiceInterface'),
+        );
+        $manager = new SessionManager(null, null, null, array(), $validators);
+        $this->assertAttributeEquals($validators, 'validatorServices', $manager);
+    }
+
     // Session-related functionality
 
     /**


### PR DESCRIPTION
This PR fixes #7381 without any BC breaks. It allows a session validator to be instantiated with dependencies and adds some default functionality to the `SessionManagerFactory` to `get()` session validators from the `ServiceManager`.

It introduces the new interface `Zend\Session\Validator\ValidatorServiceInterface` which extends `Zend\Session\Validator\ValidatorInterface`. It modifies the `Zend\Session\Service\SessionManagerFactory` to also inject validator services into the session manager. Lastly it modifies `Zend\Session\SessionManager` and `Zend\Session\ValidatorChain` to attach the validator services to the `ValidatorChain` and inject the reference value from the current session into the validator service using the `setData()` method defined in the `ValidatorServiceInterface`.

A validator which implements the `ValidatorServiceInterface` can be registered under the key `services` in the configuration array for session validators, like this:

```
array (
    'session_manager' => array(
        'validators' => array(
            'OldSessionValidatorWillWork',
            'services' => array(
                'NewValidatorServicesGoHere',
            ),
        ),
    ),
);
```

The example above illustrates that the old way of registering validators still works, and that new validator services goes under the `services` key of the `validators` array.

All validators under the `services` key must:
- implement the `ValidatorServiceInterface`, and
- be registered with the `ServiceManager`.

I'm open for discussion, but I think this is the best way to implement this feature without a BC break.

Caveats:
- In the old way of doing things we only registered session validators when creating the session. On subsequent requests the session validators would be instantiated automatically. The new validator services work differently in that they must be injected in the `SessionManager` on each request. If a service validator isn't injected it will be improperly created by the `ValidatorChain`, which may cause unknowing developers some trouble. 

Things I haven't thought of yet: (hey, that's a paradox!)
- How to insert the validators when creating the session. I'm not sure how to do this without removing them all, re-getting them from the service manager, injecting the reference value and then attaching them again. There are probably other ways, but it's still overly complicated.
