### PR TITLE
update @return to use mixed in ServiceLocatorInterface::get($name)

### DIFF
--- a/library/Zend/ServiceManager/ServiceLocatorInterface.php
+++ b/library/Zend/ServiceManager/ServiceLocatorInterface.php
@@ -19,7 +19,7 @@ interface ServiceLocatorInterface
      *
      * @param  string  $name
      * @throws Exception\ServiceNotFoundException
-     * @return object|array
+     * @return mixed
      */
     public function get($name);
 


### PR DESCRIPTION
this can be happen when we have a class like the following : 

``` php
class Foo
{
    public function __construct(BarInterface $bar)
    {}
}
```

if we use scrutinizer to check the code, when make it as service and we instantiate the class using factory, we will get documentation issue : 

```
$serviceLocator->get('Bar') is of type object|array, but the function expects a object<BarInterface>. 
```

that's why I think we can use @mixed.
