### PR TITLE
fixed return type on disconnect method in pgsql connection

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
@@ -109,6 +109,7 @@ class Connection extends AbstractConnection
     public function disconnect()
     {
         pg_close($this->resource);
+        return $this;
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -57,10 +57,11 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testDisconnect()
     {
-        $this->markTestIncomplete(
-            'This test needs work.'
-        );
-        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\ConnectionInterface',$this->connection->disconnect());
+        if (! extension_loaded('pgsql')) {
+            $this->markTestSkipped('pgsql extension not loaded');
+        }
+        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\ConnectionInterface', $this->connection->disconnect());
+        $this->assertNull($this->connection->getResource());
     }
 
     /**

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -52,6 +52,18 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test disconnect method to return instance of ConnectionInterface
+     * @TODO Exception was raised due to invalid resource. Add resource to make this test pass.
+     */
+    public function testDisconnect()
+    {
+        $this->markTestIncomplete(
+            'This test needs work.'
+        );
+        $this->assertInstanceOf('\Zend\Db\Adapter\Driver\ConnectionInterface',$this->connection->disconnect());
+    }
+
+    /**
      * @group 6760
      * @group 6787
      */


### PR DESCRIPTION
According to the inherited docs this should return an instance of ConnectionInterface. Fixed this return type, asking myself why the feedback of the pg_close (boolean) method wasn't returned.

Anyone knows why the feedback isn't returned?
