### PR TITLE
Update AutoDiscover.php

### DIFF
--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -150,7 +150,7 @@ class AutoDiscover
     /**
      * Set the class map of php to wsdl mappings.
      *
-     * @param  array $classmap
+     * @param  array $classMap
      * @return self
      * @throws Exception\InvalidArgumentException
      */


### PR DESCRIPTION
Fixed typo in docblock setClassMap $classmap = $classMap. Soms editors will complain about this error.
