### PR TITLE
Zend\Code\Generator\ClassGenerator can not generate final classes

### DIFF
--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -943,6 +943,8 @@ class ClassGenerator extends AbstractGenerator
 
         if ($this->isAbstract()) {
             $output .= 'abstract ';
+        } else if ($this->isFinal()) {
+            $output .= 'final ';
         }
 
         $output .= static::OBJECT_TYPE . ' ' . $this->getName();

--- a/library/Zend/Code/Generator/ClassGenerator.php
+++ b/library/Zend/Code/Generator/ClassGenerator.php
@@ -943,7 +943,7 @@ class ClassGenerator extends AbstractGenerator
 
         if ($this->isAbstract()) {
             $output .= 'abstract ';
-        } else if ($this->isFinal()) {
+        } elseif ($this->isFinal()) {
             $output .= 'final ';
         }
 

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -1099,4 +1099,24 @@ class myClass
 CODE;
         $this->assertEquals($classGenerator->generate(), $output);
     }
+
+    public function testGenerateWithFinalFlag()
+    {
+        $classGenerator = ClassGenerator::fromArray(array(
+            'name' => 'SomeClass',
+            'flags' => ClassGenerator::FLAG_FINAL
+        ));
+
+        $expectedOutput = <<<EOS
+final class SomeClass
+{
+
+
+}
+
+EOS;
+
+        $output = $classGenerator->generate();
+        $this->assertEquals($expectedOutput, $output, $output);
+    }
 }


### PR DESCRIPTION
Zend\Code\Generator\ClassGenerator accepts a final flag, but does not generate code for final classes.

I've added a test and fix, I restricted the implementation to declaring the class either abstract or final, not both. (http://phpsadness.com/sad/41) Preference was given to abstract classes so as to not break any existing code that set both abstract and final flags.
