### PR TITLE
Encoded backslash in route parameter

### DIFF
--- a/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
+++ b/tests/ZendTest/Mvc/Router/Http/SegmentTest.php
@@ -170,6 +170,12 @@ class SegmentTest extends TestCase
                 null,
                 array('foo' => 'foo bar')
             ),
+            'urlencoded-backslash' => array(
+                new Segment('/:slashparam', array('slashparam' => '[a-zA-Z\\\\]*')),
+                '/Zend%5CBackslash',
+                null,
+                array('slashparam' => 'Zend\Backslash')
+            ),
             'urlencode-flaws-corrected' => array(
                 new Segment('/:foo'),
                 "/!$&'()*,-.:;=@_~+",


### PR DESCRIPTION
In Apigility documentation url contains module name. We added to generated module name own namespace. After this documentation has stopped working. We have found that problem is there https://github.com/zfcampus/zf-apigility-documentation/blob/master/config/module.config.php#L17 and we change regex to `[a-zA-Z][a-zA-Z0-9_\\\\]+` what should cover namespace (`MyNamespace\ApiName`). However it doesn't work. One of working solution is `[a-zA-Z][a-zA-Z0-9_%]+`.

Question is: when param should be validate? Before or after decode. For me logical is to validate after.

I have provided falling test to demonstrate problem.
