### PR TITLE
increase loop performance by assign count() to variable

### DIFF
--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -135,8 +135,8 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                 if ($insert) {
                     $j = isset($j) ? $j : 0;
                     $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
-                    $countInsertStart = count($insertStart);
-                    for (; $j < $countInsertStart; ++$j) {
+                    $insertStartCount = count($insertStart);
+                    for (; $j < $insertStartCount; ++$j) {
                         $insertStart[$j] += strlen($insert);
                     }
                 }
@@ -200,8 +200,8 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                 if ($insert) {
                     $j = isset($j) ? $j : 0;
                     $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
-                    $countInsertStart = count($insertStart);
-                    for (; $j < $countInsertStart; ++$j) {
+                    $insertStartCount = count($insertStart);
+                    for (; $j < $insertStartCount; ++$j) {
                         $insertStart[$j] += strlen($insert);
                     }
                 }

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -135,7 +135,8 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                 if ($insert) {
                     $j = isset($j) ? $j : 0;
                     $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
-                    for (; $j < count($insertStart); ++$j) {
+                    $countInsertStart = count($insertStart);
+                    for (; $j < $countInsertStart; ++$j) {
                         $insertStart[$j] += strlen($insert);
                     }
                 }
@@ -199,7 +200,8 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
                 if ($insert) {
                     $j = isset($j) ? $j : 0;
                     $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
-                    for (; $j < count($insertStart); ++$j) {
+                    $countInsertStart = count($insertStart);
+                    for (; $j < $countInsertStart; ++$j) {
                         $insertStart[$j] += strlen($insert);
                     }
                 }

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -139,8 +139,8 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
                 if ($insert) {
                     $j = isset($j) ? $j : 0;
                     $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
-                    $countInsertStart = count($insertStart);
-                    for (; $j < $countInsertStart; ++$j) {
+                    $insertStartCount = count($insertStart);
+                    for (; $j < $insertStartCount; ++$j) {
                         $insertStart[$j] += strlen($insert);
                     }
                 }

--- a/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/library/Zend/Db/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -139,7 +139,8 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
                 if ($insert) {
                     $j = isset($j) ? $j : 0;
                     $sql = substr_replace($sql, $insert, $insertStart[$j], 0);
-                    for (; $j < count($insertStart); ++$j) {
+                    $countInsertStart = count($insertStart);
+                    for (; $j < $countInsertStart; ++$j) {
                         $insertStart[$j] += strlen($insert);
                     }
                 }

--- a/library/Zend/Ldap/Dn.php
+++ b/library/Zend/Ldap/Dn.php
@@ -553,9 +553,9 @@ class Dn implements ArrayAccess
         }
         $ret = array();
         for ($i = 0, $count = count($k); $i < $count; $i++) {
-            if (is_array($k[$i]) && is_array($v[$i]) && (count($k[$i]) === count($v[$i]))) {
+            if (is_array($k[$i]) && is_array($v[$i]) && (($countKey = count($k[$i])) === count($v[$i]))) {
                 $multi = array();
-                for ($j = 0; $j < count($k[$i]); $j++) {
+                for ($j = 0; $j < $countKey; $j++) {
                     $key         = $k[$i][$j];
                     $val         = $v[$i][$j];
                     $multi[$key] = $val;

--- a/library/Zend/Ldap/Dn.php
+++ b/library/Zend/Ldap/Dn.php
@@ -553,9 +553,9 @@ class Dn implements ArrayAccess
         }
         $ret = array();
         for ($i = 0, $count = count($k); $i < $count; $i++) {
-            if (is_array($k[$i]) && is_array($v[$i]) && (($countKey = count($k[$i])) === count($v[$i]))) {
+            if (is_array($k[$i]) && is_array($v[$i]) && (($keyCount = count($k[$i])) === count($v[$i]))) {
                 $multi = array();
-                for ($j = 0; $j < $countKey; $j++) {
+                for ($j = 0; $j < $keyCount; $j++) {
                     $key         = $k[$i][$j];
                     $val         = $v[$i][$j];
                     $multi[$key] = $val;


### PR DESCRIPTION
test : 

``` php
$data = range(1, 100000);

$time_start1 = microtime(true);
for ($i = 0; $i < count($data); $i++) {

}
$time_end1 = microtime(true);
$time1 = $time_end1 - $time_start1;

echo 'uses count() in iteration take time : ' . $time1;
echo "\r\n";

$time_start2 = microtime(true);
for ($i = 0, $count = count($data); $i < $count; $i++) {

}
$time_end2 = microtime(true);
$time2 = $time_end2 - $time_start2;

echo 'uses assignment of count() before iterated first take time ' . $time2;
echo "\r\n";
```

Result : 

```
uses count() directly in iteration take time : 0.11619091033936
uses assignment of count() before iterated first take time 0.017376184463501
```
