### PR TITLE
Added $data parameter to delete() in AbstractRestfulController

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractRestfulController.php
+++ b/library/Zend/Mvc/Controller/AbstractRestfulController.php
@@ -99,7 +99,7 @@ abstract class AbstractRestfulController extends AbstractController
      * @param  mixed $id
      * @return mixed
      */
-    public function delete($id)
+    public function delete($id, $data)
     {
         $this->response->setStatusCode(405);
 
@@ -351,7 +351,7 @@ abstract class AbstractRestfulController extends AbstractController
 
                 if ($id !== false) {
                     $action = 'delete';
-                    $return = $this->delete($id);
+                    $return = $this->delete($id, $data);
                     break;
                 }
 

--- a/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
+++ b/tests/ZendTest/Mvc/Controller/TestAsset/RestfulTestController.php
@@ -38,7 +38,7 @@ class RestfulTestController extends AbstractRestfulController
      * @param  mixed $id
      * @return mixed
      */
-    public function delete($id)
+    public function delete($id, $data)
     {
         $this->entity = array();
         return array();


### PR DESCRIPTION
Now that the $data parameter has been added to `deleteList` in #7255, it would be inconsistent to not provide it to `delete`. 
Data for a delete request can be useful for example to validate a user’s password before deleting him.
