### PR TITLE
replace self::EOL with PHP_EOL as AbstractHtmlElement::EOL is deprecated

### DIFF
--- a/library/Zend/View/Helper/HtmlList.php
+++ b/library/Zend/View/Helper/HtmlList.php
@@ -43,14 +43,14 @@ class HtmlList extends AbstractHtmlElement
                     $escaper = $this->getView()->plugin('escapeHtml');
                     $item    = $escaper($item);
                 }
-                $list .= '<li>' . $item . '</li>' . self::EOL;
+                $list .= '<li>' . $item . '</li>' . PHP_EOL;
             } else {
-                $itemLength = 5 + strlen(self::EOL);
+                $itemLength = 5 + strlen(PHP_EOL);
                 if ($itemLength < strlen($list)) {
                     $list = substr($list, 0, strlen($list) - $itemLength)
-                     . $this($item, $ordered, $attribs, $escape) . '</li>' . self::EOL;
+                     . $this($item, $ordered, $attribs, $escape) . '</li>' . PHP_EOL;
                 } else {
-                    $list .= '<li>' . $this($item, $ordered, $attribs, $escape) . '</li>' . self::EOL;
+                    $list .= '<li>' . $this($item, $ordered, $attribs, $escape) . '</li>' . PHP_EOL;
                 }
             }
         }
@@ -63,6 +63,6 @@ class HtmlList extends AbstractHtmlElement
 
         $tag = ($ordered) ? 'ol' : 'ul';
 
-        return '<' . $tag . $attribs . '>' . self::EOL . $list . '</' . $tag . '>' . self::EOL;
+        return '<' . $tag . $attribs . '>' . PHP_EOL . $list . '</' . $tag . '>' . PHP_EOL;
     }
 }

--- a/library/Zend/View/Helper/HtmlObject.php
+++ b/library/Zend/View/Helper/HtmlObject.php
@@ -57,13 +57,13 @@ class HtmlObject extends AbstractHtmlElement
 
         // Content
         if (is_array($content)) {
-            $content = implode(self::EOL, $content);
+            $content = implode(PHP_EOL, $content);
         }
 
         // Object header
-        $xhtml = '<object' . $this->htmlAttribs($attribs) . '>' . self::EOL
-                 . implode(self::EOL, $paramHtml) . self::EOL
-                 . ($content ? $content . self::EOL : '')
+        $xhtml = '<object' . $this->htmlAttribs($attribs) . '>' . PHP_EOL
+                 . implode(PHP_EOL, $paramHtml) . PHP_EOL
+                 . ($content ? $content . PHP_EOL : '')
                  . '</object>';
 
         return $xhtml;

--- a/library/Zend/View/Helper/Navigation/Links.php
+++ b/library/Zend/View/Helper/Navigation/Links.php
@@ -167,7 +167,7 @@ class Links extends AbstractHelper
                 foreach ($pages as $page) {
                     $r = $this->renderLink($page, $attrib, $relation);
                     if ($r) {
-                        $output .= $indent . $r . self::EOL;
+                        $output .= $indent . $r . PHP_EOL;
                     }
                 }
             }
@@ -176,7 +176,7 @@ class Links extends AbstractHelper
         $this->root = null;
 
         // return output (trim last newline by spec)
-        return strlen($output) ? rtrim($output, self::EOL) : '';
+        return strlen($output) ? rtrim($output, PHP_EOL) : '';
     }
 
     /**


### PR DESCRIPTION
see https://github.com/zendframework/zf2/blob/master/library/Zend/View/Helper/AbstractHtmlElement.php#L14-L19
