### PR TITLE
Get correct expression string when Zend\Db\Sql\Expression is used

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -108,6 +108,13 @@ abstract class AbstractSql implements SqlInterface
         $expressionParamIndex = &$this->instanceParameterIndex[$namedParameterPrefix];
 
         foreach ($parts as $part) {
+            // #7407: use $expression->getExpression() to get the unescaped version of the expression
+            if (is_string($part) && $expression instanceof Expression) {
+                $sql .= $expression->getExpression();
+
+                continue;
+            }
+
             // if it is a string, simply tack it onto the return sql "specification" string
             if (is_string($part)) {
                 $sql .= $part;

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -124,6 +124,18 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group #7407
+     */
+    public function testProcessExpressionWorksWithExpressionObjectWithPercentageSigns()
+    {
+        $expressionString = 'FROM_UNIXTIME(date, "%Y-%m")';
+        $expression       = new Expression($expressionString);
+        $sqlString        = $this->invokeProcessExpressionMethod($expression);
+
+        $this->assertSame($expressionString, $sqlString);
+    }
+
+    /**
      * @param \Zend\Db\Sql\ExpressionInterface $expression
      * @param \Zend\Db\Adapter\Adapter|null $adapter
      * @return \Zend\Db\Adapter\StatementContainer


### PR DESCRIPTION
Fix for #7407.

The processing of `Zend\Db\Sql\Expression` assumed the value of `$part` was the correct value to be used, however when an instance of `Zend\Db\Sql\Expression` is provided the correct value is in `Zend\Db\Sql\Expression::getExpression()`.
