### PR TITLE
Test for percentage sign in Zend\Db\Sql\Expression

### DIFF
--- a/tests/ZendTest/Db/Sql/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/ExpressionTest.php
@@ -155,4 +155,15 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
         $expression = new Expression('0');
         $this->assertSame('0', $expression->getExpression());
     }
+
+    /**
+     * @group 7407
+     */
+    public function testGetExpressionPreservesPercentageSignInFromUnixtime()
+    {
+        $expressionString = 'FROM_UNIXTIME(date, "%Y-%m")';
+        $expression       = new Expression($expressionString);
+
+        $this->assertSame($expressionString, $expression->getExpression());
+    }
 }


### PR DESCRIPTION
Additional test for #7407 to make sure percentage signs inside SQL functions are preserved the way they are.
