### PR TITLE
Fixed form collections with nested fieldsets that implements InputfilterProviderInterface

### DIFF
--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -823,11 +823,7 @@ class Form extends Fieldset implements FormInterface
 
                             // We need to copy the inputs to the collection input filter
                             if ($inputFilter instanceof CollectionInputFilter) {
-                                foreach ($inputFilter->getInputs() as $filterName => $input) {
-                                    if (!$inputFilter->getInputFilter()->has($filterName)) {
-                                        $inputFilter->getInputFilter()->add($input, $filterName);
-                                    }
-                                }
+                                $inputFilter = $this->addInputsToCollectionInputFilter($inputFilter);
                             }
 
                             // Add child elements from target element
@@ -866,13 +862,26 @@ class Form extends Fieldset implements FormInterface
 
             // We need to copy the inputs to the collection input filter to ensure that all sub filters are added
             if ($inputFilter instanceof CollectionInputFilter) {
-                foreach ($inputFilter->getInputs() as $filterName => $input) {
-                    if (!$inputFilter->getInputFilter()->has($filterName)) {
-                        $inputFilter->getInputFilter()->add($input, $filterName);
-                    }
-                }
+                $inputFilter = $this->addInputsToCollectionInputFilter($inputFilter);
             }
         }
+    }
+
+    /**
+     * Add inputs to CollectionInputFilter
+     *
+     * @param  CollectionInputFilter $inputFilter
+     * @return CollectionInputFilter
+     */
+    private function addInputsToCollectionInputFilter(CollectionInputFilter $inputFilter)
+    {
+        foreach ($inputFilter->getInputs() as $name => $input) {
+            if (!$inputFilter->getInputFilter()->has($name)) {
+                $inputFilter->getInputFilter()->add($input, $name);
+            }
+        }
+
+        return $inputFilter;
     }
 
     /**

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -788,7 +788,12 @@ class Form extends Fieldset implements FormInterface
                     }
                 }
 
-                $inputFilter->add($input, $name);
+                // Add element input filter to CollectionInputFilter
+                if ($inputFilter instanceof CollectionInputFilter && !$inputFilter->getInputFilter()->has($name)) {
+                    $inputFilter->getInputFilter()->add($input, $name);
+                } else {
+                    $inputFilter->add($input, $name);
+                }
             }
 
             if ($fieldset === $this && $fieldset instanceof InputFilterProviderInterface) {

--- a/library/Zend/Form/Form.php
+++ b/library/Zend/Form/Form.php
@@ -807,8 +807,31 @@ class Form extends Fieldset implements FormInterface
                     if ($childFieldset->getObject() instanceof InputFilterAwareInterface) {
                         $inputFilter->add($childFieldset->getObject()->getInputFilter(), $name);
                     } else {
-                        if ($fieldset instanceof Collection && $inputFilter instanceof CollectionInputFilter) {
-                            continue;
+                        // Add input filter for collections via getInputFilterSpecification()
+                        if ($childFieldset instanceof Collection
+                            && $childFieldset->getTargetElement() instanceof InputFilterProviderInterface
+                            && $childFieldset->getTargetElement()->getInputFilterSpecification()
+                        ) {
+                            $collectionContainerFilter = new CollectionInputFilter();
+
+                            $spec = $childFieldset->getTargetElement()->getInputFilterSpecification();
+                            $filter = $inputFactory->createInputFilter($spec);
+
+                            $collectionContainerFilter->setInputFilter($filter);
+
+                            $inputFilter->add($collectionContainerFilter, $name);
+
+                            // We need to copy the inputs to the collection input filter
+                            if ($inputFilter instanceof CollectionInputFilter) {
+                                foreach ($inputFilter->getInputs() as $filterName => $input) {
+                                    if (!$inputFilter->getInputFilter()->has($filterName)) {
+                                        $inputFilter->getInputFilter()->add($input, $filterName);
+                                    }
+                                }
+                            }
+
+                            // Add child elements from target element
+                            $childFieldset = $childFieldset->getTargetElement();
                         } else {
                             $inputFilter->add(new InputFilter(), $name);
                         }
@@ -840,6 +863,15 @@ class Form extends Fieldset implements FormInterface
 
             // Recursively attach sub filters
             $this->attachInputFilterDefaults($filter, $childFieldset);
+
+            // We need to copy the inputs to the collection input filter to ensure that all sub filters are added
+            if ($inputFilter instanceof CollectionInputFilter) {
+                foreach ($inputFilter->getInputs() as $filterName => $input) {
+                    if (!$inputFilter->getInputFilter()->has($filterName)) {
+                        $inputFilter->getInputFilter()->add($input, $filterName);
+                    }
+                }
+            }
         }
     }
 

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1255,7 +1255,7 @@ class FormTest extends TestCase
         $this->form->setInputFilter($inputFilter);
 
         $this->assertInstanceOf('Zend\InputFilter\CollectionInputFilter', $this->form->getInputFilter()->get('items'));
-        $this->assertCount(1, $this->form->getInputFilter()->get('items')->getInputs());
+        $this->assertCount(1, $this->form->getInputFilter()->get('items')->getInputFilter()->getInputs());
     }
 
     public function testFormValidationCanHandleNonConsecutiveKeysOfCollectionInData()

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1874,6 +1874,29 @@ class FormTest extends TestCase
         $this->assertEquals($data, $this->form->getData());
     }
 
+    public function testFormWithCollectionsAndNestedFieldsetsWithInputFilterProviderInterface()
+    {
+        $this->form->add(array(
+            'type' => 'Zend\Form\Element\Collection',
+            'name' => 'nested_fieldset_with_input_filter_provider',
+            'options' => array(
+                'label' => 'InputFilterProviderFieldset',
+                'count' => 1,
+                'target_element' => array(
+                    'type' => 'ZendTest\Form\TestAsset\InputFilterProviderFieldset'
+                )
+            ),
+        ));
+
+        $this->assertTrue(
+            $this->form->getInputFilter()
+                ->get('nested_fieldset_with_input_filter_provider')
+                ->getInputFilter()
+                ->get('foo')
+            instanceof \Zend\InputFilter\Input
+        );
+    }
+
     public function testFormElementValidatorsMergeIntoAppliedInputFilter()
     {
         $this->form->add(array(

--- a/tests/ZendTest/Form/TestAsset/InputFilterProviderFieldset.php
+++ b/tests/ZendTest/Form/TestAsset/InputFilterProviderFieldset.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Fieldset;
+use Zend\InputFilter\InputFilterProviderInterface;
+
+class InputFilterProviderFieldset extends Fieldset implements InputFilterProviderInterface
+{
+    public function __construct($name = null, $options = array())
+    {
+        parent::__construct($name, $options);
+
+        $this->add(array(
+            'name' => 'foo',
+            'options' => array(
+                'label' => 'Foo'
+            ),
+        ));
+
+        $this->add(new BasicFieldset());
+    }
+
+    public function getInputFilterSpecification()
+    {
+        return array(
+            'foo' => array(
+                'required' => true,
+            )
+        );
+    }
+}

--- a/tests/ZendTest/Mvc/Controller/Plugin/FilePostRedirectGetTest.php
+++ b/tests/ZendTest/Mvc/Controller/Plugin/FilePostRedirectGetTest.php
@@ -274,59 +274,6 @@ class FilePostRedirectGetTest extends TestCase
         $this->assertEquals(303, $prgResultRoute->getStatusCode());
     }
 
-    public function testFieldsetAmountInFormEqualsFieldsetsInInputFilter()
-    {
-        // POST
-        $url = '/';
-        $params = array(
-            'links' => array(
-                '0' => array(
-                    'foobar' => 'val',
-                ),
-                '1' => array(
-                    'foobar' => 'val',
-                ),
-            ),
-        );
-        $this->request->setMethod('POST');
-        $this->request->setPost(new Parameters($params));
-        $this->request->setUri($url);
-
-        $this->form->add($this->collection);
-
-        $routeMatch = $this->event->getRouter()->match($this->request);
-        $this->event->setRouteMatch($routeMatch);
-
-        $this->controller->dispatch($this->request, $this->response);
-        $prgResultUrl = $this->controller->fileprg($this->form);
-
-        $this->assertInstanceOf('Zend\Http\Response', $prgResultUrl);
-        $this->assertTrue($prgResultUrl->getHeaders()->has('Location'));
-        $this->assertEquals('/', $prgResultUrl->getHeaders()->get('Location')->getUri());
-        $this->assertEquals(303, $prgResultUrl->getStatusCode());
-
-        $this->assertCount(count($params['links']),  $this->form->get('links')->getFieldsets());
-        $this->assertCount(count($this->form->get('links')->getFieldsets()),  $this->form->getInputFilter()->get('links')->getInputs());
-
-        // GET
-        $this->request = new Request();
-        $form = new Form();
-        $collection = new Collection('links', array(
-            'count' => 1,
-            'allow_add' => true,
-            'target_element' => array(
-                'type' => 'ZendTest\Mvc\Controller\Plugin\TestAsset\LinksFieldset',
-            ),
-        ));
-        $form->add($collection);
-        $this->controller->dispatch($this->request, $this->response);
-        $prgResult = $this->controller->fileprg($form);
-
-        $this->assertEquals($params, $prgResult);
-        $this->assertCount(count($params['links']),  $form->get('links')->getFieldsets());
-        $this->assertCount(count($form->get('links')->getFieldsets()), $form->getInputFilter()->get('links')->getInputs());
-    }
-
     public function testCollectionInputFilterIsInitializedBeforePluginRetrievesIt()
     {
         $fieldset = new TestAsset\InputFilterProviderFieldset();


### PR DESCRIPTION
Here is a fix for the usage of collections and the `InputFilterProviderInterface`.

The problem was: If you're using `getInputFilterSpecification()` for your fieldsets and embed them in a collection, the input filters were never added to the form, resulting in errors when using `setValidationGroup()` or the inability to bind data to nested fieldsets.

The fix also ensures that infinite nested collections with `InputFilterProviderInterface`-fieldsets are working correctly.
