### PR TITLE
Untreated condition on rendering console action

### DIFF
--- a/library/Zend/Mvc/View/Console/DefaultRenderingStrategy.php
+++ b/library/Zend/Mvc/View/Console/DefaultRenderingStrategy.php
@@ -42,7 +42,7 @@ class DefaultRenderingStrategy extends AbstractListenerAggregate
         // marshal arguments
         $response  = $e->getResponse();
 
-        if (empty($result)) {
+        if (empty($result) || $result === true) {
             // There is absolutely no result, so there's nothing to display.
             // We will return an empty response object
             return $response;


### PR DESCRIPTION
I was getting the following when using PhpRender() in some console actions:

``` console
Fatal error: Call to a member function hasChildren() on boolean in C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\Mvc\View\Console\DefaultRenderingStrategy.php on line 55

Call Stack:
    0.0000     124912   1. {main}() C:\Users\taiar\Documents\NetBeansProjects\phila\public\index.php:0
    0.3810    7488888   2. Zend\Mvc\Application->run() C:\Users\taiar\Documents\NetBeansProjects\phila\public\index.php:17
    1.2061   13544048   3. Zend\Mvc\Application->completeRequest() C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\Mvc\Application.php:327
    1.2061   13544096   4. Zend\EventManager\EventManager->trigger() C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\Mvc\Application.php:352
    1.2061   13544168   5. Zend\EventManager\EventManager->triggerListeners() C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\EventManager\EventManager.php:207
    1.2071   13545376   6. call_user_func:{C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\EventManager\EventManager.php:468}() C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\EventManager\EventManager.php:468
    1.2071   13545560   7. Zend\Mvc\View\Console\DefaultRenderingStrategy->render() C:\Users\taiar\Documents\NetBeansProjects\phila\vendor\zendframework\zendframework\library\Zend\EventManager\EventManager.php:468
```

Then I found, by debugging that `if (empty($result))` doesn't catch the condition when `$result` was simply a `true` valeu (wich was happening in my case.

The proposed patch just make it work.

Thanks.
