### PR TITLE
zf7428 fixed issue with inconsistent getTrait() behaviour #7428

### DIFF
--- a/library/Zend/Code/Reflection/ClassReflection.php
+++ b/library/Zend/Code/Reflection/ClassReflection.php
@@ -187,7 +187,7 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
         $vals = array();
         $traits = parent::getTraits();
         if ($traits === null) {
-            return null;
+            return;
         }
 
         foreach ($traits as $trait) {

--- a/library/Zend/Code/Reflection/ClassReflection.php
+++ b/library/Zend/Code/Reflection/ClassReflection.php
@@ -177,12 +177,17 @@ class ClassReflection extends ReflectionClass implements ReflectionInterface
         return $methods;
     }
 
+    /**
+     * Returns an array of reflection classes of traits used by this class.
+     *
+     * @return array|null
+     */
     public function getTraits()
     {
         $vals = array();
         $traits = parent::getTraits();
-        if (! $traits) {
-            return;
+        if ($traits === null) {
+            return null;
         }
 
         foreach ($traits as $trait) {

--- a/tests/ZendTest/Code/Reflection/ClassReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/ClassReflectionTest.php
@@ -186,4 +186,19 @@ EOS;
         $reflectionClass = new ClassReflection('ReflectionClass');
         $this->assertSame('', $reflectionClass->getContents());
     }
+
+    public function testGetTraits()
+    {
+        // PHP documentations mentions that getTraits() return NULL in case of error. I don't know how to cause such
+        // error so I test just normal behaviour.
+
+        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestTraitClass4');
+        $this->assertTrue(is_array($reflectionClass->getTraits()));
+        $this->assertEquals(1, count($reflectionClass->getTraits()));
+        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $reflectionClass->getTraits()[0]);
+
+        $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass');
+        $this->assertTrue(is_array($reflectionClass->getTraits()));
+        $this->assertEquals(0, count($reflectionClass->getTraits()));
+    }
 }

--- a/tests/ZendTest/Code/Reflection/ClassReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/ClassReflectionTest.php
@@ -189,6 +189,10 @@ EOS;
 
     public function testGetTraits()
     {
+        if (version_compare(PHP_VERSION, '5.4', 'lt')) {
+            $this->markTestSkipped('This test requires PHP version 5.4+');
+        }
+
         // PHP documentations mentions that getTraits() return NULL in case of error. I don't know how to cause such
         // error so I test just normal behaviour.
 

--- a/tests/ZendTest/Code/Reflection/ClassReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/ClassReflectionTest.php
@@ -197,12 +197,14 @@ EOS;
         // error so I test just normal behaviour.
 
         $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestTraitClass4');
-        $this->assertTrue(is_array($reflectionClass->getTraits()));
-        $this->assertEquals(1, count($reflectionClass->getTraits()));
-        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $reflectionClass->getTraits()[0]);
+        $traitsArray = $reflectionClass->getTraits();
+        $this->assertTrue(is_array($traitsArray));
+        $this->assertEquals(1, count($traitsArray));
+        $this->assertInstanceOf('Zend\Code\Reflection\ClassReflection', $traitsArray[0]);
 
         $reflectionClass = new ClassReflection('ZendTest\Code\Reflection\TestAsset\TestSampleClass');
-        $this->assertTrue(is_array($reflectionClass->getTraits()));
-        $this->assertEquals(0, count($reflectionClass->getTraits()));
+        $traitsArray = $reflectionClass->getTraits();
+        $this->assertTrue(is_array($traitsArray));
+        $this->assertEquals(0, count($traitsArray));
     }
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass3.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass3.php
@@ -1,0 +1,29 @@
+<?php
+namespace ZendTest\Code\Reflection\TestAsset;
+
+//issue #7428
+trait TestTraitClass3
+{
+	/**
+	* @var bool
+	*/
+	protected $dummy = false;
+
+	/**
+	* @return bool
+	*/
+	public function getDummy()
+	{
+		return $this->dummy;
+	}
+
+	/**
+	* @param bool $autoFetchingAllowed
+	* @return Model_AbstractModel
+	*/
+	public function setDummy($dummy)
+	{
+		$this->dummy = boolval($dummy);
+		return $this;
+	}
+}

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass3.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass3.php
@@ -4,26 +4,5 @@ namespace ZendTest\Code\Reflection\TestAsset;
 //issue #7428
 trait TestTraitClass3
 {
-	/**
-	* @var bool
-	*/
-	protected $dummy = false;
 
-	/**
-	* @return bool
-	*/
-	public function getDummy()
-	{
-		return $this->dummy;
-	}
-
-	/**
-	* @param bool $autoFetchingAllowed
-	* @return Model_AbstractModel
-	*/
-	public function setDummy($dummy)
-	{
-		$this->dummy = boolval($dummy);
-		return $this;
-	}
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass4.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass4.php
@@ -6,21 +6,5 @@ use ZendTest\Code\Reflection\TestAsset\TestTraitClass3 as TestTrait;
 //issue #7428
 class TestTraitClass4
 {
-	use TestTrait;
-
-	/**
-	* @var bool
-	*/
-	protected static $other = false;
-
-
-	/**
-	* Constructor
-	*
-	* @param bool $other
-	*/
-	public function __construct($other)
-	{
-		$this->other = $other;
-	}
+    use TestTrait;
 }

--- a/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass4.php
+++ b/tests/ZendTest/Code/Reflection/TestAsset/TestTraitClass4.php
@@ -1,0 +1,26 @@
+<?php
+namespace ZendTest\Code\Reflection\TestAsset;
+
+use ZendTest\Code\Reflection\TestAsset\TestTraitClass3 as TestTrait;
+
+//issue #7428
+class TestTraitClass4
+{
+	use TestTrait;
+
+	/**
+	* @var bool
+	*/
+	protected static $other = false;
+
+
+	/**
+	* Constructor
+	*
+	* @param bool $other
+	*/
+	public function __construct($other)
+	{
+		$this->other = $other;
+	}
+}


### PR DESCRIPTION
1) Made getTraits() to behave the same was a parent method - return null only in case of error and empty array otherwise
2) Added phpdoc comment
3) Added tests for getTraits()
