### PR TITLE
Soap fixes: throw exception in construct, camelcase fixes for name of classes

### DIFF
--- a/library/Zend/Soap/Client/Common.php
+++ b/library/Zend/Soap/Client/Common.php
@@ -10,10 +10,7 @@
 namespace Zend\Soap\Client;
 
 use SoapClient;
-
-if (! extension_loaded('soap')) {
-    return;
-}
+use Zend\Soap\Exception\ExtensionNotLoadedException;
 
 class Common extends SoapClient
 {
@@ -33,6 +30,10 @@ class Common extends SoapClient
      */
     public function __construct($doRequestCallback, $wsdl, $options)
     {
+        if (!extension_loaded('soap')) {
+            throw new ExtensionNotLoadedException('SOAP extension is not loaded.');
+        }
+
         $this->doRequestCallback = $doRequestCallback;
         parent::__construct($wsdl, $options);
     }

--- a/library/Zend/Soap/Client/DotNet.php
+++ b/library/Zend/Soap/Client/DotNet.php
@@ -11,7 +11,7 @@ namespace Zend\Soap\Client;
 
 use Zend\Http\Client\Adapter\Curl as CurlClient;
 use Zend\Http\Response as HttpResponse;
-use Zend\Soap\Client as SOAPClient;
+use Zend\Soap\Client as SoapClient;
 use Zend\Soap\Client\Common as CommonClient;
 use Zend\Soap\Exception;
 use Zend\Uri\Http as HttpUri;
@@ -21,7 +21,7 @@ use Zend\Uri\Http as HttpUri;
  *
  * Class is intended to be used with .NET Web Services.
  */
-class DotNet extends SOAPClient
+class DotNet extends SoapClient
 {
     /**
      * Curl HTTP client adapter.

--- a/library/Zend/Soap/Client/Local.php
+++ b/library/Zend/Soap/Client/Local.php
@@ -9,8 +9,8 @@
 
 namespace Zend\Soap\Client;
 
-use Zend\Soap\Client as SOAPClient;
-use Zend\Soap\Server as SOAPServer;
+use Zend\Soap\Client as SoapClient;
+use Zend\Soap\Server as SoapServer;
 
 /**
  * Class is intended to be used as local SOAP client which works
@@ -18,22 +18,22 @@ use Zend\Soap\Server as SOAPServer;
  *
  * Could be used for development or testing purposes.
  */
-class Local extends SOAPClient
+class Local extends SoapClient
 {
     /**
      * Server object
-     * @var SOAPServer
+     * @var SoapServer
      */
     protected $server;
 
     /**
      * Local client constructor
      *
-     * @param SOAPServer $server
+     * @param SoapServer $server
      * @param string $wsdl
      * @param array $options
      */
-    public function __construct(SOAPServer $server, $wsdl, $options = null)
+    public function __construct(SoapServer $server, $wsdl, $options = null)
     {
         $this->server = $server;
 


### PR DESCRIPTION
This PR provides following fixes:
- throw exception in construct instead of silent return from script in `Zend\Soap\Client\Common`
- camelcase for name of using classes in `Zend\Soap\Client\DotNet` and `Zend\Soap\Client\Local`
