### PR TITLE
bugfix removing multiple fieldsets does't work

### DIFF
--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -209,6 +209,7 @@ class Collection extends Fieldset
         }
 
         // Check to see if elements have been replaced or removed
+        $removed = [];
         foreach ($this->iterator as $name => $elementOrFieldset) {
             if (isset($data[$name])) {
                 continue;
@@ -221,6 +222,10 @@ class Collection extends Fieldset
                 ));
             }
 
+            $removed[] = $name;
+        }
+
+        foreach ($removed as $name) {
             $this->remove($name);
         }
 

--- a/library/Zend/Form/Element/Collection.php
+++ b/library/Zend/Form/Element/Collection.php
@@ -209,7 +209,7 @@ class Collection extends Fieldset
         }
 
         // Check to see if elements have been replaced or removed
-        $removed = [];
+        $removed = array();
         foreach ($this->iterator as $name => $elementOrFieldset) {
             if (isset($data[$name])) {
                 continue;

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -1246,4 +1246,24 @@ class CollectionTest extends TestCase
         $this->assertTrue(is_array($object['colors']));
         $this->assertCount(1, $object['colors']);
     }
+
+    public function testCanRemoveMultipleElements()
+    {
+        /**
+         * @var \Zend\Form\Element\Collection $collection
+         */
+        $collection = $this->form->get('colors');
+        $collection->setAllowRemove(true);
+        $collection->setCount(0);
+
+        $data = array();
+        $data[] = 'blue';
+        $data[] = 'green';
+        $data[] = 'red';
+
+        $collection->populateValues($data);
+
+        $collection->populateValues(array('colors' => array('0' => 'blue')));
+        $this->assertEquals(1, count($collection->getElements()));
+    }
 }


### PR DESCRIPTION
at the same time iterating collection items and removing causes problem:
When we have 3 items but we delete second and third. It fails and does not remove third element. So we have to move remove out of foreach
