### PR TITLE
Allow use of setRequired() at different positions

### DIFF
--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -147,7 +147,7 @@ class Input implements InputInterface, EmptyContextInterface
     public function setRequired($required)
     {
         $this->required = (bool) $required;
-        $this->setAllowEmpty(!$required);
+
         return $this;
     }
 
@@ -323,6 +323,10 @@ class Input implements InputInterface, EmptyContextInterface
         $empty     = ($value === null || $value === '' || $value === array());
 
         if ($empty && $this->allowEmpty() && !$this->continueIfEmpty()) {
+            return true;
+        }
+
+        if ($empty && !$this->isRequired()) {
             return true;
         }
 

--- a/tests/ZendTest/InputFilter/InputTest.php
+++ b/tests/ZendTest/InputFilter/InputTest.php
@@ -407,4 +407,32 @@ class InputTest extends TestCase
         $this->assertTrue($input2->isRequired());
         $this->assertTrue($input2->allowEmpty());
     }
+
+    /**
+     * @group 7445
+     */
+    public function testInputIsValidWhenUsingSetRequiredAtStart()
+    {
+        $input = new Input();
+        $input->setName('foo')
+              ->setRequired(false)
+              ->setAllowEmpty(false)
+              ->setContinueIfEmpty(false);
+
+        $this->assertTrue($input->isValid());
+    }
+
+    /**
+     * @group 7445
+     */
+    public function testInputIsValidWhenUsingSetRequiredAtEnd()
+    {
+        $input = new Input();
+        $input->setName('foo')
+              ->setAllowEmpty(false)
+              ->setContinueIfEmpty(false)
+              ->setRequired(false);
+
+        $this->assertTrue($input->isValid());
+    }
 }


### PR DESCRIPTION
`Zend\InputFilter\Input` would return `false`/`true` depending of when `setRequired()` was called. This PR fixes that so it does not matter anymore when `setRequired()` is called.

This is **not** a fix for #7445, but an issue I noticed looking into issue #7445.
