### PR TITLE
Fix controller namespace in event manager

### DIFF
--- a/library/Zend/Mvc/Controller/AbstractController.php
+++ b/library/Zend/Mvc/Controller/AbstractController.php
@@ -162,7 +162,7 @@ abstract class AbstractController implements
     {
         $className = get_class($this);
 
-        $nsPos = strpos($className, '\\') ?: 0;
+        $nsPos = strrpos($className, '\\') ?: 0;
         $events->setIdentifiers(array_merge(
             array(
                 __CLASS__,


### PR DESCRIPTION
Controller was only registering the root namespace, e.g. `Foo` instead of `Foo\Bar` for a class named `Foo\Bar\Baz`.
