### PR TITLE
CS: single_line_after_imports

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -49,6 +49,7 @@ $config->fixers(
         'php_closing_tag',
         'psr0',
         'remove_lines_between_uses',
+        'single_line_after_imports',
         'short_tag',
         'standardize_not_equal',
         'trailing_spaces',

--- a/tests/ZendTest/Http/Client/CommonHttpTests.php
+++ b/tests/ZendTest/Http/Client/CommonHttpTests.php
@@ -17,7 +17,6 @@ use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Stdlib\Parameters;
 
-
 /**
  * This Testsuite includes all Zend_Http_Client that require a working web
  * server to perform. It was designed to be extendable, so that several

--- a/tests/ZendTest/Http/Client/StaticClientTest.php
+++ b/tests/ZendTest/Http/Client/StaticClientTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Http\Client;
 use Zend\Http\ClientStatic as HTTPClient;
 use Zend\Http\Client;
 
-
 /**
  * This are the test for the prototype of Zend\Http\Client
  *

--- a/tests/ZendTest/Http/Client/UseCaseTest.php
+++ b/tests/ZendTest/Http/Client/UseCaseTest.php
@@ -13,7 +13,6 @@ use Zend\Http\Client as HTTPClient;
 use Zend\Http\Client\Adapter;
 use Zend\Http\Request;
 
-
 /**
  * This are the test for the prototype of Zend\Http\Client
  *

--- a/tests/ZendTest/Http/Header/AcceptTest.php
+++ b/tests/ZendTest/Http/Header/AcceptTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Http\Header;
 
 use Zend\Http\Header\Accept;
 
-
 class AcceptTest extends \PHPUnit_Framework_TestCase
 {
     public function testInvalidHeaderLine()

--- a/tests/ZendTest/Memory/MemoryManagerTest.php
+++ b/tests/ZendTest/Memory/MemoryManagerTest.php
@@ -14,7 +14,6 @@ use Zend\Cache\Storage\Adapter\AdapterInterface as CacheAdapter;
 use Zend\Memory;
 use Zend\Memory\Container;
 
-
 /**
  * @group      Zend_Memory
  */

--- a/tests/ZendTest/Soap/WsdlTestHelper.php
+++ b/tests/ZendTest/Soap/WsdlTestHelper.php
@@ -13,7 +13,6 @@ use Zend\Soap\Wsdl;
 use Zend\Soap\Wsdl\ComplexTypeStrategy;
 use Zend\Soap\Wsdl\ComplexTypeStrategy\ComplexTypeStrategyInterface;
 
-
 /**
 * Zend_Soap_Server
 *

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -29,7 +29,6 @@ use ZendTest\Stdlib\TestAsset\ArraySerializable as ArraySerializableAsset;
 use Zend\Stdlib\Hydrator\Strategy\DefaultStrategy;
 use Zend\Stdlib\Hydrator\Strategy\SerializableStrategy;
 
-
 /**
  * @group      Zend_Stdlib
  */

--- a/tests/ZendTest/Text/FigletTest.php
+++ b/tests/ZendTest/Text/FigletTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Text;
 
 use Zend\Text\Figlet;
 
-
 /**
  * @group      Zend_Text
  */

--- a/tests/ZendTest/Validator/IsbnTest.php
+++ b/tests/ZendTest/Validator/IsbnTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Validator;
 
 use Zend\Validator\Isbn;
 
-
 /**
  * @group      Zend_Validator
  */

--- a/tests/ZendTest/Validator/StepTest.php
+++ b/tests/ZendTest/Validator/StepTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Validator;
 
 use Zend\Validator;
 
-
 /**
  * @group      Zend_Validator
  */

--- a/tests/ZendTest/View/Helper/InlineScriptTest.php
+++ b/tests/ZendTest/View/Helper/InlineScriptTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\View\Helper;
 
 use Zend\View\Helper;
 
-
 /**
  * Test class for Zend\View\Helper\InlineScript.
  *

--- a/tests/ZendTest/View/Helper/Placeholder/RegistryTest.php
+++ b/tests/ZendTest/View/Helper/Placeholder/RegistryTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\View\Helper\Placeholder;
 use Zend\View\Helper\Placeholder\Registry;
 use Zend\View\Helper\Placeholder\Container;
 
-
 /**
  * Test class for Zend\View\Helper\Placeholder\Registry.
  *


### PR DESCRIPTION
Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block.
