### PR TITLE
Replace whitespace in the parameter prefix option passed to AbstractSql::processExpression

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -106,6 +106,8 @@ abstract class AbstractSql implements SqlInterface
 
         if ($parameterContainer && ((!is_string($namedParameterPrefix) || $namedParameterPrefix == ''))) {
             $namedParameterPrefix = sprintf('expr%04dParam', ++$runtimeExpressionPrefix);
+        } else {
+            $namedParameterPrefix = preg_replace('/\s/', '__', $namedParameterPrefix);
         }
 
         $sql = '';


### PR DESCRIPTION
This PR is to allow using a parameter prefix containing spaces when processing `Db\Sql\Expression` objects, which is necessary when using `Expression`s as columns with the name containing spaces:

``` php
$select = new Select();
$select->columns(array(
    'Column Name With Spaces' => new Expression('FROM_UNIXTIME(?)', array(12345))
));
```

Here, `'Column Name With Spaces'` is passed as the last parameter to `AbstractSql::processExpression` but the resulting parameter name is invalid and the query cannot execute.

A solution is to replace any whitespace with double underscores `__` so that the parameter name is valid.
