### PR TITLE
Implement expected Input::isValid workflow

### DIFF
--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -47,18 +47,26 @@ abstract class AbstractSql implements SqlInterface
      * @param PlatformInterface $platform
      * @param null|DriverInterface $driver
      * @param null|ParameterContainer $parameterContainer
-     *
      * @return string
      */
-    protected function buildSqlString(PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
-    {
+    protected function buildSqlString(
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null
+    ) {
         $this->localizeVariables();
 
         $sqls       = array();
         $parameters = array();
 
         foreach ($this->specifications as $name => $specification) {
-            $parameters[$name] = $this->{'process' . $name}($platform, $driver, $parameterContainer, $sqls, $parameters);
+            $parameters[$name] = $this->{'process' . $name}(
+                $platform,
+                $driver,
+                $parameterContainer,
+                $sqls,
+                $parameters
+            );
 
             if ($specification && is_array($parameters[$name])) {
                 $sqls[$name] = $this->createSqlFromSpecificationAndParameters($specification, $parameters[$name]);
@@ -74,21 +82,25 @@ abstract class AbstractSql implements SqlInterface
     }
 
     /**
-     *
      * @staticvar int $runtimeExpressionPrefix
      * @param ExpressionInterface $expression
      * @param PlatformInterface $platform
      * @param null|DriverInterface $driver
      * @param null|ParameterContainer $parameterContainer
      * @param null|string $namedParameterPrefix
-     *
      * @return string
-     *
      * @throws Exception\RuntimeException
      */
-    protected function processExpression(ExpressionInterface $expression, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, $namedParameterPrefix = null)
-    {
-        $namedParameterPrefix = !$namedParameterPrefix ? $namedParameterPrefix : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
+    protected function processExpression(
+        ExpressionInterface $expression,
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null,
+        $namedParameterPrefix = null
+    ) {
+        $namedParameterPrefix = ! $namedParameterPrefix
+            ? $namedParameterPrefix
+            : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
         // static counter for the number of times this method was invoked across the PHP runtime
         static $runtimeExpressionPrefix = 0;
 
@@ -108,17 +120,17 @@ abstract class AbstractSql implements SqlInterface
         $expressionParamIndex = &$this->instanceParameterIndex[$namedParameterPrefix];
 
         foreach ($parts as $part) {
-            // #7407: use $expression->getExpression() to get the unescaped version of the expression
+            // #7407: use $expression->getExpression() to get the unescaped
+            // version of the expression
             if (is_string($part) && $expression instanceof Expression) {
                 $sql .= $expression->getExpression();
-
                 continue;
             }
 
-            // if it is a string, simply tack it onto the return sql "specification" string
+            // If it is a string, simply tack it onto the return sql
+            // "specification" string
             if (is_string($part)) {
                 $sql .= $part;
-
                 continue;
             }
 
@@ -128,7 +140,8 @@ abstract class AbstractSql implements SqlInterface
                 );
             }
 
-            // process values and types (the middle and last position of the expression data)
+            // Process values and types (the middle and last position of the
+            // expression data)
             $values = $part[1];
             $types = isset($part[2]) ? $part[2] : array();
             foreach ($values as $vIndex => $value) {
@@ -138,10 +151,18 @@ abstract class AbstractSql implements SqlInterface
                 $type = $types[$vIndex];
                 if ($value instanceof Select) {
                     // process sub-select
-                    $values[$vIndex] = '(' . $this->processSubSelect($value, $platform, $driver, $parameterContainer) . ')';
+                    $values[$vIndex] = '('
+                        . $this->processSubSelect($value, $platform, $driver, $parameterContainer)
+                        . ')';
                 } elseif ($value instanceof ExpressionInterface) {
                     // recursive call to satisfy nested expressions
-                    $values[$vIndex] = $this->processExpression($value, $platform, $driver, $parameterContainer, $namedParameterPrefix . $vIndex . 'subpart');
+                    $values[$vIndex] = $this->processExpression(
+                        $value,
+                        $platform,
+                        $driver,
+                        $parameterContainer,
+                        $namedParameterPrefix . $vIndex . 'subpart'
+                    );
                 } elseif ($type == ExpressionInterface::TYPE_IDENTIFIER) {
                     $values[$vIndex] = $platform->quoteIdentifierInFragment($value);
                 } elseif ($type == ExpressionInterface::TYPE_VALUE) {
@@ -161,7 +182,8 @@ abstract class AbstractSql implements SqlInterface
                 }
             }
 
-            // after looping the values, interpolate them into the sql string (they might be placeholder names, or values)
+            // After looping the values, interpolate them into the sql string
+            // (they might be placeholder names, or values)
             $sql .= vsprintf($part[0], $values);
         }
 
@@ -205,7 +227,10 @@ abstract class AbstractSql implements SqlInterface
                 foreach ($paramsForPosition as $multiParamsForPosition) {
                     $ppCount = count($multiParamsForPosition);
                     if (!isset($paramSpecs[$position][$ppCount])) {
-                        throw new Exception\RuntimeException('A number of parameters (' . $ppCount . ') was found that is not supported by this specification');
+                        throw new Exception\RuntimeException(sprintf(
+                            'A number of parameters (%d) was found that is not supported by this specification',
+                            $ppCount
+                        ));
                     }
                     $multiParamValues[] = vsprintf($paramSpecs[$position][$ppCount], $multiParamsForPosition);
                 }
@@ -213,7 +238,10 @@ abstract class AbstractSql implements SqlInterface
             } elseif ($paramSpecs[$position] !== null) {
                 $ppCount = count($paramsForPosition);
                 if (!isset($paramSpecs[$position][$ppCount])) {
-                    throw new Exception\RuntimeException('A number of parameters (' . $ppCount . ') was found that is not supported by this specification');
+                    throw new Exception\RuntimeException(sprintf(
+                        'A number of parameters (%d) was found that is not supported by this specification',
+                        $ppCount
+                    ));
                 }
                 $topParameters[] = vsprintf($paramSpecs[$position][$ppCount], $paramsForPosition);
             } else {
@@ -230,8 +258,12 @@ abstract class AbstractSql implements SqlInterface
      * @param null|ParameterContainer $parameterContainer
      * @return string
      */
-    protected function processSubSelect(Select $subselect, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
-    {
+    protected function processSubSelect(
+        Select $subselect,
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null
+    ) {
         if ($this instanceof PlatformDecoratorInterface) {
             $decorator = clone $this;
             $decorator->setSubject($subselect);
@@ -244,7 +276,8 @@ abstract class AbstractSql implements SqlInterface
             $processInfoContext = ($decorator instanceof PlatformDecoratorInterface) ? $subselect : $decorator;
             $this->processInfo['subselectCount']++;
             $processInfoContext->processInfo['subselectCount'] = $this->processInfo['subselectCount'];
-            $processInfoContext->processInfo['paramPrefix'] = 'subselect' . $processInfoContext->processInfo['subselectCount'];
+            $processInfoContext->processInfo['paramPrefix'] = 'subselect'
+                . $processInfoContext->processInfo['subselectCount'];
 
             $sql = $decorator->buildSqlString($platform, $driver, $parameterContainer);
 
@@ -264,9 +297,16 @@ abstract class AbstractSql implements SqlInterface
      * @param null|ParameterContainer $parameterContainer
      * @return string
      */
-    protected function resolveColumnValue($column, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null, $namedParameterPrefix = null)
-    {
-        $namedParameterPrefix = !$namedParameterPrefix ? $namedParameterPrefix : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
+    protected function resolveColumnValue(
+        $column,
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null,
+        $namedParameterPrefix = null
+    ) {
+        $namedParameterPrefix = ! $namedParameterPrefix
+            ? $namedParameterPrefix
+            : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
         $isIdentifier = false;
         $fromTable = '';
         if (is_array($column)) {
@@ -300,8 +340,12 @@ abstract class AbstractSql implements SqlInterface
      * @param ParameterContainer $parameterContainer
      * @return string
      */
-    protected function resolveTable($table, PlatformInterface $platform, DriverInterface $driver = null, ParameterContainer $parameterContainer = null)
-    {
+    protected function resolveTable(
+        $table,
+        PlatformInterface $platform,
+        DriverInterface $driver = null,
+        ParameterContainer $parameterContainer = null
+    ) {
         $schema = null;
         if ($table instanceof TableIdentifier) {
             list($table, $schema) = $table->getTableAndSchema();

--- a/library/Zend/Db/Sql/AbstractSql.php
+++ b/library/Zend/Db/Sql/AbstractSql.php
@@ -108,6 +108,13 @@ abstract class AbstractSql implements SqlInterface
         $expressionParamIndex = &$this->instanceParameterIndex[$namedParameterPrefix];
 
         foreach ($parts as $part) {
+            // #7407: use $expression->getExpression() to get the unescaped version of the expression
+            if (is_string($part) && $expression instanceof Expression) {
+                $sql .= $expression->getExpression();
+
+                continue;
+            }
+
             // if it is a string, simply tack it onto the return sql "specification" string
             if (is_string($part)) {
                 $sql .= $part;

--- a/library/Zend/InputFilter/FileInput.php
+++ b/library/Zend/InputFilter/FileInput.php
@@ -112,10 +112,17 @@ class FileInput extends Input
      */
     public function isValid($context = null)
     {
-        $rawValue     = $this->getRawValue();
-        $empty        = $this->isEmptyFile($rawValue);
+        $rawValue        = $this->getRawValue();
+        $empty           = $this->isEmptyFile($rawValue);
+        $required        = $this->isRequired();
+        $allowEmpty      = $this->allowEmpty();
+        $continueIfEmpty = $this->continueIfEmpty();
 
-        if ($empty && $this->allowEmpty() && !$this->continueIfEmpty()) {
+        if ($empty && ! $required && ! $continueIfEmpty) {
+            return true;
+        }
+
+        if ($empty && $required && $allowEmpty && ! $continueIfEmpty) {
             return true;
         }
 

--- a/library/Zend/InputFilter/Input.php
+++ b/library/Zend/InputFilter/Input.php
@@ -147,7 +147,6 @@ class Input implements InputInterface, EmptyContextInterface
     public function setRequired($required)
     {
         $this->required = (bool) $required;
-
         return $this;
     }
 
@@ -319,27 +318,31 @@ class Input implements InputInterface, EmptyContextInterface
      */
     public function isValid($context = null)
     {
-        $value     = $this->getValue();
-        $empty     = ($value === null || $value === '' || $value === array());
+        $value           = $this->getValue();
+        $empty           = ($value === null || $value === '' || $value === array());
+        $required        = $this->isRequired();
+        $allowEmpty      = $this->allowEmpty();
+        $continueIfEmpty = $this->continueIfEmpty();
 
-        if ($empty && $this->allowEmpty() && !$this->continueIfEmpty()) {
+        if ($empty && ! $required && ! $continueIfEmpty) {
             return true;
         }
 
-        if ($empty && !$this->isRequired()) {
+        if ($empty && $required && $allowEmpty && ! $continueIfEmpty) {
             return true;
         }
 
-        // Empty value needs further validation if continueIfEmpty is set
-        // so don't inject NotEmpty validator which would always
-        // mark that as false
-        if (!$this->continueIfEmpty() && !$this->allowEmpty()) {
+        // At this point, we need to run validators.
+        // If we do not allow empty and the "continue if empty" flag are
+        // BOTH false, we inject the "not empty" validator into the chain,
+        // which adds that logic into the validation routine.
+        if (! $allowEmpty && ! $continueIfEmpty) {
             $this->injectNotEmptyValidator();
         }
-        $validator = $this->getValidatorChain();
 
+        $validator = $this->getValidatorChain();
         $result    = $validator->isValid($value, $context);
-        if (!$result && $this->hasFallback()) {
+        if (! $result && $this->hasFallback()) {
             $this->setValue($this->getFallbackValue());
             $result = true;
         }

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -124,6 +124,18 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group #7407
+     */
+    public function testProcessExpressionWorksWithExpressionObjectWithPercentageSigns()
+    {
+        $expressionString = 'FROM_UNIXTIME(date, "%Y-%m")';
+        $expression       = new Expression($expressionString);
+        $sqlString        = $this->invokeProcessExpressionMethod($expression);
+
+        $this->assertSame($expressionString, $sqlString);
+    }
+
+    /**
      * @param \Zend\Db\Sql\ExpressionInterface $expression
      * @param \Zend\Db\Adapter\Adapter|null $adapter
      * @return \Zend\Db\Adapter\StatementContainer

--- a/tests/ZendTest/Db/Sql/AbstractSqlTest.php
+++ b/tests/ZendTest/Db/Sql/AbstractSqlTest.php
@@ -31,10 +31,16 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
         $this->abstractSql = $this->getMockForAbstractClass('Zend\Db\Sql\AbstractSql');
 
         $this->mockDriver = $this->getMock('Zend\Db\Adapter\Driver\DriverInterface');
-        $this->mockDriver->expects($this->any())->method('getPrepareType')->will($this->returnValue(DriverInterface::PARAMETERIZATION_NAMED));
-        $this->mockDriver->expects($this->any())->method('formatParameterName')->will($this->returnCallback(function ($x) {
-            return ':' . $x;
-        }));
+        $this->mockDriver
+            ->expects($this->any())
+            ->method('getPrepareType')
+            ->will($this->returnValue(DriverInterface::PARAMETERIZATION_NAMED));
+        $this->mockDriver
+            ->expects($this->any())
+            ->method('formatParameterName')
+            ->will($this->returnCallback(function ($x) {
+                return ':' . $x;
+            }));
     }
 
     /**
@@ -124,7 +130,7 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group #7407
+     * @group 7407
      */
     public function testProcessExpressionWorksWithExpressionObjectWithPercentageSigns()
     {
@@ -144,6 +150,12 @@ class AbstractSqlTest extends \PHPUnit_Framework_TestCase
     {
         $method = new \ReflectionMethod($this->abstractSql, 'processExpression');
         $method->setAccessible(true);
-        return $method->invoke($this->abstractSql, $expression, new TrustingSql92Platform, $this->mockDriver, $parameterContainer);
+        return $method->invoke(
+            $this->abstractSql,
+            $expression,
+            new TrustingSql92Platform,
+            $this->mockDriver,
+            $parameterContainer
+        );
     }
 }

--- a/tests/ZendTest/Db/Sql/ExpressionTest.php
+++ b/tests/ZendTest/Db/Sql/ExpressionTest.php
@@ -155,4 +155,15 @@ class ExpressionTest extends \PHPUnit_Framework_TestCase
         $expression = new Expression('0');
         $this->assertSame('0', $expression->getExpression());
     }
+
+    /**
+     * @group 7407
+     */
+    public function testGetExpressionPreservesPercentageSignInFromUnixtime()
+    {
+        $expressionString = 'FROM_UNIXTIME(date, "%Y-%m")';
+        $expression       = new Expression($expressionString);
+
+        $this->assertSame($expressionString, $expression->getExpression());
+    }
 }

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -626,22 +626,6 @@ class BaseInputFilterTest extends TestCase
         $this->assertFalse($filter->isValid());
     }
 
-    public function testValidationMarksInputInvalidWhenNotRequiredAndAllowEmptyFlagIsFalse()
-    {
-        $filter = new InputFilter();
-
-        $foo   = new Input();
-        $foo->setRequired(false);
-        $foo->setAllowEmpty(false);
-
-        $filter->add($foo, 'foo');
-
-        $data = array('foo' => '');
-        $filter->setData($data);
-
-        $this->assertFalse($filter->isValid());
-    }
-
     public static function contextDataProvider()
     {
         return array(

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -193,18 +193,6 @@ class FactoryTest extends TestCase
         }
     }
 
-    public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndImpliesAllowEmptyFlag()
-    {
-        $factory = new Factory();
-        $input   = $factory->createInput(array(
-            'name'     => 'foo',
-            'required' => false,
-        ));
-        $this->assertInstanceOf('Zend\InputFilter\InputInterface', $input);
-        $this->assertFalse($input->isRequired());
-        $this->assertTrue($input->allowEmpty());
-    }
-
     public function testFactoryWillCreateInputWithSuggestedRequiredFlagAndAlternativeAllowEmptyFlag()
     {
         $factory = new Factory();

--- a/tests/ZendTest/InputFilter/InputTest.php
+++ b/tests/ZendTest/InputFilter/InputTest.php
@@ -10,8 +10,9 @@
 namespace ZendTest\InputFilter;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\InputFilter\Input;
+use RuntimeException;
 use Zend\Filter;
+use Zend\InputFilter\Input;
 use Zend\Validator;
 
 class InputTest extends TestCase
@@ -241,12 +242,14 @@ class InputTest extends TestCase
      */
     public function testValidatorSkippedIfValueIsEmptyAndAllowedAndNotContinue($emptyValue)
     {
+        $validator = function () {
+            return false;
+        };
         $this->input->setAllowEmpty(true)
-                    ->setContinueIfEmpty(false)
-                    ->setValue($emptyValue)
-                    ->getValidatorChain()->attach(new Validator\Callback(function () {
-                        return false;
-                    }));
+            ->setContinueIfEmpty(false)
+            ->setValue($emptyValue)
+            ->getValidatorChain()->attach(new Validator\Callback($validator));
+
         $this->assertTrue($this->input->isValid());
     }
 
@@ -434,5 +437,317 @@ class InputTest extends TestCase
               ->setRequired(false);
 
         $this->assertTrue($input->isValid());
+    }
+
+    public function whenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun()
+    {
+        $validator = new Validator\Callback(function ($value) {
+            throw new RuntimeException('Validator executed when it should not be');
+        });
+
+        $requiredFirst = new Input('foo');
+        $requiredFirst->setRequired(true)
+            ->setAllowEmpty(true)
+            ->setContinueIfEmpty(false)
+            ->getValidatorChain()->attach($validator);
+
+        $requiredLast = new Input('foo');
+        $requiredLast->setAllowEmpty(true)
+            ->setContinueIfEmpty(false)
+            ->setRequired(true)
+            ->getValidatorChain()->attach($validator);
+
+        return array(
+            'required-first-null'  => array($requiredFirst, null),
+            'required-last-null'   => array($requiredLast, null),
+            'required-first-empty' => array($requiredFirst, ''),
+            'required-last-empty'  => array($requiredLast, ''),
+            'required-first-array' => array($requiredFirst, array()),
+            'required-last-array'  => array($requiredLast, array()),
+        );
+    }
+
+    /**
+     * @group 7448
+     * @dataProvider whenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
+     */
+    public function testWhenRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    {
+        $input->setValue($value);
+        $this->assertTrue($input->isValid());
+    }
+
+    public function whenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun()
+    {
+        $alwaysInvalid = new Validator\Callback(function ($value) {
+            if (! empty($value)) {
+                throw new RuntimeException('Unexpected non-empty value provided to validate');
+            }
+            return false;
+        });
+
+        $emptyIsValid = new Validator\Callback(function ($value) {
+            if (! empty($value)) {
+                throw new RuntimeException('Unexpected non-empty value provided to validate');
+            }
+            return true;
+        });
+
+        $requiredFirstInvalid = new Input('foo');
+        $requiredFirstValid   = new Input('foo');
+        foreach (array($requiredFirstValid, $requiredFirstInvalid) as $input) {
+            $input->setRequired(true)
+                ->setAllowEmpty(true)
+                ->setContinueIfEmpty(true);
+        }
+
+        $requiredLastInvalid = new Input('foo');
+        $requiredLastValid   = new Input('foo');
+        foreach (array($requiredLastValid, $requiredLastInvalid) as $input) {
+            $input->setAllowEmpty(true)
+                ->setContinueIfEmpty(true)
+                ->setRequired(true);
+        }
+
+        foreach (array($requiredFirstValid, $requiredLastValid) as $input) {
+            $input->getValidatorChain()->attach($emptyIsValid);
+        }
+
+        foreach (array($requiredFirstInvalid, $requiredLastInvalid) as $input) {
+            $input->getValidatorChain()->attach($alwaysInvalid);
+        }
+
+        return array(
+            'required-first-null-valid'    => array($requiredFirstValid, null, 'assertTrue'),
+            'required-first-null-invalid'  => array($requiredFirstInvalid, null, 'assertFalse'),
+            'required-last-null-valid'     => array($requiredLastValid, null, 'assertTrue'),
+            'required-last-null-invalid'   => array($requiredLastInvalid, null, 'assertFalse'),
+            'required-first-empty-valid'   => array($requiredFirstValid, '', 'assertTrue'),
+            'required-first-empty-invalid' => array($requiredFirstInvalid, '', 'assertFalse'),
+            'required-last-empty-valid'    => array($requiredLastValid, '', 'assertTrue'),
+            'required-last-empty-invalid'  => array($requiredLastInvalid, '', 'assertFalse'),
+            'required-first-array-valid'   => array($requiredFirstValid, array(), 'assertTrue'),
+            'required-first-array-invalid' => array($requiredFirstInvalid, array(), 'assertFalse'),
+            'required-last-array-valid'    => array($requiredLastValid, array(), 'assertTrue'),
+            'required-last-array-invalid'  => array($requiredLastInvalid, array(), 'assertFalse'),
+        );
+    }
+
+    /**
+     * @group 7448
+     * @dataProvider whenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun
+     */
+    public function testWhenRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    {
+        $input->setValue($value);
+        $this->{$assertion}($input->isValid());
+    }
+
+    public function whenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun()
+    {
+        $validator = new Validator\Callback(function ($value) {
+            throw new RuntimeException('Validator executed when it should not be');
+        });
+
+        $requiredFirst = new Input('foo');
+        $requiredFirst->setRequired(false)
+            ->setAllowEmpty(true)
+            ->setContinueIfEmpty(false)
+            ->getValidatorChain()->attach($validator);
+
+        $requiredLast = new Input('foo');
+        $requiredLast->setAllowEmpty(true)
+            ->setContinueIfEmpty(false)
+            ->setRequired(false)
+            ->getValidatorChain()->attach($validator);
+
+        return array(
+            'required-first-null'  => array($requiredFirst, null),
+            'required-last-null'   => array($requiredLast, null),
+            'required-first-empty' => array($requiredFirst, ''),
+            'required-last-empty'  => array($requiredLast, ''),
+            'required-first-array' => array($requiredFirst, array()),
+            'required-last-array'  => array($requiredLast, array()),
+        );
+    }
+
+    /**
+     * @group 7448
+     * @dataProvider whenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
+     */
+    public function testWhenNotRequiredAndAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    {
+        $input->setValue($value);
+        $this->assertTrue($input->isValid());
+    }
+
+    public function whenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun()
+    {
+        $validator = new Validator\Callback(function ($value) {
+            throw new RuntimeException('Validator executed when it should not be');
+        });
+
+        $requiredFirst = new Input('foo');
+        $requiredFirst->setRequired(false)
+            ->setAllowEmpty(false)
+            ->setContinueIfEmpty(false)
+            ->getValidatorChain()->attach($validator);
+
+        $requiredLast = new Input('foo');
+        $requiredLast->setAllowEmpty(false)
+            ->setContinueIfEmpty(false)
+            ->setRequired(false)
+            ->getValidatorChain()->attach($validator);
+
+        return array(
+            'required-first-null'  => array($requiredFirst, null),
+            'required-last-null'   => array($requiredLast, null),
+            'required-first-empty' => array($requiredFirst, ''),
+            'required-last-empty'  => array($requiredLast, ''),
+            'required-first-array' => array($requiredFirst, array()),
+            'required-last-array'  => array($requiredLast, array()),
+        );
+    }
+
+    /**
+     * @group 7448
+     * @dataProvider whenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun
+     */
+    public function testWhenNotRequiredAndNotAllowEmptyAndNotContinueIfEmptyValidatorsAreNotRun($input, $value)
+    {
+        $input->setValue($value);
+        $this->assertTrue($input->isValid());
+    }
+
+    public function whenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun()
+    {
+        $alwaysInvalid = new Validator\Callback(function ($value) {
+            if (! empty($value)) {
+                throw new RuntimeException('Unexpected non-empty value provided to validate');
+            }
+            return false;
+        });
+
+        $emptyIsValid = new Validator\Callback(function ($value) {
+            if (! empty($value)) {
+                throw new RuntimeException('Unexpected non-empty value provided to validate');
+            }
+            return true;
+        });
+
+        $requiredFirstInvalid = new Input('foo');
+        $requiredFirstValid   = new Input('foo');
+        foreach (array($requiredFirstValid, $requiredFirstInvalid) as $input) {
+            $input->setRequired(false)
+                ->setAllowEmpty(true)
+                ->setContinueIfEmpty(true);
+        }
+
+        $requiredLastInvalid = new Input('foo');
+        $requiredLastValid   = new Input('foo');
+        foreach (array($requiredLastValid, $requiredLastInvalid) as $input) {
+            $input->setAllowEmpty(true)
+                ->setContinueIfEmpty(true)
+                ->setRequired(false);
+        }
+
+        foreach (array($requiredFirstValid, $requiredLastValid) as $input) {
+            $input->getValidatorChain()->attach($emptyIsValid);
+        }
+
+        foreach (array($requiredFirstInvalid, $requiredLastInvalid) as $input) {
+            $input->getValidatorChain()->attach($alwaysInvalid);
+        }
+
+        return array(
+            'required-first-null-valid'    => array($requiredFirstValid, null, 'assertTrue'),
+            'required-first-null-invalid'  => array($requiredFirstInvalid, null, 'assertFalse'),
+            'required-last-null-valid'     => array($requiredLastValid, null, 'assertTrue'),
+            'required-last-null-invalid'   => array($requiredLastInvalid, null, 'assertFalse'),
+            'required-first-empty-valid'   => array($requiredFirstValid, '', 'assertTrue'),
+            'required-first-empty-invalid' => array($requiredFirstInvalid, '', 'assertFalse'),
+            'required-last-empty-valid'    => array($requiredLastValid, '', 'assertTrue'),
+            'required-last-empty-invalid'  => array($requiredLastInvalid, '', 'assertFalse'),
+            'required-first-array-valid'   => array($requiredFirstValid, array(), 'assertTrue'),
+            'required-first-array-invalid' => array($requiredFirstInvalid, array(), 'assertFalse'),
+            'required-last-array-valid'    => array($requiredLastValid, array(), 'assertTrue'),
+            'required-last-array-invalid'  => array($requiredLastInvalid, array(), 'assertFalse'),
+        );
+    }
+
+    /**
+     * @group 7448
+     * @dataProvider whenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun
+     */
+    public function testWhenNotRequiredAndAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    {
+        $input->setValue($value);
+        $this->{$assertion}($input->isValid());
+    }
+
+    public function whenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun()
+    {
+        $alwaysInvalid = new Validator\Callback(function ($value) {
+            if (! empty($value)) {
+                throw new RuntimeException('Unexpected non-empty value provided to validate');
+            }
+            return false;
+        });
+
+        $emptyIsValid = new Validator\Callback(function ($value) {
+            if (! empty($value)) {
+                throw new RuntimeException('Unexpected non-empty value provided to validate');
+            }
+            return true;
+        });
+
+        $requiredFirstInvalid = new Input('foo');
+        $requiredFirstValid   = new Input('foo');
+        foreach (array($requiredFirstValid, $requiredFirstInvalid) as $input) {
+            $input->setRequired(false)
+                ->setAllowEmpty(false)
+                ->setContinueIfEmpty(true);
+        }
+
+        $requiredLastInvalid = new Input('foo');
+        $requiredLastValid   = new Input('foo');
+        foreach (array($requiredLastValid, $requiredLastInvalid) as $input) {
+            $input->setAllowEmpty(false)
+                ->setContinueIfEmpty(true)
+                ->setRequired(false);
+        }
+
+        foreach (array($requiredFirstValid, $requiredLastValid) as $input) {
+            $input->getValidatorChain()->attach($emptyIsValid);
+        }
+
+        foreach (array($requiredFirstInvalid, $requiredLastInvalid) as $input) {
+            $input->getValidatorChain()->attach($alwaysInvalid);
+        }
+
+        return array(
+            'required-first-null-valid'    => array($requiredFirstValid, null, 'assertTrue'),
+            'required-first-null-invalid'  => array($requiredFirstInvalid, null, 'assertFalse'),
+            'required-last-null-valid'     => array($requiredLastValid, null, 'assertTrue'),
+            'required-last-null-invalid'   => array($requiredLastInvalid, null, 'assertFalse'),
+            'required-first-empty-valid'   => array($requiredFirstValid, '', 'assertTrue'),
+            'required-first-empty-invalid' => array($requiredFirstInvalid, '', 'assertFalse'),
+            'required-last-empty-valid'    => array($requiredLastValid, '', 'assertTrue'),
+            'required-last-empty-invalid'  => array($requiredLastInvalid, '', 'assertFalse'),
+            'required-first-array-valid'   => array($requiredFirstValid, array(), 'assertTrue'),
+            'required-first-array-invalid' => array($requiredFirstInvalid, array(), 'assertFalse'),
+            'required-last-array-valid'    => array($requiredLastValid, array(), 'assertTrue'),
+            'required-last-array-invalid'  => array($requiredLastInvalid, array(), 'assertFalse'),
+        );
+    }
+
+    /**
+     * @group 7448
+     * @dataProvider whenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun
+     */
+    public function testWhenNotRequiredAndNotAllowEmptyAndContinueIfEmptyValidatorsAreRun($input, $value, $assertion)
+    {
+        $input->setValue($value);
+        $this->{$assertion}($input->isValid());
     }
 }


### PR DESCRIPTION
This patch implements the [logic I outlined in a comment to #7448](https://github.com/zendframework/zf2/pull/7448#issuecomment-97803457):
- `required === true` + `allow_empty === true` + `continue_if_empty === false` -> validators are NOT run
- `required === true` + `allow_empty === true` + `continue_if_empty === true` -> validators are run
- `required === true` + `allow_empty === false` + `continue_if_empty === false` -> validators are NOT run
- `required === true` + `allow_empty === false` + `continue_if_empty === true` -> validators are run
- `required === false` + `allow_empty === true` + `continue_if_empty === false` -> validators are NOT run
- `required === false` + `allow_empty === true` + `continue_if_empty === true` -> validators are run
- `required === false` + `allow_empty === false` + `continue_if_empty === false` -> validators are NOT run
- `required === false` + `allow_empty === false` + `continue_if_empty === true` -> validators are run

It builds on the patch of #7448, and addresses the BC break demonstrated in #7445 and in zfcampus/zf-content-validation#46.
