### PR TITLE
[test] Replace assert(True|False) with more appropriate assertions where possible

### DIFF
--- a/tests/ZendTest/Authentication/Adapter/DbTable/CallbackCheckAdapterTest.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CallbackCheckAdapterTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Authentication\Adapter\DbTable;
 use Zend\Authentication;
 use Zend\Authentication\Adapter;
 use Zend\Db\Adapter\Adapter as DbAdapter;
-use Zend\Db\Sql\Select as DBSelect;
 
 /**
  * @group      Zend_Auth
@@ -185,7 +184,7 @@ class CallbackCheckAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterCanReturnDbSelectObject()
     {
-        $this->assertTrue($this->_adapter->getDbSelect() instanceof DBSelect);
+        $this->assertInstanceOf('Zend\Db\Sql\Select', $this->_adapter->getDbSelect());
     }
 
     /**

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CallbackCheckAdapterTest.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CallbackCheckAdapterTest.php
@@ -327,8 +327,8 @@ class CallbackCheckAdapterTest extends \PHPUnit_Framework_TestCase
                        ->setCredential('my_password')
                        ->setAmbiguityIdentity(true);
         $result = $this->_adapter->authenticate();
-        $this->assertFalse(in_array('More than one record matches the supplied identity.',
-                                    $result->getMessages()));
+        $this->assertNotContains('More than one record matches the supplied identity.',
+                                    $result->getMessages());
         $this->assertTrue($result->isValid());
         $this->assertEquals('my_username', $result->getIdentity());
 
@@ -340,8 +340,8 @@ class CallbackCheckAdapterTest extends \PHPUnit_Framework_TestCase
                        ->setCredential('my_otherpass')
                        ->setAmbiguityIdentity(true);
         $result2 = $this->_adapter->authenticate();
-        $this->assertFalse(in_array('More than one record matches the supplied identity.',
-                                    $result->getMessages()));
+        $this->assertNotContains('More than one record matches the supplied identity.',
+                                    $result->getMessages());
         $this->assertTrue($result2->isValid());
         $this->assertEquals('my_username', $result2->getIdentity());
     }

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CallbackCheckAdapterTest.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CallbackCheckAdapterTest.php
@@ -305,8 +305,8 @@ class CallbackCheckAdapterTest extends \PHPUnit_Framework_TestCase
         $this->_adapter->setIdentity('my_username')
                        ->setCredential('my_password');
         $result = $this->_adapter->authenticate();
-        $this->assertTrue(in_array('More than one record matches the supplied identity.',
-                                   $result->getMessages()));
+        $this->assertContains('More than one record matches the supplied identity.',
+                                   $result->getMessages());
         $this->assertFalse($result->isValid());
     }
 

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterDb2Test.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterDb2Test.php
@@ -358,7 +358,7 @@ class CredentialTreatmentAdapterDb2Test extends \PHPUnit_Framework_TestCase
             ->setCredential('my_password')
             ->setAmbiguityIdentity(true);
         $result = $this->authAdapter->authenticate();
-        $this->assertFalse(in_array('More than one record matches the supplied identity.', $result->getMessages()));
+        $this->assertNotContains('More than one record matches the supplied identity.', $result->getMessages());
         $this->assertTrue($result->isValid());
         $this->assertEquals('my_username', $result->getIdentity());
 
@@ -370,7 +370,7 @@ class CredentialTreatmentAdapterDb2Test extends \PHPUnit_Framework_TestCase
             ->setCredential('my_otherpass')
             ->setAmbiguityIdentity(true);
         $result2 = $this->authAdapter->authenticate();
-        $this->assertFalse(in_array('More than one record matches the supplied identity.', $result->getMessages()));
+        $this->assertNotContains('More than one record matches the supplied identity.', $result->getMessages());
         $this->assertTrue($result2->isValid());
         $this->assertEquals('my_username', $result2->getIdentity());
     }

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterDb2Test.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterDb2Test.php
@@ -337,7 +337,7 @@ class CredentialTreatmentAdapterDb2Test extends \PHPUnit_Framework_TestCase
         // test if user 1 can authenticate
         $this->authAdapter->setIdentity('my_username')->setCredential('my_password');
         $result = $this->authAdapter->authenticate();
-        $this->assertTrue(in_array('More than one record matches the supplied identity.', $result->getMessages()));
+        $this->assertContains('More than one record matches the supplied identity.', $result->getMessages());
         $this->assertFalse($result->isValid());
     }
 

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterDb2Test.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterDb2Test.php
@@ -11,7 +11,6 @@ namespace ZendTest\Authentication\Adapter\DbTable;
 use Zend\Authentication;
 use Zend\Authentication\Adapter;
 use Zend\Db\Adapter\Adapter as DbAdapter;
-use Zend\Db\Sql\Select as DBSelect;
 
 /**
  * @group Zend_Auth
@@ -208,7 +207,7 @@ class CredentialTreatmentAdapterDb2Test extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterCanReturnDbSelectObject()
     {
-        $this->assertTrue($this->authAdapter->getDbSelect() instanceof DBSelect);
+        $this->assertInstanceOf('Zend\Db\Sql\Select', $this->authAdapter->getDbSelect());
     }
 
     /**

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterTest.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterTest.php
@@ -292,8 +292,8 @@ class CredentialTreatmentAdapterTest extends \PHPUnit_Framework_TestCase
         $this->_adapter->setIdentity('my_username')
                        ->setCredential('my_password');
         $result = $this->_adapter->authenticate();
-        $this->assertTrue(in_array('More than one record matches the supplied identity.',
-                                   $result->getMessages()));
+        $this->assertContains('More than one record matches the supplied identity.',
+                                   $result->getMessages());
         $this->assertFalse($result->isValid());
     }
 

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterTest.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Authentication\Adapter\DbTable;
 use Zend\Authentication;
 use Zend\Authentication\Adapter;
 use Zend\Db\Adapter\Adapter as DbAdapter;
-use Zend\Db\Sql\Select as DBSelect;
 
 /**
  * @group      Zend_Auth
@@ -172,7 +171,7 @@ class CredentialTreatmentAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterCanReturnDbSelectObject()
     {
-        $this->assertTrue($this->_adapter->getDbSelect() instanceof DBSelect);
+        $this->assertInstanceOf('Zend\Db\Sql\Select', $this->_adapter->getDbSelect());
     }
 
     /**

--- a/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterTest.php
+++ b/tests/ZendTest/Authentication/Adapter/DbTable/CredentialTreatmentAdapterTest.php
@@ -314,8 +314,8 @@ class CredentialTreatmentAdapterTest extends \PHPUnit_Framework_TestCase
                        ->setCredential('my_password')
                        ->setAmbiguityIdentity(true);
         $result = $this->_adapter->authenticate();
-        $this->assertFalse(in_array('More than one record matches the supplied identity.',
-                                    $result->getMessages()));
+        $this->assertNotContains('More than one record matches the supplied identity.',
+                                    $result->getMessages());
         $this->assertTrue($result->isValid());
         $this->assertEquals('my_username', $result->getIdentity());
 
@@ -327,8 +327,8 @@ class CredentialTreatmentAdapterTest extends \PHPUnit_Framework_TestCase
                        ->setCredential('my_otherpass')
                        ->setAmbiguityIdentity(true);
         $result2 = $this->_adapter->authenticate();
-        $this->assertFalse(in_array('More than one record matches the supplied identity.',
-                                    $result->getMessages()));
+        $this->assertNotContains('More than one record matches the supplied identity.',
+                                    $result->getMessages());
         $this->assertTrue($result2->isValid());
         $this->assertEquals('my_username', $result2->getIdentity());
     }

--- a/tests/ZendTest/Authentication/Adapter/Http/ApacheResolverTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Http/ApacheResolverTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Authentication\Adapter\Http;
 
 use Zend\Authentication\Adapter\Http\ApacheResolver as Apache;
-use Zend\Authentication\Result as AuthResult;
 
 /**
  * @group      Zend_Auth
@@ -123,7 +122,7 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->_apache->setFile($file);
         $result = $this->_apache->resolve('test', null, 'password');
-        $this->assertTrue($result instanceof AuthResult);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid());
     }
 
@@ -137,7 +136,7 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->_apache->setFile($file);
         $result = $this->_apache->resolve('test', 'realm', 'password');
-        $this->assertTrue($result instanceof AuthResult);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid());
     }
 
@@ -150,7 +149,7 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->_apache->setFile($file);
         $result = $this->_apache->resolve('foo', null, 'password');
-        $this->assertTrue($result instanceof AuthResult);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertFalse($result->isValid());
     }
 
@@ -163,7 +162,7 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->_apache->setFile($file);
         $result = $this->_apache->resolve('test', null, 'bar');
-        $this->assertTrue($result instanceof AuthResult);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertFalse($result->isValid());
     }
 
@@ -174,7 +173,7 @@ class ApacheResolverTest extends \PHPUnit_Framework_TestCase
     {
         $this->_apache->setFile($this->_digest);
         $result = $this->_apache->resolve('test', 'auth', 'password');
-        $this->assertTrue($result instanceof AuthResult);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid());
     }
 }

--- a/tests/ZendTest/Authentication/Adapter/Http/AuthTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Http/AuthTest.php
@@ -440,7 +440,7 @@ class AuthTest extends \PHPUnit_Framework_TestCase
 
         // Check to see if the expected challenge matches the actual
         $headers = $headers->get('Www-Authenticate');
-        $this->assertTrue($headers instanceof \ArrayIterator);
+        $this->assertInstanceOf('ArrayIterator', $headers);
         $this->assertEquals(1, count($headers));
         $header = $headers[0]->getFieldValue();
         $this->assertContains($expected['type'], $header, $header);

--- a/tests/ZendTest/Authentication/Adapter/Http/ProxyTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Http/ProxyTest.php
@@ -414,7 +414,7 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
 
         // Check to see if the expected challenge matches the actual
         $headers = $headers->get('Proxy-Authenticate');
-        $this->assertTrue($headers instanceof \ArrayIterator);
+        $this->assertInstanceOf('ArrayIterator', $headers);
         $this->assertEquals(1, count($headers));
         $header = $headers[0]->getFieldValue();
         $this->assertContains($expected['type'], $header, $header);

--- a/tests/ZendTest/Authentication/Adapter/Ldap/OnlineTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Ldap/OnlineTest.php
@@ -86,7 +86,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
         $result = $adapter->authenticate();
 
-        $this->assertTrue($result instanceof Authentication\Result);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid());
         $this->assertTrue($result->getCode() == Authentication\Result::SUCCESS);
     }
@@ -107,7 +107,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
             foreach ($this->names as $username) {
                 $adapter->setUsername($username);
                 $result = $adapter->authenticate();
-                $this->assertTrue($result instanceof Authentication\Result);
+                $this->assertInstanceOf('Zend\Authentication\Result', $result);
                 $this->assertTrue($result->isValid());
                 $this->assertTrue($result->getCode() == Authentication\Result::SUCCESS);
                 $this->assertTrue($result->getIdentity() === $formName);
@@ -124,7 +124,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         );
 
         $result = $adapter->authenticate();
-        $this->assertTrue($result instanceof Authentication\Result);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid() === false);
         $this->assertTrue($result->getCode() == Authentication\Result::FAILURE_CREDENTIAL_INVALID);
     }
@@ -138,7 +138,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         );
 
         $result = $adapter->authenticate();
-        $this->assertTrue($result instanceof Authentication\Result);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid() === false);
         $this->assertTrue(
             $result->getCode() == Authentication\Result::FAILURE_IDENTITY_NOT_FOUND ||
@@ -155,7 +155,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         );
 
         $result = $adapter->authenticate();
-        $this->assertTrue($result instanceof Authentication\Result);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertFalse($result->isValid());
         $this->assertThat($result->getCode(), $this->lessThanOrEqual(Authentication\Result::FAILURE));
         $messages = $result->getMessages();

--- a/tests/ZendTest/Authentication/Adapter/Ldap/OnlineTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Ldap/OnlineTest.php
@@ -125,7 +125,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
         $result = $adapter->authenticate();
         $this->assertInstanceOf('Zend\Authentication\Result', $result);
-        $this->assertTrue($result->isValid() === false);
+        $this->assertFalse($result->isValid());
         $this->assertEquals(Authentication\Result::FAILURE_CREDENTIAL_INVALID, $result->getCode());
     }
 
@@ -139,7 +139,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
         $result = $adapter->authenticate();
         $this->assertInstanceOf('Zend\Authentication\Result', $result);
-        $this->assertTrue($result->isValid() === false);
+        $this->assertFalse($result->isValid());
         $this->assertTrue(
             $result->getCode() == Authentication\Result::FAILURE_IDENTITY_NOT_FOUND ||
             $result->getCode() == Authentication\Result::FAILURE_CREDENTIAL_INVALID

--- a/tests/ZendTest/Authentication/Adapter/Ldap/OnlineTest.php
+++ b/tests/ZendTest/Authentication/Adapter/Ldap/OnlineTest.php
@@ -88,7 +88,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid());
-        $this->assertTrue($result->getCode() == Authentication\Result::SUCCESS);
+        $this->assertEquals(Authentication\Result::SUCCESS, $result->getCode());
     }
 
     public function testCanonAuth()
@@ -109,8 +109,8 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
                 $result = $adapter->authenticate();
                 $this->assertInstanceOf('Zend\Authentication\Result', $result);
                 $this->assertTrue($result->isValid());
-                $this->assertTrue($result->getCode() == Authentication\Result::SUCCESS);
-                $this->assertTrue($result->getIdentity() === $formName);
+                $this->assertEquals(Authentication\Result::SUCCESS, $result->getCode());
+                $this->assertEquals($formName, $result->getIdentity());
             }
         }
     }
@@ -126,7 +126,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         $result = $adapter->authenticate();
         $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($result->isValid() === false);
-        $this->assertTrue($result->getCode() == Authentication\Result::FAILURE_CREDENTIAL_INVALID);
+        $this->assertEquals(Authentication\Result::FAILURE_CREDENTIAL_INVALID, $result->getCode());
     }
 
     public function testInvalidUserAuth()

--- a/tests/ZendTest/Authentication/AuthenticationServiceTest.php
+++ b/tests/ZendTest/Authentication/AuthenticationServiceTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Authentication;
 
 use Zend\Authentication\AuthenticationService;
-use Zend\Authentication as Auth;
 
 /**
  * @group      Zend_Auth
@@ -30,7 +29,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
     public function testGetStorage()
     {
         $storage = $this->auth->getStorage();
-        $this->assertTrue($storage instanceof Auth\Storage\Session);
+        $this->assertInstanceOf('Zend\Authentication\Storage\Session', $storage);
     }
 
     public function testAdapter()
@@ -50,7 +49,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
     public function testAuthenticate()
     {
         $result = $this->authenticate();
-        $this->assertTrue($result instanceof Auth\Result);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
     }
@@ -58,7 +57,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
     public function testAuthenticateSetAdapter()
     {
         $result = $this->authenticate(new TestAsset\SuccessAdapter());
-        $this->assertTrue($result instanceof Auth\Result);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
     }

--- a/tests/ZendTest/Barcode/FactoryTest.php
+++ b/tests/ZendTest/Barcode/FactoryTest.php
@@ -336,7 +336,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         }
         $resource = Barcode\Barcode::draw('code25', 'image', array('text' => '012345'));
         $this->assertInternalType('resource', $resource, 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
+        $this->assertEquals('gd', get_resource_type($resource), 'Image must be a GD resource');
     }
 
     public function testProxyBarcodeRendererDrawAsImageAutomaticallyRenderImageIfException()
@@ -346,7 +346,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         }
         $resource = Barcode\Barcode::draw('code25', 'image');
         $this->assertInternalType('resource', $resource, 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
+        $this->assertEquals('gd', get_resource_type($resource), 'Image must be a GD resource');
     }
 
     public function testProxyBarcodeRendererDrawAsPdf()

--- a/tests/ZendTest/Barcode/FactoryTest.php
+++ b/tests/ZendTest/Barcode/FactoryTest.php
@@ -56,8 +56,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->checkGDRequirement();
         $renderer = Barcode\Barcode::factory('code39');
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Code39);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code39', $renderer->getBarcode());
     }
 
     /**
@@ -66,8 +66,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testMinimalFactoryWithRenderer()
     {
         $renderer = Barcode\Barcode::factory('code39', 'pdf');
-        $this->assertTrue($renderer instanceof Renderer\Pdf);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Code39);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Pdf', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code39', $renderer->getBarcode());
     }
 
     public function testFactoryWithOptions()
@@ -83,8 +83,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->checkGDRequirement();
         $options = array('barHeight' => - 1);
         $renderer = Barcode\Barcode::factory('code39', 'image', $options);
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Error);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Error', $renderer->getBarcode());
     }
 
     public function testFactoryWithoutAutomaticObjectExceptionRendering()
@@ -109,8 +109,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $config = new Config(array('barcode'  => 'code39',
                                    'renderer' => 'image'));
         $renderer = Barcode\Barcode::factory($config);
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Code39);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code39', $renderer->getBarcode());
     }
 
     public function testFactoryWithZendConfigAndObjectOptions()
@@ -120,8 +120,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
                                    'barcodeParams' => array(
                                    'barHeight'     => 123)));
         $renderer = Barcode\Barcode::factory($config);
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Code25);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code25', $renderer->getBarcode());
         $this->assertEquals(123, $renderer->getBarcode()->getBarHeight());
     }
 
@@ -132,8 +132,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
                                    'rendererParams' => array(
                                    'imageType'      => 'gif')));
         $renderer = Barcode\Barcode::factory($config);
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Code25);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code25', $renderer->getBarcode());
         $this->assertSame('gif', $renderer->getImageType());
     }
 
@@ -141,8 +141,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->checkGDRequirement();
         $renderer = Barcode\Barcode::factory(null);
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Error);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Error', $renderer->getBarcode());
     }
 
     public function testFactoryWithoutBarcodeWithAutomaticExceptionRenderWithZendConfig()
@@ -150,8 +150,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->checkGDRequirement();
         $config = new Config(array('barcode' => null));
         $renderer = Barcode\Barcode::factory($config);
-        $this->assertTrue($renderer instanceof Renderer\Image);
-        $this->assertTrue($renderer->getBarcode() instanceof Object\Error);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
+        $this->assertInstanceOf('Zend\Barcode\Object\Error', $renderer->getBarcode());
     }
 
     public function testFactoryWithExistingBarcodeObject()
@@ -172,7 +172,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testBarcodeObjectFactoryWithBarcodeAsString()
     {
         $barcode = Barcode\Barcode::makeBarcode('code25');
-        $this->assertTrue($barcode instanceof Object\Code25);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code25', $barcode);
 
         // ensure makeBarcode creates unique instances
         $this->assertNotSame($barcode, Barcode\Barcode::makeBarcode('code25'));
@@ -181,7 +181,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testBarcodeObjectFactoryWithBarcodeAsStringAndConfigAsArray()
     {
         $barcode = Barcode\Barcode::makeBarcode('code25', array('barHeight' => 123));
-        $this->assertTrue($barcode instanceof Object\Code25);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code25', $barcode);
         $this->assertSame(123, $barcode->getBarHeight());
     }
 
@@ -189,7 +189,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $config = new Config(array('barHeight' => 123));
         $barcode = Barcode\Barcode::makeBarcode('code25', $config);
-        $this->assertTrue($barcode instanceof Object\Code25);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code25', $barcode);
         $this->assertSame(123, $barcode->getBarHeight());
     }
 
@@ -199,7 +199,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
                                    'barcodeParams' => array(
                                    'barHeight' => 123)));
         $barcode = Barcode\Barcode::makeBarcode($config);
-        $this->assertTrue($barcode instanceof Object\Code25);
+        $this->assertInstanceOf('Zend\Barcode\Object\Code25', $barcode);
         $this->assertSame(123, $barcode->getBarHeight());
     }
 
@@ -221,7 +221,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $plugins = Barcode\Barcode::getObjectPluginManager();
         $plugins->setInvokableClass('barcodeNamespace', 'ZendTest\Barcode\Object\TestAsset\BarcodeNamespace');
         $barcode = Barcode\Barcode::makeBarcode('barcodeNamespace');
-        $this->assertTrue($barcode instanceof \ZendTest\Barcode\Object\TestAsset\BarcodeNamespace);
+        $this->assertInstanceOf('ZendTest\Barcode\Object\TestAsset\BarcodeNamespace', $barcode);
     }
 
     public function testBarcodeObjectFactoryWithNamespaceExtendStandardLibray()
@@ -229,7 +229,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $plugins = Barcode\Barcode::getObjectPluginManager();
         $plugins->setInvokableClass('error', 'ZendTest\Barcode\Object\TestAsset\Error');
         $barcode = Barcode\Barcode::makeBarcode('error');
-        $this->assertTrue($barcode instanceof \ZendTest\Barcode\Object\TestAsset\Error);
+        $this->assertInstanceOf('ZendTest\Barcode\Object\TestAsset\Error', $barcode);
     }
 
     public function testBarcodeObjectFactoryWithNamespaceButWithoutExtendingObjectAbstract()
@@ -259,7 +259,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->checkGDRequirement();
         $renderer = Barcode\Barcode::makeRenderer('image');
-        $this->assertTrue($renderer instanceof Renderer\Image);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
 
         // ensure unique instance is created
         $this->assertNotSame($renderer, Barcode\Barcode::makeRenderer('image'));
@@ -270,7 +270,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->checkGDRequirement();
 
         $renderer = Barcode\Barcode::makeRenderer('image', array('imageType' => 'gif'));
-        $this->assertTrue($renderer instanceof Renderer\Image);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
         $this->assertSame('gif', $renderer->getImageType());
     }
 
@@ -279,7 +279,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->checkGDRequirement();
         $config = new Config(array('imageType' => 'gif'));
         $renderer = Barcode\Barcode::makeRenderer('image', $config);
-        $this->assertTrue($renderer instanceof Renderer\Image);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
         $this->assertSame('gif', $renderer->getimageType());
     }
 
@@ -289,7 +289,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $config = new Config(array('renderer'       => 'image',
                                    'rendererParams' => array('imageType' => 'gif')));
         $renderer = Barcode\Barcode::makeRenderer($config);
-        $this->assertTrue($renderer instanceof Renderer\Image);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\Image', $renderer);
         $this->assertSame('gif', $renderer->getimageType());
     }
 
@@ -312,7 +312,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $plugins = Barcode\Barcode::getRendererPluginManager();
         $plugins->setInvokableClass('rendererNamespace', 'ZendTest\Barcode\Renderer\TestAsset\RendererNamespace');
         $renderer = Barcode\Barcode::makeRenderer('rendererNamespace');
-        $this->assertTrue($renderer instanceof \Zend\Barcode\Renderer\RendererInterface);
+        $this->assertInstanceOf('Zend\Barcode\Renderer\RendererInterface', $renderer);
     }
 
     public function testBarcodeFactoryWithNamespaceButWithoutExtendingRendererAbstract()
@@ -357,7 +357,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/Object/_fonts/Vera.ttf');
         $resource = Barcode\Barcode::draw('code25', 'pdf', array('text' => '012345'));
-        $this->assertTrue($resource instanceof Pdf\PdfDocument);
+        $this->assertInstanceOf('ZendPdf\PdfDocument', $resource);
         Barcode\Barcode::setBarcodeFont('');
     }
 
@@ -369,7 +369,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/Object/_fonts/Vera.ttf');
         $resource = Barcode\Barcode::draw('code25', 'pdf');
-        $this->assertTrue($resource instanceof Pdf\PdfDocument);
+        $this->assertInstanceOf('ZendPdf\PdfDocument', $resource);
         Barcode\Barcode::setBarcodeFont('');
     }
 
@@ -377,7 +377,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/Object/_fonts/Vera.ttf');
         $resource = Barcode\Barcode::draw('code25', 'svg', array('text' => '012345'));
-        $this->assertTrue($resource instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $resource);
         Barcode\Barcode::setBarcodeFont('');
     }
 
@@ -385,7 +385,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/Object/_fonts/Vera.ttf');
         $resource = Barcode\Barcode::draw('code25', 'svg');
-        $this->assertTrue($resource instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $resource);
         Barcode\Barcode::setBarcodeFont('');
     }
 

--- a/tests/ZendTest/Barcode/FactoryTest.php
+++ b/tests/ZendTest/Barcode/FactoryTest.php
@@ -335,7 +335,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('GD extension is required to run this test');
         }
         $resource = Barcode\Barcode::draw('code25', 'image', array('text' => '012345'));
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+        $this->assertInternalType('resource', $resource, 'Image must be a resource');
         $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
     }
 
@@ -345,7 +345,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('GD extension is required to run this test');
         }
         $resource = Barcode\Barcode::draw('code25', 'image');
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+        $this->assertInternalType('resource', $resource, 'Image must be a resource');
         $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
     }
 

--- a/tests/ZendTest/Barcode/Renderer/ImageTest.php
+++ b/tests/ZendTest/Barcode/Renderer/ImageTest.php
@@ -103,7 +103,7 @@ class ImageTest extends TestCommon
         $this->renderer->setBarcode($barcode);
         $resource = $this->renderer->draw();
         $this->assertInternalType('resource', $resource, 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
+        $this->assertEquals('gd', get_resource_type($resource), 'Image must be a GD resource');
     }
 
     public function testDrawWithExistantResourceReturnResource()
@@ -115,7 +115,7 @@ class ImageTest extends TestCommon
         $this->renderer->setResource($imageResource);
         $resource = $this->renderer->draw();
         $this->assertInternalType('resource', $resource, 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
+        $this->assertEquals('gd', get_resource_type($resource), 'Image must be a GD resource');
         $this->assertSame($resource, $imageResource);
     }
 

--- a/tests/ZendTest/Barcode/Renderer/ImageTest.php
+++ b/tests/ZendTest/Barcode/Renderer/ImageTest.php
@@ -327,7 +327,7 @@ class ImageTest extends TestCommon
         $this->renderer->setImageType('gif');
         $image = $this->renderer->draw();
         $index = imagecolortransparent($image);
-        $this->assertTrue($index !== -1);
+        $this->assertNotEquals(-1, $index);
     }
 
     /**
@@ -345,7 +345,7 @@ class ImageTest extends TestCommon
         $this->renderer->setImageType('png');
         $image = $this->renderer->draw();
         $index = imagecolortransparent($image);
-        $this->assertTrue($index !== -1);
+        $this->assertNotEquals(-1, $index);
     }
 
     protected function checkTTFRequirement()

--- a/tests/ZendTest/Barcode/Renderer/ImageTest.php
+++ b/tests/ZendTest/Barcode/Renderer/ImageTest.php
@@ -102,7 +102,7 @@ class ImageTest extends TestCommon
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $this->renderer->setBarcode($barcode);
         $resource = $this->renderer->draw();
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+        $this->assertInternalType('resource', $resource, 'Image must be a resource');
         $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
     }
 
@@ -114,7 +114,7 @@ class ImageTest extends TestCommon
         $imageResource = imagecreatetruecolor(500, 500);
         $this->renderer->setResource($imageResource);
         $resource = $this->renderer->draw();
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+        $this->assertInternalType('resource', $resource, 'Image must be a resource');
         $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
         $this->assertSame($resource, $imageResource);
     }

--- a/tests/ZendTest/Barcode/Renderer/PdfTest.php
+++ b/tests/ZendTest/Barcode/Renderer/PdfTest.php
@@ -48,7 +48,7 @@ class PdfTest extends TestCommon
         $barcode = new Object\Code39(array('text' => '0123456789'));
         $this->renderer->setBarcode($barcode);
         $resource = $this->renderer->draw();
-        $this->assertTrue($resource instanceof Pdf\PdfDocument);
+        $this->assertInstanceOf('ZendPdf\PdfDocument', $resource);
         Barcode\Barcode::setBarcodeFont('');
     }
 
@@ -60,7 +60,7 @@ class PdfTest extends TestCommon
         $pdfResource = new Pdf\PdfDocument();
         $this->renderer->setResource($pdfResource);
         $resource = $this->renderer->draw();
-        $this->assertTrue($resource instanceof Pdf\PdfDocument);
+        $this->assertInstanceOf('ZendPdf\PdfDocument', $resource);
         $this->assertSame($resource, $pdfResource);
         Barcode\Barcode::setBarcodeFont('');
     }

--- a/tests/ZendTest/Barcode/Renderer/SvgTest.php
+++ b/tests/ZendTest/Barcode/Renderer/SvgTest.php
@@ -106,7 +106,7 @@ class SvgTest extends TestCommon
         $barcode = new Code39(array('text' => '0123456789'));
         $this->renderer->setBarcode($barcode);
         $resource = $this->renderer->draw();
-        $this->assertTrue($resource instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $resource);
         Barcode\Barcode::setBarcodeFont('');
     }
 
@@ -124,7 +124,7 @@ class SvgTest extends TestCommon
         $svgResource->appendChild($rootElement);
         $this->renderer->setResource($svgResource);
         $resource = $this->renderer->draw();
-        $this->assertTrue($resource instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $resource);
         $this->assertSame($resource, $svgResource);
         Barcode\Barcode::setBarcodeFont('');
     }

--- a/tests/ZendTest/Cache/Pattern/CaptureCacheTest.php
+++ b/tests/ZendTest/Cache/Pattern/CaptureCacheTest.php
@@ -92,7 +92,7 @@ class CaptureCacheTest extends CommonPatternTest
     public function testSetWithNormalPageId()
     {
         $this->_pattern->set('content', '/dir1/dir2/file');
-        $this->assertTrue(file_exists($this->_tmpCacheDir . '/dir1/dir2/file'));
+        $this->assertFileExists($this->_tmpCacheDir . '/dir1/dir2/file');
         $this->assertSame(file_get_contents($this->_tmpCacheDir . '/dir1/dir2/file'), 'content');
     }
 
@@ -101,7 +101,7 @@ class CaptureCacheTest extends CommonPatternTest
         $this->_options->setIndexFilename('test.html');
 
         $this->_pattern->set('content', '/dir1/dir2/');
-        $this->assertTrue(file_exists($this->_tmpCacheDir . '/dir1/dir2/test.html'));
+        $this->assertFileExists($this->_tmpCacheDir . '/dir1/dir2/test.html');
         $this->assertSame(file_get_contents($this->_tmpCacheDir . '/dir1/dir2/test.html'), 'content');
     }
 

--- a/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
+++ b/tests/ZendTest/Cache/Storage/Adapter/RedisTest.php
@@ -213,7 +213,7 @@ class RedisTest extends CommonAdapterTest
         $this->_options->setLibOptions($options);
         $this->_storage->setItem($key, $value);
         //should not serialize array correctly
-        $this->assertFalse(is_array($this->_storage->getItem($key)), 'Redis should not serialize automatically anymore, lib options were not set correctly');
+        $this->assertNotInternalType('array', $this->_storage->getItem($key), 'Redis should not serialize automatically anymore, lib options were not set correctly');
     }
 
     public function testGetSetLibOptionsWithCleanRedisResourceInstance()
@@ -233,7 +233,7 @@ class RedisTest extends CommonAdapterTest
         $this->_options->setLibOptions($options);
         $redis->setItem($key, $value);
         //should not serialize array correctly
-        $this->assertFalse(is_array($redis->getItem($key)), 'Redis should not serialize automatically anymore, lib options were not set correctly');
+        $this->assertNotInternalType('array', $redis->getItem($key), 'Redis should not serialize automatically anymore, lib options were not set correctly');
     }
 
     /* RedisOptions */

--- a/tests/ZendTest/Captcha/CommonWordTest.php
+++ b/tests/ZendTest/Captcha/CommonWordTest.php
@@ -37,6 +37,6 @@ abstract class CommonWordTest extends \PHPUnit_Framework_TestCase
         $wordAdapter = new $this->wordClass;
         $this->assertFalse($wordAdapter->isValid('foo'));
         $messages = $wordAdapter->getMessages();
-        $this->assertFalse(empty($messages));
+        $this->assertNotEmpty($messages);
     }
 }

--- a/tests/ZendTest/Captcha/FigletTest.php
+++ b/tests/ZendTest/Captcha/FigletTest.php
@@ -89,8 +89,8 @@ class FigletTest extends CommonWordTest
 
         $this->assertNotEmpty($id1);
         $this->assertNotEmpty($id2);
-        $this->assertFalse($id1 == $id2);
-        $this->assertFalse($word1 == $word2);
+        $this->assertNotEquals($id1, $id2);
+        $this->assertNotEquals($word1, $word2);
     }
 
     public function testGenerateInitializesSessionData()

--- a/tests/ZendTest/Captcha/FigletTest.php
+++ b/tests/ZendTest/Captcha/FigletTest.php
@@ -41,7 +41,7 @@ class FigletTest extends CommonWordTest
     {
         $ttl = $this->captcha->getTimeout();
         $this->assertFalse(empty($ttl));
-        $this->assertTrue(is_int($ttl));
+        $this->assertInternalType('integer', $ttl);
     }
 
     public function testCanSetTimeout()
@@ -56,7 +56,7 @@ class FigletTest extends CommonWordTest
     {
         $id = $this->captcha->generate();
         $this->assertFalse(empty($id));
-        $this->assertTrue(is_string($id));
+        $this->assertInternalType('string', $id);
         $this->id = $id;
     }
 
@@ -65,7 +65,7 @@ class FigletTest extends CommonWordTest
         $this->captcha->generate();
         $word = $this->captcha->getWord();
         $this->assertFalse(empty($word));
-        $this->assertTrue(is_string($word));
+        $this->assertInternalType('string', $word);
         $this->assertTrue(strlen($word) == 8);
         $this->word = $word;
     }
@@ -75,7 +75,7 @@ class FigletTest extends CommonWordTest
         $this->captcha->setWordLen(4);
         $this->captcha->generate();
         $word = $this->captcha->getWord();
-        $this->assertTrue(is_string($word));
+        $this->assertInternalType('string', $word);
         $this->assertTrue(strlen($word) == 4);
         $this->word = $word;
     }

--- a/tests/ZendTest/Captcha/FigletTest.php
+++ b/tests/ZendTest/Captcha/FigletTest.php
@@ -40,7 +40,7 @@ class FigletTest extends CommonWordTest
     public function testTimeoutPopulatedByDefault()
     {
         $ttl = $this->captcha->getTimeout();
-        $this->assertFalse(empty($ttl));
+        $this->assertNotEmpty($ttl);
         $this->assertInternalType('integer', $ttl);
     }
 
@@ -55,7 +55,7 @@ class FigletTest extends CommonWordTest
     public function testGenerateReturnsId()
     {
         $id = $this->captcha->generate();
-        $this->assertFalse(empty($id));
+        $this->assertNotEmpty($id);
         $this->assertInternalType('string', $id);
         $this->id = $id;
     }
@@ -64,7 +64,7 @@ class FigletTest extends CommonWordTest
     {
         $this->captcha->generate();
         $word = $this->captcha->getWord();
-        $this->assertFalse(empty($word));
+        $this->assertNotEmpty($word);
         $this->assertInternalType('string', $word);
         $this->assertTrue(strlen($word) == 8);
         $this->word = $word;
@@ -87,8 +87,8 @@ class FigletTest extends CommonWordTest
         $id2 = $this->captcha->generate();
         $word2 = $this->captcha->getWord();
 
-        $this->assertFalse(empty($id1));
-        $this->assertFalse(empty($id2));
+        $this->assertNotEmpty($id1);
+        $this->assertNotEmpty($id2);
         $this->assertFalse($id1 == $id2);
         $this->assertFalse($word1 == $word2);
     }

--- a/tests/ZendTest/Captcha/FigletTest.php
+++ b/tests/ZendTest/Captcha/FigletTest.php
@@ -66,7 +66,7 @@ class FigletTest extends CommonWordTest
         $word = $this->captcha->getWord();
         $this->assertNotEmpty($word);
         $this->assertInternalType('string', $word);
-        $this->assertTrue(strlen($word) == 8);
+        $this->assertEquals(8, strlen($word));
         $this->word = $word;
     }
 
@@ -76,7 +76,7 @@ class FigletTest extends CommonWordTest
         $this->captcha->generate();
         $word = $this->captcha->getWord();
         $this->assertInternalType('string', $word);
-        $this->assertTrue(strlen($word) == 4);
+        $this->assertEquals(4, strlen($word));
         $this->word = $word;
     }
 

--- a/tests/ZendTest/Captcha/ImageTest.php
+++ b/tests/ZendTest/Captcha/ImageTest.php
@@ -163,7 +163,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $word = $this->captcha->getWord();
         $this->assertNotEmpty($word);
         $this->assertInternalType('string', $word);
-        $this->assertTrue(strlen($word) == 8);
+        $this->assertEquals(8, strlen($word));
         $this->word = $word;
     }
 
@@ -173,7 +173,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->captcha->generate();
         $word = $this->captcha->getWord();
         $this->assertInternalType('string', $word);
-        $this->assertTrue(strlen($word) == 4);
+        $this->assertEquals(4, strlen($word));
         $this->word = $word;
     }
 

--- a/tests/ZendTest/Captcha/ImageTest.php
+++ b/tests/ZendTest/Captcha/ImageTest.php
@@ -186,8 +186,8 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($id1);
         $this->assertNotEmpty($id2);
-        $this->assertFalse($id1 == $id2);
-        $this->assertFalse($word1 == $word2);
+        $this->assertNotEquals($id1, $id2);
+        $this->assertNotEquals($word1, $word2);
     }
 
     public function testRenderInitializesSessionData()

--- a/tests/ZendTest/Captcha/ImageTest.php
+++ b/tests/ZendTest/Captcha/ImageTest.php
@@ -153,7 +153,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     {
         $id = $this->captcha->generate();
         $this->assertFalse(empty($id));
-        $this->assertTrue(is_string($id));
+        $this->assertInternalType('string', $id);
         $this->id = $id;
     }
 
@@ -162,7 +162,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->captcha->generate();
         $word = $this->captcha->getWord();
         $this->assertFalse(empty($word));
-        $this->assertTrue(is_string($word));
+        $this->assertInternalType('string', $word);
         $this->assertTrue(strlen($word) == 8);
         $this->word = $word;
     }
@@ -172,7 +172,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->captcha->setWordLen(4);
         $this->captcha->generate();
         $word = $this->captcha->getWord();
-        $this->assertTrue(is_string($word));
+        $this->assertInternalType('string', $word);
         $this->assertTrue(strlen($word) == 4);
         $this->word = $word;
     }

--- a/tests/ZendTest/Captcha/ImageTest.php
+++ b/tests/ZendTest/Captcha/ImageTest.php
@@ -119,7 +119,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         sleep(2);
         $this->captcha->generate();
         clearstatcache();
-        $this->assertFalse(file_exists($filename), "File $filename was found even after GC");
+        $this->assertFileNotExists($filename, "File $filename was found even after GC");
     }
 
     /**
@@ -145,7 +145,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         sleep(2);
         $this->captcha->generate();
         clearstatcache();
-        $this->assertFalse(file_exists($filename), "File $filename was found even after GC");
+        $this->assertFileNotExists($filename, "File $filename was found even after GC");
         $this->assertFileExists($otherFile, "File $otherFile was not found after GC");
     }
 

--- a/tests/ZendTest/Captcha/ImageTest.php
+++ b/tests/ZendTest/Captcha/ImageTest.php
@@ -152,7 +152,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     public function testGenerateReturnsId()
     {
         $id = $this->captcha->generate();
-        $this->assertFalse(empty($id));
+        $this->assertNotEmpty($id);
         $this->assertInternalType('string', $id);
         $this->id = $id;
     }
@@ -161,7 +161,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     {
         $this->captcha->generate();
         $word = $this->captcha->getWord();
-        $this->assertFalse(empty($word));
+        $this->assertNotEmpty($word);
         $this->assertInternalType('string', $word);
         $this->assertTrue(strlen($word) == 8);
         $this->word = $word;
@@ -184,8 +184,8 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $id2   = $this->captcha->generate();
         $word2 = $this->captcha->getWord();
 
-        $this->assertFalse(empty($id1));
-        $this->assertFalse(empty($id2));
+        $this->assertNotEmpty($id1);
+        $this->assertNotEmpty($id2);
         $this->assertFalse($id1 == $id2);
         $this->assertFalse($word1 == $word2);
     }

--- a/tests/ZendTest/Captcha/ImageTest.php
+++ b/tests/ZendTest/Captcha/ImageTest.php
@@ -99,7 +99,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     public function testCaptchaCreatesImage()
     {
         $this->captcha->generate();
-        $this->assertTrue(file_exists($this->testDir . "/" . $this->captcha->getId() . ".png"));
+        $this->assertFileExists($this->testDir . "/" . $this->captcha->getId() . '.png');
     }
 
     public function testCaptchaSetExpiration()
@@ -113,7 +113,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     {
         $this->captcha->generate();
         $filename = $this->testDir . "/" . $this->captcha->getId() . ".png";
-        $this->assertTrue(file_exists($filename));
+        $this->assertFileExists($filename);
         $this->captcha->setExpiration(1);
         $this->captcha->setGcFreq(1);
         sleep(2);
@@ -134,19 +134,19 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         }
         $this->captcha->generate();
         $filename = $this->testDir . "/" . $this->captcha->getId() . ".png";
-        $this->assertTrue(file_exists($filename));
+        $this->assertFileExists($filename);
 
         //Create other cache file
         $otherFile = $this->testDir . "/zf10006.cache";
         file_put_contents($otherFile, '');
-        $this->assertTrue(file_exists($otherFile));
+        $this->assertFileExists($otherFile);
         $this->captcha->setExpiration(1);
         $this->captcha->setGcFreq(1);
         sleep(2);
         $this->captcha->generate();
         clearstatcache();
         $this->assertFalse(file_exists($filename), "File $filename was found even after GC");
-        $this->assertTrue(file_exists($otherFile), "File $otherFile was not found after GC");
+        $this->assertFileExists($otherFile, "File $otherFile was not found after GC");
     }
 
     public function testGenerateReturnsId()

--- a/tests/ZendTest/Captcha/ReCaptchaTest.php
+++ b/tests/ZendTest/Captcha/ReCaptchaTest.php
@@ -55,7 +55,7 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
         $test = $service->getParams();
         $compare = array('ssl' => $options['ssl'], 'xhtml' => $options['xhtml']);
         foreach ($compare as $key => $value) {
-            $this->assertTrue(array_key_exists($key, $test));
+            $this->assertArrayHasKey($key, $test);
             $this->assertSame($value, $test[$key]);
         }
     }

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -770,7 +770,7 @@ CODE;
         $classGenerator->addTraitAlias('myTrait::method', 'useMe', ReflectionMethod::IS_PRIVATE);
 
         $aliases = $classGenerator->getTraitAliases();
-        $this->assertTrue(array_key_exists('myTrait::method', $aliases));
+        $this->assertArrayHasKey('myTrait::method', $aliases);
         $this->assertEquals($aliases['myTrait::method']['alias'], 'useMe');
         $this->assertEquals($aliases['myTrait::method']['visibility'], ReflectionMethod::IS_PRIVATE);
     }
@@ -790,7 +790,7 @@ CODE;
         ), 'useMe', ReflectionMethod::IS_PRIVATE);
 
         $aliases = $classGenerator->getTraitAliases();
-        $this->assertTrue(array_key_exists('myTrait::method', $aliases));
+        $this->assertArrayHasKey('myTrait::method', $aliases);
         $this->assertEquals($aliases['myTrait::method']['alias'], 'useMe');
         $this->assertEquals($aliases['myTrait::method']['visibility'], ReflectionMethod::IS_PRIVATE);
     }

--- a/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/ClassGeneratorTest.php
@@ -754,8 +754,8 @@ CODE;
         $classGenerator->addTraits(array('myTrait', 'hisTrait'));
 
         $traits = $classGenerator->getTraits();
-        $this->assertTrue(in_array('myTrait', $traits));
-        $this->assertTrue(in_array('hisTrait', $traits));
+        $this->assertContains('myTrait', $traits);
+        $this->assertContains('hisTrait', $traits);
     }
 
     public function testCanAddTraitAliasWithString()

--- a/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
@@ -32,8 +32,7 @@ class MethodGeneratorTest extends \PHPUnit_Framework_TestCase
         $methodGenerator->setParameters(array('one'));
         $params = $methodGenerator->getParameters();
         $param = array_shift($params);
-        $this->assertTrue($param instanceof \Zend\Code\Generator\ParameterGenerator,
-                          'Failed because $param was not instance of Zend\Code\Generator\ParameterGenerator');
+        $this->assertInstanceOf('Zend\Code\Generator\ParameterGenerator', $param);
     }
 
     public function testMethodParameterMutator()

--- a/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
+++ b/tests/ZendTest/Code/Generator/MethodGeneratorTest.php
@@ -75,7 +75,7 @@ class MethodGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $method = new MethodGenerator();
         $method->setDocBlock($docblockGenerator);
-        $this->assertTrue($docblockGenerator === $method->getDocBlock());
+        $this->assertSame($docblockGenerator, $method->getDocBlock());
     }
 
 

--- a/tests/ZendTest/Code/Reflection/FileReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FileReflectionTest.php
@@ -63,7 +63,7 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
 
     public function testFileConstructorFromAReflectedFilenameInIncludePath()
     {
-        $this->assertFalse(in_array(realpath(__DIR__ . '/TestAsset/a_second_empty_file.php'), get_included_files()));
+        $this->assertNotContains(realpath(__DIR__ . '/TestAsset/a_second_empty_file.php'), get_included_files());
         $oldIncludePath = set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/TestAsset/');
 
         try {

--- a/tests/ZendTest/Code/Reflection/FileReflectionTest.php
+++ b/tests/ZendTest/Code/Reflection/FileReflectionTest.php
@@ -138,7 +138,7 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
         $reflectionFile = new FileReflection($fileToReflect);
 
         $reflectionDocBlock = $reflectionFile->getDocBlock();
-        $this->assertTrue($reflectionDocBlock instanceof \Zend\Code\Reflection\DocBlockReflection);
+        $this->assertInstanceOf('Zend\Code\Reflection\DocBlockReflection', $reflectionDocBlock);
 
         $authorTag = $reflectionDocBlock->getTag('author');
         $this->assertEquals('Jeremiah Small', $authorTag->getAuthorName());
@@ -153,7 +153,7 @@ class FileReflectionTest extends \PHPUnit_Framework_TestCase
         include_once $fileToRequire;
         $reflectionFile = new FileReflection($fileToRequire);
         $funcs = $reflectionFile->getFunctions();
-        $this->assertTrue(current($funcs) instanceof \Zend\Code\Reflection\FunctionReflection);
+        $this->assertInstanceOf('Zend\Code\Reflection\FunctionReflection', current($funcs));
     }
 
     public function testFileCanReflectFileWithInterface()

--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -268,7 +268,7 @@ class ClassScannerTest extends TestCase
             $this->assertTrue($class->hasMethod($methodName), "Cannot find method $methodName");
 
             $method = $class->getMethod($methodName);
-            $this->assertTrue($method instanceof MethodScanner, $methodName . " not found.");
+            $this->assertInstanceOf('Zend\Code\Scanner\MethodScanner', $method, $methodName . ' not found.');
 
             $this->assertTrue($method->$testMethod());
 

--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -209,8 +209,8 @@ class ClassScannerTest extends TestCase
         $this->assertFalse($class->isTrait());
         $traitNames = $class->getTraitNames();
         $class->getTraitAliases();
-        $this->assertTrue(in_array('ZendTest\Code\TestAsset\BarTrait', $traitNames));
-        $this->assertTrue(in_array('ZendTest\Code\TestAsset\FooTrait', $traitNames));
+        $this->assertContains('ZendTest\Code\TestAsset\BarTrait', $traitNames);
+        $this->assertContains('ZendTest\Code\TestAsset\FooTrait', $traitNames);
     }
 
     /**

--- a/tests/ZendTest/Code/Scanner/PropertyScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/PropertyScannerTest.php
@@ -94,7 +94,7 @@ CLASS;
                     $this->assertEquals('string', $valueType);
                     break;
                 case "status":
-                    $this->assertTrue("false" === $value);
+                    $this->assertEquals('false', $value);
                     $this->assertEquals('boolean', $valueType);
                     break;
             }

--- a/tests/ZendTest/Config/ConfigTest.php
+++ b/tests/ZendTest/Config/ConfigTest.php
@@ -270,11 +270,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config($configArray);
         $this->assertEquals(count($configArray), count($config));
         foreach ($config as $key => $value) {
-            if ($key === 'false1') {
-                $this->assertTrue($value === false);
-            } else {
-                $this->assertTrue($value === 'someValue');
-            }
+            $this->assertEquals($configArray[$key], $value);
         }
     }
 
@@ -297,7 +293,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     {
         $config = new Config($this->all);
         $value = $config->get('notthere', 'default');
-        $this->assertTrue($value === 'default');
+        $this->assertEquals('default', $value);
         $this->assertNull($config->notThere);
     }
 

--- a/tests/ZendTest/Config/ConfigTest.php
+++ b/tests/ZendTest/Config/ConfigTest.php
@@ -301,7 +301,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config($this->all);
         $value = $config->get('notthere', 'default');
         $this->assertTrue($value === 'default');
-        $this->assertTrue($config->notThere === null);
+        $this->assertNull($config->notThere);
     }
 
     public function testUnsetException()

--- a/tests/ZendTest/Config/ConfigTest.php
+++ b/tests/ZendTest/Config/ConfigTest.php
@@ -268,17 +268,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'data3'  => 'someValue'
             );
         $config = new Config($configArray);
-        $this->assertTrue(count($config) === count($configArray));
-        $count = 0;
+        $this->assertEquals(count($configArray), count($config));
         foreach ($config as $key => $value) {
             if ($key === 'false1') {
                 $this->assertTrue($value === false);
             } else {
                 $this->assertTrue($value === 'someValue');
             }
-            $count++;
         }
-        $this->assertTrue($count === 4);
     }
 
     public function testZf1019_HandlingInvalidKeyNames()

--- a/tests/ZendTest/Config/FactoryTest.php
+++ b/tests/ZendTest/Config/FactoryTest.php
@@ -132,10 +132,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         $configArray = Factory::fromFile($files[0]);
-        $this->assertTrue(is_array($configArray));
+        $this->assertInternalType('array', $configArray);
 
         $configArray = Factory::fromFiles($files);
-        $this->assertTrue(is_array($configArray));
+        $this->assertInternalType('array', $configArray);
 
         $configObject = Factory::fromFile($files[0], true);
         $this->assertInstanceOf('Zend\Config\Config', $configObject);

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -350,7 +350,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         $tokens = $processor->getTokens();
         $this->assertInternalType('array', $tokens);
-        $this->assertTrue(in_array('SOME_USERLAND_CONSTANT', $tokens));
+        $this->assertContains('SOME_USERLAND_CONSTANT', $tokens);
         $this->assertTrue(!$processor->getUserOnly());
 
         $this->assertEquals('some constant value', $config->simple);
@@ -371,7 +371,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $tokens = $processor->getTokens();
 
         $this->assertInternalType('array', $tokens);
-        $this->assertTrue(in_array('SOME_USERLAND_CONSTANT', $tokens));
+        $this->assertContains('SOME_USERLAND_CONSTANT', $tokens);
         $this->assertTrue($processor->getUserOnly());
 
         $this->assertEquals('some constant value', $config->simple);

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -349,7 +349,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->process($config);
 
         $tokens = $processor->getTokens();
-        $this->assertTrue(is_array($tokens));
+        $this->assertInternalType('array', $tokens);
         $this->assertTrue(in_array('SOME_USERLAND_CONSTANT', $tokens));
         $this->assertTrue(!$processor->getUserOnly());
 
@@ -370,7 +370,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         $tokens = $processor->getTokens();
 
-        $this->assertTrue(is_array($tokens));
+        $this->assertInternalType('array', $tokens);
         $this->assertTrue(in_array('SOME_USERLAND_CONSTANT', $tokens));
         $this->assertTrue($processor->getUserOnly());
 

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -477,7 +477,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $filter = new StringToLower();
         $processor = new FilterProcessor($filter);
 
-        $this->assertTrue($processor->getFilter() instanceof StringToLower);
+        $this->assertInstanceOf('Zend\Filter\StringToLower', $processor->getFilter());
         $processor->process($config);
 
         $this->assertEquals('some mixedcase value', $config->simple);

--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -351,7 +351,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $tokens = $processor->getTokens();
         $this->assertInternalType('array', $tokens);
         $this->assertContains('SOME_USERLAND_CONSTANT', $tokens);
-        $this->assertTrue(!$processor->getUserOnly());
+        $this->assertFalse($processor->getUserOnly());
 
         $this->assertEquals('some constant value', $config->simple);
         $this->assertEquals('some text with some constant value inside', $config->inside);

--- a/tests/ZendTest/Config/Reader/AbstractReaderTestCase.php
+++ b/tests/ZendTest/Config/Reader/AbstractReaderTestCase.php
@@ -46,6 +46,6 @@ abstract class AbstractReaderTestCase extends TestCase
     public function testFromEmptyString()
     {
         $config = $this->reader->fromString('');
-        $this->assertTrue(!$config);
+        $this->assertEmpty($config);
     }
 }

--- a/tests/ZendTest/Console/ConsoleTest.php
+++ b/tests/ZendTest/Console/ConsoleTest.php
@@ -28,7 +28,7 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Console::isConsole());
         $className = Console::detectBestAdapter();
         $adpater = new $className;
-        $this->assertTrue($adpater instanceof Adapter\AdapterInterface);
+        $this->assertInstanceOf('Zend\Console\Adapter\AdapterInterface', $adpater);
 
         Console::overrideIsConsole(false);
 
@@ -56,7 +56,7 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
     public function testCanGetInstance()
     {
         $console = Console::getInstance();
-        $this->assertTrue($console instanceof Adapter\AdapterInterface);
+        $this->assertInstanceOf('Zend\Console\Adapter\AdapterInterface', $console);
     }
 
     public function testCanNotGetInstanceInNoConsoleMode()
@@ -69,14 +69,14 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
     public function testCanForceInstance()
     {
         $console = Console::getInstance('Posix');
-        $this->assertTrue($console instanceof Adapter\AdapterInterface);
-        $this->assertTrue($console instanceof Adapter\Posix);
+        $this->assertInstanceOf('Zend\Console\Adapter\AdapterInterface', $console);
+        $this->assertInstanceOf('Zend\Console\Adapter\Posix', $console);
 
         Console::overrideIsConsole(null);
         Console::resetInstance();
 
         $console = Console::getInstance('Windows');
-        $this->assertTrue($console instanceof Adapter\AdapterInterface);
-        $this->assertTrue($console instanceof Adapter\Windows);
+        $this->assertInstanceOf('Zend\Console\Adapter\AdapterInterface', $console);
+        $this->assertInstanceOf('Zend\Console\Adapter\Windows', $console);
     }
 }

--- a/tests/ZendTest/Console/Prompt/NumberTest.php
+++ b/tests/ZendTest/Console/Prompt/NumberTest.php
@@ -58,7 +58,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $response = $number->show();
         $text = ob_get_clean();
-        $this->assertTrue((bool) preg_match('#a is not a number#', $text));
+        $this->assertContains('a is not a number', $text);
         $this->assertEquals('123', $response);
     }
 
@@ -74,7 +74,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $response = $number->show();
         $text = ob_get_clean();
-        $this->assertTrue((bool) preg_match('#Please enter a non-floating number#', $text));
+        $this->assertContains('Please enter a non-floating number', $text);
         $this->assertEquals('123', $response);
     }
 
@@ -108,8 +108,8 @@ class NumberTest extends \PHPUnit_Framework_TestCase
         $response = $number->show();
         $text = ob_get_clean();
 
-        $this->assertTrue((bool) preg_match('#Please enter a number not smaller than 5#', $text));
-        $this->assertTrue((bool) preg_match('#Please enter a number not greater than 10#', $text));
+        $this->assertContains('Please enter a number not smaller than 5', $text);
+        $this->assertContains('Please enter a number not greater than 10', $text);
         $this->assertEquals('6', $response);
     }
 }

--- a/tests/ZendTest/Console/Prompt/SelectTest.php
+++ b/tests/ZendTest/Console/Prompt/SelectTest.php
@@ -42,8 +42,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $response = $select->show();
         $text = ob_get_clean();
-        $this->assertTrue((bool) preg_match('#0\) foo#', $text));
-        $this->assertTrue((bool) preg_match('#1\) bar#', $text));
+        $this->assertContains('0) foo', $text);
+        $this->assertContains('1) bar', $text);
         $this->assertEquals('0', $response);
     }
 
@@ -56,8 +56,8 @@ class SelectTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $response = $select->show();
         $text = ob_get_clean();
-        $this->assertTrue((bool) preg_match('#2\) foo#', $text));
-        $this->assertTrue((bool) preg_match('#6\) bar#', $text));
+        $this->assertContains('2) foo', $text);
+        $this->assertContains('6) bar', $text);
         $this->assertEquals('2', $response);
     }
 }

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -135,7 +135,7 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         foreach ($this->blockCipher->getCipherSupportedAlgorithms() as $algo) {
             $this->blockCipher->setCipherAlgorithm($algo);
             $encrypted = $this->blockCipher->encrypt($this->plaintext);
-            $this->assertTrue(!empty($encrypted));
+            $this->assertNotEmpty($encrypted);
             $decrypted = $this->blockCipher->decrypt($encrypted);
             $this->assertEquals($decrypted, $this->plaintext);
         }
@@ -149,7 +149,7 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         foreach ($this->blockCipher->getCipherSupportedAlgorithms() as $algo) {
             $this->blockCipher->setCipherAlgorithm($algo);
             $encrypted = $this->blockCipher->encrypt($this->plaintext);
-            $this->assertTrue(!empty($encrypted));
+            $this->assertNotEmpty($encrypted);
             $decrypted = $this->blockCipher->decrypt($encrypted);
             $this->assertEquals($decrypted, $this->plaintext);
         }
@@ -175,7 +175,7 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
             $this->blockCipher->setCipherAlgorithm($algo);
 
             $encrypted = $this->blockCipher->encrypt($value);
-            $this->assertTrue(!empty($encrypted));
+            $this->assertNotEmpty($encrypted);
             $decrypted = $this->blockCipher->decrypt($encrypted);
             $this->assertEquals($value, $decrypted);
         }
@@ -186,7 +186,7 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         $this->blockCipher->setKey('test');
         $this->blockCipher->setKeyIteration(1000);
         $encrypted = $this->blockCipher->encrypt($this->plaintext);
-        $this->assertTrue(!empty($encrypted));
+        $this->assertNotEmpty($encrypted);
         // tamper the encrypted data
         $encrypted = substr($encrypted, -1);
         $decrypted = $this->blockCipher->decrypt($encrypted);

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -190,6 +190,6 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
         // tamper the encrypted data
         $encrypted = substr($encrypted, -1);
         $decrypted = $this->blockCipher->decrypt($encrypted);
-        $this->assertTrue($decrypted === false);
+        $this->assertFalse($decrypted);
     }
 }

--- a/tests/ZendTest/Crypt/BlockCipherTest.php
+++ b/tests/ZendTest/Crypt/BlockCipherTest.php
@@ -50,14 +50,14 @@ class BlockCipherTest extends \PHPUnit_Framework_TestCase
     public function testFactory()
     {
         $this->blockCipher = BlockCipher::factory('mcrypt', array('algo' => 'blowfish'));
-        $this->assertTrue($this->blockCipher->getCipher() instanceof Mcrypt);
+        $this->assertInstanceOf('Zend\Crypt\Symmetric\Mcrypt', $this->blockCipher->getCipher());
         $this->assertEquals('blowfish', $this->blockCipher->getCipher()->getAlgorithm());
     }
 
     public function testFactoryEmptyOptions()
     {
         $this->blockCipher = BlockCipher::factory('mcrypt');
-        $this->assertTrue($this->blockCipher->getCipher() instanceof Mcrypt);
+        $this->assertInstanceOf('Zend\Crypt\Symmetric\Mcrypt', $this->blockCipher->getCipher());
     }
 
     public function testSetKey()

--- a/tests/ZendTest/Crypt/FileCipherTest.php
+++ b/tests/ZendTest/Crypt/FileCipherTest.php
@@ -182,7 +182,7 @@ class FileCipherTest extends \PHPUnit_Framework_TestCase
         file_put_contents($this->fileOut, $ciphertext);
 
         $this->assertFalse($this->fileCipher->decrypt($this->fileOut, $fileOut2, false));
-        $this->assertFalse(file_exists($fileOut2));
+        $this->assertFileNotExists($fileOut2);
     }
 
     public function testEncryptFileWithNoKey()

--- a/tests/ZendTest/Crypt/Password/BcryptShaTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptShaTest.php
@@ -99,7 +99,7 @@ class BcryptShaTest extends \PHPUnit_Framework_TestCase
     public function testCreateWithRandomSalt()
     {
         $password = $this->bcrypt->create('test');
-        $this->assertTrue(!empty($password));
+        $this->assertNotEmpty($password);
         $this->assertTrue(strlen($password) === 60);
     }
 

--- a/tests/ZendTest/Crypt/Password/BcryptShaTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptShaTest.php
@@ -98,7 +98,7 @@ class BcryptShaTest extends \PHPUnit_Framework_TestCase
     {
         $password = $this->bcrypt->create('test');
         $this->assertNotEmpty($password);
-        $this->assertTrue(strlen($password) === 60);
+        $this->assertEquals(60, strlen($password));
     }
 
     public function testCreateWithSalt()

--- a/tests/ZendTest/Crypt/Password/BcryptShaTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptShaTest.php
@@ -45,7 +45,6 @@ class BcryptShaTest extends \PHPUnit_Framework_TestCase
             'salt'       => $this->salt
         );
         $bcrypt  = new BcryptSha($options);
-        $this->assertTrue($bcrypt instanceof BcryptSha);
         $this->assertEquals('15', $bcrypt->getCost());
         $this->assertEquals($this->salt, $bcrypt->getSalt());
     }
@@ -58,7 +57,6 @@ class BcryptShaTest extends \PHPUnit_Framework_TestCase
         );
         $config  = new Config($options);
         $bcrypt  = new BcryptSha($config);
-        $this->assertTrue($bcrypt instanceof BcryptSha);
         $this->assertEquals('15', $bcrypt->getCost());
         $this->assertEquals($this->salt, $bcrypt->getSalt());
     }

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -44,7 +44,6 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
             'salt'       => $this->salt
         );
         $bcrypt  = new Bcrypt($options);
-        $this->assertTrue($bcrypt instanceof Bcrypt);
         $this->assertEquals('15', $bcrypt->getCost());
         $this->assertEquals($this->salt, $bcrypt->getSalt());
     }
@@ -57,7 +56,6 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
         );
         $config  = new Config($options);
         $bcrypt  = new Bcrypt($config);
-        $this->assertTrue($bcrypt instanceof Bcrypt);
         $this->assertEquals('15', $bcrypt->getCost());
         $this->assertEquals($this->salt, $bcrypt->getSalt());
     }

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -97,7 +97,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
     {
         $password = $this->bcrypt->create('test');
         $this->assertNotEmpty($password);
-        $this->assertTrue(strlen($password) === 60);
+        $this->assertEquals(60, strlen($password));
     }
 
     public function testCreateWithSalt()

--- a/tests/ZendTest/Crypt/Password/BcryptTest.php
+++ b/tests/ZendTest/Crypt/Password/BcryptTest.php
@@ -98,7 +98,7 @@ class BcryptTest extends \PHPUnit_Framework_TestCase
     public function testCreateWithRandomSalt()
     {
         $password = $this->bcrypt->create('test');
-        $this->assertTrue(!empty($password));
+        $this->assertNotEmpty($password);
         $this->assertTrue(strlen($password) === 60);
     }
 

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -49,12 +49,11 @@ class McryptTest extends \PHPUnit_Framework_TestCase
             'padding'   => 'pkcs7'
         );
         $mcrypt  = new Mcrypt($options);
-        $this->assertTrue($mcrypt instanceof Mcrypt);
         $this->assertEquals($mcrypt->getAlgorithm(), MCRYPT_BLOWFISH);
         $this->assertEquals($mcrypt->getMode(), MCRYPT_MODE_CFB);
         $this->assertEquals($mcrypt->getKey(), substr($this->key, 0, $mcrypt->getKeySize()));
         $this->assertEquals($mcrypt->getSalt(), substr($this->salt, 0, $mcrypt->getSaltSize()));
-        $this->assertTrue($mcrypt->getPadding() instanceof PKCS7);
+        $this->assertInstanceOf('Zend\Crypt\Symmetric\Padding\PKCS7', $mcrypt->getPadding());
     }
 
     public function testConstructByConfig()
@@ -68,12 +67,11 @@ class McryptTest extends \PHPUnit_Framework_TestCase
         );
         $config  = new Config($options);
         $mcrypt  = new Mcrypt($config);
-        $this->assertTrue($mcrypt instanceof Mcrypt);
         $this->assertEquals($mcrypt->getAlgorithm(), MCRYPT_BLOWFISH);
         $this->assertEquals($mcrypt->getMode(), MCRYPT_MODE_CFB);
         $this->assertEquals($mcrypt->getKey(), substr($this->key, 0, $mcrypt->getKeySize()));
         $this->assertEquals($mcrypt->getSalt(), substr($this->salt, 0, $mcrypt->getSaltSize()));
-        $this->assertTrue($mcrypt->getPadding() instanceof PKCS7);
+        $this->assertInstanceOf('Zend\Crypt\Symmetric\Padding\PKCS7', $mcrypt->getPadding());
     }
 
     public function testConstructWrongParam()

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -169,7 +169,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
                 $this->assertNotEmpty($encrypted);
                 $decrypted = $this->mcrypt->decrypt($encrypted);
                 $this->assertTrue($decrypted !== false);
-                $this->assertEquals($decrypted, $this->plaintext);
+                $this->assertEquals($this->plaintext, $decrypted);
             }
         }
     }

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -168,7 +168,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
                 $encrypted = $this->mcrypt->encrypt($this->plaintext);
                 $this->assertNotEmpty($encrypted);
                 $decrypted = $this->mcrypt->decrypt($encrypted);
-                $this->assertTrue($decrypted !== false);
+                $this->assertNotFalse($decrypted);
                 $this->assertEquals($this->plaintext, $decrypted);
             }
         }

--- a/tests/ZendTest/Crypt/Symmetric/McryptTest.php
+++ b/tests/ZendTest/Crypt/Symmetric/McryptTest.php
@@ -168,7 +168,7 @@ class McryptTest extends \PHPUnit_Framework_TestCase
                 $this->mcrypt->setAlgorithm($algo);
                 $this->mcrypt->setMode($mode);
                 $encrypted = $this->mcrypt->encrypt($this->plaintext);
-                $this->assertTrue(!empty($encrypted));
+                $this->assertNotEmpty($encrypted);
                 $decrypted = $this->mcrypt->decrypt($encrypted);
                 $this->assertTrue($decrypted !== false);
                 $this->assertEquals($decrypted, $this->plaintext);

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -43,7 +43,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         try {
             $resource = $this->connection->getResource();
             // connected with empty string
-            $this->assertTrue(is_resource($resource));
+            $this->assertInternalType('resource', $resource);
         } catch (AdapterException\RuntimeException $exc) {
             // If it throws an exception it has failed to connect
             $this->setExpectedException('Zend\Db\Adapter\Exception\RuntimeException');

--- a/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
+++ b/tests/ZendTest/Db/Adapter/Platform/SqliteTest.php
@@ -176,6 +176,6 @@ class SqliteTest extends \PHPUnit_Framework_TestCase
 
         @unlink($filePath);
 
-        $this->assertFalse(file_exists($filePath));
+        $this->assertFileNotExists($filePath);
     }
 }

--- a/tests/ZendTest/Dom/Document/QueryTest.php
+++ b/tests/ZendTest/Dom/Document/QueryTest.php
@@ -26,7 +26,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     public function testTransformShouldReturnStringByDefault()
     {
         $test = Query::cssToXpath('');
-        $this->assertTrue(is_string($test));
+        $this->assertInternalType('string', $test);
     }
 
     /**
@@ -35,7 +35,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     public function testTransformShouldReturnMultiplePathsWhenExpressionContainsCommas()
     {
         $test = Query::cssToXpath('#foo, #bar');
-        $this->assertTrue(is_string($test));
+        $this->assertInternalType('string', $test);
         $this->assertContains('|', $test);
         $this->assertEquals(2, count(explode('|', $test)));
     }
@@ -77,7 +77,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     public function testMultipleComplexCssSpecificationShouldTransformToExpectedXpath()
     {
         $test = Query::cssToXpath('div#foo span.bar, #bar li.baz a');
-        $this->assertTrue(is_string($test));
+        $this->assertInternalType('string', $test);
         $this->assertContains('|', $test);
         $actual   = explode('|', $test);
         $expected = array(

--- a/tests/ZendTest/Dom/DocumentTest.php
+++ b/tests/ZendTest/Dom/DocumentTest.php
@@ -133,20 +133,20 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
     {
         $html  = $this->getHtml();
         $document = new Document($html);
-        $this->assertTrue($document->getDomDocument() instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $document->getDomDocument());
     }
 
     public function testgetDomMethodShouldReturnDomDocumentWithStringDocumentSetFromMethod()
     {
         $this->loadHtml();
-        $this->assertTrue($this->document->getDomDocument() instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $this->document->getDomDocument());
     }
 
     public function testQueryShouldReturnResultObject()
     {
         $this->loadHtml();
         $result = Document\Query::execute('.foo', $this->document, Document\Query::TYPE_CSS);
-        $this->assertTrue($result instanceof Document\NodeList);
+        $this->assertInstanceOf('Zend\Dom\Document\NodeList', $result);
     }
 
     public function testResultShouldIndicateNumberOfFoundNodes()
@@ -162,7 +162,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $result = Document\Query::execute('.foo', $this->document, Document\Query::TYPE_CSS);
         $this->assertEquals(3, count($result));
         foreach ($result as $node) {
-            $this->assertTrue($node instanceof \DOMNode, var_export($result, 1));
+            $this->assertInstanceOf('DOMNode', $node, var_export($result, true));
         }
     }
 

--- a/tests/ZendTest/Dom/DocumentTest.php
+++ b/tests/ZendTest/Dom/DocumentTest.php
@@ -209,7 +209,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             return;
         }
-        $this->assertTrue(false, 'XPath PHPFunctions should be disabled by default');
+        $this->fail('XPath PHPFunctions should be disabled by default');
     }
 
     public function testXpathPhpFunctionsShouldBeEnabledWithoutParameter()
@@ -233,7 +233,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
             // $e->getMessage() - Not allowed to call handler 'strtolower()
             return;
         }
-        $this->assertTrue(false, 'Not allowed to call handler strtolower()');
+        $this->fail('Not allowed to call handler strtolower()');
     }
 
     /**

--- a/tests/ZendTest/Dom/DocumentTest.php
+++ b/tests/ZendTest/Dom/DocumentTest.php
@@ -246,7 +246,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $result = Document\Query::execute('p', $this->document, Document\Query::TYPE_CSS);
         $errors = $this->document->getErrors();
         $this->assertInternalType('array', $errors);
-        $this->assertTrue(0 < count($errors));
+        $this->assertNotEmpty($errors);
     }
 
     /**

--- a/tests/ZendTest/Dom/DocumentTest.php
+++ b/tests/ZendTest/Dom/DocumentTest.php
@@ -245,7 +245,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $this->document = new Document($file);
         $result = Document\Query::execute('p', $this->document, Document\Query::TYPE_CSS);
         $errors = $this->document->getErrors();
-        $this->assertTrue(is_array($errors));
+        $this->assertInternalType('array', $errors);
         $this->assertTrue(0 < count($errors));
     }
 

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -73,7 +73,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
         foreach (array('foo', 'bar') as $event) {
             $listeners = $this->events->getListeners($event);
-            $this->assertTrue(count($listeners) > 0);
+            $this->assertNotEmpty($listeners);
             foreach ($listeners as $listener) {
                 $this->assertSame($callback, $listener->getCallback());
             }

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -43,7 +43,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
     public function testAttachShouldReturnCallbackHandler()
     {
         $listener = $this->events->attach('test', array($this, __METHOD__));
-        $this->assertTrue($listener instanceof CallbackHandler);
+        $this->assertInstanceOf('Zend\Stdlib\CallbackHandler', $listener);
     }
 
     public function testAttachShouldAddListenerToEvent()
@@ -144,7 +144,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             return str_rot13($string);
         });
         $responses = $this->events->trigger('string.transform', $this, array('string' => ' foo '));
-        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertEquals(2, $responses->count());
         $this->assertEquals('foo', $responses->first());
         $this->assertEquals(\str_rot13(' foo '), $responses->last());
@@ -168,7 +168,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
             array('string' => 'foo', 'search' => 'f'),
             array($this, 'evaluateStringCallback')
         );
-        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertSame(0, $responses->last());
     }
 
@@ -208,7 +208,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $responses = $this->events->trigger('foo.bar', $this, array(), function ($result) {
             return ($result === 'found');
         });
-        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertTrue($responses->stopped());
         $result = $responses->last();
         $this->assertEquals('found', $result);
@@ -224,7 +224,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $responses = $this->events->trigger('foo.bar', $this, array(), function ($result) {
             return ($result === 'found');
         });
-        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertTrue($responses->stopped());
         $this->assertEquals('found', $responses->last());
     }
@@ -238,7 +238,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $responses = $this->events->trigger('foo.bar', $this, array(), function ($result) {
             return ($result === 'never found');
         });
-        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertFalse($responses->stopped());
         $this->assertEquals('zero', $responses->last());
     }
@@ -375,7 +375,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->events->attach('foo.bar', function ($e) { return 'found'; }, 2);
         $this->events->attach('foo.bar', function ($e) { return 'zero'; }, 1);
         $responses = $this->events->trigger('foo.bar', $this, array());
-        $this->assertTrue($responses instanceof ResponseCollection);
+        $this->assertInstanceOf('Zend\EventManager\ResponseCollection', $responses);
         $this->assertTrue($responses->stopped());
         $this->assertEquals('nada', $responses->last());
         $this->assertTrue($responses->contains('bogus'));
@@ -629,7 +629,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
                 return true;
             }
         );
-        $this->assertTrue($callbackHandler instanceof CallbackHandler);
+        $this->assertInstanceOf('Zend\Stdlib\CallbackHandler', $callbackHandler);
     }
 
     public function testDoesNotCreateStaticInstanceIfNonePresent()

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -60,7 +60,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($events, var_export($events, 1));
         $listener = $this->events->attach('test', array($this, __METHOD__));
         $events = $this->events->getEvents();
-        $this->assertFalse(empty($events));
+        $this->assertNotEmpty($events);
         $this->assertContains('test', $events);
     }
 

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -57,7 +57,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
     public function testAttachShouldAddEventIfItDoesNotExist()
     {
         $events = $this->events->getEvents();
-        $this->assertTrue(empty($events), var_export($events, 1));
+        $this->assertEmpty($events, var_export($events, 1));
         $listener = $this->events->attach('test', array($this, __METHOD__));
         $events = $this->events->getEvents();
         $this->assertFalse(empty($events));

--- a/tests/ZendTest/EventManager/FilterChainTest.php
+++ b/tests/ZendTest/EventManager/FilterChainTest.php
@@ -33,7 +33,7 @@ class FilterChainTest extends \PHPUnit_Framework_TestCase
     public function testSubscribeShouldReturnCallbackHandler()
     {
         $handle = $this->filterchain->attach(array( $this, __METHOD__ ));
-        $this->assertTrue($handle instanceof CallbackHandler);
+        $this->assertInstanceOf('Zend\Stdlib\CallbackHandler', $handle);
     }
 
     public function testSubscribeShouldAddCallbackHandlerToFilters()

--- a/tests/ZendTest/EventManager/StaticEventManagerTest.php
+++ b/tests/ZendTest/EventManager/StaticEventManagerTest.php
@@ -58,7 +58,7 @@ class StaticEventManagerTest extends TestCase
         $found     = false;
         $listeners = $events->getListeners('foo', 'bar');
         $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
-        $this->assertTrue(0 < count($listeners), 'Empty listeners!');
+        $this->assertNotEmpty($listeners, 'Empty listeners!');
         foreach ($listeners as $listener) {
             if ($expected === $listener->getCallback()) {
                 $found = true;
@@ -79,7 +79,7 @@ class StaticEventManagerTest extends TestCase
             $found     = false;
             $listeners = $events->getListeners('bar', $event);
             $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
-            $this->assertTrue(0 < count($listeners), 'Empty listeners!');
+            $this->assertNotEmpty($listeners, 'Empty listeners!');
             foreach ($listeners as $listener) {
                 if ($expected === $listener->getCallback()) {
                     $found = true;
@@ -101,7 +101,7 @@ class StaticEventManagerTest extends TestCase
             $found     = false;
             $listeners = $events->getListeners($id, 'bar');
             $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
-            $this->assertTrue(0 < count($listeners), 'Empty listeners!');
+            $this->assertNotEmpty($listeners, 'Empty listeners!');
             foreach ($listeners as $listener) {
                 if ($expected === $listener->getCallback()) {
                     $found = true;
@@ -124,7 +124,7 @@ class StaticEventManagerTest extends TestCase
                 $found     = false;
                 $listeners = $events->getListeners($resource, $event);
                 $this->assertInstanceOf('Zend\Stdlib\PriorityQueue', $listeners);
-                $this->assertTrue(0 < count($listeners), 'Empty listeners!');
+                $this->assertNotEmpty($listeners, 'Empty listeners!');
                 foreach ($listeners as $listener) {
                     if ($expected === $listener->getCallback()) {
                         $found = true;

--- a/tests/ZendTest/Feed/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/tests/ZendTest/Feed/PubSubHubbub/Subscriber/CallbackTest.php
@@ -246,7 +246,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     {
         unset($this->_get['hub_mode']);
         $this->_callback->handle($this->_get);
-        $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 404);
+        $this->assertEquals(404, $this->_callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToValidConfirmationWith200Response()
@@ -281,7 +281,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $this->_callback->handle($this->_get);
-        $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 200);
+        $this->assertEquals(200, $this->_callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToValidConfirmationWithBodyContainingHubChallenge()
@@ -323,7 +323,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->_callback->handle($this->_get);
-        $this->assertTrue($this->_callback->getHttpResponse()->getContent() == 'abc');
+        $this->assertEquals('abc', $this->_callback->getHttpResponse()->getContent());
     }
 
     public function testRespondsToValidFeedUpdateRequestWith200Response()
@@ -356,7 +356,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(1));
 
         $this->_callback->handle(array());
-        $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 200);
+        $this->assertEquals(200, $this->_callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToInvalidFeedUpdateNotPostWith404Response()
@@ -368,7 +368,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $GLOBALS['HTTP_RAW_POST_DATA'] = $feedXml;
 
         $this->_callback->handle(array());
-        $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 404);
+        $this->assertEquals(404, $this->_callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToInvalidFeedUpdateWrongMimeWith404Response()
@@ -379,7 +379,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $feedXml                       = file_get_contents(__DIR__ . '/_files/atom10.xml');
         $GLOBALS['HTTP_RAW_POST_DATA'] = $feedXml;
         $this->_callback->handle(array());
-        $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 404);
+        $this->assertEquals(404, $this->_callback->getHttpResponse()->getStatusCode());
     }
 
     /**
@@ -420,7 +420,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(1));
 
         $this->_callback->handle(array());
-        $this->assertTrue($this->_callback->getHttpResponse()->getStatusCode() == 200);
+        $this->assertEquals(200, $this->_callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToValidFeedUpdateWithXHubOnBehalfOfHeader()
@@ -455,7 +455,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(1));
 
         $this->_callback->handle(array());
-        $this->assertTrue($this->_callback->getHttpResponse()->getHeader('X-Hub-On-Behalf-Of') == 1);
+        $this->assertEquals(1, $this->_callback->getHttpResponse()->getHeader('X-Hub-On-Behalf-Of'));
     }
 
     protected function _getCleanMock($className)

--- a/tests/ZendTest/Feed/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/tests/ZendTest/Feed/PubSubHubbub/Subscriber/CallbackTest.php
@@ -74,12 +74,12 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
     public function testCanSetHttpResponseObject()
     {
         $this->_callback->setHttpResponse(new HttpResponse);
-        $this->assertTrue($this->_callback->getHttpResponse() instanceof HttpResponse);
+        $this->assertInstanceOf('Zend\Feed\PubSubHubbub\HttpResponse', $this->_callback->getHttpResponse());
     }
 
     public function testCanUsesDefaultHttpResponseObject()
     {
-        $this->assertTrue($this->_callback->getHttpResponse() instanceof HttpResponse);
+        $this->assertInstanceOf('Zend\Feed\PubSubHubbub\HttpResponse', $this->_callback->getHttpResponse());
     }
 
     public function testThrowsExceptionOnInvalidHttpResponseObjectSet()

--- a/tests/ZendTest/Feed/Reader/Entry/AtomStandaloneEntryTest.php
+++ b/tests/ZendTest/Feed/Reader/Entry/AtomStandaloneEntryTest.php
@@ -65,7 +65,7 @@ class AtomStandaloneEntryTest extends \PHPUnit_Framework_TestCase
         $object = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath . '/id/atom10.xml')
         );
-        $this->assertTrue($object instanceof Reader\Entry\Atom);
+        $this->assertInstanceOf('Zend\Feed\Reader\Entry\Atom', $object);
     }
 
     /**

--- a/tests/ZendTest/Feed/Reader/Entry/CommonTest.php
+++ b/tests/ZendTest/Feed/Reader/Entry/CommonTest.php
@@ -35,7 +35,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
         $entry = $feed->current();
-        $this->assertTrue($entry->getDomDocument() instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $entry->getDomDocument());
     }
 
     public function testGetsDomXpathObject()
@@ -44,7 +44,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
         $entry = $feed->current();
-        $this->assertTrue($entry->getXpath() instanceof \DOMXPath);
+        $this->assertInstanceOf('DOMXPath', $entry->getXpath());
     }
 
     public function testGetsXpathPrefixString()
@@ -62,7 +62,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
         $entry = $feed->current();
-        $this->assertTrue($entry->getElement() instanceof \DOMElement);
+        $this->assertInstanceOf('DOMElement', $entry->getElement());
     }
 
     public function testSaveXmlOutputsXmlStringForEntry()
@@ -82,7 +82,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
         $entry = $feed->current();
-        $this->assertTrue($entry->getExtension('Atom') instanceof Extension\Atom\Entry);
+        $this->assertInstanceOf('Zend\Feed\Reader\Extension\Atom\Entry', $entry->getExtension('Atom'));
     }
 
     public function testReturnsNullIfExtensionDoesNotExist()

--- a/tests/ZendTest/Feed/Reader/Entry/RssTest.php
+++ b/tests/ZendTest/Feed/Reader/Entry/RssTest.php
@@ -1861,7 +1861,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
         );
         $entry = $feed->current();
 
-        $this->assertTrue($edate == $entry->getDateModified());
+        $this->assertEquals($edate, $entry->getDateModified());
     }
 
     public function dateModifiedProvider()

--- a/tests/ZendTest/Feed/Reader/Feed/AtomSourceTest.php
+++ b/tests/ZendTest/Feed/Reader/Feed/AtomSourceTest.php
@@ -67,7 +67,7 @@ class AtomSourceTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/title/atom10.xml')
         );
         $source = $feed->current()->getSource();
-        $this->assertTrue($source instanceof Reader\Feed\Atom\Source);
+        $this->assertInstanceOf('Zend\Feed\Reader\Feed\Atom\Source', $source);
     }
 
     /**

--- a/tests/ZendTest/Feed/Reader/Feed/CommonTest.php
+++ b/tests/ZendTest/Feed/Reader/Feed/CommonTest.php
@@ -33,7 +33,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
-        $this->assertTrue($feed->getDomDocument() instanceof \DOMDocument);
+        $this->assertInstanceOf('DOMDocument', $feed->getDomDocument());
     }
 
     public function testGetsDomXpathObject()
@@ -41,7 +41,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
-        $this->assertTrue($feed->getXpath() instanceof \DOMXPath);
+        $this->assertInstanceOf('DOMXPath', $feed->getXpath());
     }
 
     public function testGetsXpathPrefixString()
@@ -57,7 +57,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
-        $this->assertTrue($feed->getElement() instanceof \DOMElement);
+        $this->assertInstanceOf('DOMElement', $feed->getElement());
     }
 
     public function testSaveXmlOutputsXmlStringForFeed()
@@ -75,7 +75,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
-        $this->assertTrue($feed->getExtension('Atom') instanceof Reader\Extension\Atom\Feed);
+        $this->assertInstanceOf('Zend\Feed\Reader\Extension\Atom\Feed', $feed->getExtension('Atom'));
     }
 
     public function testReturnsNullIfExtensionDoesNotExist()

--- a/tests/ZendTest/Feed/Reader/Feed/CommonTest.php
+++ b/tests/ZendTest/Feed/Reader/Feed/CommonTest.php
@@ -49,7 +49,7 @@ class CommonTest extends \PHPUnit_Framework_TestCase
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath.'/atom.xml')
         );
-        $this->assertTrue($feed->getXpathPrefix() == '/atom:feed');
+        $this->assertEquals('/atom:feed', $feed->getXpathPrefix());
     }
 
     public function testGetsDomElementObject()

--- a/tests/ZendTest/Feed/Reader/Feed/RssTest.php
+++ b/tests/ZendTest/Feed/Reader/Feed/RssTest.php
@@ -2075,7 +2075,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath.'/lastbuilddate/plain/rss20.xml')
         );
         $edate = DateTime::createFromFormat(DateTime::ISO8601, '2009-03-07T08:03:50Z');
-        $this->assertTrue($edate == $feed->getLastBuildDate());
+        $this->assertEquals($edate, $feed->getLastBuildDate());
     }
 
     public function testGetsLastBuildDateFromRss20_None()
@@ -2096,7 +2096,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
             file_get_contents($this->feedSamplePath . $path)
         );
 
-        $this->assertTrue($edate == $feed->getDateModified());
+        $this->assertEquals($edate, $feed->getDateModified());
     }
 
     public function dateModifiedProvider()

--- a/tests/ZendTest/Feed/Reader/ReaderTest.php
+++ b/tests/ZendTest/Feed/Reader/ReaderTest.php
@@ -178,7 +178,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('testGetsFeedLinksAsValueObject() requires a network connection');
         }
         $links = Reader\Reader::findFeedLinks('http://www.planet-php.net');
-        $this->assertTrue($links instanceof Reader\FeedSet);
+        $this->assertInstanceOf('Zend\Feed\Reader\FeedSet', $links);
         $this->assertEquals(array(
             'rel' => 'alternate', 'type' => 'application/rss+xml', 'href' => 'http://www.planet-php.org/rss/'
         ), (array) $links->getIterator()->current());
@@ -191,7 +191,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         }
         $links = Reader\Reader::findFeedLinks('http://www.planet-php.net');
         $link = $links->getIterator()->current();
-        $this->assertTrue($link['feed'] instanceof Reader\Feed\Rss);
+        $this->assertInstanceOf('Zend\Feed\Reader\Feed\Rss', $link['feed']);
     }
 
     public function testZeroCountFeedSetReturnedFromEmptyList()

--- a/tests/ZendTest/Feed/Writer/DeletedTest.php
+++ b/tests/ZendTest/Feed/Writer/DeletedTest.php
@@ -38,7 +38,7 @@ class DeletedTest extends \PHPUnit_Framework_TestCase
     public function testGetReferenceReturnsNullIfNotSet()
     {
         $entry = new Writer\Deleted;
-        $this->assertTrue(null === $entry->getReference());
+        $this->assertNull($entry->getReference());
     }
 
     public function testSetWhenDefaultsToCurrentTime()
@@ -100,7 +100,7 @@ class DeletedTest extends \PHPUnit_Framework_TestCase
     public function testGetWhenReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Deleted;
-        $this->assertTrue(null === $entry->getWhen());
+        $this->assertNull($entry->getWhen());
     }
 
     public function testAddsByNameFromArray()

--- a/tests/ZendTest/Feed/Writer/DeletedTest.php
+++ b/tests/ZendTest/Feed/Writer/DeletedTest.php
@@ -46,7 +46,7 @@ class DeletedTest extends \PHPUnit_Framework_TestCase
         $entry = new Writer\Deleted;
         $entry->setWhen();
         $dateNow = new DateTime();
-        $this->assertTrue($dateNow >= $entry->getWhen());
+        $this->assertLessThanOrEqual($dateNow, $entry->getWhen());
     }
 
     public function testSetWhenUsesGivenUnixTimestamp()

--- a/tests/ZendTest/Feed/Writer/EntryTest.php
+++ b/tests/ZendTest/Feed/Writer/EntryTest.php
@@ -193,7 +193,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $entry = new Writer\Entry;
         $entry->setDateCreated();
         $dateNow = new DateTime();
-        $this->assertTrue($dateNow >= $entry->getDateCreated());
+        $this->assertLessThanOrEqual($dateNow, $entry->getDateCreated());
     }
 
     public function testSetDateCreatedUsesGivenUnixTimestamp()
@@ -239,7 +239,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
         $entry = new Writer\Entry;
         $entry->setDateModified();
         $dateNow = new DateTime();
-        $this->assertTrue($dateNow >= $entry->getDateModified());
+        $this->assertLessThanOrEqual($dateNow, $entry->getDateModified());
     }
 
     public function testSetDateModifiedUsesGivenUnixTimestamp()

--- a/tests/ZendTest/Feed/Writer/EntryTest.php
+++ b/tests/ZendTest/Feed/Writer/EntryTest.php
@@ -303,25 +303,25 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetDateCreatedReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getDateCreated());
+        $this->assertNull($entry->getDateCreated());
     }
 
     public function testGetDateModifiedReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getDateModified());
+        $this->assertNull($entry->getDateModified());
     }
 
     public function testGetCopyrightReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getCopyright());
+        $this->assertNull($entry->getCopyright());
     }
 
     public function testGetContentReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getContent());
+        $this->assertNull($entry->getContent());
     }
 
     public function testSetsDescription()
@@ -344,7 +344,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetDescriptionReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getDescription());
+        $this->assertNull($entry->getDescription());
     }
 
     public function testSetsId()
@@ -367,7 +367,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetIdReturnsNullIfNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getId());
+        $this->assertNull($entry->getId());
     }
 
     public function testSetsLink()
@@ -400,13 +400,13 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetLinkReturnsNullIfNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getLink());
+        $this->assertNull($entry->getLink());
     }
 
     public function testGetLinksReturnsNullIfNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getLinks());
+        $this->assertNull($entry->getLinks());
     }
 
     public function testSetsCommentLink()
@@ -439,7 +439,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetCommentLinkReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getCommentLink());
+        $this->assertNull($entry->getCommentLink());
     }
 
     public function testSetsCommentFeedLink()
@@ -489,7 +489,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetCommentFeedLinkReturnsNullIfNoneSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getCommentFeedLinks());
+        $this->assertNull($entry->getCommentFeedLinks());
     }
 
     public function testSetsTitle()
@@ -512,7 +512,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetTitleReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getTitle());
+        $this->assertNull($entry->getTitle());
     }
 
     public function testSetsCommentCount()
@@ -597,7 +597,7 @@ class EntryTest extends \PHPUnit_Framework_TestCase
     public function testGetCommentCountReturnsNullIfDateNotSet()
     {
         $entry = new Writer\Entry;
-        $this->assertTrue(null === $entry->getCommentCount());
+        $this->assertNull($entry->getCommentCount());
     }
 
     /**

--- a/tests/ZendTest/Feed/Writer/FeedTest.php
+++ b/tests/ZendTest/Feed/Writer/FeedTest.php
@@ -130,7 +130,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $writer->setDateCreated();
         $dateNow = new DateTime();
-        $this->assertTrue($dateNow >= $writer->getDateCreated());
+        $this->assertLessThanOrEqual($dateNow, $writer->getDateCreated());
     }
 
     public function testSetDateCreatedUsesGivenUnixTimestamp()
@@ -176,7 +176,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $writer->setDateModified();
         $dateNow = new DateTime();
-        $this->assertTrue($dateNow >= $writer->getDateModified());
+        $this->assertLessThanOrEqual($dateNow, $writer->getDateModified());
     }
 
     public function testSetDateModifiedUsesGivenUnixTimestamp()
@@ -254,7 +254,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
         $writer = new Writer\Feed;
         $writer->setLastBuildDate();
         $dateNow = new DateTime();
-        $this->assertTrue($dateNow >= $writer->getLastBuildDate());
+        $this->assertLessThanOrEqual($dateNow, $writer->getLastBuildDate());
     }
 
     public function testSetLastBuildDateUsesGivenUnixTimestamp()

--- a/tests/ZendTest/Feed/Writer/FeedTest.php
+++ b/tests/ZendTest/Feed/Writer/FeedTest.php
@@ -240,13 +240,13 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetDateCreatedReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getDateCreated());
+        $this->assertNull($writer->getDateCreated());
     }
 
     public function testGetDateModifiedReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getDateModified());
+        $this->assertNull($writer->getDateModified());
     }
 
     public function testSetLastBuildDateDefaultsToCurrentTime()
@@ -308,13 +308,13 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetLastBuildDateReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getLastBuildDate());
+        $this->assertNull($writer->getLastBuildDate());
     }
 
     public function testGetCopyrightReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getCopyright());
+        $this->assertNull($writer->getCopyright());
     }
 
     public function testSetsDescription()
@@ -337,7 +337,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetDescriptionReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getDescription());
+        $this->assertNull($writer->getDescription());
     }
 
     public function testSetsId()
@@ -392,7 +392,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetIdReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getId());
+        $this->assertNull($writer->getId());
     }
 
     public function testSetsLanguage()
@@ -415,7 +415,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetLanguageReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getLanguage());
+        $this->assertNull($writer->getLanguage());
     }
 
     public function testSetsLink()
@@ -448,7 +448,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetLinkReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getLink());
+        $this->assertNull($writer->getLink());
     }
 
     public function testSetsEncoding()
@@ -494,7 +494,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetTitleReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getTitle());
+        $this->assertNull($writer->getTitle());
     }
 
     public function testSetsGeneratorName()
@@ -630,7 +630,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetGeneratorReturnsNullIfDateNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getGenerator());
+        $this->assertNull($writer->getGenerator());
     }
 
     public function testSetsFeedLink()
@@ -663,7 +663,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetFeedLinksReturnsNullIfNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getFeedLinks());
+        $this->assertNull($writer->getFeedLinks());
     }
 
     public function testSetsBaseUrl()
@@ -686,7 +686,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetBaseUrlReturnsNullIfNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getBaseUrl());
+        $this->assertNull($writer->getBaseUrl());
     }
 
     public function testAddsHubUrl()
@@ -716,7 +716,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testAddingHubUrlReturnsNullIfNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getHubs());
+        $this->assertNull($writer->getHubs());
     }
 
     public function testCreatesNewEntryDataContainer()
@@ -874,7 +874,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     public function testGetCategoriesReturnsNullIfNotSet()
     {
         $writer = new Writer\Feed;
-        $this->assertTrue(null === $writer->getCategories());
+        $this->assertNull($writer->getCategories());
     }
 
     public function testAddsAndOrdersEntriesByDateIfRequested()

--- a/tests/ZendTest/Feed/Writer/FeedTest.php
+++ b/tests/ZendTest/Feed/Writer/FeedTest.php
@@ -723,7 +723,7 @@ class FeedTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $entry  = $writer->createEntry();
-        $this->assertTrue($entry instanceof Writer\Entry);
+        $this->assertInstanceOf('Zend\Feed\Writer\Entry', $entry);
     }
 
     public function testAddsCategory()

--- a/tests/ZendTest/Feed/Writer/Renderer/Feed/AtomTest.php
+++ b/tests/ZendTest/Feed/Writer/Renderer/Feed/AtomTest.php
@@ -45,7 +45,7 @@ class AtomTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $feed   = new Renderer\Feed\Atom($writer);
-        $this->assertTrue($feed->getDataContainer() instanceof Writer\Feed);
+        $this->assertInstanceOf('Zend\Feed\Writer\Feed', $feed->getDataContainer());
     }
 
     public function testBuildMethodRunsMinimalWriterContainerProperlyBeforeICheckAtomCompliance()

--- a/tests/ZendTest/Feed/Writer/Renderer/Feed/RssTest.php
+++ b/tests/ZendTest/Feed/Writer/Renderer/Feed/RssTest.php
@@ -42,7 +42,7 @@ class RssTest extends \PHPUnit_Framework_TestCase
     {
         $writer = new Writer\Feed;
         $feed   = new Renderer\Feed\Rss($writer);
-        $this->assertTrue($feed->getDataContainer() instanceof Writer\Feed);
+        $this->assertInstanceOf('Zend\Feed\Writer\Feed', $feed->getDataContainer());
     }
 
     public function testBuildMethodRunsMinimalWriterContainerProperlyBeforeICheckRssCompliance()

--- a/tests/ZendTest/File/ClassFileLocatorTest.php
+++ b/tests/ZendTest/File/ClassFileLocatorTest.php
@@ -83,7 +83,7 @@ class ClassFileLocatorTest extends \PHPUnit_Framework_TestCase
         $locator = new ClassFileLocator(__DIR__);
         foreach ($locator as $file) {
             $namespaces = $file->getNamespaces();
-            $this->assertTrue(count($namespaces) > 0);
+            $this->assertNotEmpty($namespaces);
         }
     }
 

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -514,7 +514,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testEmptyTempDirectoryDetection()
     {
         $this->adapter->tmpDir = "";
-        $this->assertTrue(empty($this->adapter->tmpDir), "Empty temporary directory");
+        $this->assertEmpty($this->adapter->tmpDir, "Empty temporary directory");
     }
 
     public function testTempDirectoryDetection()

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -90,7 +90,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         );
         $this->adapter->addValidators($validators);
         $test = $this->adapter->getValidators();
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertEquals(4, count($test), var_export($test, 1));
         $count = array_shift($test);
         $this->assertTrue($count instanceof FileValidator\Count);
@@ -148,7 +148,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = $this->adapter->getValidators();
-        $this->assertTrue(is_array($validators));
+        $this->assertInternalType('array', $validators);
         $this->assertEquals(4, count($validators));
         foreach ($validators as $validator) {
             $this->assertTrue($validator instanceof Validator\ValidatorInterface);
@@ -187,7 +187,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->adapter->clearValidators();
         $validators = $this->adapter->getValidators();
-        $this->assertTrue(is_array($validators));
+        $this->assertInternalType('array', $validators);
         $this->assertEquals(0, count($validators));
     }
 
@@ -216,7 +216,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testErrorMessagesShouldBeEmptyByDefault()
     {
         $messages = $this->adapter->getMessages();
-        $this->assertTrue(is_array($messages));
+        $this->assertInternalType('array', $messages);
         $this->assertEquals(0, count($messages));
     }
 
@@ -224,14 +224,14 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testValidationShouldReturnFalseForInvalidTransfer();
         $messages = $this->adapter->getMessages();
-        $this->assertTrue(is_array($messages));
+        $this->assertInternalType('array', $messages);
         $this->assertFalse(empty($messages));
     }
 
     public function testErrorCodesShouldBeNullByDefault()
     {
         $errors = $this->adapter->getErrors();
-        $this->assertTrue(is_array($errors));
+        $this->assertInternalType('array', $errors);
         $this->assertEquals(0, count($errors));
     }
 
@@ -239,7 +239,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testValidationShouldReturnFalseForInvalidTransfer();
         $errors = $this->adapter->getErrors();
-        $this->assertTrue(is_array($errors));
+        $this->assertInternalType('array', $errors);
         $this->assertFalse(empty($errors));
     }
 
@@ -283,7 +283,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         );
         $this->adapter->addFilters($filters);
         $test = $this->adapter->getFilters();
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertEquals(3, count($test), var_export($test, 1));
         $count = array_shift($test);
         $this->assertTrue($count instanceof Word\SeparatorToCamelCase);
@@ -338,7 +338,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testAdapterShouldAllowAddingMultipleFiltersAtOnceUsingBothInstancesAndPluginLoader();
         $filters = $this->adapter->getFilters();
-        $this->assertTrue(is_array($filters));
+        $this->assertInternalType('array', $filters);
         $this->assertEquals(3, count($filters));
         foreach ($filters as $filter) {
             $this->assertTrue($filter instanceof Filter\FilterInterface);
@@ -377,7 +377,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->testAdapterShouldAllowAddingMultipleFiltersAtOnceUsingBothInstancesAndPluginLoader();
         $this->adapter->clearFilters();
         $filters = $this->adapter->getFilters();
-        $this->assertTrue(is_array($filters));
+        $this->assertInternalType('array', $filters);
         $this->assertEquals(0, count($filters));
     }
 
@@ -386,7 +386,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $directory = __DIR__;
         $this->adapter->setDestination($directory);
         $destinations = $this->adapter->getDestination();
-        $this->assertTrue(is_array($destinations));
+        $this->assertInternalType('array', $destinations);
         foreach ($destinations as $file => $destination) {
             $this->assertEquals($directory, $destination);
         }
@@ -402,7 +402,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->adapter->setDestination(__DIR__);
         $destinations = $this->adapter->getDestination(array('bar', 'baz'));
-        $this->assertTrue(is_array($destinations));
+        $this->assertInternalType('array', $destinations);
         $directory = __DIR__;
         foreach ($destinations as $file => $destination) {
             $this->assertTrue(in_array($file, array('bar', 'baz')));
@@ -484,7 +484,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
               . DIRECTORY_SEPARATOR . '_files';
         $this->adapter->setDestination($path);
         $files = $this->adapter->getFileName();
-        $this->assertTrue(is_array($files));
+        $this->assertInternalType('array', $files);
         $this->assertEquals($path . DIRECTORY_SEPARATOR . 'bar.png', $files['bar']);
     }
 
@@ -494,7 +494,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
               . DIRECTORY_SEPARATOR . '_files';
         $this->adapter->setDestination($path);
         $files = $this->adapter->getFileName(null, false);
-        $this->assertTrue(is_array($files));
+        $this->assertInternalType('array', $files);
         $this->assertEquals('bar.png', $files['bar']);
     }
 
@@ -592,7 +592,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($directory, $this->adapter->getDestination('nonexisting'));
 
         $this->setExpectedException('Zend\File\Transfer\Exception\InvalidArgumentException', 'not find');
-        $this->assertTrue(is_string($this->adapter->getDestination('reallynonexisting')));
+        $this->assertInternalType('string', $this->adapter->getDestination('reallynonexisting'));
     }
 
     /**

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -68,7 +68,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->adapter->addValidator('Count', false, array('min' => 1, 'max' => 1));
         $test = $this->adapter->getValidator('Count');
-        $this->assertTrue($test instanceof FileValidator\Count);
+        $this->assertInstanceOf('Zend\Validator\File\Count', $test);
     }
 
     public function testAdapterhShouldRaiseExceptionWhenAddingInvalidValidatorType()
@@ -93,13 +93,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $test);
         $this->assertEquals(4, count($test), var_export($test, 1));
         $count = array_shift($test);
-        $this->assertTrue($count instanceof FileValidator\Count);
+        $this->assertInstanceOf('Zend\Validator\File\Count', $count);
         $exists = array_shift($test);
-        $this->assertTrue($exists instanceof FileValidator\Exists);
+        $this->assertInstanceOf('Zend\Validator\File\Exists', $exists);
         $size = array_shift($test);
-        $this->assertTrue($size instanceof FileValidator\Upload);
+        $this->assertInstanceOf('Zend\Validator\File\Upload', $size);
         $ext = array_shift($test);
-        $this->assertTrue($ext instanceof FileValidator\Extension);
+        $this->assertInstanceOf('Zend\Validator\File\Extension', $ext);
         $orig = array_pop($validators);
         $this->assertSame($orig, $ext);
     }
@@ -115,7 +115,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $validators = $this->adapter->getValidators('foo');
         $this->assertEquals(1, count($validators));
         $validator = array_shift($validators);
-        $this->assertTrue($validator instanceof Validator\Between);
+        $this->assertInstanceOf('Zend\Validator\Between', $validator);
     }
 
     public function testCallingSetValidatorsOnAdapterShouldOverwriteExistingValidators()
@@ -134,14 +134,14 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $ext = $this->adapter->getValidator('Zend\Validator\File\Extension');
-        $this->assertTrue($ext instanceof FileValidator\Extension);
+        $this->assertInstanceOf('Zend\Validator\File\Extension', $ext);
     }
 
     public function testAdapterShouldAllowRetrievingValidatorInstancesByPluginName()
     {
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $count = $this->adapter->getValidator('Count');
-        $this->assertTrue($count instanceof FileValidator\Count);
+        $this->assertInstanceOf('Zend\Validator\File\Count', $count);
     }
 
     public function testAdapterShouldAllowRetrievingAllValidatorsAtOnce()
@@ -151,7 +151,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $validators);
         $this->assertEquals(4, count($validators));
         foreach ($validators as $validator) {
-            $this->assertTrue($validator instanceof Validator\ValidatorInterface);
+            $this->assertInstanceOf('Zend\Validator\ValidatorInterface', $validator);
         }
     }
 
@@ -261,7 +261,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->adapter->addFilter('StringTrim');
         $test = $this->adapter->getFilter('StringTrim');
-        $this->assertTrue($test instanceof Filter\StringTrim);
+        $this->assertInstanceOf('Zend\Filter\StringTrim', $test);
     }
 
 
@@ -286,9 +286,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $test);
         $this->assertEquals(3, count($test), var_export($test, 1));
         $count = array_shift($test);
-        $this->assertTrue($count instanceof Word\SeparatorToCamelCase);
+        $this->assertInstanceOf('Zend\Filter\Word\SeparatorToCamelCase', $count);
         $size = array_shift($test);
-        $this->assertTrue($size instanceof Filter\Boolean);
+        $this->assertInstanceOf('Zend\Filter\Boolean', $size);
         $ext  = array_shift($test);
         $orig = array_pop($filters);
         $this->assertSame($orig, $ext);
@@ -305,7 +305,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $filters = $this->adapter->getFilters('foo');
         $this->assertEquals(1, count($filters));
         $filter = array_shift($filters);
-        $this->assertTrue($filter instanceof Filter\Boolean);
+        $this->assertInstanceOf('Zend\Filter\Boolean', $filter);
     }
 
     public function testCallingSetFiltersOnAdapterShouldOverwriteExistingFilters()
@@ -324,14 +324,14 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->testAdapterShouldAllowAddingMultipleFiltersAtOnceUsingBothInstancesAndPluginLoader();
         $ext = $this->adapter->getFilter('Zend\Filter\BaseName');
-        $this->assertTrue($ext instanceof Filter\BaseName);
+        $this->assertInstanceOf('Zend\Filter\BaseName', $ext);
     }
 
     public function testAdapterShouldAllowRetrievingFilterInstancesByPluginName()
     {
         $this->testAdapterShouldAllowAddingMultipleFiltersAtOnceUsingBothInstancesAndPluginLoader();
         $count = $this->adapter->getFilter('Boolean');
-        $this->assertTrue($count instanceof Filter\Boolean);
+        $this->assertInstanceOf('Zend\Filter\Boolean', $count);
     }
 
     public function testAdapterShouldAllowRetrievingAllFiltersAtOnce()
@@ -341,7 +341,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $filters);
         $this->assertEquals(3, count($filters));
         foreach ($filters as $filter) {
-            $this->assertTrue($filter instanceof Filter\FilterInterface);
+            $this->assertInstanceOf('Zend\Filter\FilterInterface', $filter);
         }
     }
 
@@ -628,16 +628,16 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $test = $this->adapter->getValidators('foo');
         $this->assertEquals(2, count($test));
         $mimeType = array_shift($test);
-        $this->assertTrue($mimeType instanceof FileValidator\MimeType);
+        $this->assertInstanceOf('Zend\Validator\File\MimeType', $mimeType);
         $filesSize = array_shift($test);
-        $this->assertTrue($filesSize instanceof FileValidator\FilesSize);
+        $this->assertInstanceOf('Zend\Validator\File\FilesSize', $filesSize);
 
         $test = $this->adapter->getValidators('bar');
         $this->assertEquals(2, count($test));
         $filesSize = array_shift($test);
-        $this->assertTrue($filesSize instanceof FileValidator\Count);
+        $this->assertInstanceOf('Zend\Validator\File\Count', $filesSize);
         $mimeType = array_shift($test);
-        $this->assertTrue($mimeType instanceof FileValidator\MimeType);
+        $this->assertInstanceOf('Zend\Validator\File\MimeType', $mimeType);
 
         $test = $this->adapter->getValidators('baz');
         $this->assertEquals(0, count($test));

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -520,7 +520,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testTempDirectoryDetection()
     {
         $this->adapter->getTmpDir();
-        $this->assertTrue(!empty($this->adapter->tmpDir), "Temporary directory filled");
+        $this->assertNotEmpty($this->adapter->tmpDir, "Temporary directory filled");
     }
 
     public function testTemporaryDirectoryAccessDetection()

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -405,7 +405,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $destinations);
         $directory = __DIR__;
         foreach ($destinations as $file => $destination) {
-            $this->assertTrue(in_array($file, array('bar', 'baz')));
+            $this->assertContains($file, array('bar', 'baz'));
             $this->assertEquals($directory, $destination);
         }
     }

--- a/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/AbstractTest.php
@@ -225,7 +225,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->testValidationShouldReturnFalseForInvalidTransfer();
         $messages = $this->adapter->getMessages();
         $this->assertInternalType('array', $messages);
-        $this->assertFalse(empty($messages));
+        $this->assertNotEmpty($messages);
     }
 
     public function testErrorCodesShouldBeNullByDefault()
@@ -240,7 +240,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->testValidationShouldReturnFalseForInvalidTransfer();
         $errors = $this->adapter->getErrors();
         $this->assertInternalType('array', $errors);
-        $this->assertFalse(empty($errors));
+        $this->assertNotEmpty($errors);
     }
 
     public function testAdapterShouldLazyLoadFilterPluginManager()

--- a/tests/ZendTest/File/Transfer/Adapter/HttpTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/HttpTest.php
@@ -231,22 +231,22 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $adapter = new AdapterProgressBar\Console();
         $status = array('progress' => $adapter, 'session' => 'upload');
         $status = HttpTestMockAdapter::getProgress($status);
-        $this->assertTrue(array_key_exists('total', $status));
-        $this->assertTrue(array_key_exists('current', $status));
-        $this->assertTrue(array_key_exists('rate', $status));
-        $this->assertTrue(array_key_exists('id', $status));
-        $this->assertTrue(array_key_exists('message', $status));
-        $this->assertTrue(array_key_exists('progress', $status));
+        $this->assertArrayHasKey('total', $status);
+        $this->assertArrayHasKey('current', $status);
+        $this->assertArrayHasKey('rate', $status);
+        $this->assertArrayHasKey('id', $status);
+        $this->assertArrayHasKey('message', $status);
+        $this->assertArrayHasKey('progress', $status);
         $this->assertTrue($status['progress'] instanceof ProgressBar\ProgressBar);
 
         $this->adapter->switchApcToUP();
         $status = HttpTestMockAdapter::getProgress($status);
-        $this->assertTrue(array_key_exists('total', $status));
-        $this->assertTrue(array_key_exists('current', $status));
-        $this->assertTrue(array_key_exists('rate', $status));
-        $this->assertTrue(array_key_exists('id', $status));
-        $this->assertTrue(array_key_exists('message', $status));
-        $this->assertTrue(array_key_exists('progress', $status));
+        $this->assertArrayHasKey('total', $status);
+        $this->assertArrayHasKey('current', $status);
+        $this->assertArrayHasKey('rate', $status);
+        $this->assertArrayHasKey('id', $status);
+        $this->assertArrayHasKey('message', $status);
+        $this->assertArrayHasKey('progress', $status);
         $this->assertTrue($status['progress'] instanceof ProgressBar\ProgressBar);
     }
 

--- a/tests/ZendTest/File/Transfer/Adapter/HttpTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/HttpTest.php
@@ -64,7 +64,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         );
         $this->adapter->setValidators($validators);
         $test = $this->adapter->getValidator('Upload');
-        $this->assertTrue($test instanceof FileValidator\Upload);
+        $this->assertInstanceOf('Zend\Validator\File\Upload', $test);
     }
 
     public function testSendingFiles()
@@ -237,7 +237,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('id', $status);
         $this->assertArrayHasKey('message', $status);
         $this->assertArrayHasKey('progress', $status);
-        $this->assertTrue($status['progress'] instanceof ProgressBar\ProgressBar);
+        $this->assertInstanceOf('Zend\ProgressBar\ProgressBar', $status['progress']);
 
         $this->adapter->switchApcToUP();
         $status = HttpTestMockAdapter::getProgress($status);
@@ -247,7 +247,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('id', $status);
         $this->assertArrayHasKey('message', $status);
         $this->assertArrayHasKey('progress', $status);
-        $this->assertTrue($status['progress'] instanceof ProgressBar\ProgressBar);
+        $this->assertInstanceOf('Zend\ProgressBar\ProgressBar', $status['progress']);
     }
 
     public function testValidationOfPhpExtendsFormError()

--- a/tests/ZendTest/Filter/Compress/RarTest.php
+++ b/tests/ZendTest/Filter/Compress/RarTest.php
@@ -265,11 +265,11 @@ class RarTest extends \PHPUnit_Framework_TestCase
 
         $base = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files'
               . DIRECTORY_SEPARATOR . '_compress' . DIRECTORY_SEPARATOR . 'Compress' . DIRECTORY_SEPARATOR;
-        $this->assertTrue(file_exists($base));
-        $this->assertTrue(file_exists($base . 'zipextracted.txt'));
-        $this->assertTrue(file_exists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt'));
-        $this->assertTrue(file_exists($base . 'First' . DIRECTORY_SEPARATOR .
-                          'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt'));
+        $this->assertFileExists($base);
+        $this->assertFileExists($base . 'zipextracted.txt');
+        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
+        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR .
+                          'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
         $content = file_get_contents(dirname(__DIR__) . '/_files/Compress/zipextracted.txt');
         $this->assertEquals('compress me', $content);
     }

--- a/tests/ZendTest/Filter/Compress/ZipTest.php
+++ b/tests/ZendTest/Filter/Compress/ZipTest.php
@@ -249,11 +249,11 @@ class ZipTest extends \PHPUnit_Framework_TestCase
                             . DIRECTORY_SEPARATOR, $content);
 
         $base = $this->tmp . DIRECTORY_SEPARATOR . '_compress' . DIRECTORY_SEPARATOR . 'Compress' . DIRECTORY_SEPARATOR;
-        $this->assertTrue(file_exists($base));
-        $this->assertTrue(file_exists($base . 'zipextracted.txt'));
-        $this->assertTrue(file_exists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt'));
-        $this->assertTrue(file_exists($base . 'First' . DIRECTORY_SEPARATOR .
-                          'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt'));
+        $this->assertFileExists($base);
+        $this->assertFileExists($base . 'zipextracted.txt');
+        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
+        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR .
+                          'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
         $content = file_get_contents($this->tmp . '/Compress/zipextracted.txt');
         $this->assertEquals('compress me', $content);
     }

--- a/tests/ZendTest/Filter/CompressTest.php
+++ b/tests/ZendTest/Filter/CompressTest.php
@@ -167,7 +167,7 @@ class CompressTest extends \PHPUnit_Framework_TestCase
     {
         $filter = new CompressFilter('bz2');
         $adapter = $filter->getAdapter();
-        $this->assertTrue($adapter instanceof \Zend\Filter\Compress\CompressionAlgorithmInterface);
+        $this->assertInstanceOf('Zend\Filter\Compress\CompressionAlgorithmInterface', $adapter);
         $this->assertEquals('Bz2', $filter->getAdapterName());
     }
 

--- a/tests/ZendTest/Filter/Encrypt/OpensslTest.php
+++ b/tests/ZendTest/Filter/Encrypt/OpensslTest.php
@@ -232,7 +232,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
             'passphrase' => $passphrase,
             'private' => __DIR__ . '/../_files/privatekey_pass.pem'));
         $public = $filter->getPublicKey();
-        $this->assertFalse(empty($public));
+        $this->assertNotEmpty($public);
         $this->assertEquals($passphrase, $filter->getPassphrase());
     }
 

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -128,7 +128,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
     public function testFluentInterface()
     {
         $instance = $this->_filter->setCharSet('UTF-8')->setQuoteStyle(ENT_QUOTES)->setDoubleQuote(false);
-        $this->assertTrue($instance instanceof HtmlEntitiesFilter);
+        $this->assertInstanceOf('Zend\Filter\HtmlEntities', $instance);
     }
 
     /**
@@ -251,7 +251,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
             $result = $this->_filter->filter($string);
             $this->fail('Expected exception from single non-utf-8 character');
         } catch (\Exception $e) {
-            $this->assertTrue($e instanceof Exception\DomainException);
+            $this->assertInstanceOf('Zend\Filter\Exception\DomainException', $e);
         }
     }
 

--- a/tests/ZendTest/Filter/HtmlEntitiesTest.php
+++ b/tests/ZendTest/Filter/HtmlEntitiesTest.php
@@ -209,7 +209,7 @@ class HtmlEntitiesTest extends \PHPUnit_Framework_TestCase
         $result = $this->_filter->filter($string);
         restore_error_handler();
 
-        $this->assertTrue(strlen($result) > 0);
+        $this->assertGreaterThan(0, strlen($result));
     }
 
     /**

--- a/tests/ZendTest/Filter/InflectorTest.php
+++ b/tests/ZendTest/Filter/InflectorTest.php
@@ -44,7 +44,7 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetPluginManagerReturnsFilterManagerByDefault()
     {
         $broker = $this->inflector->getPluginManager();
-        $this->assertTrue($broker instanceof FilterPluginManager);
+        $this->assertInstanceOf('Zend\Filter\FilterPluginManager', $broker);
     }
 
     public function testSetPluginManagerAllowsSettingAlternatePluginManager()
@@ -91,7 +91,7 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
         $rules = $this->inflector->getRules('controller');
         $this->assertEquals(1, count($rules));
         $filter = $rules[0];
-        $this->assertTrue($filter instanceof \Zend\Filter\FilterInterface);
+        $this->assertInstanceOf('Zend\Filter\FilterInterface', $filter);
     }
 
     public function testSetFilterRuleWithFilterObjectCreatesRuleEntryWithFilterObject()
@@ -103,7 +103,7 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
         $rules = $this->inflector->getRules('controller');
         $this->assertEquals(1, count($rules));
         $received = $rules[0];
-        $this->assertTrue($received instanceof \Zend\Filter\FilterInterface);
+        $this->assertInstanceOf('Zend\Filter\FilterInterface', $received);
         $this->assertSame($filter, $received);
     }
 
@@ -118,8 +118,8 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
         $this->inflector->setFilterRule('controller', array('PregReplace', 'Alpha'));
         $rules = $this->inflector->getRules('controller');
         $this->assertEquals(2, count($rules));
-        $this->assertTrue($rules[0] instanceof \Zend\Filter\FilterInterface);
-        $this->assertTrue($rules[1] instanceof \Zend\Filter\FilterInterface);
+        $this->assertInstanceOf('Zend\Filter\FilterInterface', $rules[0]);
+        $this->assertInstanceOf('Zend\Filter\FilterInterface', $rules[1]);
     }
 
     public function testSetStaticRuleCreatesScalarRuleEntry()
@@ -200,7 +200,7 @@ class InflectorTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->inflector->setFilterRule(':controller', array('Alpha', 'StringToLower'));
-        $this->assertTrue($this->inflector->getRule('controller', 1) instanceof \Zend\Filter\StringToLower);
+        $this->assertInstanceOf('Zend\Filter\StringToLower', $this->inflector->getRule('controller', 1));
         $this->assertFalse($this->inflector->getRule('controller', 2));
     }
 

--- a/tests/ZendTest/Filter/PregReplaceTest.php
+++ b/tests/ZendTest/Filter/PregReplaceTest.php
@@ -63,7 +63,7 @@ class PregReplaceTest extends \PHPUnit_Framework_TestCase
     public function testReplacementIsEmptyByDefault()
     {
         $replacement = $this->filter->getReplacement();
-        $this->assertTrue(empty($replacement));
+        $this->assertEmpty($replacement);
     }
 
     public function testReplacementAccessorsWork()

--- a/tests/ZendTest/Filter/StripTagsTest.php
+++ b/tests/ZendTest/Filter/StripTagsTest.php
@@ -441,7 +441,7 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
         $input    = 'äöü<!-- a comment -->äöü';
         $input    = iconv("UTF-8", "ISO-8859-1", $input);
         $output   = $filter($input);
-        $this->assertFalse(empty($output));
+        $this->assertNotEmpty($output);
     }
 
     /**
@@ -457,7 +457,7 @@ class StripTagsTest extends \PHPUnit_Framework_TestCase
         $input    = 'äöü<!-- a comment -->äöü';
         $input    = iconv("UTF-8", "ISO-8859-1", $input);
         $output   = $filter($input);
-        $this->assertFalse(empty($output));
+        $this->assertNotEmpty($output);
     }
 
     /**

--- a/tests/ZendTest/Form/Element/CheckboxTest.php
+++ b/tests/ZendTest/Form/Element/CheckboxTest.php
@@ -34,7 +34,7 @@ class CheckboxTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\InArray':
                     $this->assertEquals(array($element->getCheckedValue(), $element->getUncheckedValue()), $validator->getHaystack());

--- a/tests/ZendTest/Form/Element/CollectionTest.php
+++ b/tests/ZendTest/Form/Element/CollectionTest.php
@@ -1243,7 +1243,7 @@ class CollectionTest extends TestCase
         $object = new \ArrayObject();
         $form->bind($object);
         $this->assertTrue($form->isValid());
-        $this->assertTrue(is_array($object['colors']));
+        $this->assertInternalType('array', $object['colors']);
         $this->assertCount(1, $object['colors']);
     }
 }

--- a/tests/ZendTest/Form/Element/ColorTest.php
+++ b/tests/ZendTest/Form/Element/ColorTest.php
@@ -45,7 +45,7 @@ class ColorTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Regex':
                     $this->assertEquals('/^#[0-9a-fA-F]{6}$/', $validator->getPattern());

--- a/tests/ZendTest/Form/Element/CsrfTest.php
+++ b/tests/ZendTest/Form/Element/CsrfTest.php
@@ -27,7 +27,7 @@ class CsrfTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Csrf':
                     $this->assertEquals('foo', $validator->getName());

--- a/tests/ZendTest/Form/Element/DateSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateSelectTest.php
@@ -29,7 +29,7 @@ class DateSelectTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Date':
                     $this->assertEquals('Y-m-d', $validator->getFormat());

--- a/tests/ZendTest/Form/Element/DateTest.php
+++ b/tests/ZendTest/Form/Element/DateTest.php
@@ -55,7 +55,7 @@ class DateTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\DateStep':
                     $dateInterval = new \DateInterval('P1D');
@@ -90,7 +90,7 @@ class DateTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/Element/DateTimeLocalTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeLocalTest.php
@@ -36,7 +36,7 @@ class DateTimeLocalTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/Element/DateTimeSelectTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeSelectTest.php
@@ -30,7 +30,7 @@ class DateTimeSelectTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Date':
                     $this->assertEquals('Y-m-d H:i:s', $validator->getFormat());

--- a/tests/ZendTest/Form/Element/DateTimeTest.php
+++ b/tests/ZendTest/Form/Element/DateTimeTest.php
@@ -37,7 +37,7 @@ class DateTimeTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/Element/MonthSelectTest.php
+++ b/tests/ZendTest/Form/Element/MonthSelectTest.php
@@ -28,7 +28,7 @@ class MonthSelectTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Regex':
                     $this->assertEquals('/^[0-9]{4}\-(0?[1-9]|1[012])$/', $validator->getPattern());

--- a/tests/ZendTest/Form/Element/MonthTest.php
+++ b/tests/ZendTest/Form/Element/MonthTest.php
@@ -36,7 +36,7 @@ class MonthTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/Element/MultiCheckboxTest.php
+++ b/tests/ZendTest/Form/Element/MultiCheckboxTest.php
@@ -44,7 +44,7 @@ class MultiCheckboxTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Explode':
                     $inArrayValidator = $validator->getValidator();
@@ -186,6 +186,6 @@ class MultiCheckboxTest extends TestCase
         $optionValue = 'option3';
         $selectedOptions = array('option1', 'option3');
         $element->setValue($selectedOptions);
-        $this->assertTrue(in_array($optionValue, $element->getValue()));
+        $this->assertContains($optionValue, $element->getValue());
     }
 }

--- a/tests/ZendTest/Form/Element/NumberTest.php
+++ b/tests/ZendTest/Form/Element/NumberTest.php
@@ -28,7 +28,7 @@ class NumberTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Step':
                     $this->assertEquals(1, $validator->getStep());
@@ -61,7 +61,7 @@ class NumberTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/Element/RadioTest.php
+++ b/tests/ZendTest/Form/Element/RadioTest.php
@@ -44,7 +44,7 @@ class RadioTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
         }
     }
 

--- a/tests/ZendTest/Form/Element/RangeTest.php
+++ b/tests/ZendTest/Form/Element/RangeTest.php
@@ -35,7 +35,7 @@ class RangeTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());
@@ -81,7 +81,7 @@ class RangeTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -32,7 +32,7 @@ class SelectTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
         }
     }
 
@@ -92,7 +92,7 @@ class SelectTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Explode':
                     $this->assertInstanceOf('Zend\Validator\InArray', $validator->getValidator());

--- a/tests/ZendTest/Form/Element/SelectTest.php
+++ b/tests/ZendTest/Form/Element/SelectTest.php
@@ -162,7 +162,7 @@ class SelectTest extends TestCase
     public function testOptionsHasArrayOnConstruct()
     {
         $element = new SelectElement();
-        $this->assertTrue(is_array($element->getValueOptions()));
+        $this->assertInternalType('array', $element->getValueOptions());
     }
 
     public function testDeprecateOptionsInAttributes()

--- a/tests/ZendTest/Form/Element/TimeTest.php
+++ b/tests/ZendTest/Form/Element/TimeTest.php
@@ -36,7 +36,7 @@ class TimeTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Date':
                     $this->assertEquals('H:i:s', $validator->getFormat());

--- a/tests/ZendTest/Form/Element/UrlTest.php
+++ b/tests/ZendTest/Form/Element/UrlTest.php
@@ -31,7 +31,7 @@ class UrlTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\Uri':
                     $this->assertEquals(true, $validator->getAllowAbsolute());

--- a/tests/ZendTest/Form/Element/WeekTest.php
+++ b/tests/ZendTest/Form/Element/WeekTest.php
@@ -36,7 +36,7 @@ class WeekTest extends TestCase
         );
         foreach ($inputSpec['validators'] as $validator) {
             $class = get_class($validator);
-            $this->assertTrue(in_array($class, $expectedClasses), $class);
+            $this->assertContains($class, $expectedClasses, $class);
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1540,7 +1540,7 @@ class FormTest extends TestCase
 
         // Returned object has to be the same as when binding or properties
         // will be lost. (For example entity IDs.)
-        $this->assertTrue($hash1 == $hash2);
+        $this->assertEquals($hash1, $hash2);
     }
 
     public function testAddRemove()

--- a/tests/ZendTest/Form/FormTest.php
+++ b/tests/ZendTest/Form/FormTest.php
@@ -1081,14 +1081,16 @@ class FormTest extends TestCase
         $fieldsetBar = $fieldsets[1];
 
         $objectFoo = $fieldsetFoo->getObject();
-        $this->assertTrue(
-            $objectFoo instanceof Entity\Orphan,
+        $this->assertInstanceOf(
+            'ZendTest\Form\TestAsset\Entity\Orphan',
+            $objectFoo,
             'FormCollection with orphans does not bind objects from fieldsets'
         );
 
         $objectBar = $fieldsetBar->getObject();
-        $this->assertTrue(
-            $objectBar instanceof Entity\Orphan,
+        $this->assertInstanceOf(
+            'ZendTest\Form\TestAsset\Entity\Orphan',
+            $objectBar,
             'FormCollection with orphans does not bind objects from fieldsets'
         );
 

--- a/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormMultiCheckboxTest.php
@@ -179,7 +179,7 @@ class FormMultiCheckboxTest extends CommonTestCase
         $element = $this->getElement();
         $element->setAttribute('id', 'foo');
         $markup  = $this->helper->render($element);
-        $this->assertTrue(1 >= substr_count($markup, 'id="foo"'));
+        $this->assertLessThanOrEqual(1, substr_count($markup, 'id="foo"'));
     }
 
     public function testIdShouldBeRenderedOnceIfProvided()

--- a/tests/ZendTest/Form/View/Helper/FormRadioTest.php
+++ b/tests/ZendTest/Form/View/Helper/FormRadioTest.php
@@ -188,7 +188,7 @@ class FormRadioTest extends CommonTestCase
         $element = $this->getElement();
         $element->setAttribute('id', 'foo');
         $markup  = $this->helper->render($element);
-        $this->assertTrue(1 >= substr_count($markup, 'id="foo"'));
+        $this->assertLessThanOrEqual(1, substr_count($markup, 'id="foo"'));
     }
 
     public function testIdShouldBeRenderedOnceIfProvided()

--- a/tests/ZendTest/Http/Client/CommonHttpTests.php
+++ b/tests/ZendTest/Http/Client/CommonHttpTests.php
@@ -314,7 +314,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
         $this->assertNotContains(serialize($params), $res->getBody(),
             "returned body contains GET or POST parameters (it shouldn't!)");
         $headerXFoo= $this->client->getHeader("X-Foo");
-        $this->assertTrue(empty($headerXFoo), "Header not preserved by reset");
+        $this->assertEmpty($headerXFoo, "Header not preserved by reset");
     }
 
     /**

--- a/tests/ZendTest/Http/Client/CommonHttpTests.php
+++ b/tests/ZendTest/Http/Client/CommonHttpTests.php
@@ -901,7 +901,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
         $response = $this->client->send();
 
         $this->assertTrue($response instanceof Response\Stream, 'Request did not return stream response!');
-        $this->assertTrue(is_resource($response->getStream()), 'Request does not contain stream!');
+        $this->assertInternalType('resource', $response->getStream(), 'Request does not contain stream!');
 
         $stream_name = $response->getStreamName();
 
@@ -928,7 +928,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
         $response = $this->client->send();
 
         $this->assertTrue($response instanceof Response\Stream, 'Request did not return stream response!');
-        $this->assertTrue(is_resource($response->getStream()), 'Request does not contain stream!');
+        $this->assertInternalType('resource', $response->getStream(), 'Request does not contain stream!');
 
         $body = $response->getBody();
 
@@ -949,7 +949,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
         $response = $this->client->send();
 
         $this->assertTrue($response instanceof Response\Stream, 'Request did not return stream response!');
-        $this->assertTrue(is_resource($response->getStream()), 'Request does not contain stream!');
+        $this->assertInternalType('resource', $response->getStream(), 'Request does not contain stream!');
 
         $this->assertEquals($outfile, $response->getStreamName());
 

--- a/tests/ZendTest/Http/Client/CommonHttpTests.php
+++ b/tests/ZendTest/Http/Client/CommonHttpTests.php
@@ -900,7 +900,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
 
         $response = $this->client->send();
 
-        $this->assertTrue($response instanceof Response\Stream, 'Request did not return stream response!');
+        $this->assertInstanceOf('Zend\Http\Response\Stream', $response, 'Request did not return stream response!');
         $this->assertInternalType('resource', $response->getStream(), 'Request does not contain stream!');
 
         $stream_name = $response->getStreamName();
@@ -927,7 +927,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
 
         $response = $this->client->send();
 
-        $this->assertTrue($response instanceof Response\Stream, 'Request did not return stream response!');
+        $this->assertInstanceOf('Zend\Http\Response\Stream', $response, 'Request did not return stream response!');
         $this->assertInternalType('resource', $response->getStream(), 'Request does not contain stream!');
 
         $body = $response->getBody();
@@ -948,7 +948,7 @@ abstract class CommonHttpTests extends \PHPUnit_Framework_TestCase
 
         $response = $this->client->send();
 
-        $this->assertTrue($response instanceof Response\Stream, 'Request did not return stream response!');
+        $this->assertInstanceOf('Zend\Http\Response\Stream', $response, 'Request did not return stream response!');
         $this->assertInternalType('resource', $response->getStream(), 'Request does not contain stream!');
 
         $this->assertEquals($outfile, $response->getStreamName());

--- a/tests/ZendTest/Http/Client/CurlTest.php
+++ b/tests/ZendTest/Http/Client/CurlTest.php
@@ -327,7 +327,7 @@ class CurlTest extends CommonHttpTests
         $adapter->setOptions(array('timeout' => 2, 'maxredirects' => 1));
         $adapter->connect("http://framework.zend.com");
 
-        $this->assertTrue(is_resource($adapter->getHandle()));
+        $this->assertInternalType('resource', $adapter->getHandle());
     }
 
     /**

--- a/tests/ZendTest/Http/Client/StaticTest.php
+++ b/tests/ZendTest/Http/Client/StaticTest.php
@@ -178,7 +178,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $this->_client->clearCookies();
         $cookies = $this->_client->getCookies();
 
-        $this->assertTrue(empty($cookies), 'Cookies is expected to be null but it is not');
+        $this->assertEquals(array(), $cookies, 'Cookies are expected to be an empty array but it is not');
     }
 
     /**

--- a/tests/ZendTest/Http/Client/StaticTest.php
+++ b/tests/ZendTest/Http/Client/StaticTest.php
@@ -295,7 +295,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $this->_client->setAdapter('Zend\Http\Client\Adapter\Test');
 
         $response = $this->_client->send();
-        $this->assertTrue(($response === $this->_client->getResponse()),
+        $this->assertSame($response, $this->_client->getResponse(),
             'Response is expected to be identical to the result of getResponse()');
     }
 

--- a/tests/ZendTest/Http/Client/StaticTest.php
+++ b/tests/ZendTest/Http/Client/StaticTest.php
@@ -70,7 +70,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($uri->__toString(), $uristr, 'Returned Uri object does not hold the expected URI');
 
         $uri = $this->_client->getUri()->toString();
-        $this->assertTrue(is_string($uri), 'Returned value expected to be a string, ' . gettype($uri) . ' returned');
+        $this->assertInternalType('string', $uri, 'Returned value expected to be a string, ' . gettype($uri) . ' returned');
         $this->assertEquals($uri, $uristr, 'Returned string is not the expected URI');
     }
 

--- a/tests/ZendTest/Http/Client/StaticTest.php
+++ b/tests/ZendTest/Http/Client/StaticTest.php
@@ -66,7 +66,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $this->_client->setUri($uristr);
 
         $uri = $this->_client->getUri();
-        $this->assertTrue($uri instanceof UriHttp, 'Returned value is not a Uri object as expected');
+        $this->assertInstanceOf('Zend\Uri\Http', $uri, 'Returned value is not a Uri object as expected');
         $this->assertEquals($uri->__toString(), $uristr, 'Returned Uri object does not hold the expected URI');
 
         $uri = $this->_client->getUri()->toString();
@@ -85,7 +85,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $this->_client->setUri($uriobj);
 
         $uri = $this->_client->getUri();
-        $this->assertTrue($uri instanceof UriHttp, 'Returned value is not a Uri object as expected');
+        $this->assertInstanceOf('Zend\Uri\Http', $uri, 'Returned value is not a Uri object as expected');
         $this->assertEquals($uri, $uriobj, 'Returned object is not the excepted Uri object');
     }
 
@@ -159,8 +159,9 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         $cookies = $this->_client->getCookies();
 
         // Check we got the right cookiejar
-        $this->assertTrue((is_array($cookies) && $cookies['chocolate'] instanceof SetCookie), '$cookie is not an array of Zend\Http\Header\SetCookie');
-        $this->assertEquals(count($cookies), 2, '$cookies does not contain 2 SetCokie as expected');
+        $this->assertInternalType('array', $cookies);
+        $this->assertContainsOnlyInstancesOf('Zend\Http\Header\SetCookie', $cookies);
+        $this->assertCount(2, $cookies);
     }
 
     /**

--- a/tests/ZendTest/Http/ClientTest.php
+++ b/tests/ZendTest/Http/ClientTest.php
@@ -265,7 +265,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $response = $client->setMethod('GET')->send();
 
         // the last request should contain the Authorization header
-        $this->assertTrue(strpos($client->getLastRawRequest(), $encoded) !== false);
+        $this->assertContains($encoded, $client->getLastRawRequest());
     }
 
     public function testIfClientDoesNotForwardAuthenticationToForeignHost()
@@ -296,7 +296,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // the last request should NOT contain the Authorization header,
         // because example.com is different from example.org
-        $this->assertTrue(strpos($client->getLastRawRequest(), $encoded) === false);
+        $this->assertNotContains($encoded, $client->getLastRawRequest());
 
         // set up two responses that simulate a rediration from example.org to sub.example.org
         $testAdapter->setResponse(
@@ -316,7 +316,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // the last request should contain the Authorization header,
         // because sub.example.org is a subdomain unter example.org
-        $this->assertFalse(strpos($client->getLastRawRequest(), $encoded) === false);
+        $this->assertContains($encoded, $client->getLastRawRequest());
 
         // set up two responses that simulate a rediration from sub.example.org to example.org
         $testAdapter->setResponse(
@@ -336,7 +336,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         // the last request should NOT contain the Authorization header,
         // because example.org is not a subdomain unter sub.example.org
-        $this->assertTrue(strpos($client->getLastRawRequest(), $encoded) === false);
+        $this->assertNotContains($encoded, $client->getLastRawRequest());
     }
 
     public function testAdapterAlwaysReachableIfSpecified()

--- a/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
+++ b/tests/ZendTest/Http/PhpEnvironment/RemoteAddressTest.php
@@ -75,7 +75,7 @@ class RemoteAddressTest extends TestCase
         $result = $this->remoteAddress->setTrustedProxies(array(
             '192.168.0.10', '192.168.0.1'
         ));
-        $this->assertTrue($result instanceof RemoteAddr);
+        $this->assertInstanceOf('Zend\Http\PhpEnvironment\RemoteAddress', $result);
     }
 
     public function testGetIpAddress()

--- a/tests/ZendTest/InputFilter/BaseInputFilterTest.php
+++ b/tests/ZendTest/InputFilter/BaseInputFilterTest.php
@@ -781,9 +781,9 @@ class BaseInputFilterTest extends TestCase
         $filter->setData($unknown);
         $unknown = $filter->getUnknown();
         $this->assertEquals(2, count($unknown));
-        $this->assertTrue(array_key_exists('gru', $unknown));
+        $this->assertArrayHasKey('gru', $unknown);
         $this->assertEquals(10, $unknown['gru']);
-        $this->assertTrue(array_key_exists('test', $unknown));
+        $this->assertArrayHasKey('test', $unknown);
         $this->assertEquals('ok', $unknown['test']);
 
         $filter = $this->getInputFilter();

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -262,7 +262,7 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
         $this->assertTrue($inputFilter->has('foo'));
-        $this->assertTrue($inputFilter->get('foo') === $input);
+        $this->assertEquals($input, $inputFilter->get('foo'));
     }
 
     public function testFactoryAcceptsInputFilterInterface()
@@ -276,7 +276,7 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
         $this->assertTrue($inputFilter->has('foo'));
-        $this->assertTrue($inputFilter->get('foo') === $input);
+        $this->assertEquals($input, $inputFilter->get('foo'));
     }
 
     public function testFactoryWillCreateInputFilterAndAllInputObjectsFromGivenConfiguration()

--- a/tests/ZendTest/InputFilter/InputTest.php
+++ b/tests/ZendTest/InputFilter/InputTest.php
@@ -102,7 +102,7 @@ class InputTest extends TestCase
         $input->isValid();
         $validators = $input->getValidatorChain()
                                 ->getValidators();
-        $this->assertTrue(0 == count($validators));
+        $this->assertEmpty($validators);
     }
 
     public function testValueIsNullByDefault()

--- a/tests/ZendTest/Json/JsonTest.php
+++ b/tests/ZendTest/Json/JsonTest.php
@@ -245,9 +245,8 @@ class JsonTest extends \PHPUnit_Framework_TestCase
 
         $encoded = Json\Encoder::encode($value);
         $decoded = Json\Decoder::decode($encoded, Json\Json::TYPE_OBJECT);
-        $this->assertTrue(is_object($decoded), 'Not decoded as an object');
-        $this->assertTrue($decoded instanceof \stdClass, 'Not a stdClass object');
-        $this->assertTrue(isset($decoded->one), 'Expected property not set');
+        $this->assertInstanceOf('stdClass', $decoded);
+        $this->assertObjectHasAttribute('one', $decoded);
         $this->assertEquals($value->one, $decoded->one, 'Unexpected value');
     }
 

--- a/tests/ZendTest/Json/Server/ErrorTest.php
+++ b/tests/ZendTest/Json/Server/ErrorTest.php
@@ -150,14 +150,14 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
 
     public function validateArray($error)
     {
-        $this->assertTrue(is_array($error));
+        $this->assertInternalType('array', $error);
         $this->assertTrue(array_key_exists('code', $error));
         $this->assertTrue(array_key_exists('message', $error));
         $this->assertTrue(array_key_exists('data', $error));
 
-        $this->assertTrue(is_int($error['code']));
-        $this->assertTrue(is_string($error['message']));
-        $this->assertTrue(is_array($error['data']));
+        $this->assertInternalType('integer', $error['code']);
+        $this->assertInternalType('string', $error['message']);
+        $this->assertInternalType('array', $error['data']);
 
         $this->assertEquals($this->error->getCode(), $error['code']);
         $this->assertEquals($this->error->getMessage(), $error['message']);

--- a/tests/ZendTest/Json/Server/ErrorTest.php
+++ b/tests/ZendTest/Json/Server/ErrorTest.php
@@ -151,9 +151,9 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     public function validateArray($error)
     {
         $this->assertInternalType('array', $error);
-        $this->assertTrue(array_key_exists('code', $error));
-        $this->assertTrue(array_key_exists('message', $error));
-        $this->assertTrue(array_key_exists('data', $error));
+        $this->assertArrayHasKey('code', $error);
+        $this->assertArrayHasKey('message', $error);
+        $this->assertArrayHasKey('data', $error);
 
         $this->assertInternalType('integer', $error['code']);
         $this->assertInternalType('string', $error['message']);

--- a/tests/ZendTest/Json/Server/RequestTest.php
+++ b/tests/ZendTest/Json/Server/RequestTest.php
@@ -41,7 +41,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testShouldHaveNoParamsByDefault()
     {
         $params = $this->request->getParams();
-        $this->assertTrue(empty($params));
+        $this->assertEmpty($params);
     }
 
     public function testShouldBeAbleToAddAParamAsValueOnly()

--- a/tests/ZendTest/Json/Server/RequestTest.php
+++ b/tests/ZendTest/Json/Server/RequestTest.php
@@ -252,15 +252,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function validateJSON($json, array $options)
     {
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
-        $this->assertTrue(is_array($test), var_export($json, 1));
+        $this->assertInternalType('array', $test, var_export($json, 1));
 
         $this->assertTrue(array_key_exists('id', $test));
         $this->assertTrue(array_key_exists('method', $test));
         $this->assertTrue(array_key_exists('params', $test));
 
-        $this->assertTrue(is_string($test['id']));
-        $this->assertTrue(is_string($test['method']));
-        $this->assertTrue(is_array($test['params']));
+        $this->assertInternalType('string', $test['id']);
+        $this->assertInternalType('string', $test['method']);
+        $this->assertInternalType('array', $test['params']);
 
         $this->assertEquals($options['id'], $test['id']);
         $this->assertEquals($options['method'], $test['method']);

--- a/tests/ZendTest/Json/Server/RequestTest.php
+++ b/tests/ZendTest/Json/Server/RequestTest.php
@@ -58,7 +58,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->request->addParam('bar', 'foo');
         $params = $this->request->getParams();
         $this->assertEquals(1, count($params));
-        $this->assertTrue(array_key_exists('foo', $params));
+        $this->assertArrayHasKey('foo', $params);
         $this->assertEquals('bar', $params['foo']);
     }
 
@@ -108,8 +108,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->request->addParams($params);
         $test = $this->request->getParams();
         $this->assertEquals(array_values($params), array_values($test));
-        $this->assertTrue(array_key_exists('foo', $test));
-        $this->assertTrue(array_key_exists('baz', $test));
+        $this->assertArrayHasKey('foo', $test);
+        $this->assertArrayHasKey('baz', $test);
         $this->assertContains('baz', $test);
     }
 
@@ -254,9 +254,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
         $this->assertInternalType('array', $test, var_export($json, 1));
 
-        $this->assertTrue(array_key_exists('id', $test));
-        $this->assertTrue(array_key_exists('method', $test));
-        $this->assertTrue(array_key_exists('params', $test));
+        $this->assertArrayHasKey('id', $test);
+        $this->assertArrayHasKey('method', $test);
+        $this->assertArrayHasKey('params', $test);
 
         $this->assertInternalType('string', $test['id']);
         $this->assertInternalType('string', $test['method']);

--- a/tests/ZendTest/Json/Server/RequestTest.php
+++ b/tests/ZendTest/Json/Server/RequestTest.php
@@ -110,7 +110,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array_values($params), array_values($test));
         $this->assertTrue(array_key_exists('foo', $test));
         $this->assertTrue(array_key_exists('baz', $test));
-        $this->assertTrue(in_array('baz', $test));
+        $this->assertContains('baz', $test);
     }
 
     public function testSetParamsShouldOverwriteParams()

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -124,10 +124,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertInternalType('array', $test);
-        $this->assertTrue(array_key_exists('result', $test));
+        $this->assertArrayHasKey('result', $test);
         $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
-        $this->assertTrue(array_key_exists('id', $test));
-        $this->assertTrue(array_key_exists('jsonrpc', $test));
+        $this->assertArrayHasKey('id', $test);
+        $this->assertArrayHasKey('jsonrpc', $test);
 
         $this->assertTrue($test['result']);
         $this->assertEquals($this->response->getId(), $test['id']);
@@ -147,8 +147,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $test);
         $this->assertFalse(array_key_exists('result', $test), "'result' may not coexist with 'error'");
-        $this->assertTrue(array_key_exists('error', $test));
-        $this->assertTrue(array_key_exists('id', $test));
+        $this->assertArrayHasKey('error', $test);
+        $this->assertArrayHasKey('id', $test);
         $this->assertFalse(array_key_exists('jsonrpc', $test));
 
         $this->assertEquals($this->response->getId(), $test['id']);
@@ -164,9 +164,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertInternalType('array', $test);
-        $this->assertTrue(array_key_exists('result', $test));
+        $this->assertArrayHasKey('result', $test);
         $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
-        $this->assertTrue(array_key_exists('id', $test));
+        $this->assertArrayHasKey('id', $test);
         $this->assertFalse(array_key_exists('jsonrpc', $test));
 
         $this->assertTrue($test['result']);

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -125,7 +125,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $test);
         $this->assertArrayHasKey('result', $test);
-        $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
+        $this->assertArrayNotHasKey('error', $test, "'error' may not coexist with 'result'");
         $this->assertArrayHasKey('id', $test);
         $this->assertArrayHasKey('jsonrpc', $test);
 
@@ -146,10 +146,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
         $this->assertInternalType('array', $test);
-        $this->assertFalse(array_key_exists('result', $test), "'result' may not coexist with 'error'");
+        $this->assertArrayNotHasKey('result', $test, "'result' may not coexist with 'error'");
         $this->assertArrayHasKey('error', $test);
         $this->assertArrayHasKey('id', $test);
-        $this->assertFalse(array_key_exists('jsonrpc', $test));
+        $this->assertArrayNotHasKey('jsonrpc', $test);
 
         $this->assertEquals($this->response->getId(), $test['id']);
         $this->assertEquals($error->getCode(), $test['error']['code']);
@@ -165,9 +165,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $test);
         $this->assertArrayHasKey('result', $test);
-        $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
+        $this->assertArrayNotHasKey('error', $test, "'error' may not coexist with 'result'");
         $this->assertArrayHasKey('id', $test);
-        $this->assertFalse(array_key_exists('jsonrpc', $test));
+        $this->assertArrayNotHasKey('jsonrpc', $test);
 
         $this->assertTrue($test['result']);
         $this->assertEquals($this->response->getId(), $test['id']);

--- a/tests/ZendTest/Json/Server/ResponseTest.php
+++ b/tests/ZendTest/Json/Server/ResponseTest.php
@@ -123,7 +123,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $json = $this->response->toJSON();
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertTrue(array_key_exists('result', $test));
         $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
         $this->assertTrue(array_key_exists('id', $test));
@@ -145,7 +145,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $json = $this->response->toJSON();
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertFalse(array_key_exists('result', $test), "'result' may not coexist with 'error'");
         $this->assertTrue(array_key_exists('error', $test));
         $this->assertTrue(array_key_exists('id', $test));
@@ -163,7 +163,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $json = $this->response->__toString();
         $test = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
 
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertTrue(array_key_exists('result', $test));
         $this->assertFalse(array_key_exists('error', $test), "'error' may not coexist with 'result'");
         $this->assertTrue(array_key_exists('id', $test));

--- a/tests/ZendTest/Json/Server/Smd/ServiceTest.php
+++ b/tests/ZendTest/Json/Server/Smd/ServiceTest.php
@@ -129,7 +129,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $this->testTargetShouldBeNullInitially();
         $this->service->setTarget(123);
         $value = $this->service->getTarget();
-        $this->assertTrue(is_string($value));
+        $this->assertInternalType('string', $value);
         $this->assertEquals((string) 123, $value);
     }
 
@@ -175,7 +175,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $params = $this->service->getParams();
         $param  = array_shift($params);
         $test   = $param['type'];
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertEquals($type, $test);
     }
 
@@ -297,7 +297,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $smd  = \Zend\Json\Json::decode($json, \Zend\Json\Json::TYPE_ARRAY);
 
         $this->assertTrue(array_key_exists('foo', $smd));
-        $this->assertTrue(is_array($smd['foo']));
+        $this->assertInternalType('array', $smd['foo']);
 
         $this->validateSmdArray($smd['foo']);
     }

--- a/tests/ZendTest/Json/Server/Smd/ServiceTest.php
+++ b/tests/ZendTest/Json/Server/Smd/ServiceTest.php
@@ -156,7 +156,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
     public function testShouldHaveNoParamsByDefault()
     {
         $params = $this->service->getParams();
-        $this->assertTrue(empty($params));
+        $this->assertEmpty($params);
     }
 
     public function testShouldBeAbleToAddParamsByTypeOnly()

--- a/tests/ZendTest/Json/Server/Smd/ServiceTest.php
+++ b/tests/ZendTest/Json/Server/Smd/ServiceTest.php
@@ -296,7 +296,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $json = $this->service->toJSON();
         $smd  = \Zend\Json\Json::decode($json, \Zend\Json\Json::TYPE_ARRAY);
 
-        $this->assertTrue(array_key_exists('foo', $smd));
+        $this->assertArrayHasKey('foo', $smd);
         $this->assertInternalType('array', $smd['foo']);
 
         $this->validateSmdArray($smd['foo']);
@@ -316,13 +316,13 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
 
     public function validateSmdArray(array $smd)
     {
-        $this->assertTrue(array_key_exists('transport', $smd));
+        $this->assertArrayHasKey('transport', $smd);
         $this->assertEquals('POST', $smd['transport']);
 
-        $this->assertTrue(array_key_exists('envelope', $smd));
+        $this->assertArrayHasKey('envelope', $smd);
         $this->assertEquals(Server\Smd::ENV_JSONRPC_2, $smd['envelope']);
 
-        $this->assertTrue(array_key_exists('parameters', $smd));
+        $this->assertArrayHasKey('parameters', $smd);
         $params = $smd['parameters'];
         $this->assertEquals(3, count($params));
         $param = array_shift($params);
@@ -332,7 +332,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $param = array_shift($params);
         $this->assertEquals('object', $param['type']);
 
-        $this->assertTrue(array_key_exists('returns', $smd));
+        $this->assertArrayHasKey('returns', $smd);
         $this->assertEquals('boolean', $smd['returns']);
     }
 }

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -162,7 +162,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
     {
         $services = $this->smd->getServices();
         $this->assertInternalType('array', $services);
-        $this->assertTrue(empty($services));
+        $this->assertEmpty($services);
     }
 
     public function testShouldBeAbleToUseServiceObjectToAddService()

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -179,7 +179,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         );
         $this->smd->addService($service);
         $foo = $this->smd->getService('foo');
-        $this->assertTrue($foo instanceof Smd\Service);
+        $this->assertInstanceOf('Zend\Json\Server\Smd\Service', $foo);
         $this->assertEquals('foo', $foo->getName());
     }
 

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -161,7 +161,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
     public function testServicesShouldBeEmptyByDefault()
     {
         $services = $this->smd->getServices();
-        $this->assertTrue(is_array($services));
+        $this->assertInternalType('array', $services);
         $this->assertTrue(empty($services));
     }
 
@@ -286,7 +286,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $this->smd->setOptions($options);
         $smd = $this->smd->toDojoArray();
 
-        $this->assertTrue(is_array($smd));
+        $this->assertInternalType('array', $smd);
 
         $this->assertTrue(array_key_exists('SMDVersion', $smd));
         $this->assertTrue(array_key_exists('serviceType', $smd));
@@ -303,7 +303,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('parameters', $foo));
         $this->assertEquals('foo', $foo['name']);
         $this->assertEquals($this->smd->getTarget(), $foo['serviceURL']);
-        $this->assertTrue(is_array($foo['parameters']));
+        $this->assertInternalType('array', $foo['parameters']);
         $this->assertEquals(1, count($foo['parameters']));
 
         $bar = array_shift($methods);
@@ -312,7 +312,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('parameters', $bar));
         $this->assertEquals('bar', $bar['name']);
         $this->assertEquals($this->smd->getTarget(), $bar['serviceURL']);
-        $this->assertTrue(is_array($bar['parameters']));
+        $this->assertInternalType('array', $bar['parameters']);
         $this->assertEquals(1, count($bar['parameters']));
     }
 
@@ -360,7 +360,7 @@ class SmdTest extends \PHPUnit_Framework_TestCase
 
     public function validateServiceArray(array $smd, array $options)
     {
-        $this->assertTrue(is_array($smd));
+        $this->assertInternalType('array', $smd);
 
         $this->assertTrue(array_key_exists('SMDVersion', $smd));
         $this->assertTrue(array_key_exists('target', $smd));

--- a/tests/ZendTest/Json/Server/SmdTest.php
+++ b/tests/ZendTest/Json/Server/SmdTest.php
@@ -288,9 +288,9 @@ class SmdTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $smd);
 
-        $this->assertTrue(array_key_exists('SMDVersion', $smd));
-        $this->assertTrue(array_key_exists('serviceType', $smd));
-        $this->assertTrue(array_key_exists('methods', $smd));
+        $this->assertArrayHasKey('SMDVersion', $smd);
+        $this->assertArrayHasKey('serviceType', $smd);
+        $this->assertArrayHasKey('methods', $smd);
 
         $this->assertEquals('.1', $smd['SMDVersion']);
         $this->assertEquals('JSON-RPC', $smd['serviceType']);
@@ -298,18 +298,18 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($methods));
 
         $foo = array_shift($methods);
-        $this->assertTrue(array_key_exists('name', $foo));
-        $this->assertTrue(array_key_exists('serviceURL', $foo));
-        $this->assertTrue(array_key_exists('parameters', $foo));
+        $this->assertArrayHasKey('name', $foo);
+        $this->assertArrayHasKey('serviceURL', $foo);
+        $this->assertArrayHasKey('parameters', $foo);
         $this->assertEquals('foo', $foo['name']);
         $this->assertEquals($this->smd->getTarget(), $foo['serviceURL']);
         $this->assertInternalType('array', $foo['parameters']);
         $this->assertEquals(1, count($foo['parameters']));
 
         $bar = array_shift($methods);
-        $this->assertTrue(array_key_exists('name', $bar));
-        $this->assertTrue(array_key_exists('serviceURL', $bar));
-        $this->assertTrue(array_key_exists('parameters', $bar));
+        $this->assertArrayHasKey('name', $bar);
+        $this->assertArrayHasKey('serviceURL', $bar);
+        $this->assertArrayHasKey('parameters', $bar);
         $this->assertEquals('bar', $bar['name']);
         $this->assertEquals($this->smd->getTarget(), $bar['serviceURL']);
         $this->assertInternalType('array', $bar['parameters']);
@@ -362,13 +362,13 @@ class SmdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInternalType('array', $smd);
 
-        $this->assertTrue(array_key_exists('SMDVersion', $smd));
-        $this->assertTrue(array_key_exists('target', $smd));
-        $this->assertTrue(array_key_exists('id', $smd));
-        $this->assertTrue(array_key_exists('transport', $smd));
-        $this->assertTrue(array_key_exists('envelope', $smd));
-        $this->assertTrue(array_key_exists('contentType', $smd));
-        $this->assertTrue(array_key_exists('services', $smd));
+        $this->assertArrayHasKey('SMDVersion', $smd);
+        $this->assertArrayHasKey('target', $smd);
+        $this->assertArrayHasKey('id', $smd);
+        $this->assertArrayHasKey('transport', $smd);
+        $this->assertArrayHasKey('envelope', $smd);
+        $this->assertArrayHasKey('contentType', $smd);
+        $this->assertArrayHasKey('services', $smd);
 
         $this->assertEquals(Smd::SMD_VERSION, $smd['SMDVersion']);
         $this->assertEquals($options['target'], $smd['target']);
@@ -378,8 +378,8 @@ class SmdTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->smd->getContentType(), $smd['contentType']);
         $services = $smd['services'];
         $this->assertEquals(2, count($services));
-        $this->assertTrue(array_key_exists('foo', $services));
-        $this->assertTrue(array_key_exists('bar', $services));
+        $this->assertArrayHasKey('foo', $services);
+        $this->assertArrayHasKey('bar', $services);
     }
 
     /**

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -67,7 +67,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->server->setClass('Zend\Json\Server\Server');
         $test = $this->server->getFunctions();
-        $this->assertTrue(0 < count($test));
+        $this->assertNotEmpty($test);
     }
 
     public function testBindingClassToServerShouldRegisterAllPublicMethods()
@@ -88,7 +88,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $object = new Server\Server();
         $this->server->setClass($object);
         $test = $this->server->getFunctions();
-        $this->assertTrue(0 < count($test));
+        $this->assertNotEmpty($test);
     }
 
     public function testBindingObjectToServerShouldRegisterAllPublicMethods()
@@ -224,7 +224,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $services = $smd->getServices();
         $this->assertInternalType('array', $services);
-        $this->assertTrue(0 < count($services));
+        $this->assertNotEmpty($services);
         $this->assertArrayHasKey('strtolower', $services);
         $methods = get_class_methods('Zend\Json\Server\Server');
         foreach ($methods as $method) {

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -486,7 +486,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $decoded);
         $this->assertTrue(array_key_exists('result', $decoded));
         $this->assertTrue(array_key_exists('id', $decoded));
-        $this->assertTrue(in_array('unique', $decoded['result']));
+        $this->assertContains('unique', $decoded['result']);
 
         $response = $this->server->getResponse();
         $this->assertEquals($response->getResult(), $decoded['result']);

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -129,7 +129,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testGetRequestShouldInstantiateRequestObjectByDefault()
     {
         $request = $this->server->getRequest();
-        $this->assertTrue($request instanceof Request);
+        $this->assertInstanceOf('Zend\Json\Server\Request', $request);
     }
 
     public function testShouldAllowSettingRequestObjectManually()
@@ -145,7 +145,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testGetResponseShouldInstantiateResponseObjectByDefault()
     {
         $response = $this->server->getResponse();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
     }
 
     public function testShouldAllowSettingResponseObjectManually()
@@ -184,7 +184,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testShouldBeAbleToRetrieveSmdObject()
     {
         $smd = $this->server->getServiceMap();
-        $this->assertTrue($smd instanceof \Zend\Json\Server\Smd);
+        $this->assertInstanceOf('Zend\Json\Server\Smd', $smd);
     }
 
     public function testShouldBeAbleToSetArbitrarySmdMetadata()
@@ -245,14 +245,14 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                 ->setParams(array(true, 'foo', 'bar'))
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertFalse($response->isError());
 
 
         $request->setMethod('ZendTest\\Json\\TestAsset\\FooFunc')
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertFalse($response->isError());
     }
 
@@ -266,7 +266,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                 ->setParams(array(true, NULL, 'bar'))
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertFalse($response->isError());
     }
 
@@ -279,7 +279,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                 ->setParams(array(true))
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertFalse($response->isError());
         $result = $response->getResult();
         $this->assertInternalType('array', $result);
@@ -297,7 +297,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                 ->setParams(array('one' => true))
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertFalse($response->isError());
         $result = $response->getResult();
         $this->assertInternalType('array', $result);
@@ -315,7 +315,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                 ->setParams(array(true, 'foo', 'bar', 'baz'))
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertFalse($response->isError());
         $result = $response->getResult();
         $this->assertInternalType('array', $result);
@@ -379,7 +379,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                 ->setId('foo');
         $response = $this->server->handle();
 
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertTrue($response->isError());
         $this->assertEquals(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
@@ -389,7 +389,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->server->setClass('ZendTest\Json\TestAsset\Foo')
                      ->setReturnResponse(true);
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertTrue($response->isError());
         $this->assertEquals(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
     }
@@ -402,7 +402,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('bogus')
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertTrue($response->isError());
         $this->assertEquals(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
     }
@@ -415,7 +415,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('baz')
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\Json\Server\Response', $response);
         $this->assertTrue($response->isError());
         $this->assertEquals(Server\Error::ERROR_OTHER, $response->getError()->getCode());
         $this->assertEquals('application error', $response->getError()->getMessage());

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -283,7 +283,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isError());
         $result = $response->getResult();
         $this->assertInternalType('array', $result);
-        $this->assertTrue(3 == count($result));
+        $this->assertCount(3, $result);
         $this->assertEquals('two', $result[1], var_export($result, 1));
         $this->assertNull($result[2]);
     }
@@ -301,7 +301,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isError());
         $result = $response->getResult();
         $this->assertInternalType('array', $result);
-        $this->assertTrue(3 == count($result));
+        $this->assertCount(3, $result);
         $this->assertEquals('two', $result[1], var_export($result, 1));
         $this->assertNull($result[2]);
     }
@@ -319,7 +319,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isError());
         $result = $response->getResult();
         $this->assertInternalType('array', $result);
-        $this->assertTrue(3 == count($result));
+        $this->assertCount(3, $result);
         $this->assertEquals('foo', $result[1]);
         $this->assertEquals('bar', $result[2]);
     }

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -223,7 +223,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('This is a test service', $this->server->getDescription());
 
         $services = $smd->getServices();
-        $this->assertTrue(is_array($services));
+        $this->assertInternalType('array', $services);
         $this->assertTrue(0 < count($services));
         $this->assertTrue(array_key_exists('strtolower', $services));
         $methods = get_class_methods('Zend\Json\Server\Server');
@@ -282,7 +282,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response instanceof Response);
         $this->assertFalse($response->isError());
         $result = $response->getResult();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertTrue(3 == count($result));
         $this->assertEquals('two', $result[1], var_export($result, 1));
         $this->assertNull($result[2]);
@@ -300,7 +300,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response instanceof Response);
         $this->assertFalse($response->isError());
         $result = $response->getResult();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertTrue(3 == count($result));
         $this->assertEquals('two', $result[1], var_export($result, 1));
         $this->assertNull($result[2]);
@@ -318,7 +318,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response instanceof Response);
         $this->assertFalse($response->isError());
         $result = $response->getResult();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertTrue(3 == count($result));
         $this->assertEquals('foo', $result[1]);
         $this->assertEquals('bar', $result[2]);
@@ -339,7 +339,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $response = $this->server->handle();
         $result = $response->getResult();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertEquals(1, $result[0]);
         $this->assertEquals(2, $result[1]);
         $this->assertEquals(3, $result[2]);
@@ -360,7 +360,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $response = $this->server->handle();
         $result = $response->getResult();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertEquals(1, $result[0]);
         $this->assertEquals(2, $result[1]);
         $this->assertEquals(3, $result[2]);
@@ -433,7 +433,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $buffer = ob_get_clean();
 
         $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
-        $this->assertTrue(is_array($decoded));
+        $this->assertInternalType('array', $decoded);
         $this->assertTrue(array_key_exists('result', $decoded));
         $this->assertTrue(array_key_exists('id', $decoded));
 
@@ -483,7 +483,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
 
-        $this->assertTrue(is_array($decoded));
+        $this->assertInternalType('array', $decoded);
         $this->assertTrue(array_key_exists('result', $decoded));
         $this->assertTrue(array_key_exists('id', $decoded));
         $this->assertTrue(in_array('unique', $decoded['result']));
@@ -510,7 +510,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $response = $this->server->handle();
         $result = $response->getResult();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertEquals(1, $result[0]);
         $this->assertEquals(2, $result[1]);
         $this->assertEquals(null, $result[2]);
@@ -533,7 +533,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $response = $this->server->handle();
         $result = $response->getResult();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertEquals(1, $result[0]);
         $this->assertEquals('two', $result[1]);
         $this->assertEquals(3, $result[2]);

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -225,13 +225,13 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $services = $smd->getServices();
         $this->assertInternalType('array', $services);
         $this->assertTrue(0 < count($services));
-        $this->assertTrue(array_key_exists('strtolower', $services));
+        $this->assertArrayHasKey('strtolower', $services);
         $methods = get_class_methods('Zend\Json\Server\Server');
         foreach ($methods as $method) {
             if ('_' == $method[0]) {
                 continue;
             }
-            $this->assertTrue(array_key_exists($method, $services));
+            $this->assertArrayHasKey($method, $services);
         }
     }
 
@@ -434,8 +434,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
         $this->assertInternalType('array', $decoded);
-        $this->assertTrue(array_key_exists('result', $decoded));
-        $this->assertTrue(array_key_exists('id', $decoded));
+        $this->assertArrayHasKey('result', $decoded);
+        $this->assertArrayHasKey('id', $decoded);
 
         $response = $this->server->getResponse();
         $this->assertEquals($response->getResult(), $decoded['result']);
@@ -484,8 +484,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
 
         $this->assertInternalType('array', $decoded);
-        $this->assertTrue(array_key_exists('result', $decoded));
-        $this->assertTrue(array_key_exists('id', $decoded));
+        $this->assertArrayHasKey('result', $decoded);
+        $this->assertArrayHasKey('id', $decoded);
         $this->assertContains('unique', $decoded['result']);
 
         $response = $this->server->getResponse();

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -452,7 +452,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->server->handle();
         $buffer = ob_get_clean();
 
-        $this->assertTrue(empty($buffer));
+        $this->assertEmpty($buffer);
     }
 
     public function testLoadFunctionsShouldLoadResultOfGetFunctions()

--- a/tests/ZendTest/Json/ServerTest.php
+++ b/tests/ZendTest/Json/ServerTest.php
@@ -112,8 +112,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $methods = $this->server->getFunctions();
         $zjsMethods = get_class_methods('Zend\Json\Server\Server');
         $zjMethods  = get_class_methods('Zend_JSON');
-        $this->assertTrue(count($zjsMethods) < count($methods));
-        $this->assertTrue(count($zjMethods) < count($methods));
+        $this->assertGreaterThan(count($zjsMethods), count($methods));
+        $this->assertGreaterThan(count($zjMethods), count($methods));
     }
 
     public function testNamingCollisionsShouldResolveToLastRegisteredMethod()

--- a/tests/ZendTest/Ldap/BindTest.php
+++ b/tests/ZendTest/Ldap/BindTest.php
@@ -264,7 +264,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
     {
         $ldap = new Ldap\Ldap($this->options);
         $this->assertNotNull($ldap->getResource());
-        $this->assertTrue(is_resource($ldap->getResource()));
+        $this->assertInternalType('resource', $ldap->getResource());
         $this->assertEquals(TESTS_ZEND_LDAP_USERNAME, $ldap->getBoundUser());
     }
 

--- a/tests/ZendTest/Ldap/CanonTest.php
+++ b/tests/ZendTest/Ldap/CanonTest.php
@@ -117,7 +117,7 @@ class CanonTest extends \PHPUnit_Framework_TestCase
             $ldap->bind('BOGUS\\doesntmatter', 'doesntmatter');
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertTrue($zle->getCode() == Exception\LdapException::LDAP_X_DOMAIN_MISMATCH);
+            $this->assertEquals(Exception\LdapException::LDAP_X_DOMAIN_MISMATCH, $zle->getCode());
         }
     }
 

--- a/tests/ZendTest/Ldap/Dn/ExplodingTest.php
+++ b/tests/ZendTest/Ldap/Dn/ExplodingTest.php
@@ -59,7 +59,7 @@ class ExplodingTest extends \PHPUnit_Framework_TestCase
     public function testExplodeDnOperation($input, $expected)
     {
         $ret = Ldap\Dn::checkDn($input);
-        $this->assertTrue($ret === $expected);
+        $this->assertEquals($expected, $ret);
     }
 
     public function testExplodeDnCaseFold()

--- a/tests/ZendTest/Loader/AutoloaderFactoryTest.php
+++ b/tests/ZendTest/Loader/AutoloaderFactoryTest.php
@@ -59,7 +59,7 @@ class AutoloaderFactoryTest extends \PHPUnit_Framework_TestCase
         ));
         $loader = AutoloaderFactory::getRegisteredAutoloader('Zend\Loader\ClassMapAutoloader');
         $map = $loader->getAutoloadMap();
-        $this->assertTrue(is_array($map));
+        $this->assertInternalType('array', $map);
         $this->assertEquals(2, count($map));
     }
 

--- a/tests/ZendTest/Loader/ClassMapAutoloaderTest.php
+++ b/tests/ZendTest/Loader/ClassMapAutoloaderTest.php
@@ -88,13 +88,13 @@ class ClassMapAutoloaderTest extends \PHPUnit_Framework_TestCase
     {
         $this->loader->registerAutoloadMap(__DIR__ . '/_files/goodmap.php');
         $map = $this->loader->getAutoloadMap();
-        $this->assertTrue(is_array($map));
+        $this->assertInternalType('array', $map);
         $this->assertEquals(2, count($map));
         // Just to make sure nothing changes after loading the same map again
         // (loadMapFromFile should just return)
         $this->loader->registerAutoloadMap(__DIR__ . '/_files/goodmap.php');
         $map = $this->loader->getAutoloadMap();
-        $this->assertTrue(is_array($map));
+        $this->assertInternalType('array', $map);
         $this->assertEquals(2, count($map));
     }
 
@@ -108,7 +108,7 @@ class ClassMapAutoloaderTest extends \PHPUnit_Framework_TestCase
         $this->loader->registerAutoloadMap(__DIR__ . '/_files/goodmap.php');
 
         $test = $this->loader->getAutoloadMap();
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertEquals(3, count($test));
         $this->assertNotEquals($map['ZendTest\Loader\StandardAutoloaderTest'], $test['ZendTest\Loader\StandardAutoloaderTest']);
     }
@@ -122,7 +122,7 @@ class ClassMapAutoloaderTest extends \PHPUnit_Framework_TestCase
         $maps = array($map, __DIR__ . '/_files/goodmap.php');
         $this->loader->registerAutoloadMaps($maps);
         $test = $this->loader->getAutoloadMap();
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertEquals(3, count($test));
     }
 

--- a/tests/ZendTest/Loader/ClassMapAutoloaderTest.php
+++ b/tests/ZendTest/Loader/ClassMapAutoloaderTest.php
@@ -160,7 +160,7 @@ class ClassMapAutoloaderTest extends \PHPUnit_Framework_TestCase
     {
         $this->loader->register();
         $loaders = spl_autoload_functions();
-        $this->assertTrue(count($this->loaders) < count($loaders));
+        $this->assertGreaterThan(count($this->loaders), count($loaders));
         $test = array_shift($loaders);
         $this->assertEquals(array($this->loader, 'autoload'), $test);
     }

--- a/tests/ZendTest/Loader/PluginClassLoaderTest.php
+++ b/tests/ZendTest/Loader/PluginClassLoaderTest.php
@@ -32,7 +32,7 @@ class PluginClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testPluginClassLoaderHasNoAssociationsByDefault()
     {
         $plugins = $this->loader->getRegisteredPlugins();
-        $this->assertTrue(empty($plugins));
+        $this->assertEmpty($plugins);
     }
 
     public function testRegisterPluginRegistersShortNameClassNameAssociation()

--- a/tests/ZendTest/Loader/PluginClassLoaderTest.php
+++ b/tests/ZendTest/Loader/PluginClassLoaderTest.php
@@ -115,7 +115,7 @@ class PluginClassLoaderTest extends \PHPUnit_Framework_TestCase
         $this->loader->unregisterPlugin('test');
 
         $test = $this->loader->getRegisteredPlugins();
-        $this->assertFalse(array_key_exists('test', $test));
+        $this->assertArrayNotHasKey('test', $test);
     }
 
     public function testIsLoadedReturnsFalseIfPluginIsNotInMap()

--- a/tests/ZendTest/Loader/StandardAutoloaderTest.php
+++ b/tests/ZendTest/Loader/StandardAutoloaderTest.php
@@ -199,7 +199,7 @@ class StandardAutoloaderTest extends \PHPUnit_Framework_TestCase
         $loader->registerNamespace('ZendTest\Loader\TestAsset\Parent', __DIR__ . '/TestAsset/Parent');
         $loader->registerNamespace('ZendTest\Loader\TestAsset\Parent\Child', __DIR__ . '/TestAsset/Child');
         $result = $loader->autoload('ZendTest\Loader\TestAsset\Parent\Child\Subclass');
-        $this->assertTrue($result !== false);
+        $this->assertNotFalse($result);
         $this->assertTrue(class_exists('ZendTest\Loader\TestAsset\Parent\Child\Subclass', false));
     }
 }

--- a/tests/ZendTest/Loader/StandardAutoloaderTest.php
+++ b/tests/ZendTest/Loader/StandardAutoloaderTest.php
@@ -161,7 +161,7 @@ class StandardAutoloaderTest extends \PHPUnit_Framework_TestCase
         $loader = new StandardAutoloader();
         $loader->register();
         $loaders = spl_autoload_functions();
-        $this->assertTrue(count($this->loaders) < count($loaders));
+        $this->assertGreaterThan(count($this->loaders), count($loaders));
         $test = array_pop($loaders);
         $this->assertEquals(array($loader, 'autoload'), $test);
     }

--- a/tests/ZendTest/Log/Formatter/XmlTest.php
+++ b/tests/ZendTest/Log/Formatter/XmlTest.php
@@ -93,7 +93,7 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $line = $f->format(array('message' => '&key1=value1&key2=value2', 'priority' => 42));
 
         $this->assertContains("&amp;", $line);
-        $this->assertTrue(substr_count($line, "&amp;") == 2);
+        $this->assertEquals(2, substr_count($line, "&amp;"));
     }
 
     /**

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -105,9 +105,9 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $writers = $this->logger->getWriters();
         $this->assertInstanceOf('Zend\Stdlib\SplPriorityQueue', $writers);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Noop);
+        $this->assertInstanceOf('Zend\Log\Writer\Noop', $writer);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
+        $this->assertInstanceOf('Zend\Log\Writer\Mock', $writer);
     }
 
     public function testAddWriterWithPriority()
@@ -120,9 +120,9 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Zend\Stdlib\SplPriorityQueue', $writers);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Noop);
+        $this->assertInstanceOf('Zend\Log\Writer\Noop', $writer);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
+        $this->assertInstanceOf('Zend\Log\Writer\Mock', $writer);
     }
 
     public function testAddWithSamePriority()
@@ -135,9 +135,9 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Zend\Stdlib\SplPriorityQueue', $writers);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Mock);
+        $this->assertInstanceOf('Zend\Log\Writer\Mock', $writer);
         $writer = $writers->extract();
-        $this->assertTrue($writer instanceof \Zend\Log\Writer\Noop);
+        $this->assertInstanceOf('Zend\Log\Writer\Noop', $writer);
     }
 
     public function testLogging()

--- a/tests/ZendTest/Log/LoggerTest.php
+++ b/tests/ZendTest/Log/LoggerTest.php
@@ -260,7 +260,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $previous = Logger::registerErrorHandler($this->logger);
         $this->assertNotNull($previous);
-        $this->assertTrue(false !== $previous);
+        $this->assertNotFalse($previous);
 
         // check for single error handler instance
         $this->assertFalse(Logger::registerErrorHandler($this->logger));

--- a/tests/ZendTest/Log/Writer/AbstractTest.php
+++ b/tests/ZendTest/Log/Writer/AbstractTest.php
@@ -44,13 +44,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testAddMockFilterByName()
     {
         $instance = $this->_writer->addFilter('mock');
-        $this->assertTrue($instance instanceof ConcreteWriter);
+        $this->assertInstanceOf('ZendTest\Log\TestAsset\ConcreteWriter', $instance);
     }
 
     public function testAddRegexFilterWithParamsByName()
     {
         $instance = $this->_writer->addFilter('regex', array( 'regex' => '/mess/' ));
-        $this->assertTrue($instance instanceof ConcreteWriter);
+        $this->assertInstanceOf('ZendTest\Log\TestAsset\ConcreteWriter', $instance);
     }
 
     /**
@@ -61,7 +61,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $instance = $this->_writer->addFilter(1)
                                   ->setFormatter(new SimpleFormatter());
 
-        $this->assertTrue($instance instanceof ConcreteWriter);
+        $this->assertInstanceOf('ZendTest\Log\TestAsset\ConcreteWriter', $instance);
     }
 
     public function testConvertErrorsToException()

--- a/tests/ZendTest/Log/Writer/ChromePhpTest.php
+++ b/tests/ZendTest/Log/Writer/ChromePhpTest.php
@@ -62,7 +62,7 @@ class ChromePhpTest extends \PHPUnit_Framework_TestCase
             'message' => 'my msg',
             'priority' => Logger::DEBUG
         ));
-        $this->assertTrue(empty($this->chromephp->calls));
+        $this->assertEmpty($this->chromephp->calls);
     }
 
     public function testConstructWithOptions()

--- a/tests/ZendTest/Log/Writer/ChromePhpTest.php
+++ b/tests/ZendTest/Log/Writer/ChromePhpTest.php
@@ -31,7 +31,7 @@ class ChromePhpTest extends \PHPUnit_Framework_TestCase
     public function testGetChromePhp()
     {
         $writer = new ChromePhp($this->chromephp);
-        $this->assertTrue($writer->getChromePhp() instanceof ChromePhpInterface);
+        $this->assertInstanceOf('Zend\Log\Writer\ChromePhp\ChromePhpInterface', $writer->getChromePhp());
     }
 
     public function testSetChromePhp()
@@ -40,7 +40,7 @@ class ChromePhpTest extends \PHPUnit_Framework_TestCase
         $chromephp2 = new MockChromePhp();
 
         $writer->setChromePhp($chromephp2);
-        $this->assertTrue($writer->getChromePhp() instanceof ChromePhpInterface);
+        $this->assertInstanceOf('Zend\Log\Writer\ChromePhp\ChromePhpInterface', $writer->getChromePhp());
         $this->assertEquals($chromephp2, $writer->getChromePhp());
     }
 
@@ -74,7 +74,7 @@ class ChromePhpTest extends \PHPUnit_Framework_TestCase
             'formatter' => $formatter,
             'instance'  => $this->chromephp,
         ));
-        $this->assertTrue($writer->getChromePhp() instanceof ChromePhpInterface);
+        $this->assertInstanceOf('Zend\Log\Writer\ChromePhp\ChromePhpInterface', $writer->getChromePhp());
         $this->assertAttributeInstanceOf('Zend\Log\Formatter\ChromePhp', 'formatter', $writer);
 
         $filters = self::readAttribute($writer, 'filters');

--- a/tests/ZendTest/Log/Writer/DbTest.php
+++ b/tests/ZendTest/Log/Writer/DbTest.php
@@ -336,10 +336,9 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $data = $method->invoke($this->writer, $event, $columnMap);
 
         foreach ($data as $field => $value) {
-            $this->assertTrue(is_scalar($value), sprintf(
-                'Value of column "%s" should be scalar, %s given',
-                $field,
-                gettype($value)
+            $this->assertInternalType('scalar', $value, sprintf(
+                'Value of column "%s" should be scalar',
+                $field
             ));
         }
     }
@@ -370,10 +369,9 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $data = $method->invoke($this->writer, $event);
 
         foreach ($data as $field => $value) {
-            $this->assertTrue(is_scalar($value), sprintf(
-                'Value of column "%s" should be scalar, %s given',
-                $field,
-                gettype($value)
+            $this->assertInternalType('scalar', $value, sprintf(
+                'Value of column "%s" should be scalar',
+                $field
             ));
         }
     }

--- a/tests/ZendTest/Log/Writer/FirePhpTest.php
+++ b/tests/ZendTest/Log/Writer/FirePhpTest.php
@@ -33,7 +33,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
     public function testGetFirePhp()
     {
         $writer = new FirePhp($this->firephp);
-        $this->assertTrue($writer->getFirePhp() instanceof FirePhpInterface);
+        $this->assertInstanceOf('Zend\Log\Writer\FirePhp\FirePhpInterface', $writer->getFirePhp());
     }
     /**
      * Test set firephp
@@ -44,7 +44,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
         $firephp2 = new MockFirePhp();
 
         $writer->setFirePhp($firephp2);
-        $this->assertTrue($writer->getFirePhp() instanceof FirePhpInterface);
+        $this->assertInstanceOf('Zend\Log\Writer\FirePhp\FirePhpInterface', $writer->getFirePhp());
         $this->assertEquals($firephp2, $writer->getFirePhp());
     }
     /**
@@ -82,7 +82,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
                 'formatter' => $formatter,
                 'instance'  => $this->firephp,
         ));
-        $this->assertTrue($writer->getFirePhp() instanceof FirePhpInterface);
+        $this->assertInstanceOf('Zend\Log\Writer\FirePhp\FirePhpInterface', $writer->getFirePhp());
         $this->assertAttributeInstanceOf('Zend\Log\Formatter\FirePhp', 'formatter', $writer);
 
         $filters = self::readAttribute($writer, 'filters');

--- a/tests/ZendTest/Log/Writer/FirePhpTest.php
+++ b/tests/ZendTest/Log/Writer/FirePhpTest.php
@@ -70,7 +70,7 @@ class FirePhpTest extends \PHPUnit_Framework_TestCase
             'message' => 'my msg',
             'priority' => Logger::DEBUG
         ));
-        $this->assertTrue(empty($this->firephp->calls));
+        $this->assertEmpty($this->firephp->calls);
     }
 
     public function testConstructWithOptions()

--- a/tests/ZendTest/Log/Writer/SyslogTest.php
+++ b/tests/ZendTest/Log/Writer/SyslogTest.php
@@ -61,7 +61,7 @@ class SyslogTest extends \PHPUnit_Framework_TestCase
         $instance = $writer->setFacility(LOG_USER)
                            ->setApplicationName('my_app');
 
-        $this->assertTrue($instance instanceof SyslogWriter);
+        $this->assertInstanceOf('Zend\Log\Writer\Syslog', $instance);
     }
 
     /**

--- a/tests/ZendTest/Mail/Storage/ImapTest.php
+++ b/tests/ZendTest/Mail/Storage/ImapTest.php
@@ -579,7 +579,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
         $capa = $protocol->capability();
-        $this->assertTrue(is_array($capa));
+        $this->assertInternalType('array', $capa);
         $this->assertEquals($capa[0], 'CAPABILITY');
     }
 
@@ -588,7 +588,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
         $status = $protocol->select('INBOX');
-        $this->assertTrue(is_array($status['flags']));
+        $this->assertInternalType('array', $status['flags']);
         $this->assertEquals($status['exists'], 7);
     }
 
@@ -598,7 +598,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $protocol = new Protocol\Imap($this->params['host']);
         $protocol->login($this->params['user'], $this->params['password']);
         $status = $protocol->examine('INBOX');
-        $this->assertTrue(is_array($status['flags']));
+        $this->assertInternalType('array', $status['flags']);
         $this->assertEquals($status['exists'], 7);
     }
 
@@ -635,12 +635,12 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($protocol->fetch('UID', 1, INF), $range);
         $this->assertEquals($protocol->fetch('UID', 1, 7), $range);
         $this->assertEquals($protocol->fetch('UID', range(1, 7)), $range);
-        $this->assertTrue(is_numeric($protocol->fetch('UID', 1)));
+        $this->assertInternalType('numeric', $protocol->fetch('UID', 1));
 
         $result = $protocol->fetch(array('UID', 'FLAGS'), 1, INF);
         foreach ($result as $k => $v) {
             $this->assertEquals($k, $v['UID']);
-            $this->assertTrue(is_array($v['FLAGS']));
+            $this->assertInternalType('array', $v['FLAGS']);
         }
 
         $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');

--- a/tests/ZendTest/Mail/Storage/ImapTest.php
+++ b/tests/ZendTest/Mail/Storage/ImapTest.php
@@ -396,7 +396,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
 
         $flags = $mail->getMessage(1)->getFlags();
         $this->assertTrue(isset($flags[Storage::FLAG_RECENT]));
-        $this->assertTrue(in_array(Storage::FLAG_RECENT, $flags));
+        $this->assertContains(Storage::FLAG_RECENT, $flags);
     }
 
     public function testRawHeader()
@@ -658,11 +658,11 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($protocol->store(array('\Flagged'), 1, null, '+'));
 
         $result = $protocol->store(array('\Flagged'), 1, null, '', false);
-        $this->assertTrue(in_array('\Flagged', $result[1]));
+        $this->assertContains('\Flagged', $result[1]);
         $result = $protocol->store(array('\Flagged'), 1, null, '-', false);
         $this->assertFalse(in_array('\Flagged', $result[1]));
         $result = $protocol->store(array('\Flagged'), 1, null, '+', false);
-        $this->assertTrue(in_array('\Flagged', $result[1]));
+        $this->assertContains('\Flagged', $result[1]);
     }
 
     public function testMove()

--- a/tests/ZendTest/Mail/Storage/ImapTest.php
+++ b/tests/ZendTest/Mail/Storage/ImapTest.php
@@ -660,7 +660,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $result = $protocol->store(array('\Flagged'), 1, null, '', false);
         $this->assertContains('\Flagged', $result[1]);
         $result = $protocol->store(array('\Flagged'), 1, null, '-', false);
-        $this->assertFalse(in_array('\Flagged', $result[1]));
+        $this->assertNotContains('\Flagged', $result[1]);
         $result = $protocol->store(array('\Flagged'), 1, null, '+', false);
         $this->assertContains('\Flagged', $result[1]);
     }

--- a/tests/ZendTest/Mail/Storage/ImapTest.php
+++ b/tests/ZendTest/Mail/Storage/ImapTest.php
@@ -403,7 +403,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Imap($this->params);
 
-        $this->assertTrue(strpos($mail->getRawHeader(1), "\r\nSubject: Simple Message\r\n") > 0);
+        $this->assertContains("\r\nSubject: Simple Message\r\n", $mail->getRawHeader(1));
     }
 
     public function testUniqueId()

--- a/tests/ZendTest/Mail/Storage/MaildirMessageOldTest.php
+++ b/tests/ZendTest/Mail/Storage/MaildirMessageOldTest.php
@@ -148,7 +148,7 @@ class MaildirMessageOldTest extends \PHPUnit_Framework_TestCase
 
         $flags = $mail->getMessage(1)->getFlags();
         $this->assertTrue(isset($flags[Storage::FLAG_SEEN]));
-        $this->assertTrue(in_array(Storage::FLAG_SEEN, $flags));
+        $this->assertContains(Storage::FLAG_SEEN, $flags);
     }
 
     public function testFetchPart()

--- a/tests/ZendTest/Mail/Storage/MaildirTest.php
+++ b/tests/ZendTest/Mail/Storage/MaildirTest.php
@@ -236,7 +236,7 @@ class MaildirTest extends \PHPUnit_Framework_TestCase
 
         $flags = $mail->getMessage(1)->getFlags();
         $this->assertTrue(isset($flags[Storage::FLAG_SEEN]));
-        $this->assertTrue(in_array(Storage::FLAG_SEEN, $flags));
+        $this->assertContains(Storage::FLAG_SEEN, $flags);
     }
 
     public function testUniqueId()

--- a/tests/ZendTest/Mail/Storage/MboxInterfaceTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxInterfaceTest.php
@@ -139,7 +139,7 @@ class MboxInterfaceTest extends \PHPUnit_Framework_TestCase
     {
         $list = new Storage\Mbox(array('filename' => $this->_mboxFile));
         $headers = $list[1]->getHeaders();
-        $this->assertTrue(count($headers) > 0);
+        $this->assertNotEmpty($headers);
     }
 
     public function testWrongHeader()

--- a/tests/ZendTest/Mail/Storage/MboxInterfaceTest.php
+++ b/tests/ZendTest/Mail/Storage/MboxInterfaceTest.php
@@ -79,7 +79,7 @@ class MboxInterfaceTest extends \PHPUnit_Framework_TestCase
         $list = new Storage\Mbox(array('filename' => $this->_mboxFile));
 
         foreach ($list as $key => $message) {
-            $this->assertTrue($message instanceof Message\MessageInterface, 'value in iteration is not a mail message');
+            $this->assertInstanceOf('Zend\Mail\Storage\Message\MessageInterface', $message, 'value in iteration is not a mail message');
         }
     }
 

--- a/tests/ZendTest/Mail/Storage/MessageTest.php
+++ b/tests/ZendTest/Mail/Storage/MessageTest.php
@@ -282,7 +282,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         }
 
         $message = new Message(array());
-        $this->assertTrue($message->countParts() == 0);
+        $this->assertEquals(0, $message->countParts());
     }
 
     /**

--- a/tests/ZendTest/Mail/Storage/MessageTest.php
+++ b/tests/ZendTest/Mail/Storage/MessageTest.php
@@ -240,7 +240,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function testToplines()
     {
         $message = new Message(array('headers' => file_get_contents($this->_file)));
-        $this->assertTrue(strpos($message->getToplines(), 'multipart message') === 0);
+        $this->assertStringStartsWith('multipart message', $message->getToplines());
     }
 
     public function testNoContent()
@@ -323,7 +323,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($message->subject, 'multipart');
 
         $message = new Message(array('handler' => $mail, 'id' => 5));
-        $this->assertTrue(strpos($message->getContent(), 'multipart message') === 0);
+        $this->assertStringStartsWith('multipart message', $message->getContent());
     }
 
     public function testManualIterator()

--- a/tests/ZendTest/Mail/Storage/Pop3Test.php
+++ b/tests/ZendTest/Mail/Storage/Pop3Test.php
@@ -271,7 +271,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
     public function testServerCapa()
     {
         $mail = new Protocol\Pop3($this->_params['host']);
-        $this->assertTrue(is_array($mail->capa()));
+        $this->assertInternalType('array', $mail->capa());
     }
 
     public function testServerUidl()

--- a/tests/ZendTest/Mail/Storage/Pop3Test.php
+++ b/tests/ZendTest/Mail/Storage/Pop3Test.php
@@ -289,7 +289,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Pop3($this->_params);
 
-        $this->assertTrue(strpos($mail->getRawHeader(1), "\r\nSubject: Simple Message\r\n") > 0);
+        $this->assertContains("\r\nSubject: Simple Message\r\n", $mail->getRawHeader(1));
     }
 
     public function testUniqueId()

--- a/tests/ZendTest/Mail/Transport/FileOptionsTest.php
+++ b/tests/ZendTest/Mail/Transport/FileOptionsTest.php
@@ -29,7 +29,7 @@ class FileOptionsTest extends \PHPUnit_Framework_TestCase
     public function testDefaultCallbackIsSetByDefault()
     {
         $callback = $this->options->getCallback();
-        $this->assertTrue(is_callable($callback));
+        $this->assertInternalType('callable', $callback);
         $test     = call_user_func($callback, '');
         $this->assertRegExp('#^ZendMail_\d+_\d+\.eml$#', $test);
     }

--- a/tests/ZendTest/Math/BigInteger/BigIntegerTest.php
+++ b/tests/ZendTest/Math/BigInteger/BigIntegerTest.php
@@ -25,7 +25,7 @@ class BigIntegerTest extends \PHPUnit_Framework_TestCase
         }
 
         $bigInt = BigInt::factory('Bcmath');
-        $this->assertTrue($bigInt instanceof Adapter\Bcmath);
+        $this->assertInstanceOf('Zend\Math\BigInteger\Adapter\Bcmath', $bigInt);
     }
 
     public function testFactoryCreatesGmpAdapter()
@@ -35,7 +35,7 @@ class BigIntegerTest extends \PHPUnit_Framework_TestCase
         }
 
         $bigInt = BigInt::factory('Gmp');
-        $this->assertTrue($bigInt instanceof Adapter\Gmp);
+        $this->assertInstanceOf('Zend\Math\BigInteger\Adapter\Gmp', $bigInt);
     }
 
     public function testFactoryUsesDefaultAdapter()
@@ -43,7 +43,7 @@ class BigIntegerTest extends \PHPUnit_Framework_TestCase
         if (!extension_loaded('bcmath') && !extension_loaded('gmp')) {
             $this->markTestSkipped('Missing bcmath or gmp extensions');
         }
-        $this->assertTrue(BigInt::factory() instanceof AdapterInterface);
+        $this->assertInstanceOf('Zend\Math\BigInteger\Adapter\AdapterInterface', BigInt::factory());
     }
 
     public function testFactoryUnknownAdapterRaisesServiceManagerException()

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -144,7 +144,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
             $values += Rand::getInteger(0, PHP_INT_MAX);
         }
 
-        $this->assertFalse($values === 0);
+        $this->assertGreaterThan(0, $values);
     }
 
     public function testRandFloat()
@@ -152,7 +152,8 @@ class RandTest extends \PHPUnit_Framework_TestCase
         for ($length = 1; $length < 512; $length++) {
             $rand = Rand::getFloat();
             $this->assertInternalType('float', $rand);
-            $this->assertTrue(($rand >= 0 && $rand <= 1));
+            $this->assertGreaterThanOrEqual(0, $rand);
+            $this->assertLessThanOrEqual(1, $rand);
         }
     }
 

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -144,7 +144,8 @@ class RandTest extends \PHPUnit_Framework_TestCase
             $values += Rand::getInteger(0, PHP_INT_MAX);
         }
 
-        $this->assertGreaterThan(0, $values);
+        // It's not possible to test $values > 0 because $values may suffer a integer overflow
+        $this->assertNotEquals(0, $values);
     }
 
     public function testRandFloat()

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -29,7 +29,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
     {
         for ($length = 1; $length < 4096; $length++) {
             $rand = Rand::getBytes($length);
-            $this->assertTrue($rand !== false);
+            $this->assertNotFalse($rand);
             $this->assertEquals($length, strlen($rand));
         }
     }

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -38,7 +38,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
     {
         for ($length = 1; $length < 512; $length++) {
             $rand = Rand::getBoolean();
-            $this->assertTrue(is_bool($rand));
+            $this->assertInternalType('bool', $rand);
         }
     }
 
@@ -151,7 +151,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
     {
         for ($length = 1; $length < 512; $length++) {
             $rand = Rand::getFloat();
-            $this->assertTrue(is_float($rand));
+            $this->assertInternalType('float', $rand);
             $this->assertTrue(($rand >= 0 && $rand <= 1));
         }
     }

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -183,7 +183,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
     {
         $source = new Math\Source\HashTiming;
         $rand = $source->generate(32);
-        $this->assertTrue(32 === strlen($rand));
+        $this->assertEquals(32, strlen($rand));
         $rand2 = $source->generate(32);
         $this->assertNotEquals($rand, $rand2);
     }
@@ -192,7 +192,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
     {
         $source = Math\Rand::getAlternativeGenerator();
         $rand = $source->generate(32);
-        $this->assertTrue(32 === strlen($rand));
+        $this->assertEquals(32, strlen($rand));
         $rand2 = $source->generate(32);
         $this->assertNotEquals($rand, $rand2);
     }

--- a/tests/ZendTest/Math/RandTest.php
+++ b/tests/ZendTest/Math/RandTest.php
@@ -162,7 +162,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
         for ($length = 1; $length < 512; $length++) {
             $rand = Rand::getString($length, '0123456789abcdef');
             $this->assertEquals(strlen($rand), $length);
-            $this->assertTrue(preg_match('#^[0-9a-f]+$#', $rand) === 1);
+            $this->assertEquals(1, preg_match('#^[0-9a-f]+$#', $rand));
         }
     }
 
@@ -171,7 +171,7 @@ class RandTest extends \PHPUnit_Framework_TestCase
         for ($length = 1; $length < 512; $length++) {
             $rand = Rand::getString($length);
             $this->assertEquals(strlen($rand), $length);
-            $this->assertTrue(preg_match('#^[0-9a-zA-Z+/]+$#', $rand) === 1);
+            $this->assertEquals(1, preg_match('#^[0-9a-zA-Z+/]+$#', $rand));
         }
     }
 

--- a/tests/ZendTest/Memory/AccessControllerTest.php
+++ b/tests/ZendTest/Memory/AccessControllerTest.php
@@ -39,7 +39,7 @@ class AccessControllerTest extends \PHPUnit_Framework_TestCase
         $memoryManager  = new Memory\MemoryManager($this->_cache);
         $memObject      = $memoryManager->create('012345678');
 
-        $this->assertTrue($memObject instanceof \Zend\Memory\Container\AccessController);
+        $this->assertInstanceOf('Zend\Memory\Container\AccessController', $memObject);
     }
 
     /**
@@ -64,7 +64,7 @@ class AccessControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals((string) $memObject->value, '012_456_89');
 
         $memObject->value = 'another value';
-        $this->assertTrue($memObject->value instanceof \Zend\Memory\Value);
+        $this->assertInstanceOf('Zend\Memory\Value', $memObject->value);
         $this->assertEquals((string) $memObject->value, 'another value');
     }
 

--- a/tests/ZendTest/Memory/LockedTest.php
+++ b/tests/ZendTest/Memory/LockedTest.php
@@ -23,7 +23,7 @@ class LockedTest extends \PHPUnit_Framework_TestCase
     {
         $memObject = new Container\Locked('0123456789');
 
-        $this->assertTrue($memObject instanceof Container\Locked);
+        $this->assertInstanceOf('Zend\Memory\Container\Locked', $memObject);
     }
 
     /**

--- a/tests/ZendTest/Memory/MemoryManagerTest.php
+++ b/tests/ZendTest/Memory/MemoryManagerTest.php
@@ -39,12 +39,12 @@ class MemoryManagerTest extends \PHPUnit_Framework_TestCase
     {
         /** Without caching */
         $memoryManager = new Memory\MemoryManager();
-        $this->assertTrue($memoryManager instanceof Memory\MemoryManager);
+        $this->assertInstanceOf('Zend\Memory\MemoryManager', $memoryManager);
         unset($memoryManager);
 
         /** Caching using 'File' backend */
         $memoryManager = new Memory\MemoryManager($this->_cache);
-        $this->assertTrue($memoryManager instanceof Memory\MemoryManager);
+        $this->assertInstanceOf('Zend\Memory\MemoryManager', $memoryManager);
         unset($memoryManager);
     }
 
@@ -73,19 +73,19 @@ class MemoryManagerTest extends \PHPUnit_Framework_TestCase
         $memoryManager = new Memory\MemoryManager($this->_cache);
 
         $memObject1 = $memoryManager->create('Value of object 1');
-        $this->assertTrue($memObject1 instanceof Container\AccessController);
+        $this->assertInstanceOf('Zend\Memory\Container\AccessController', $memObject1);
         $this->assertEquals($memObject1->getRef(), 'Value of object 1');
 
         $memObject2 = $memoryManager->create();
-        $this->assertTrue($memObject2 instanceof Container\AccessController);
+        $this->assertInstanceOf('Zend\Memory\Container\AccessController', $memObject2);
         $this->assertEquals($memObject2->getRef(), '');
 
         $memObject3 = $memoryManager->createLocked('Value of object 3');
-        $this->assertTrue($memObject3 instanceof Container\Locked);
+        $this->assertInstanceOf('Zend\Memory\Container\Locked', $memObject3);
         $this->assertEquals($memObject3->getRef(), 'Value of object 3');
 
         $memObject4 = $memoryManager->createLocked();
-        $this->assertTrue($memObject4 instanceof Container\Locked);
+        $this->assertInstanceOf('Zend\Memory\Container\Locked', $memObject4);
         $this->assertEquals($memObject4->getRef(), '');
     }
 

--- a/tests/ZendTest/Memory/MovableTest.php
+++ b/tests/ZendTest/Memory/MovableTest.php
@@ -25,7 +25,7 @@ class MovableTest extends \PHPUnit_Framework_TestCase
         $memoryManager = new DummyMemoryManager();
         $memObject = new Container\Movable($memoryManager, 10, '0123456789');
 
-        $this->assertTrue($memObject instanceof Container\Movable);
+        $this->assertInstanceOf('Zend\Memory\Container\Movable', $memObject);
     }
 
     /**
@@ -50,7 +50,7 @@ class MovableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals((string) $memObject->value, '012_456_89');
 
         $memObject->value = 'another value';
-        $this->assertTrue($memObject->value instanceof \Zend\Memory\Value);
+        $this->assertInstanceOf('Zend\Memory\Value', $memObject->value);
         $this->assertEquals((string) $memObject->value, 'another value');
     }
 

--- a/tests/ZendTest/Memory/MovableTest.php
+++ b/tests/ZendTest/Memory/MovableTest.php
@@ -84,8 +84,8 @@ class MovableTest extends \PHPUnit_Framework_TestCase
         $memObject->touch();
 
         $this->assertTrue($memoryManager->processUpdatePassed);
-        $this->assertTrue($memoryManager->processedObject === $memObject);
-        $this->assertEquals($memoryManager->processedId, 10);
+        $this->assertEquals($memObject, $memoryManager->processedObject);
+        $this->assertEquals(10, $memoryManager->processedId);
     }
 
     /**
@@ -105,8 +105,8 @@ class MovableTest extends \PHPUnit_Framework_TestCase
         $memObject->value[6] = '_';
 
         $this->assertTrue($memoryManager->processUpdatePassed);
-        $this->assertTrue($memoryManager->processedObject === $memObject);
-        $this->assertEquals($memoryManager->processedId, 10);
+        $this->assertEquals($memObject, $memoryManager->processedObject);
+        $this->assertEquals(10, $memoryManager->processedId);
     }
 
     public function testInvalidGetThrowException()

--- a/tests/ZendTest/Memory/ValueTest.php
+++ b/tests/ZendTest/Memory/ValueTest.php
@@ -23,7 +23,7 @@ class ValueTest extends \PHPUnit_Framework_TestCase
     public function testCreation()
     {
         $valueObject = new Memory\Value('data data data ...', new DummyMovableContainer());
-        $this->assertTrue($valueObject instanceof Memory\Value);
+        $this->assertInstanceOf('Zend\Memory\Value', $valueObject);
         $this->assertEquals($valueObject->getRef(), 'data data data ...');
     }
 

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -26,7 +26,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $msg = new Mime\Message();  // No Parts
         $p = $msg->getParts();
-        $this->assertTrue(is_array($p));
+        $this->assertInternalType('array', $p);
         $this->assertTrue(count($p) == 0);
 
         $p2 = array();
@@ -34,7 +34,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $p2[] = new Mime\Part('This is another test');
         $msg->setParts($p2);
         $p = $msg->getParts();
-        $this->assertTrue(is_array($p));
+        $this->assertInternalType('array', $p);
         $this->assertTrue(count($p) == 2);
     }
 

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -35,7 +35,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $msg->setParts($p2);
         $p = $msg->getParts();
         $this->assertInternalType('array', $p);
-        $this->assertTrue(count($p) == 2);
+        $this->assertCount(2, $p);
     }
 
     public function testGetMime()

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -70,8 +70,8 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($p2 !== false);
         }
         // check if the two test messages appear:
-        $this->assertTrue(strpos($res, 'This is a test') !== false);
-        $this->assertTrue(strpos($res, 'This is another test') !== false);
+        $this->assertContains('This is a test', $res);
+        $this->assertContains('This is another test', $res);
         // ... more in ZMailTest
     }
 

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -64,10 +64,10 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $boundary = $mime->boundary();
         $p1 = strpos($res, $boundary);
         // $boundary must appear once for every mime part
-        $this->assertTrue($p1 !== false);
+        $this->assertNotFalse($p1);
         if ($p1) {
             $p2 = strpos($res, $boundary, $p1 + strlen($boundary));
-            $this->assertTrue($p2 !== false);
+            $this->assertNotFalse($p2);
         }
         // check if the two test messages appear:
         $this->assertContains('This is a test', $res);

--- a/tests/ZendTest/Mime/MessageTest.php
+++ b/tests/ZendTest/Mime/MessageTest.php
@@ -27,7 +27,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $msg = new Mime\Message();  // No Parts
         $p = $msg->getParts();
         $this->assertInternalType('array', $p);
-        $this->assertTrue(count($p) == 0);
+        $this->assertEmpty($p);
 
         $p2 = array();
         $p2[] = new Mime\Part('This is a test');

--- a/tests/ZendTest/Mime/PartTest.php
+++ b/tests/ZendTest/Mime/PartTest.php
@@ -75,22 +75,22 @@ class PartTest extends \PHPUnit_Framework_TestCase
 
         // Test Base64
         $fp = fopen($testfile, 'rb');
-        $this->assertTrue(is_resource($fp));
+        $this->assertInternalType('resource', $fp);
         $part = new Mime\Part($fp);
         $part->encoding = Mime\Mime::ENCODING_BASE64;
         $fp2 = $part->getEncodedStream();
-        $this->assertTrue(is_resource($fp2));
+        $this->assertInternalType('resource', $fp2);
         $encoded = stream_get_contents($fp2);
         fclose($fp);
         $this->assertEquals(base64_decode($encoded), $original);
 
         // test QuotedPrintable
         $fp = fopen($testfile, 'rb');
-        $this->assertTrue(is_resource($fp));
+        $this->assertInternalType('resource', $fp);
         $part = new Mime\Part($fp);
         $part->encoding = Mime\Mime::ENCODING_QUOTEDPRINTABLE;
         $fp2 = $part->getEncodedStream();
-        $this->assertTrue(is_resource($fp2));
+        $this->assertInternalType('resource', $fp2);
         $encoded = stream_get_contents($fp2);
         fclose($fp);
         $this->assertEquals(quoted_printable_decode($encoded), $original);

--- a/tests/ZendTest/ModuleManager/Listener/LocatorRegistrationListenerTest.php
+++ b/tests/ZendTest/ModuleManager/Listener/LocatorRegistrationListenerTest.php
@@ -136,9 +136,9 @@ class LocatorRegistrationListenerTest extends TestCase
         $instances = $registeredServices['instances'];
 
         $this->assertContains('zendmodulemanagermodulemanager', $aliases);
-        $this->assertFalse(in_array('modulemanager', $aliases));
+        $this->assertNotContains('modulemanager', $aliases);
 
         $this->assertContains('modulemanager', $instances);
-        $this->assertFalse(in_array('zendmodulemanagermodulemanager', $instances));
+        $this->assertNotContains('zendmodulemanagermodulemanager', $instances);
     }
 }

--- a/tests/ZendTest/Paginator/Adapter/IteratorTest.php
+++ b/tests/ZendTest/Paginator/Adapter/IteratorTest.php
@@ -97,7 +97,7 @@ class IteratorTest extends \PHPUnit_Framework_TestCase
         $items = $this->adapter->getItems(0, 1);
         $innerIterator = $items->getInnerIterator();
         $items = unserialize(serialize($items));
-        $this->assertTrue(($items->getInnerIterator() == $innerIterator), 'getItems has to be serializable to use caching');
+        $this->assertEquals($items->getInnerIterator(), $innerIterator, 'getItems has to be serializable to use caching');
     }
 
     /**

--- a/tests/ZendTest/Paginator/PaginatorTest.php
+++ b/tests/ZendTest/Paginator/PaginatorTest.php
@@ -551,15 +551,15 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
     {
         // Current page number
         $this->paginator->setCurrentPageNumber(3.3);
-        $this->assertTrue($this->paginator->getCurrentPageNumber() == 3);
+        $this->assertEquals(3, $this->paginator->getCurrentPageNumber());
 
         // Item count per page
         $this->paginator->setItemCountPerPage(3.3);
-        $this->assertTrue($this->paginator->getItemCountPerPage() == 3);
+        $this->assertEquals(3, $this->paginator->getItemCountPerPage());
 
         // Page range
         $this->paginator->setPageRange(3.3);
-        $this->assertTrue($this->paginator->getPageRange() == 3);
+        $this->assertEquals(3, $this->paginator->getPageRange());
     }
 
     /**

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -161,10 +161,10 @@ class AclTest extends \PHPUnit_Framework_TestCase
                      ->add($roleEditor, $roleMember);
         $this->assertEmpty($roleRegistry->getParents($roleGuest));
         $roleMemberParents = $roleRegistry->getParents($roleMember);
-        $this->assertTrue(1 === count($roleMemberParents));
+        $this->assertCount(1, $roleMemberParents);
         $this->assertTrue(isset($roleMemberParents['guest']));
         $roleEditorParents = $roleRegistry->getParents($roleEditor);
-        $this->assertTrue(1 === count($roleEditorParents));
+        $this->assertCount(1, $roleEditorParents);
         $this->assertTrue(isset($roleEditorParents['member']));
         $this->assertTrue($roleRegistry->inherits($roleMember, $roleGuest, true));
         $this->assertTrue($roleRegistry->inherits($roleEditor, $roleMember, true));
@@ -192,7 +192,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
                      ->add($roleParent2)
                      ->add($roleChild, array($roleParent1, $roleParent2));
         $roleChildParents = $roleRegistry->getParents($roleChild);
-        $this->assertTrue(2 === count($roleChildParents));
+        $this->assertCount(2, $roleChildParents);
         $i = 1;
         foreach ($roleChildParents as $roleParentId => $roleParent) {
             $this->assertTrue("parent$i" === $roleParentId);
@@ -202,7 +202,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($roleRegistry->inherits($roleChild, $roleParent2));
         $roleRegistry->remove($roleParent1);
         $roleChildParents = $roleRegistry->getParents($roleChild);
-        $this->assertTrue(1 === count($roleChildParents));
+        $this->assertCount(1, $roleChildParents);
         $this->assertTrue(isset($roleChildParents['parent2']));
         $this->assertTrue($roleRegistry->inherits($roleChild, $roleParent2));
     }
@@ -225,7 +225,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
                 new \ArrayIterator(array($roleParent1, $roleParent2))
             );
         $roleChildParents = $roleRegistry->getParents($roleChild);
-        $this->assertTrue(2 === count($roleChildParents));
+        $this->assertCount(2, $roleChildParents);
         $i = 1;
         foreach ($roleChildParents as $roleParentId => $roleParent) {
             $this->assertTrue("parent$i" === $roleParentId);
@@ -235,7 +235,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($roleRegistry->inherits($roleChild, $roleParent2));
         $roleRegistry->remove($roleParent1);
         $roleChildParents = $roleRegistry->getParents($roleChild);
-        $this->assertTrue(1 === count($roleChildParents));
+        $this->assertCount(1, $roleChildParents);
         $this->assertTrue(isset($roleChildParents['parent2']));
         $this->assertTrue($roleRegistry->inherits($roleChild, $roleParent2));
     }

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -159,7 +159,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $roleRegistry->add($roleGuest)
                      ->add($roleMember, $roleGuest->getRoleId())
                      ->add($roleEditor, $roleMember);
-        $this->assertTrue(0 === count($roleRegistry->getParents($roleGuest)));
+        $this->assertEmpty($roleRegistry->getParents($roleGuest));
         $roleMemberParents = $roleRegistry->getParents($roleMember);
         $this->assertTrue(1 === count($roleMemberParents));
         $this->assertTrue(isset($roleMemberParents['guest']));
@@ -173,7 +173,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($roleRegistry->inherits($roleMember, $roleEditor));
         $this->assertFalse($roleRegistry->inherits($roleGuest, $roleEditor));
         $roleRegistry->remove($roleMember);
-        $this->assertTrue(0 === count($roleRegistry->getParents($roleEditor)));
+        $this->assertEmpty($roleRegistry->getParents($roleEditor));
         $this->assertFalse($roleRegistry->inherits($roleEditor, $roleGuest));
     }
 

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -195,7 +195,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $roleChildParents);
         $i = 1;
         foreach ($roleChildParents as $roleParentId => $roleParent) {
-            $this->assertTrue("parent$i" === $roleParentId);
+            $this->assertEquals("parent$i", $roleParentId);
             $i++;
         }
         $this->assertTrue($roleRegistry->inherits($roleChild, $roleParent1));
@@ -228,7 +228,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $roleChildParents);
         $i = 1;
         foreach ($roleChildParents as $roleParentId => $roleParent) {
-            $this->assertTrue("parent$i" === $roleParentId);
+            $this->assertEquals("parent$i", $roleParentId);
             $i++;
         }
         $this->assertTrue($roleRegistry->inherits($roleChild, $roleParent1));

--- a/tests/ZendTest/Permissions/Acl/AclTest.php
+++ b/tests/ZendTest/Permissions/Acl/AclTest.php
@@ -46,9 +46,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
 
         $role = $this->_acl->addRole($roleGuest)
                           ->getRole($roleGuest->getRoleId());
-        $this->assertTrue($roleGuest === $role);
+        $this->assertEquals($roleGuest, $role);
         $role = $this->_acl->getRole($roleGuest);
-        $this->assertTrue($roleGuest === $role);
+        $this->assertEquals($roleGuest, $role);
     }
 
     /**
@@ -279,9 +279,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $resourceArea = new Resource\GenericResource('area');
         $resource = $this->_acl->addResource($resourceArea)
                           ->getResource($resourceArea->getResourceId());
-        $this->assertTrue($resourceArea === $resource);
+        $this->assertEquals($resourceArea, $resource);
         $resource = $this->_acl->getResource($resourceArea);
-        $this->assertTrue($resourceArea === $resource);
+        $this->assertEquals($resourceArea, $resource);
     }
 
     /**
@@ -305,9 +305,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $resourceArea = new Resource\GenericResource('area');
         $resource = $this->_acl->addResource($resourceArea)
                                ->getResource($resourceArea->getResourceId());
-        $this->assertTrue($resourceArea === $resource);
+        $this->assertEquals($resourceArea, $resource);
         $resource = $this->_acl->getResource($resourceArea);
-        $this->assertTrue($resourceArea === $resource);
+        $this->assertEquals($resourceArea, $resource);
     }
 
     /**

--- a/tests/ZendTest/ProgressBar/Adapter/ConsoleTest.php
+++ b/tests/ZendTest/ProgressBar/Adapter/ConsoleTest.php
@@ -44,7 +44,7 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new ConsoleStub();
 
-        $this->assertTrue(is_resource($adapter->getOutputStream()));
+        $this->assertInternalType('resource', $adapter->getOutputStream());
 
         $metaData = stream_get_meta_data($adapter->getOutputStream());
         $this->assertEquals('php://stdout', $metaData['uri']);
@@ -54,7 +54,7 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new ConsoleStub(array('outputStream' => 'php://stdout'));
 
-        $this->assertTrue(is_resource($adapter->getOutputStream()));
+        $this->assertInternalType('resource', $adapter->getOutputStream());
 
         $metaData = stream_get_meta_data($adapter->getOutputStream());
         $this->assertEquals('php://stdout', $metaData['uri']);
@@ -64,7 +64,7 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new ConsoleStub(array('outputStream' => 'php://stderr'));
 
-        $this->assertTrue(is_resource($adapter->getOutputStream()));
+        $this->assertInternalType('resource', $adapter->getOutputStream());
 
         $metaData = stream_get_meta_data($adapter->getOutputStream());
         $this->assertEquals('php://stderr', $metaData['uri']);
@@ -251,7 +251,7 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new Adapter\Console();
         $resource = $adapter->getOutputStream();
-        $this->assertTrue(is_resource($resource));
+        $this->assertInternalType('resource', $resource);
     }
 
     public function testFinishEol()

--- a/tests/ZendTest/Serializer/SerializerTest.php
+++ b/tests/ZendTest/Serializer/SerializerTest.php
@@ -36,7 +36,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
     {
         $newPluginManager = new AdapterPluginManager();
         Serializer::setAdapterPluginManager($newPluginManager);
-        $this->assertTrue(Serializer::getAdapterPluginManager() === $newPluginManager);
+        $this->assertSame($newPluginManager, Serializer::getAdapterPluginManager());
     }
 
     public function testDefaultAdapter()
@@ -77,7 +77,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $newAdapter = new Adapter\PhpSerialize();
 
         Serializer::setDefaultAdapter($newAdapter);
-        $this->assertTrue($newAdapter === Serializer::getDefaultAdapter());
+        $this->assertSame($newAdapter, Serializer::getDefaultAdapter());
     }
 
     public function testFactoryPassesAdapterOptions()

--- a/tests/ZendTest/Serializer/SerializerTest.php
+++ b/tests/ZendTest/Serializer/SerializerTest.php
@@ -29,7 +29,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDefaultAdapterPluginManager()
     {
-        $this->assertTrue(Serializer::getAdapterPluginManager() instanceof AdapterPluginManager);
+        $this->assertInstanceOf('Zend\Serializer\AdapterPluginManager', Serializer::getAdapterPluginManager());
     }
 
     public function testChangeAdapterPluginManager()
@@ -42,13 +42,13 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
     public function testDefaultAdapter()
     {
         $adapter = Serializer::getDefaultAdapter();
-        $this->assertTrue($adapter instanceof Adapter\AdapterInterface);
+        $this->assertInstanceOf('Zend\Serializer\Adapter\AdapterInterface', $adapter);
     }
 
     public function testFactoryValidCall()
     {
         $serializer = Serializer::factory('PhpSerialize');
-        $this->assertTrue($serializer instanceof Adapter\PHPSerialize);
+        $this->assertInstanceOf('Zend\Serializer\Adapter\PHPSerialize', $serializer);
     }
 
     public function testFactoryUnknownAdapter()
@@ -69,7 +69,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
     public function testChangeDefaultAdapterWithString()
     {
         Serializer::setDefaultAdapter('Json');
-        $this->assertTrue(Serializer::getDefaultAdapter() instanceof Adapter\Json);
+        $this->assertInstanceOf('Zend\Serializer\Adapter\Json', Serializer::getDefaultAdapter());
     }
 
     public function testChangeDefaultAdapterWithInstance()
@@ -85,7 +85,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $options = new Adapter\PythonPickleOptions(array('protocol' => 2));
         /** @var Adapter\PythonPickle $adapter  */
         $adapter = Serializer::factory('pythonpickle', $options);
-        $this->assertTrue($adapter instanceof Adapter\PythonPickle);
+        $this->assertInstanceOf('Zend\Serializer\Adapter\PythonPickle', $adapter);
         $this->assertEquals(2, $adapter->getOptions()->getProtocol());
     }
 

--- a/tests/ZendTest/Server/DefinitionTest.php
+++ b/tests/ZendTest/Server/DefinitionTest.php
@@ -44,7 +44,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $methods = $this->definition->getMethods();
         $this->assertInternalType('array', $methods);
-        $this->assertTrue(empty($methods));
+        $this->assertEmpty($methods);
     }
 
     public function testDefinitionShouldAllowAddingSingleMethods()
@@ -106,7 +106,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->testDefinitionShouldAllowAddingMultipleMethods();
         $this->definition->clearMethods();
         $test = $this->definition->getMethods();
-        $this->assertTrue(empty($test));
+        $this->assertEmpty($test);
     }
 
     public function testDefinitionShouldSerializeToArray()

--- a/tests/ZendTest/Server/DefinitionTest.php
+++ b/tests/ZendTest/Server/DefinitionTest.php
@@ -43,7 +43,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     public function testMethodsShouldBeEmptyArrayByDefault()
     {
         $methods = $this->definition->getMethods();
-        $this->assertTrue(is_array($methods));
+        $this->assertInternalType('array', $methods);
         $this->assertTrue(empty($methods));
     }
 

--- a/tests/ZendTest/Server/Method/CallbackTest.php
+++ b/tests/ZendTest/Server/Method/CallbackTest.php
@@ -99,7 +99,7 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
                        ->setMethod('bar')
                        ->setType('instance');
         $test = $this->callback->toArray();
-        $this->assertTrue(is_array($test));
+        $this->assertInternalType('array', $test);
         $this->assertEquals('Foo', $test['class']);
         $this->assertEquals('bar', $test['method']);
         $this->assertEquals('instance', $test['type']);

--- a/tests/ZendTest/Server/Method/DefinitionTest.php
+++ b/tests/ZendTest/Server/Method/DefinitionTest.php
@@ -109,7 +109,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     public function testInvokeArgumentsShouldBeEmptyArrayByDefault()
     {
         $args = $this->definition->getInvokeArguments();
-        $this->assertTrue(is_array($args));
+        $this->assertInternalType('array', $args);
         $this->assertTrue(empty($args));
     }
 
@@ -124,7 +124,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     public function testPrototypesShouldBeEmptyArrayByDefault()
     {
         $prototypes = $this->definition->getPrototypes();
-        $this->assertTrue(is_array($prototypes));
+        $this->assertInternalType('array', $prototypes);
         $this->assertTrue(empty($prototypes));
     }
 

--- a/tests/ZendTest/Server/Method/DefinitionTest.php
+++ b/tests/ZendTest/Server/Method/DefinitionTest.php
@@ -110,7 +110,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $args = $this->definition->getInvokeArguments();
         $this->assertInternalType('array', $args);
-        $this->assertTrue(empty($args));
+        $this->assertEmpty($args);
     }
 
     public function testInvokeArgumentsShouldBeMutable()
@@ -125,7 +125,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $prototypes = $this->definition->getPrototypes();
         $this->assertInternalType('array', $prototypes);
-        $this->assertTrue(empty($prototypes));
+        $this->assertEmpty($prototypes);
     }
 
     public function testDefinitionShouldAllowAddingSinglePrototypes()

--- a/tests/ZendTest/Server/Method/PrototypeTest.php
+++ b/tests/ZendTest/Server/Method/PrototypeTest.php
@@ -55,7 +55,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
     {
         $params = $this->prototype->getParameters();
         $this->assertInternalType('array', $params);
-        $this->assertTrue(empty($params));
+        $this->assertEmpty($params);
     }
 
     public function testPrototypeShouldAllowAddingSingleParameters()

--- a/tests/ZendTest/Server/Method/PrototypeTest.php
+++ b/tests/ZendTest/Server/Method/PrototypeTest.php
@@ -103,7 +103,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
         $this->prototype->addParameters(array('string', 'array'));
         $parameters = $this->prototype->getParameterObjects();
         foreach ($parameters as $parameter) {
-            $this->assertTrue($parameter instanceof Method\Parameter);
+            $this->assertInstanceOf('Zend\Server\Method\Parameter', $parameter);
         }
     }
 

--- a/tests/ZendTest/Server/Method/PrototypeTest.php
+++ b/tests/ZendTest/Server/Method/PrototypeTest.php
@@ -54,7 +54,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
     public function testParametersShouldBeEmptyArrayByDefault()
     {
         $params = $this->prototype->getParameters();
-        $this->assertTrue(is_array($params));
+        $this->assertInternalType('array', $params);
         $this->assertTrue(empty($params));
     }
 
@@ -63,7 +63,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
         $this->testParametersShouldBeEmptyArrayByDefault();
         $this->prototype->addParameter('string');
         $params = $this->prototype->getParameters();
-        $this->assertTrue(is_array($params));
+        $this->assertInternalType('array', $params);
         $this->assertEquals(1, count($params));
         $this->assertEquals('string', $params[0]);
 

--- a/tests/ZendTest/Server/Reflection/NodeTest.php
+++ b/tests/ZendTest/Server/Reflection/NodeTest.php
@@ -28,14 +28,14 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('string', $node->getValue());
         $this->assertNull($node->getParent());
         $children = $node->getChildren();
-        $this->assertTrue(empty($children));
+        $this->assertEmpty($children);
 
         $child = new Node('array', $node);
         $this->assertTrue($child instanceof Node);
         $this->assertEquals('array', $child->getValue());
         $this->assertTrue($node === $child->getParent());
         $children = $child->getChildren();
-        $this->assertTrue(empty($children));
+        $this->assertEmpty($children);
 
         $children = $node->getChildren();
         $this->assertTrue($child === $children[0]);

--- a/tests/ZendTest/Server/Reflection/NodeTest.php
+++ b/tests/ZendTest/Server/Reflection/NodeTest.php
@@ -33,12 +33,12 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $child = new Node('array', $node);
         $this->assertInstanceOf('Zend\Server\Reflection\Node', $child);
         $this->assertEquals('array', $child->getValue());
-        $this->assertTrue($node === $child->getParent());
+        $this->assertEquals($node, $child->getParent());
         $children = $child->getChildren();
         $this->assertEmpty($children);
 
         $children = $node->getChildren();
-        $this->assertTrue($child === $children[0]);
+        $this->assertEquals($child, $children[0]);
     }
 
     /**
@@ -51,7 +51,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
 
         $child->setParent($parent);
 
-        $this->assertTrue($parent === $child->getParent());
+        $this->assertEquals($parent, $child->getParent());
     }
 
     /**
@@ -63,9 +63,9 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $child = $parent->createChild('array');
 
         $this->assertInstanceOf('Zend\Server\Reflection\Node', $child);
-        $this->assertTrue($parent === $child->getParent());
+        $this->assertEquals($parent, $child->getParent());
         $children = $parent->getChildren();
-        $this->assertTrue($child === $children[0]);
+        $this->assertEquals($child, $children[0]);
     }
 
     /**
@@ -77,9 +77,9 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $child  = new Node('array');
 
         $parent->attachChild($child);
-        $this->assertTrue($parent === $child->getParent());
+        $this->assertEquals($parent, $child->getParent());
         $children = $parent->getChildren();
-        $this->assertTrue($child === $children[0]);
+        $this->assertEquals($child, $children[0]);
     }
 
     /**
@@ -97,7 +97,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertInternalType('array', $children);
         $this->assertEquals(1, count($children), var_export($types, 1));
-        $this->assertTrue($child === $children[0]);
+        $this->assertEquals($child, $children[0]);
     }
 
     /**
@@ -121,7 +121,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $child = $parent->createChild('array');
 
         $this->assertNull($parent->getParent());
-        $this->assertTrue($parent === $child->getParent());
+        $this->assertEquals($parent, $child->getParent());
     }
 
     /**
@@ -173,6 +173,6 @@ class NodeTest extends \PHPUnit_Framework_TestCase
             'child2grand2great2'
         );
 
-        $this->assertTrue($test === $endPointsArray, 'Test was [' . var_export($test, 1) . ']; endPoints were [' . var_export($endPointsArray, 1) . ']');
+        $this->assertEquals($test, $endPointsArray, 'Test was [' . var_export($test, 1) . ']; endPoints were [' . var_export($endPointsArray, 1) . ']');
     }
 }

--- a/tests/ZendTest/Server/Reflection/NodeTest.php
+++ b/tests/ZendTest/Server/Reflection/NodeTest.php
@@ -95,7 +95,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         foreach ($children as $c) {
             $types[] = $c->getValue();
         }
-        $this->assertTrue(is_array($children));
+        $this->assertInternalType('array', $children);
         $this->assertEquals(1, count($children), var_export($types, 1));
         $this->assertTrue($child === $children[0]);
     }

--- a/tests/ZendTest/Server/Reflection/NodeTest.php
+++ b/tests/ZendTest/Server/Reflection/NodeTest.php
@@ -24,14 +24,14 @@ class NodeTest extends \PHPUnit_Framework_TestCase
     public function test__construct()
     {
         $node = new Node('string');
-        $this->assertTrue($node instanceof Node);
+        $this->assertInstanceOf('Zend\Server\Reflection\Node', $node);
         $this->assertEquals('string', $node->getValue());
         $this->assertNull($node->getParent());
         $children = $node->getChildren();
         $this->assertEmpty($children);
 
         $child = new Node('array', $node);
-        $this->assertTrue($child instanceof Node);
+        $this->assertInstanceOf('Zend\Server\Reflection\Node', $child);
         $this->assertEquals('array', $child->getValue());
         $this->assertTrue($node === $child->getParent());
         $children = $child->getChildren();
@@ -62,7 +62,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $parent = new Node('string');
         $child = $parent->createChild('array');
 
-        $this->assertTrue($child instanceof Node);
+        $this->assertInstanceOf('Zend\Server\Reflection\Node', $child);
         $this->assertTrue($parent === $child->getParent());
         $children = $parent->getChildren();
         $this->assertTrue($child === $children[0]);

--- a/tests/ZendTest/Server/Reflection/NodeTest.php
+++ b/tests/ZendTest/Server/Reflection/NodeTest.php
@@ -26,7 +26,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $node = new Node('string');
         $this->assertTrue($node instanceof Node);
         $this->assertEquals('string', $node->getValue());
-        $this->assertTrue(null === $node->getParent());
+        $this->assertNull($node->getParent());
         $children = $node->getChildren();
         $this->assertTrue(empty($children));
 
@@ -120,7 +120,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $parent = new Node('string');
         $child = $parent->createChild('array');
 
-        $this->assertTrue(null === $parent->getParent());
+        $this->assertNull($parent->getParent());
         $this->assertTrue($parent === $child->getParent());
     }
 

--- a/tests/ZendTest/Server/Reflection/PrototypeTest.php
+++ b/tests/ZendTest/Server/Reflection/PrototypeTest.php
@@ -78,7 +78,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructWorks()
     {
-        $this->assertTrue($this->_r instanceof Reflection\Prototype);
+        $this->assertInstanceOf('Zend\Server\Reflection\Prototype', $this->_r);
     }
 
     public function testConstructionThrowsExceptionOnInvalidParam()
@@ -108,7 +108,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetReturnValue()
     {
-        $this->assertTrue($this->_r->getReturnValue() instanceof Reflection\ReflectionReturnValue);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionReturnValue', $this->_r->getReturnValue());
     }
 
     /**
@@ -125,7 +125,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $p);
         foreach ($p as $parameter) {
-            $this->assertTrue($parameter instanceof Reflection\ReflectionParameter);
+            $this->assertInstanceOf('Zend\Server\Reflection\ReflectionParameter', $parameter);
         }
 
         $this->assertTrue($p === $this->_parameters);

--- a/tests/ZendTest/Server/Reflection/PrototypeTest.php
+++ b/tests/ZendTest/Server/Reflection/PrototypeTest.php
@@ -128,6 +128,6 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Zend\Server\Reflection\ReflectionParameter', $parameter);
         }
 
-        $this->assertTrue($p === $this->_parameters);
+        $this->assertEquals($this->_parameters, $p);
     }
 }

--- a/tests/ZendTest/Server/Reflection/PrototypeTest.php
+++ b/tests/ZendTest/Server/Reflection/PrototypeTest.php
@@ -123,7 +123,7 @@ class PrototypeTest extends \PHPUnit_Framework_TestCase
         $r = new Reflection\Prototype($this->_r->getReturnValue(), $this->_parameters);
         $p = $r->getParameters();
 
-        $this->assertTrue(is_array($p));
+        $this->assertInternalType('array', $p);
         foreach ($p as $parameter) {
             $this->assertTrue($parameter instanceof Reflection\ReflectionParameter);
         }

--- a/tests/ZendTest/Server/Reflection/ReflectionClassTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionClassTest.php
@@ -37,7 +37,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $r->getNamespace());
 
         $methods = $r->getMethods();
-        $this->assertTrue(is_array($methods));
+        $this->assertInternalType('array', $methods);
         foreach ($methods as $m) {
             $this->assertTrue($m instanceof Reflection\ReflectionMethod);
         }
@@ -60,7 +60,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
     public function test__call()
     {
         $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
-        $this->assertTrue(is_string($r->getName()));
+        $this->assertInternalType('string', $r->getName());
         $this->assertEquals('Zend\Server\Reflection', $r->getName());
     }
 
@@ -86,7 +86,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
 
         $methods = $r->getMethods();
-        $this->assertTrue(is_array($methods));
+        $this->assertInternalType('array', $methods);
         foreach ($methods as $m) {
             $this->assertTrue($m instanceof Reflection\ReflectionMethod);
         }

--- a/tests/ZendTest/Server/Reflection/ReflectionClassTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionClassTest.php
@@ -33,13 +33,13 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
     public function test__construct()
     {
         $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'));
-        $this->assertTrue($r instanceof Reflection\ReflectionClass);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionClass', $r);
         $this->assertEquals('', $r->getNamespace());
 
         $methods = $r->getMethods();
         $this->assertInternalType('array', $methods);
         foreach ($methods as $m) {
-            $this->assertTrue($m instanceof Reflection\ReflectionMethod);
+            $this->assertInstanceOf('Zend\Server\Reflection\ReflectionMethod', $m);
         }
 
         $r = new Reflection\ReflectionClass(new \ReflectionClass('\Zend\Server\Reflection'), 'namespace');
@@ -88,7 +88,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $methods = $r->getMethods();
         $this->assertInternalType('array', $methods);
         foreach ($methods as $m) {
-            $this->assertTrue($m instanceof Reflection\ReflectionMethod);
+            $this->assertInstanceOf('Zend\Server\Reflection\ReflectionMethod', $m);
         }
     }
 
@@ -116,7 +116,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $s = serialize($r);
         $u = unserialize($s);
 
-        $this->assertTrue($u instanceof Reflection\ReflectionClass);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionClass', $u);
         $this->assertEquals('', $u->getNamespace());
         $this->assertEquals($r->getName(), $u->getName());
         $rMethods = $r->getMethods();

--- a/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
@@ -20,8 +20,8 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
     {
         $function = new \ReflectionFunction('\ZendTest\Server\Reflection\function1');
         $r = new Reflection\ReflectionFunction($function);
-        $this->assertTrue($r instanceof Reflection\ReflectionFunction);
-        $this->assertTrue($r instanceof Reflection\AbstractFunction);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionFunction', $r);
+        $this->assertInstanceOf('Zend\Server\Reflection\AbstractFunction', $r);
         $params = $r->getParameters();
 
         $r = new Reflection\ReflectionFunction($function, 'namespace');
@@ -75,7 +75,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(8, count($prototypes));
 
         foreach ($prototypes as $p) {
-            $this->assertTrue($p instanceof Reflection\Prototype);
+            $this->assertInstanceOf('Zend\Server\Reflection\Prototype', $p);
         }
     }
 
@@ -90,7 +90,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($prototypes));
 
         foreach ($prototypes as $p) {
-            $this->assertTrue($p instanceof Reflection\Prototype);
+            $this->assertInstanceOf('Zend\Server\Reflection\Prototype', $p);
         }
     }
 
@@ -117,7 +117,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $r = new Reflection\ReflectionFunction($function);
         $s = serialize($r);
         $u = unserialize($s);
-        $this->assertTrue($u instanceof Reflection\ReflectionFunction);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionFunction', $u);
         $this->assertEquals('', $u->getNamespace());
     }
 

--- a/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
@@ -29,11 +29,11 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 
         $argv = array('string1', 'string2');
         $r = new Reflection\ReflectionFunction($function, 'namespace', $argv);
-        $this->assertTrue(is_array($r->getInvokeArguments()));
+        $this->assertInternalType('array', $r->getInvokeArguments());
         $this->assertTrue($argv === $r->getInvokeArguments());
 
         $prototypes = $r->getPrototypes();
-        $this->assertTrue(is_array($prototypes));
+        $this->assertInternalType('array', $prototypes);
         $this->assertTrue(0 < count($prototypes));
     }
 
@@ -85,7 +85,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $r = new Reflection\ReflectionFunction($function);
 
         $prototypes = $r->getPrototypes();
-        $this->assertTrue(is_array($prototypes));
+        $this->assertInternalType('array', $prototypes);
         $this->assertTrue(0 < count($prototypes));
         $this->assertEquals(1, count($prototypes));
 
@@ -100,13 +100,13 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $function = new \ReflectionFunction('\ZendTest\Server\Reflection\function1');
         $r = new Reflection\ReflectionFunction($function);
         $args = $r->getInvokeArguments();
-        $this->assertTrue(is_array($args));
+        $this->assertInternalType('array', $args);
         $this->assertEquals(0, count($args));
 
         $argv = array('string1', 'string2');
         $r = new Reflection\ReflectionFunction($function, null, $argv);
         $args = $r->getInvokeArguments();
-        $this->assertTrue(is_array($args));
+        $this->assertInternalType('array', $args);
         $this->assertEquals(2, count($args));
         $this->assertTrue($argv === $args);
     }
@@ -127,13 +127,13 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $r = new Reflection\ReflectionFunction($function);
 
         $prototypes = $r->getPrototypes();
-        $this->assertTrue(is_array($prototypes));
+        $this->assertInternalType('array', $prototypes);
         $this->assertTrue(0 < count($prototypes));
         $this->assertEquals(1, count($prototypes));
 
         $proto = $prototypes[0];
         $params = $proto->getParameters();
-        $this->assertTrue(is_array($params));
+        $this->assertInternalType('array', $params);
         $this->assertEquals(1, count($params));
         $this->assertEquals('string', $params[0]->getType());
     }

--- a/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
@@ -34,7 +34,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 
         $prototypes = $r->getPrototypes();
         $this->assertInternalType('array', $prototypes);
-        $this->assertTrue(0 < count($prototypes));
+        $this->assertNotEmpty($prototypes);
     }
 
     public function test__getSet()
@@ -86,7 +86,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 
         $prototypes = $r->getPrototypes();
         $this->assertInternalType('array', $prototypes);
-        $this->assertTrue(0 < count($prototypes));
+        $this->assertNotEmpty($prototypes);
         $this->assertEquals(1, count($prototypes));
 
         foreach ($prototypes as $p) {
@@ -128,7 +128,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 
         $prototypes = $r->getPrototypes();
         $this->assertInternalType('array', $prototypes);
-        $this->assertTrue(0 < count($prototypes));
+        $this->assertNotEmpty($prototypes);
         $this->assertEquals(1, count($prototypes));
 
         $proto = $prototypes[0];

--- a/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionFunctionTest.php
@@ -30,7 +30,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $argv = array('string1', 'string2');
         $r = new Reflection\ReflectionFunction($function, 'namespace', $argv);
         $this->assertInternalType('array', $r->getInvokeArguments());
-        $this->assertTrue($argv === $r->getInvokeArguments());
+        $this->assertEquals($argv, $r->getInvokeArguments());
 
         $prototypes = $r->getPrototypes();
         $this->assertInternalType('array', $prototypes);
@@ -106,9 +106,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $argv = array('string1', 'string2');
         $r = new Reflection\ReflectionFunction($function, null, $argv);
         $args = $r->getInvokeArguments();
-        $this->assertInternalType('array', $args);
-        $this->assertEquals(2, count($args));
-        $this->assertTrue($argv === $args);
+        $this->assertEquals($argv, $args);
     }
 
     public function test__wakeup()

--- a/tests/ZendTest/Server/Reflection/ReflectionMethodTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionMethodTest.php
@@ -45,8 +45,8 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
     public function test__construct()
     {
         $r = new Reflection\ReflectionMethod($this->_class, $this->_method);
-        $this->assertTrue($r instanceof Reflection\ReflectionMethod);
-        $this->assertTrue($r instanceof Reflection\AbstractFunction);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionMethod', $r);
+        $this->assertInstanceOf('Zend\Server\Reflection\AbstractFunction', $r);
 
         $r = new Reflection\ReflectionMethod($this->_class, $this->_method, 'namespace');
         $this->assertEquals('namespace', $r->getNamespace());
@@ -65,7 +65,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
 
         $class = $r->getDeclaringClass();
 
-        $this->assertTrue($class instanceof Reflection\ReflectionClass);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionClass', $class);
         $this->assertTrue($this->_class === $class);
     }
 
@@ -82,8 +82,8 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $s = serialize($r);
         $u = unserialize($s);
 
-        $this->assertTrue($u instanceof Reflection\ReflectionMethod);
-        $this->assertTrue($u instanceof Reflection\AbstractFunction);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionMethod', $u);
+        $this->assertInstanceOf('Zend\Server\Reflection\AbstractFunction', $u);
         $this->assertEquals($r->getName(), $u->getName());
         $this->assertEquals($r->getDeclaringClass()->getName(), $u->getDeclaringClass()->getName());
     }

--- a/tests/ZendTest/Server/Reflection/ReflectionMethodTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionMethodTest.php
@@ -66,7 +66,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $class = $r->getDeclaringClass();
 
         $this->assertInstanceOf('Zend\Server\Reflection\ReflectionClass', $class);
-        $this->assertTrue($this->_class === $class);
+        $this->assertEquals($this->_class, $class);
     }
 
     /**

--- a/tests/ZendTest/Server/Reflection/ReflectionParameterTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionParameterTest.php
@@ -42,7 +42,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $parameter = $this->_getParameter();
 
         $reflection = new Reflection\ReflectionParameter($parameter);
-        $this->assertTrue($reflection instanceof Reflection\ReflectionParameter);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionParameter', $reflection);
     }
 
     /**

--- a/tests/ZendTest/Server/Reflection/ReflectionParameterTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionParameterTest.php
@@ -61,8 +61,8 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $r = new Reflection\ReflectionParameter($this->_getParameter());
 
         // just test a few call proxies...
-        $this->assertTrue(is_bool($r->allowsNull()));
-        $this->assertTrue(is_bool($r->isOptional()));
+        $this->assertInternalType('bool', $r->allowsNull());
+        $this->assertInternalType('bool', $r->isOptional());
     }
 
     /**

--- a/tests/ZendTest/Server/Reflection/ReflectionReturnValueTest.php
+++ b/tests/ZendTest/Server/Reflection/ReflectionReturnValueTest.php
@@ -32,7 +32,7 @@ class ReflectionReturnValueTest extends \PHPUnit_Framework_TestCase
     public function test__construct()
     {
         $obj = new Reflection\ReflectionReturnValue();
-        $this->assertTrue($obj instanceof Reflection\ReflectionReturnValue);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionReturnValue', $obj);
     }
 
     /**

--- a/tests/ZendTest/Server/ReflectionTest.php
+++ b/tests/ZendTest/Server/ReflectionTest.php
@@ -22,10 +22,10 @@ class ReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReflectClass()
     {
         $reflection = Reflection::reflectClass('ZendTest\Server\ReflectionTestClass');
-        $this->assertTrue($reflection instanceof Reflection\ReflectionClass);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionClass', $reflection);
 
         $reflection = Reflection::reflectClass(new ReflectionTestClass());
-        $this->assertTrue($reflection instanceof Reflection\ReflectionClass);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionClass', $reflection);
     }
 
     public function testReflectClassThrowsExceptionOnInvalidClass()
@@ -55,7 +55,7 @@ class ReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReflectFunction()
     {
         $reflection = Reflection::reflectFunction('ZendTest\Server\reflectionTestFunction');
-        $this->assertTrue($reflection instanceof Reflection\ReflectionFunction);
+        $this->assertInstanceOf('Zend\Server\Reflection\ReflectionFunction', $reflection);
     }
 
     public function testReflectFunctionThrowsExceptionOnInvalidFunction()

--- a/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
+++ b/tests/ZendTest/ServiceManager/AbstractPluginManagerTest.php
@@ -96,7 +96,7 @@ class AbstractPluginManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->pluginManager->addAbstractFactory($abstractFactory);
         $instance = $this->pluginManager->get('classnoexists', $creationOptions);
-        $this->assertTrue(is_object($instance));
+        $this->assertInternalType('object', $instance);
     }
 
     public function testMutableMethodNeverCalledWithoutCreationOptions()

--- a/tests/ZendTest/Session/Config/SessionConfigTest.php
+++ b/tests/ZendTest/Session/Config/SessionConfigTest.php
@@ -392,7 +392,7 @@ class SessionConfigTest extends \PHPUnit_Framework_TestCase
     {
         $value = !ini_get('session.use_cookies');
         $this->config->setUseCookies($value);
-        $this->assertEquals($value, (bool) $this->config->getUseCookies());
+        $this->assertEquals($value, $this->config->getUseCookies());
     }
 
     public function testUseCookiesAltersIniSetting()

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -211,7 +211,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->setExpirationSeconds(3600);
         $storage = $this->manager->getStorage();
         $metadata = $storage->getMetadata($this->container->getName());
-        $this->assertTrue(array_key_exists('EXPIRE', $metadata));
+        $this->assertArrayHasKey('EXPIRE', $metadata);
         $this->assertEquals($_SERVER['REQUEST_TIME'] + 3600, $metadata['EXPIRE']);
     }
 
@@ -221,8 +221,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->setExpirationSeconds(3600, 'foo');
         $storage = $this->manager->getStorage();
         $metadata = $storage->getMetadata($this->container->getName());
-        $this->assertTrue(array_key_exists('EXPIRE_KEYS', $metadata));
-        $this->assertTrue(array_key_exists('foo', $metadata['EXPIRE_KEYS']));
+        $this->assertArrayHasKey('EXPIRE_KEYS', $metadata);
+        $this->assertArrayHasKey('foo', $metadata['EXPIRE_KEYS']);
         $this->assertEquals($_SERVER['REQUEST_TIME'] + 3600, $metadata['EXPIRE_KEYS']['foo']);
     }
 
@@ -321,7 +321,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->setExpirationHops(2);
         $storage = $this->manager->getStorage();
         $metadata = $storage->getMetadata('Default');
-        $this->assertTrue(array_key_exists('EXPIRE_HOPS', $metadata));
+        $this->assertArrayHasKey('EXPIRE_HOPS', $metadata);
         $this->assertEquals(
             array('hops' => 2, 'ts' => $storage->getRequestAccessTime()),
             $metadata['EXPIRE_HOPS']
@@ -334,8 +334,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->setExpirationHops(2, 'foo');
         $storage = $this->manager->getStorage();
         $metadata = $storage->getMetadata('Default');
-        $this->assertTrue(array_key_exists('EXPIRE_HOPS_KEYS', $metadata));
-        $this->assertTrue(array_key_exists('foo', $metadata['EXPIRE_HOPS_KEYS']));
+        $this->assertArrayHasKey('EXPIRE_HOPS_KEYS', $metadata);
+        $this->assertArrayHasKey('foo', $metadata['EXPIRE_HOPS_KEYS']);
         $this->assertEquals(
             array('hops' => 2, 'ts' => $storage->getRequestAccessTime()),
             $metadata['EXPIRE_HOPS_KEYS']['foo']
@@ -350,7 +350,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->setExpirationHops(2, array('foo', 'baz'));
         $storage = $this->manager->getStorage();
         $metadata = $storage->getMetadata('Default');
-        $this->assertTrue(array_key_exists('EXPIRE_HOPS_KEYS', $metadata));
+        $this->assertArrayHasKey('EXPIRE_HOPS_KEYS', $metadata);
 
         $hops     = $metadata['EXPIRE_HOPS_KEYS'];
         $ts       = $storage->getRequestAccessTime();

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -148,7 +148,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testDefaultManagerIsAlwaysPopulated()
     {
         $manager = Container::getDefaultManager();
-        $this->assertTrue($manager instanceof Manager);
+        $this->assertInstanceOf('Zend\Session\ManagerInterface', $manager);
     }
 
     public function testCanSetDefaultManager()
@@ -177,11 +177,11 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     {
         $container = new Container();
         $manager   = $container->getManager();
-        $this->assertTrue($manager instanceof Manager);
+        $this->assertInstanceOf('Zend\Session\ManagerInterface', $manager);
         $config  = $manager->getConfig();
-        $this->assertTrue($config instanceof Session\Config\SessionConfig);
+        $this->assertInstanceOf('Zend\Session\Config\SessionConfig', $config);
         $storage = $manager->getStorage();
-        $this->assertTrue($storage instanceof Session\Storage\SessionArrayStorage);
+        $this->assertInstanceOf('Zend\Session\Storage\SessionArrayStorage', $storage);
     }
 
     public function testContainerAllowsInjectingManagerViaConstructor()

--- a/tests/ZendTest/Session/SessionArrayStorageTest.php
+++ b/tests/ZendTest/Session/SessionArrayStorageTest.php
@@ -34,7 +34,7 @@ class SessionArrayStorageTest extends \PHPUnit_Framework_TestCase
         $this->storage['foo'] = 'bar';
         $this->assertSame($_SESSION['foo'], $this->storage->foo);
         unset($this->storage['foo']);
-        $this->assertFalse(array_key_exists('foo', $_SESSION));
+        $this->assertArrayNotHasKey('foo', $_SESSION);
     }
 
     public function testPassingArrayToConstructorOverwritesSessionSuperglobal()

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -172,7 +172,8 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $storage = $this->manager->getStorage();
         $storage['foo'] = 'bar';
         $this->manager->writeClose();
-        $this->assertTrue(isset($storage['foo']) && $storage['foo'] == 'bar');
+        $this->assertArrayHasKey('foo', $storage);
+        $this->assertEquals('bar', $storage['foo']);
     }
 
     /**

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -487,7 +487,7 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         }
         $compare = $_SERVER['REQUEST_TIME'] + $ttl;
         $cookieTs = $ts->getTimestamp();
-        $this->assertTrue(in_array($cookieTs, range($compare, $compare + 10)), 'Session cookie: ' . var_export($headers, 1));
+        $this->assertContains($cookieTs, range($compare, $compare + 10), 'Session cookie: ' . var_export($headers, 1));
     }
 
     /**

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -60,7 +60,7 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
     public function testManagerUsesSessionConfigByDefault()
     {
         $config = $this->manager->getConfig();
-        $this->assertTrue($config instanceof Session\Config\SessionConfig);
+        $this->assertInstanceOf('Zend\Session\Config\SessionConfig', $config);
     }
 
     public function testCanPassConfigurationToConstructor()
@@ -73,7 +73,7 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
     public function testManagerUsesSessionStorageByDefault()
     {
         $storage = $this->manager->getStorage();
-        $this->assertTrue($storage instanceof Session\Storage\SessionArrayStorage);
+        $this->assertInstanceOf('Zend\Session\Storage\SessionArrayStorage', $storage);
     }
 
     public function testCanPassStorageToConstructor()

--- a/tests/ZendTest/Session/SessionManagerTest.php
+++ b/tests/ZendTest/Session/SessionManagerTest.php
@@ -202,7 +202,7 @@ class SessionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(headers_sent());
         $this->manager->start();
         restore_error_handler();
-        $this->assertTrue(is_string($this->error));
+        $this->assertInternalType('string', $this->error);
         $this->assertContains('already sent', $this->error);
     }
 

--- a/tests/ZendTest/Session/SessionStorageTest.php
+++ b/tests/ZendTest/Session/SessionStorageTest.php
@@ -39,7 +39,7 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->storage['foo'] = 'bar';
         $this->assertSame($_SESSION, $this->storage);
         unset($this->storage['foo']);
-        $this->assertFalse(array_key_exists('foo', $_SESSION));
+        $this->assertArrayNotHasKey('foo', $_SESSION);
     }
 
     public function testPassingArrayToConstructorOverwritesSessionSuperglobal()

--- a/tests/ZendTest/Session/SessionStorageTest.php
+++ b/tests/ZendTest/Session/SessionStorageTest.php
@@ -30,8 +30,8 @@ class SessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testSessionStorageInheritsFromArrayStorage()
     {
-        $this->assertTrue($this->storage instanceof SessionStorage);
-        $this->assertTrue($this->storage instanceof ArrayStorage);
+        $this->assertInstanceOf('Zend\Session\Storage\SessionStorage', $this->storage);
+        $this->assertInstanceOf('Zend\Session\Storage\ArrayStorage', $this->storage);
     }
 
     public function testStorageWritesToSessionSuperglobal()

--- a/tests/ZendTest/Session/StorageTest.php
+++ b/tests/ZendTest/Session/StorageTest.php
@@ -118,7 +118,7 @@ class StorageTest extends \PHPUnit_Framework_TestCase
         $this->storage->foo = 'bar';
         $this->storage->lock('foo');
         $locks = $this->storage->getMetadata('_LOCKS');
-        $this->assertTrue(is_array($locks));
+        $this->assertInternalType('array', $locks);
         $this->assertTrue(array_key_exists('foo', $locks));
     }
 

--- a/tests/ZendTest/Session/StorageTest.php
+++ b/tests/ZendTest/Session/StorageTest.php
@@ -119,7 +119,7 @@ class StorageTest extends \PHPUnit_Framework_TestCase
         $this->storage->lock('foo');
         $locks = $this->storage->getMetadata('_LOCKS');
         $this->assertInternalType('array', $locks);
-        $this->assertTrue(array_key_exists('foo', $locks));
+        $this->assertArrayHasKey('foo', $locks);
     }
 
     public function testUnlockShouldUnlockEntireObject()

--- a/tests/ZendTest/Soap/AutoDiscover/OnlineTest.php
+++ b/tests/ZendTest/Soap/AutoDiscover/OnlineTest.php
@@ -60,7 +60,7 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         $client = new Client($wsdl);
         $ret = $client->request("test", "test");
 
-        $this->assertTrue(($ret instanceof \stdClass));
+        $this->assertInstanceOf('stdClass', $ret);
         $this->assertEquals("test", $ret->foo);
         $this->assertEquals("test", $ret->bar);
     }

--- a/tests/ZendTest/Soap/AutoDiscover/OnlineTest.php
+++ b/tests/ZendTest/Soap/AutoDiscover/OnlineTest.php
@@ -39,9 +39,9 @@ class OnlineTest extends \PHPUnit_Framework_TestCase
         $client = new Client($wsdl);
         $ret = $client->request($b);
 
-        $this->assertTrue(is_array($ret));
+        $this->assertInternalType('array', $ret);
         $this->assertEquals(1, count($ret));
-        $this->assertTrue(is_array($ret[0]->baz));
+        $this->assertInternalType('array', $ret[0]->baz);
         $this->assertEquals(3, count($ret[0]->baz));
 
         $baz = $ret[0]->baz;

--- a/tests/ZendTest/Soap/AutoDiscoverTest.php
+++ b/tests/ZendTest/Soap/AutoDiscoverTest.php
@@ -1305,8 +1305,9 @@ class AutoDiscoverTest extends \PHPUnit_Framework_TestCase
             '//wsdl:part[@name="test" and @type="tns:AutoDiscoverTestClass1"]',
             'AutoDiscoverTestClass1 appears once or more than once in the message parts section.'
         );
-        $this->assertTrue(
-            $nodes->length >= 1,
+        $this->assertGreaterThanOrEqual(
+            1,
+            $nodes->length,
             'AutoDiscoverTestClass1 appears once or more than once in the message parts section.'
         );
 

--- a/tests/ZendTest/Soap/ClientTest.php
+++ b/tests/ZendTest/Soap/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
          *************************************************************/
         $client = new Client();
 
-        $this->assertTrue($client->getOptions() == array('encoding' => 'UTF-8', 'soap_version' => SOAP_1_2));
+        $this->assertEquals(array('encoding' => 'UTF-8', 'soap_version' => SOAP_1_2), $client->getOptions());
 
         $ctx = stream_context_create();
 
@@ -83,14 +83,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
 
         $client->setOptions($nonWSDLOptions);
-        $this->assertTrue($client->getOptions() == $nonWSDLOptions);
+        $this->assertEquals($nonWSDLOptions, $client->getOptions());
 
         /*************************************************************
          * ------ Test non-WSDL mode options -----------------------------
          *************************************************************/
         $client1 = new Client();
 
-        $this->assertTrue($client1->getOptions() == array('encoding' => 'UTF-8', 'soap_version' => SOAP_1_2));
+        $this->assertEquals(array('encoding' => 'UTF-8', 'soap_version' => SOAP_1_2), $client1->getOptions());
 
         $wsdlOptions = array('soap_version'   => SOAP_1_1,
                              'wsdl'           => __DIR__.'/TestAsset/wsdl_example.wsdl',
@@ -116,14 +116,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
 
         $client1->setOptions($wsdlOptions);
-        $this->assertTrue($client1->getOptions() == $wsdlOptions);
+        $this->assertEquals($wsdlOptions, $client1->getOptions());
     }
 
     public function testGetOptions()
     {
         $client = new Client();
 
-        $this->assertTrue($client->getOptions() == array('encoding' => 'UTF-8', 'soap_version' => SOAP_1_2));
+        $this->assertEquals(array('encoding' => 'UTF-8', 'soap_version' => SOAP_1_2), $client->getOptions());
 
         $typeMap = array(
             array(
@@ -167,7 +167,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
 
         $client->setOptions($options);
-        $this->assertTrue($client->getOptions() == $options);
+        $this->assertEquals($options, $client->getOptions());
     }
 
     /**
@@ -270,10 +270,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client = new Client\Local($server, __DIR__ . '/TestAsset/wsdl_example.wsdl');
 
-        $this->assertTrue($client->getFunctions() == array('string testFunc()',
-                                                           'string testFunc2(string $who)',
-                                                           'string testFunc3(string $who, int $when)',
-                                                           'string testFunc4()'));
+        $expected = array('string testFunc()',
+            'string testFunc2(string $who)',
+            'string testFunc3(string $who, int $when)',
+            'string testFunc4()');
+        $this->assertEquals($expected, $client->getFunctions());
     }
 
     public function testGetTypes()

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -723,7 +723,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server = new Server();
         $fault = $server->fault('FaultMessage!');
 
-        $this->assertTrue($fault instanceof \SoapFault);
+        $this->assertInstanceOf('SoapFault', $fault);
         $this->assertContains('FaultMessage!', $fault->getMessage());
     }
 
@@ -732,7 +732,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server = new Server();
         $fault = $server->fault(new \Exception('MyException'));
 
-        $this->assertTrue($fault instanceof \SoapFault);
+        $this->assertInstanceOf('SoapFault', $fault);
         $this->assertContains('Unknown error', $fault->getMessage());
         $this->assertNotContains('MyException', $fault->getMessage());
     }
@@ -743,7 +743,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server->registerFaultException('\Zend\Soap\Exception\RuntimeException');
         $server->registerFaultException('\Zend\Soap\Exception\InvalidArgumentException');
         $fault = $server->fault(new \Zend\Soap\Exception\RuntimeException('MyException'));
-        $this->assertTrue($fault instanceof \SoapFault);
+        $this->assertInstanceOf('SoapFault', $fault);
         $this->assertNotContains('Unknown error', $fault->getMessage());
         $this->assertContains('MyException', $fault->getMessage());
     }
@@ -764,7 +764,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server = new Server();
         $fault = $server->fault("FaultMessage!", 5000);
 
-        $this->assertTrue($fault instanceof \SoapFault);
+        $this->assertInstanceOf('SoapFault', $fault);
     }
 
     /**

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -903,7 +903,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $server = new \ZendTest\Soap\TestAsset\MockServer();
         $r = $server->handle(new \DOMDocument('1.0', 'UTF-8'));
-        $this->assertTrue(is_string($server->mockSoapServer->handle[0]));
+        $this->assertInternalType('string', $server->mockSoapServer->handle[0]);
     }
 
     /**

--- a/tests/ZendTest/Soap/ServerTest.php
+++ b/tests/ZendTest/Soap/ServerTest.php
@@ -33,7 +33,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $server = new Server();
 
-        $this->assertTrue($server->getOptions() == array('soap_version' => SOAP_1_2));
+        $this->assertEquals(array('soap_version' => SOAP_1_2), $server->getOptions());
 
         $options = array('soap_version' => SOAP_1_1,
                          'actor' => 'http://framework.zend.com/Zend_Soap_ServerTest.php',
@@ -44,7 +44,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
                         );
         $server->setOptions($options);
 
-        $this->assertTrue($server->getOptions() == $options);
+        $this->assertEquals($options, $server->getOptions());
     }
 
     public function testSetOptionsViaSecondConstructorArgument()
@@ -61,7 +61,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         );
         $server = new Server(null, $options);
 
-        $this->assertTrue($server->getOptions() == $options);
+        $this->assertEquals($options, $server->getOptions());
     }
 
     /**
@@ -91,14 +91,14 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $server = new Server();
 
-        $this->assertTrue($server->getOptions() == array('soap_version' => SOAP_1_2));
+        $this->assertEquals(array('soap_version' => SOAP_1_2), $server->getOptions());
 
         $options = array('soap_version' => SOAP_1_1,
                          'uri' => 'http://framework.zend.com/Zend_Soap_ServerTest.php'
                         );
         $server->setOptions($options);
 
-        $this->assertTrue($server->getOptions() == $options);
+        $this->assertEquals($options, $server->getOptions());
     }
 
     public function testEncoding()
@@ -186,7 +186,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($server->getClassmap());
         $server->setClassmap($classmap);
-        $this->assertTrue($classmap == $server->getClassmap());
+        $this->assertSame($classmap, $server->getClassmap());
     }
 
     public function testSetClassmapThrowsExceptionOnBogusStringParameter()
@@ -214,7 +214,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($server->getClassmap());
         $server->setClassmap($classmap);
-        $this->assertTrue($classmap == $server->getClassmap());
+        $this->assertSame($classmap, $server->getClassmap());
     }
 
     public function testSetWsdl()
@@ -423,7 +423,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
             '\ZendTest\Soap\TestAsset\TestFunc5',
             '\ZendTest\Soap\TestAsset\TestFunc6'
         );
-        $this->assertTrue($server->getFunctions() == $allAddedFunctions);
+        $this->assertEquals($allAddedFunctions, $server->getFunctions());
     }
 
     public function testGetFunctionsWithClassAttached()

--- a/tests/ZendTest/Soap/Wsdl/CompositeStrategyTest.php
+++ b/tests/ZendTest/Soap/Wsdl/CompositeStrategyTest.php
@@ -36,8 +36,8 @@ class CompositeStrategyTest extends WsdlTestHelper
         $bookStrategy = $strategy->getStrategyOfType('Book');
         $cookieStrategy = $strategy->getStrategyOfType('Cookie');
 
-        $this->assertTrue($bookStrategy instanceof ArrayOfTypeComplex);
-        $this->assertTrue($cookieStrategy instanceof ArrayOfTypeSequence);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\ArrayOfTypeComplex', $bookStrategy);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\ArrayOfTypeSequence', $cookieStrategy);
     }
 
     public function testConstructorTypeMapSyntax()
@@ -51,8 +51,8 @@ class CompositeStrategyTest extends WsdlTestHelper
         $bookStrategy = $strategy->getStrategyOfType('Book');
         $cookieStrategy = $strategy->getStrategyOfType('Cookie');
 
-        $this->assertTrue($bookStrategy instanceof ArrayOfTypeComplex);
-        $this->assertTrue($cookieStrategy instanceof ArrayOfTypeSequence);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\ArrayOfTypeComplex', $bookStrategy);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\ArrayOfTypeSequence', $cookieStrategy);
     }
 
     public function testCompositeThrowsExceptionOnInvalidType()

--- a/tests/ZendTest/Soap/WsdlTest.php
+++ b/tests/ZendTest/Soap/WsdlTest.php
@@ -622,18 +622,18 @@ class WsdlTest extends WsdlTestHelper
     public function testGetComplexTypeBasedOnStrategiesBackwardsCompabilityBoolean()
     {
         $this->assertEquals('tns:WsdlTestClass', $this->wsdl->getType('\ZendTest\Soap\TestAsset\WsdlTestClass'));
-        $this->assertTrue($this->wsdl->getComplexTypeStrategy() instanceof Wsdl\ComplexTypeStrategy\DefaultComplexType);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\DefaultComplexType', $this->wsdl->getComplexTypeStrategy());
     }
 
     public function testGetComplexTypeBasedOnStrategiesStringNames()
     {
         $this->wsdl = new Wsdl($this->defaultServiceName, 'http://localhost/MyService.php', new Wsdl\ComplexTypeStrategy\DefaultComplexType);
         $this->assertEquals('tns:WsdlTestClass', $this->wsdl->getType('\ZendTest\Soap\TestAsset\WsdlTestClass'));
-        $this->assertTrue($this->wsdl->getComplexTypeStrategy() instanceof Wsdl\ComplexTypeStrategy\DefaultComplexType);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\DefaultComplexType', $this->wsdl->getComplexTypeStrategy());
 
         $wsdl2 = new Wsdl($this->defaultServiceName, $this->defaultServiceUri, new Wsdl\ComplexTypeStrategy\AnyType);
         $this->assertEquals('xsd:anyType', $wsdl2->getType('\ZendTest\Soap\TestAsset\WsdlTestClass'));
-        $this->assertTrue($wsdl2->getComplexTypeStrategy() instanceof Wsdl\ComplexTypeStrategy\AnyType);
+        $this->assertInstanceOf('Zend\Soap\Wsdl\ComplexTypeStrategy\AnyType', $wsdl2->getComplexTypeStrategy());
     }
 
     public function testAddingSameComplexTypeMoreThanOnceIsIgnored()

--- a/tests/ZendTest/Stdlib/HydratorTest.php
+++ b/tests/ZendTest/Stdlib/HydratorTest.php
@@ -463,7 +463,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $hydrator = new ClassMethods(false);
         $foo = new ClassMethodsFilterProviderInterface();
         $data = $hydrator->extract($foo);
-        $this->assertFalse(array_key_exists("filter", $data));
+        $this->assertArrayNotHasKey("filter", $data);
         $this->assertSame("bar", $data["foo"]);
         $this->assertSame("foo", $data["bar"]);
     }

--- a/tests/ZendTest/Tag/ItemTest.php
+++ b/tests/ZendTest/Tag/ItemTest.php
@@ -76,7 +76,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase
         $tag->setWeight('10');
 
         $this->assertEquals(10.0, $tag->getWeight());
-        $this->assertTrue(is_float($tag->getWeight()));
+        $this->assertInternalType('float', $tag->getWeight());
     }
 
     public function testInvalidWeight()

--- a/tests/ZendTest/Test/PHPUnit/Util/ModuleLoaderTest.php
+++ b/tests/ZendTest/Test/PHPUnit/Util/ModuleLoaderTest.php
@@ -47,7 +47,7 @@ class ModuleLoaderTest extends PHPUnit_Framework_TestCase
 
         $loader = new ModuleLoader(array('Baz'));
         $baz = $loader->getModule('Baz');
-        $this->assertTrue($baz instanceof \Baz\Module);
+        $this->assertInstanceOf('Baz\Module', $baz);
     }
 
     public function testCanNotLoadModule()
@@ -60,7 +60,7 @@ class ModuleLoaderTest extends PHPUnit_Framework_TestCase
     {
         $loader = new ModuleLoader(array('Baz' => __DIR__ . '/../../_files/Baz'));
         $baz = $loader->getModule('Baz');
-        $this->assertTrue($baz instanceof \Baz\Module);
+        $this->assertInstanceOf('Baz\Module', $baz);
     }
 
     public function testCanLoadModules()
@@ -70,9 +70,9 @@ class ModuleLoaderTest extends PHPUnit_Framework_TestCase
 
         $loader = new ModuleLoader(array('Baz', 'Foo'));
         $baz = $loader->getModule('Baz');
-        $this->assertTrue($baz instanceof \Baz\Module);
+        $this->assertInstanceOf('Baz\Module', $baz);
         $foo = $loader->getModule('Foo');
-        $this->assertTrue($foo instanceof \Foo\Module);
+        $this->assertInstanceOf('Foo\Module', $foo);
     }
 
     public function testCanLoadModulesWithPath()
@@ -83,7 +83,7 @@ class ModuleLoaderTest extends PHPUnit_Framework_TestCase
         ));
 
         $fooObject = $loader->getServiceManager()->get('FooObject');
-        $this->assertTrue($fooObject instanceof \stdClass);
+        $this->assertInstanceOf('stdClass', $fooObject);
     }
 
     public function testCanLoadModulesFromConfig()
@@ -91,7 +91,7 @@ class ModuleLoaderTest extends PHPUnit_Framework_TestCase
         $config = include __DIR__ . '/../../_files/application.config.php';
         $loader = new ModuleLoader($config);
         $baz = $loader->getModule('Baz');
-        $this->assertTrue($baz instanceof \Baz\Module);
+        $this->assertInstanceOf('Baz\Module', $baz);
     }
 
     public function testCanGetService()

--- a/tests/ZendTest/Text/TableTest.php
+++ b/tests/ZendTest/Text/TableTest.php
@@ -297,7 +297,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $row = new Table\Row();
         $row->createColumn('foo');
 
-        $this->assertTrue($row->getColumn(0) instanceof Table\Column);
+        $this->assertInstanceOf('Zend\Text\Table\Column', $row->getColumn(0));
     }
 
     public function testRowGetInvalidColumn()

--- a/tests/ZendTest/Validator/AbstractTest.php
+++ b/tests/ZendTest/Validator/AbstractTest.php
@@ -85,7 +85,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->validator->setTranslator($translator);
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('fooMessage', $messages));
+        $this->assertArrayHasKey('fooMessage', $messages);
         $this->assertContains('bar', $messages['fooMessage'], var_export($messages, 1));
         $this->assertContains('This is the translated message for ', $messages['fooMessage']);
     }
@@ -122,7 +122,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->validator->isValid(new \stdClass()));
         $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('fooMessage', $messages));
+        $this->assertArrayHasKey('fooMessage', $messages);
     }
 
     public function testTranslatorEnabledPerDefault()
@@ -150,7 +150,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('fooMessage', $messages));
+        $this->assertArrayHasKey('fooMessage', $messages);
         $this->assertContains('bar', $messages['fooMessage']);
         $this->assertContains('This is the translated message for ', $messages['fooMessage']);
 
@@ -159,7 +159,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('fooMessage', $messages));
+        $this->assertArrayHasKey('fooMessage', $messages);
         $this->assertContains('bar', $messages['fooMessage']);
         $this->assertContains('bar was passed', $messages['fooMessage']);
     }

--- a/tests/ZendTest/Validator/BarcodeTest.php
+++ b/tests/ZendTest/Validator/BarcodeTest.php
@@ -61,7 +61,7 @@ class BarcodeTest extends \PHPUnit_Framework_TestCase
         require_once __DIR__ . "/_files/MyBarcode1.php";
         $barcode = new Barcode('MyBarcode1');
         $this->assertFalse($barcode->isValid('0000000'));
-        $this->assertTrue(array_key_exists('barcodeFailed', $barcode->getMessages()));
+        $this->assertArrayHasKey('barcodeFailed', $barcode->getMessages());
         $this->assertFalse($barcode->getAdapter()->hasValidChecksum('0000000'));
     }
 
@@ -404,7 +404,7 @@ class BarcodeTest extends \PHPUnit_Framework_TestCase
         $barcode = new Barcode('ean8');
         $this->assertFalse($barcode->isValid('123'));
         $message = $barcode->getMessages();
-        $this->assertTrue(array_key_exists('barcodeInvalidLength', $message));
+        $this->assertArrayHasKey('barcodeInvalidLength', $message);
         $this->assertContains("length of 7/8 characters", $message['barcodeInvalidLength']);
     }
 

--- a/tests/ZendTest/Validator/BarcodeTest.php
+++ b/tests/ZendTest/Validator/BarcodeTest.php
@@ -128,7 +128,7 @@ class BarcodeTest extends \PHPUnit_Framework_TestCase
     public function testArrayConstructAdapter()
     {
         $barcode = new Barcode(array('adapter' => 'Ean13', 'options' => 'unknown', 'useChecksum' => false));
-        $this->assertTrue($barcode->getAdapter() instanceof Barcode\Ean13);
+        $this->assertInstanceOf('Zend\Validator\Barcode\Ean13', $barcode->getAdapter());
         $this->assertFalse($barcode->useChecksum());
     }
 

--- a/tests/ZendTest/Validator/CsrfTest.php
+++ b/tests/ZendTest/Validator/CsrfTest.php
@@ -129,7 +129,7 @@ class CsrfTest extends \PHPUnit_Framework_TestCase
     public function testHashIsGeneratedOnFirstRetrieval()
     {
         $hash = $this->validator->getHash();
-        $this->assertFalse(empty($hash));
+        $this->assertNotEmpty($hash);
         $test = $this->validator->getHash();
         $this->assertEquals($hash, $test);
     }

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -633,7 +633,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
     public function testNotSetHostnameValidator()
     {
         $hostname = $this->validator->getHostnameValidator();
-        $this->assertTrue($hostname instanceof Hostname);
+        $this->assertInstanceOf('Zend\Validator\Hostname', $hostname);
     }
 
     /**

--- a/tests/ZendTest/Validator/EmailAddressTest.php
+++ b/tests/ZendTest/Validator/EmailAddressTest.php
@@ -652,7 +652,7 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($validator->isValid('john.doe@gmail.com'));
         $result = $validator->getMXRecord();
-        $this->assertTrue(!empty($result));
+        $this->assertNotEmpty($result);
     }
 
     public function testEqualsMessageTemplates()

--- a/tests/ZendTest/Validator/File/Crc32Test.php
+++ b/tests/ZendTest/Validator/File/Crc32Test.php
@@ -66,7 +66,7 @@ class Crc32Test extends \PHPUnit_Framework_TestCase
         $validator = new File\Crc32($options);
         $this->assertEquals($expected, $validator->isValid($isValidParam));
         if (!$expected) {
-            $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 
@@ -82,7 +82,7 @@ class Crc32Test extends \PHPUnit_Framework_TestCase
             $validator = new File\Crc32($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
             if (!$expected) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -182,7 +182,7 @@ class Crc32Test extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Crc32('3f8d07e2');
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileCrc32NotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileCrc32NotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/ExcludeExtensionTest.php
+++ b/tests/ZendTest/Validator/File/ExcludeExtensionTest.php
@@ -61,7 +61,7 @@ class ExcludeExtensionTest extends \PHPUnit_Framework_TestCase
         $validator = new File\ExcludeExtension($options);
         $this->assertEquals($expected, $validator->isValid($isValidParam));
         if (!$expected) {
-            $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 
@@ -77,7 +77,7 @@ class ExcludeExtensionTest extends \PHPUnit_Framework_TestCase
             $validator = new File\ExcludeExtension($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
             if (!$expected) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -158,7 +158,7 @@ class ExcludeExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\ExcludeExtension('mo');
         $this->assertEquals(false, $validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileExcludeExtensionNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileExcludeExtensionNotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/ExistsTest.php
+++ b/tests/ZendTest/Validator/File/ExistsTest.php
@@ -134,7 +134,7 @@ class ExistsTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Exists(__DIR__);
         $this->assertFalse($validator->isValid('nofile.mo'));
-        $this->assertTrue(array_key_exists('fileExistsDoesNotExist', $validator->getMessages()));
+        $this->assertArrayHasKey('fileExistsDoesNotExist', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/ExtensionTest.php
+++ b/tests/ZendTest/Validator/File/ExtensionTest.php
@@ -61,7 +61,7 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $validator = new File\Extension($options);
         $this->assertEquals($expected, $validator->isValid($isValidParam));
         if (!$expected) {
-            $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 
@@ -77,7 +77,7 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
             $validator = new File\Extension($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
             if (!$expected) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -161,7 +161,7 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Extension('gif');
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileExtensionNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileExtensionNotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/FilesSizeTest.php
+++ b/tests/ZendTest/Validator/File/FilesSizeTest.php
@@ -63,7 +63,7 @@ class FilesSizeTest extends \PHPUnit_Framework_TestCase
 
         $validator = new File\FilesSize(array('min' => 0, 'max' => 200));
         $this->assertEquals(false, $validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileFilesSizeNotReadable', $validator->getMessages()));
+        $this->assertArrayHasKey('fileFilesSizeNotReadable', $validator->getMessages());
 
         $validator = new File\FilesSize(array('min' => 0, 'max' => 500000));
         $this->assertEquals(true, $validator->isValid(array(

--- a/tests/ZendTest/Validator/File/HashTest.php
+++ b/tests/ZendTest/Validator/File/HashTest.php
@@ -84,7 +84,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
         $validator = new File\Hash($options);
         $this->assertEquals($expected, $validator->isValid($isValidParam));
         if (!$expected) {
-            $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 
@@ -100,7 +100,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
             $validator = new File\Hash($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
             if (!$expected) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -156,7 +156,7 @@ class HashTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Hash('3f8d07e2');
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileHashNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileHashNotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/ImageSizeTest.php
+++ b/tests/ZendTest/Validator/File/ImageSizeTest.php
@@ -103,7 +103,7 @@ class ImageSizeTest extends \PHPUnit_Framework_TestCase
                 $messageKeys = array($messageKeys);
             }
             foreach ($messageKeys as $messageKey) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -125,7 +125,7 @@ class ImageSizeTest extends \PHPUnit_Framework_TestCase
                     $messageKeys = array($messageKeys);
                 }
                 foreach ($messageKeys as $messageKey) {
-                    $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                    $this->assertArrayHasKey($messageKey, $validator->getMessages());
                 }
             }
         }
@@ -260,7 +260,7 @@ class ImageSizeTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\ImageSize(array('minWidth' => 100, 'minHeight' => 1000, 'maxWidth' => 10000, 'maxHeight' => 100000));
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileImageSizeNotReadable', $validator->getMessages()));
+        $this->assertArrayHasKey('fileImageSizeNotReadable', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/IsCompressedTest.php
+++ b/tests/ZendTest/Validator/File/IsCompressedTest.php
@@ -219,7 +219,7 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
         $validator->enableHeaderCheck();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/picture.jpg', $files));
         $error = $validator->getMessages();
-        $this->assertTrue(array_key_exists('fileIsCompressedFalseType', $error));
+        $this->assertArrayHasKey('fileIsCompressedFalseType', $error);
     }
 
     public function testOptionsAtConstructor()
@@ -256,7 +256,7 @@ class IsCompressedTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\IsCompressed();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileIsCompressedNotReadable', $validator->getMessages()));
+        $this->assertArrayHasKey('fileIsCompressedNotReadable', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 }

--- a/tests/ZendTest/Validator/File/IsImageTest.php
+++ b/tests/ZendTest/Validator/File/IsImageTest.php
@@ -170,7 +170,7 @@ class IsImageTest extends \PHPUnit_Framework_TestCase
         $validator->enableHeaderCheck();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/picture.jpg', $files));
         $error = $validator->getMessages();
-        $this->assertTrue(array_key_exists('fileIsImageFalseType', $error));
+        $this->assertArrayHasKey('fileIsImageFalseType', $error);
     }
 
     public function testOptionsAtConstructor()
@@ -207,7 +207,7 @@ class IsImageTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\IsImage();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileIsImageNotReadable', $validator->getMessages()));
+        $this->assertArrayHasKey('fileIsImageNotReadable', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 }

--- a/tests/ZendTest/Validator/File/Md5Test.php
+++ b/tests/ZendTest/Validator/File/Md5Test.php
@@ -80,7 +80,7 @@ class Md5Test extends \PHPUnit_Framework_TestCase
         $validator = new File\Md5($options);
         $this->assertEquals($expected, $validator->isValid($isValidParam));
         if (!$expected) {
-            $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 
@@ -96,7 +96,7 @@ class Md5Test extends \PHPUnit_Framework_TestCase
             $validator = new File\Md5($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
             if (!$expected) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -196,7 +196,7 @@ class Md5Test extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Md5('12345');
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileMd5NotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileMd5NotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/MimeTypeTest.php
+++ b/tests/ZendTest/Validator/File/MimeTypeTest.php
@@ -183,7 +183,7 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
             'image/jpg',
             'headerCheck' => true));
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileMimeTypeNotReadable', $validator->getMessages()));
+        $this->assertArrayHasKey('fileMimeTypeNotReadable', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/NotExistsTest.php
+++ b/tests/ZendTest/Validator/File/NotExistsTest.php
@@ -136,7 +136,7 @@ class NotExistsTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\NotExists();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/testsize.mo'));
-        $this->assertTrue(array_key_exists('fileNotExistsDoesExist', $validator->getMessages()));
+        $this->assertArrayHasKey('fileNotExistsDoesExist', $validator->getMessages());
         $this->assertContains("File exists", current($validator->getMessages()));
     }
 }

--- a/tests/ZendTest/Validator/File/Sha1Test.php
+++ b/tests/ZendTest/Validator/File/Sha1Test.php
@@ -67,7 +67,7 @@ class Sha1Test extends \PHPUnit_Framework_TestCase
         $validator = new File\Sha1($options);
         $this->assertEquals($expected, $validator->isValid($isValidParam));
         if (!$expected) {
-            $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 
@@ -83,7 +83,7 @@ class Sha1Test extends \PHPUnit_Framework_TestCase
             $validator = new File\Sha1($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
             if (!$expected) {
-                $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
         }
     }
@@ -183,7 +183,7 @@ class Sha1Test extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Sha1('12345');
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileSha1NotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileSha1NotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/SizeTest.php
+++ b/tests/ZendTest/Validator/File/SizeTest.php
@@ -200,7 +200,7 @@ class SizeTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Size(array('min' => 1, 'max' => 10000));
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileSizeNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileSizeNotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/UploadFileTest.php
+++ b/tests/ZendTest/Validator/File/UploadFileTest.php
@@ -60,7 +60,7 @@ class UploadFileTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\UploadFile();
         $this->assertFalse($validator->isValid($fileInfo));
-        $this->assertTrue(array_key_exists($messageKey, $validator->getMessages()));
+        $this->assertArrayHasKey($messageKey, $validator->getMessages());
     }
 
     /**
@@ -80,7 +80,7 @@ class UploadFileTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\UploadFile();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileUploadFileErrorFileNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadFileErrorFileNotFound', $validator->getMessages());
         $this->assertContains("not found", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/UploadTest.php
+++ b/tests/ZendTest/Validator/File/UploadTest.php
@@ -82,51 +82,51 @@ class UploadTest extends \PHPUnit_Framework_TestCase
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test'));
-        $this->assertTrue(array_key_exists('fileUploadErrorAttack', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorAttack', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test2'));
-        $this->assertTrue(array_key_exists('fileUploadErrorIniSize', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorIniSize', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test3'));
-        $this->assertTrue(array_key_exists('fileUploadErrorFormSize', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorFormSize', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test4'));
-        $this->assertTrue(array_key_exists('fileUploadErrorPartial', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorPartial', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test5'));
-        $this->assertTrue(array_key_exists('fileUploadErrorNoFile', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorNoFile', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test6'));
-        $this->assertTrue(array_key_exists('fileUploadErrorUnknown', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorUnknown', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test7'));
-        $this->assertTrue(array_key_exists('fileUploadErrorNoTmpDir', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorNoTmpDir', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test8'));
-        $this->assertTrue(array_key_exists('fileUploadErrorCantWrite', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorCantWrite', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test9'));
-        $this->assertTrue(array_key_exists('fileUploadErrorExtension', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorExtension', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test1'));
-        $this->assertTrue(array_key_exists('fileUploadErrorAttack', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorAttack', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('tmp_test1'));
-        $this->assertTrue(array_key_exists('fileUploadErrorAttack', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorAttack', $validator->getMessages());
 
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid('test000'));
-        $this->assertTrue(array_key_exists('fileUploadErrorFileNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorFileNotFound', $validator->getMessages());
     }
 
     /**
@@ -242,7 +242,7 @@ class UploadTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\Upload();
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileUploadErrorFileNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileUploadErrorFileNotFound', $validator->getMessages());
         $this->assertContains("nofile.mo'", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/File/WordCountTest.php
+++ b/tests/ZendTest/Validator/File/WordCountTest.php
@@ -133,7 +133,7 @@ class WordCountTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new File\WordCount(array('min' => 1, 'max' => 10000));
         $this->assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        $this->assertTrue(array_key_exists('fileWordCountNotFound', $validator->getMessages()));
+        $this->assertArrayHasKey('fileWordCountNotFound', $validator->getMessages());
         $this->assertContains("does not exist", current($validator->getMessages()));
     }
 

--- a/tests/ZendTest/Validator/IdenticalTest.php
+++ b/tests/ZendTest/Validator/IdenticalTest.php
@@ -53,7 +53,7 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
     {
         $this->testValidatingWhenTokenNullReturnsFalse();
         $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('missingToken', $messages));
+        $this->assertArrayHasKey('missingToken', $messages);
     }
 
     public function testValidatingAgainstTokenWithNonMatchingValueReturnsFalse()
@@ -66,7 +66,7 @@ class IdenticalTest extends \PHPUnit_Framework_TestCase
     {
         $this->testValidatingAgainstTokenWithNonMatchingValueReturnsFalse();
         $messages = $this->validator->getMessages();
-        $this->assertTrue(array_key_exists('notSame', $messages));
+        $this->assertArrayHasKey('notSame', $messages);
     }
 
     public function testValidatingAgainstTokenWithMatchingValueReturnsTrue()

--- a/tests/ZendTest/Validator/IsbnTest.php
+++ b/tests/ZendTest/Validator/IsbnTest.php
@@ -57,13 +57,13 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $validator = new Isbn();
 
         $validator->setType(Isbn::AUTO);
-        $this->assertTrue($validator->getType() == Isbn::AUTO);
+        $this->assertEquals(Isbn::AUTO, $validator->getType());
 
         $validator->setType(Isbn::ISBN10);
-        $this->assertTrue($validator->getType() == Isbn::ISBN10);
+        $this->assertEquals(Isbn::ISBN10, $validator->getType());
 
         $validator->setType(Isbn::ISBN13);
-        $this->assertTrue($validator->getType() == Isbn::ISBN13);
+        $this->assertEquals(Isbn::ISBN13, $validator->getType());
 
         $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException', 'Invalid ISBN type');
         $validator->setType('X');
@@ -79,13 +79,13 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $validator = new Isbn();
 
         $validator->setSeparator('-');
-        $this->assertTrue($validator->getSeparator() == '-');
+        $this->assertEquals('-', $validator->getSeparator());
 
         $validator->setSeparator(' ');
-        $this->assertTrue($validator->getSeparator() == ' ');
+        $this->assertEquals(' ', $validator->getSeparator());
 
         $validator->setSeparator('');
-        $this->assertTrue($validator->getSeparator() == '');
+        $this->assertEquals('', $validator->getSeparator());
 
         $this->setExpectedException('Zend\Validator\Exception\InvalidArgumentException', 'Invalid ISBN separator');
         $validator->setSeparator('X');
@@ -102,20 +102,20 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $options = array('type'      => Isbn::AUTO,
                          'separator' => ' ');
         $validator = new Isbn($options);
-        $this->assertTrue($validator->getType() == Isbn::AUTO);
-        $this->assertTrue($validator->getSeparator() == ' ');
+        $this->assertEquals(Isbn::AUTO, $validator->getType());
+        $this->assertEquals(' ', $validator->getSeparator());
 
         $options = array('type'      => Isbn::ISBN10,
                          'separator' => '-');
         $validator = new Isbn($options);
-        $this->assertTrue($validator->getType() == Isbn::ISBN10);
-        $this->assertTrue($validator->getSeparator() == '-');
+        $this->assertEquals(Isbn::ISBN10, $validator->getType());
+        $this->assertEquals('-', $validator->getSeparator());
 
         $options = array('type'      => Isbn::ISBN13,
                          'separator' => '');
         $validator = new Isbn($options);
-        $this->assertTrue($validator->getType() == Isbn::ISBN13);
-        $this->assertTrue($validator->getSeparator() == '');
+        $this->assertEquals(Isbn::ISBN13, $validator->getType());
+        $this->assertEquals('', $validator->getSeparator());
     }
 
     /**

--- a/tests/ZendTest/Validator/NotEmptyTest.php
+++ b/tests/ZendTest/Validator/NotEmptyTest.php
@@ -866,7 +866,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($valid->isValid(''));
         $messages = $valid->getMessages();
-        $this->assertTrue(array_key_exists('isEmpty', $messages));
+        $this->assertArrayHasKey('isEmpty', $messages);
         $this->assertContains("can't be empty", $messages['isEmpty']);
     }
 

--- a/tests/ZendTest/Validator/StaticValidatorTest.php
+++ b/tests/ZendTest/Validator/StaticValidatorTest.php
@@ -118,7 +118,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
         $valid = new Between(1, 10);
         $this->assertFalse($valid->isValid(24));
         $message = current($valid->getMessages());
-        $this->assertTrue(strlen($message) <= 5);
+        $this->assertLessThanOrEqual(5, strlen($message));
     }
 
     public function testSetGetDefaultTranslator()

--- a/tests/ZendTest/Validator/StaticValidatorTest.php
+++ b/tests/ZendTest/Validator/StaticValidatorTest.php
@@ -106,7 +106,7 @@ class StaticValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid(123));
         $messages = $this->validator->getMessages();
 
-        $this->assertTrue(array_key_exists(Alpha::INVALID, $messages));
+        $this->assertArrayHasKey(Alpha::INVALID, $messages);
         $this->assertEquals('This is...', $messages[Alpha::INVALID]);
     }
 

--- a/tests/ZendTest/Validator/ValidatorChainTest.php
+++ b/tests/ZendTest/Validator/ValidatorChainTest.php
@@ -132,7 +132,7 @@ class ValidatorChainTest extends \PHPUnit_Framework_TestCase
         $valid = new Between(1, 10);
         $this->assertFalse($valid->isValid(24));
         $message = current($valid->getMessages());
-        $this->assertTrue(strlen($message) <= 5);
+        $this->assertLessThanOrEqual(5, strlen($message));
     }
 
     public function testSetGetDefaultTranslator()

--- a/tests/ZendTest/View/Helper/CycleTest.php
+++ b/tests/ZendTest/View/Helper/CycleTest.php
@@ -49,7 +49,7 @@ class CycleTest extends \PHPUnit_Framework_TestCase
     public function testCycleMethodReturnsObjectInstance()
     {
         $cycle = $this->helper->__invoke();
-        $this->assertTrue($cycle instanceof Helper\Cycle);
+        $this->assertInstanceOf('Zend\View\Helper\Cycle', $cycle);
     }
 
     public function testAssignAndGetValues()

--- a/tests/ZendTest/View/Helper/DoctypeTest.php
+++ b/tests/ZendTest/View/Helper/DoctypeTest.php
@@ -55,7 +55,7 @@ class DoctypeTest extends \PHPUnit_Framework_TestCase
     public function testDoctypeMethodReturnsObjectInstance()
     {
         $doctype = $this->helper->__invoke();
-        $this->assertTrue($doctype instanceof Helper\Doctype);
+        $this->assertInstanceOf('Zend\View\Helper\Doctype', $doctype);
     }
 
     public function testPassingDoctypeSetsDoctype()

--- a/tests/ZendTest/View/Helper/EscapeCssTest.php
+++ b/tests/ZendTest/View/Helper/EscapeCssTest.php
@@ -51,7 +51,7 @@ class EscapeCssTest extends TestCase
     {
         $this->helper->setEncoding('BIG5-HKSCS');
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 
@@ -60,7 +60,7 @@ class EscapeCssTest extends TestCase
         $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
         $this->helper->setEscaper($escaper);
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 

--- a/tests/ZendTest/View/Helper/EscapeHtmlAttrTest.php
+++ b/tests/ZendTest/View/Helper/EscapeHtmlAttrTest.php
@@ -51,7 +51,7 @@ class EscapeHtmlAttrTest extends TestCase
     {
         $this->helper->setEncoding('BIG5-HKSCS');
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 
@@ -60,7 +60,7 @@ class EscapeHtmlAttrTest extends TestCase
         $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
         $this->helper->setEscaper($escaper);
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 

--- a/tests/ZendTest/View/Helper/EscapeHtmlTest.php
+++ b/tests/ZendTest/View/Helper/EscapeHtmlTest.php
@@ -51,7 +51,7 @@ class EscapeHtmlTest extends TestCase
     {
         $this->helper->setEncoding('BIG5-HKSCS');
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 
@@ -60,7 +60,7 @@ class EscapeHtmlTest extends TestCase
         $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
         $this->helper->setEscaper($escaper);
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 

--- a/tests/ZendTest/View/Helper/EscapeJsTest.php
+++ b/tests/ZendTest/View/Helper/EscapeJsTest.php
@@ -51,7 +51,7 @@ class EscapeJsTest extends TestCase
     {
         $this->helper->setEncoding('BIG5-HKSCS');
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 
@@ -60,7 +60,7 @@ class EscapeJsTest extends TestCase
         $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
         $this->helper->setEscaper($escaper);
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 

--- a/tests/ZendTest/View/Helper/EscapeUrlTest.php
+++ b/tests/ZendTest/View/Helper/EscapeUrlTest.php
@@ -51,7 +51,7 @@ class EscapeUrlTest extends TestCase
     {
         $this->helper->setEncoding('BIG5-HKSCS');
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 
@@ -60,7 +60,7 @@ class EscapeUrlTest extends TestCase
         $escaper = new \Zend\Escaper\Escaper('big5-hkscs');
         $this->helper->setEscaper($escaper);
         $escaper = $this->helper->getEscaper();
-        $this->assertTrue($escaper instanceof \Zend\Escaper\Escaper);
+        $this->assertInstanceOf('Zend\Escaper\Escaper', $escaper);
         $this->assertEquals('big5-hkscs', $escaper->getEncoding());
     }
 

--- a/tests/ZendTest/View/Helper/FlashMessengerTest.php
+++ b/tests/ZendTest/View/Helper/FlashMessengerTest.php
@@ -86,11 +86,11 @@ class FlashMessengerTest extends TestCase
 
         $this->seedMessages();
 
-        $this->assertTrue(count($helper('default')) > 0);
-        $this->assertTrue(count($helper('info')) > 0);
-        $this->assertTrue(count($helper('success')) > 0);
-        $this->assertTrue(count($helper('warning')) > 0);
-        $this->assertTrue(count($helper('error')) > 0);
+        $this->assertNotEmpty($helper('default'));
+        $this->assertNotEmpty($helper('info'));
+        $this->assertNotEmpty($helper('success'));
+        $this->assertNotEmpty($helper('warning'));
+        $this->assertNotEmpty($helper('error'));
 
         $this->assertTrue($this->plugin->hasMessages());
         $this->assertTrue($this->plugin->hasInfoMessages());
@@ -110,10 +110,10 @@ class FlashMessengerTest extends TestCase
 
         $this->seedCurrentMessages();
 
-        $this->assertTrue(count($helper('default')) > 0);
-        $this->assertTrue(count($helper('info')) > 0);
-        $this->assertTrue(count($helper('success')) > 0);
-        $this->assertTrue(count($helper('error')) > 0);
+        $this->assertNotEmpty($helper('default'));
+        $this->assertNotEmpty($helper('info'));
+        $this->assertNotEmpty($helper('success'));
+        $this->assertNotEmpty($helper('error'));
 
         $this->assertFalse($this->plugin->hasCurrentMessages());
         $this->assertFalse($this->plugin->hasCurrentInfoMessages());

--- a/tests/ZendTest/View/Helper/HeadLinkTest.php
+++ b/tests/ZendTest/View/Helper/HeadLinkTest.php
@@ -60,7 +60,7 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
     public function testHeadLinkReturnsObjectInstance()
     {
         $placeholder = $this->helper->__invoke();
-        $this->assertTrue($placeholder instanceof Helper\HeadLink);
+        $this->assertInstanceOf('Zend\View\Helper\HeadLink', $placeholder);
     }
 
     public function testPrependThrowsExceptionWithoutArrayArgument()

--- a/tests/ZendTest/View/Helper/HeadMetaTest.php
+++ b/tests/ZendTest/View/Helper/HeadMetaTest.php
@@ -67,7 +67,7 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
     public function testHeadMetaReturnsObjectInstance()
     {
         $placeholder = $this->helper->__invoke();
-        $this->assertTrue($placeholder instanceof Helper\HeadMeta);
+        $this->assertInstanceOf('Zend\View\Helper\HeadMeta', $placeholder);
     }
 
     public function testAppendPrependAndSetThrowExceptionsWhenNonMetaValueProvided()

--- a/tests/ZendTest/View/Helper/HeadMetaTest.php
+++ b/tests/ZendTest/View/Helper/HeadMetaTest.php
@@ -213,9 +213,9 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
 
         $this->assertObjectHasAttribute('modifiers', $value);
         $modifiers = $value->modifiers;
-        $this->assertTrue(array_key_exists('lang', $modifiers));
+        $this->assertArrayHasKey('lang', $modifiers);
         $this->assertEquals('us_en', $modifiers['lang']);
-        $this->assertTrue(array_key_exists('scheme', $modifiers));
+        $this->assertArrayHasKey('scheme', $modifiers);
         $this->assertEquals('foo', $modifiers['scheme']);
     }
 
@@ -272,7 +272,7 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
         $this->helper->offsetSetName(100, 'keywords', 'foo');
         $values = $this->helper->getArrayCopy();
         $this->assertEquals(1, count($values));
-        $this->assertTrue(array_key_exists(100, $values));
+        $this->assertArrayHasKey(100, $values);
         $item = $values[100];
         $this->assertEquals('foo', $item->content);
         $this->assertEquals('name', $item->type);

--- a/tests/ZendTest/View/Helper/HeadMetaTest.php
+++ b/tests/ZendTest/View/Helper/HeadMetaTest.php
@@ -253,7 +253,7 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
         set_error_handler(array($this, 'handleErrors'));
         $string = @$this->helper->toString();
         $this->assertEquals('', $string);
-        $this->assertTrue(is_string($this->error));
+        $this->assertInternalType('string', $this->error);
     }
 
     public function testHeadMetaHelperCreatesItemEntry()

--- a/tests/ZendTest/View/Helper/HeadScriptTest.php
+++ b/tests/ZendTest/View/Helper/HeadScriptTest.php
@@ -272,7 +272,7 @@ class HeadScriptTest extends \PHPUnit_Framework_TestCase
 
         $doc = new \DOMDocument;
         $dom = $doc->loadHtml($string);
-        $this->assertTrue($dom !== false);
+        $this->assertTrue($dom);
     }
 
     public function testCapturingCapturesToObject()

--- a/tests/ZendTest/View/Helper/HeadScriptTest.php
+++ b/tests/ZendTest/View/Helper/HeadScriptTest.php
@@ -57,7 +57,7 @@ class HeadScriptTest extends \PHPUnit_Framework_TestCase
     public function testHeadScriptReturnsObjectInstance()
     {
         $placeholder = $this->helper->__invoke();
-        $this->assertTrue($placeholder instanceof Helper\HeadScript);
+        $this->assertInstanceOf('Zend\View\Helper\HeadScript', $placeholder);
     }
 
     public function testSetPrependAppendAndOffsetSetThrowExceptionsOnInvalidItems()

--- a/tests/ZendTest/View/Helper/HeadStyleTest.php
+++ b/tests/ZendTest/View/Helper/HeadStyleTest.php
@@ -56,7 +56,7 @@ class HeadStyleTest extends \PHPUnit_Framework_TestCase
     public function testHeadStyleReturnsObjectInstance()
     {
         $placeholder = $this->helper->__invoke();
-        $this->assertTrue($placeholder instanceof Helper\HeadStyle);
+        $this->assertInstanceOf('Zend\View\Helper\HeadStyle', $placeholder);
     }
 
     public function testAppendPrependAndSetThrowExceptionsWhenNonStyleValueProvided()
@@ -93,7 +93,7 @@ class HeadStyleTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($i + 1, count($values));
             $item = $values[$i];
 
-            $this->assertTrue($item instanceof \stdClass);
+            $this->assertInstanceOf('stdClass', $item);
             $this->assertObjectHasAttribute('content', $item);
             $this->assertObjectHasAttribute('attributes', $item);
             $this->assertEquals($string, $item->content);
@@ -110,7 +110,7 @@ class HeadStyleTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($i + 1, count($values));
             $item = array_shift($values);
 
-            $this->assertTrue($item instanceof \stdClass);
+            $this->assertInstanceOf('stdClass', $item);
             $this->assertObjectHasAttribute('content', $item);
             $this->assertObjectHasAttribute('attributes', $item);
             $this->assertEquals($string, $item->content);
@@ -129,7 +129,7 @@ class HeadStyleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($values));
         $item = array_shift($values);
 
-        $this->assertTrue($item instanceof \stdClass);
+        $this->assertInstanceOf('stdClass', $item);
         $this->assertObjectHasAttribute('content', $item);
         $this->assertObjectHasAttribute('attributes', $item);
         $this->assertEquals($string, $item->content);

--- a/tests/ZendTest/View/Helper/HeadStyleTest.php
+++ b/tests/ZendTest/View/Helper/HeadStyleTest.php
@@ -221,7 +221,7 @@ class HeadStyleTest extends \PHPUnit_Framework_TestCase
         $html = $this->helper->toString();
         $doc  = new \DOMDocument;
         $dom  = $doc->loadHtml($html);
-        $this->assertTrue(($dom !== false));
+        $this->assertTrue($dom);
 
         $styles = substr_count($html, '<style type="text/css"');
         $this->assertEquals(3, $styles);

--- a/tests/ZendTest/View/Helper/HeadStyleTest.php
+++ b/tests/ZendTest/View/Helper/HeadStyleTest.php
@@ -204,9 +204,9 @@ class HeadStyleTest extends \PHPUnit_Framework_TestCase
                      ->__invoke($style3, 'APPEND');
         $this->assertEquals(3, count($this->helper));
         $values = $this->helper->getArrayCopy();
-        $this->assertTrue((bool) strstr($values[0]->content, $style2));
-        $this->assertTrue((bool) strstr($values[1]->content, $style1));
-        $this->assertTrue((bool) strstr($values[2]->content, $style3));
+        $this->assertContains($values[0]->content, $style2);
+        $this->assertContains($values[1]->content, $style1);
+        $this->assertContains($values[2]->content, $style3);
     }
 
     public function testToStyleGeneratesValidHtml()

--- a/tests/ZendTest/View/Helper/HeadTitleTest.php
+++ b/tests/ZendTest/View/Helper/HeadTitleTest.php
@@ -56,7 +56,7 @@ class HeadTitleTest extends \PHPUnit_Framework_TestCase
     public function testHeadTitleReturnsObjectInstance()
     {
         $placeholder = $this->helper->__invoke();
-        $this->assertTrue($placeholder instanceof Helper\HeadTitle);
+        $this->assertInstanceOf('Zend\View\Helper\HeadTitle', $placeholder);
     }
 
     public function testCanSetTitleViaHeadTitle()
@@ -218,7 +218,7 @@ class HeadTitleTest extends \PHPUnit_Framework_TestCase
      */
     public function testReturnTypeDefaultAttachOrder()
     {
-        $this->assertTrue($this->helper->setDefaultAttachOrder('PREPEND') instanceof Helper\HeadTitle);
+        $this->assertInstanceOf('Zend\View\Helper\HeadTitle', $this->helper->setDefaultAttachOrder('PREPEND'));
         $this->assertEquals('PREPEND', $this->helper->getDefaultAttachOrder());
     }
 }

--- a/tests/ZendTest/View/Helper/InlineScriptTest.php
+++ b/tests/ZendTest/View/Helper/InlineScriptTest.php
@@ -56,6 +56,6 @@ class InlineScriptTest extends \PHPUnit_Framework_TestCase
     public function testInlineScriptReturnsObjectInstance()
     {
         $placeholder = $this->helper->__invoke();
-        $this->assertTrue($placeholder instanceof Helper\InlineScript);
+        $this->assertInstanceOf('Zend\View\Helper\InlineScript', $placeholder);
     }
 }

--- a/tests/ZendTest/View/Helper/JsonTest.php
+++ b/tests/ZendTest/View/Helper/JsonTest.php
@@ -52,7 +52,7 @@ class JsonTest extends TestCase
     public function testJsonHelperReturnsJsonEncodedString()
     {
         $data = $this->helper->__invoke('foobar');
-        $this->assertTrue(is_string($data));
+        $this->assertInternalType('string', $data);
         $this->assertEquals('foobar', JsonFormatter::decode($data));
     }
 }

--- a/tests/ZendTest/View/Helper/Navigation/NavigationTest.php
+++ b/tests/ZendTest/View/Helper/Navigation/NavigationTest.php
@@ -442,13 +442,13 @@ class NavigationTest extends AbstractTest
 
         $render = $this->_helper->menu()->render($container);
 
-        $this->assertFalse(strpos($render, 'p2'));
+        $this->assertNotContains('p2', $render);
 
         $this->_helper->menu()->setRenderInvisible();
 
         $render = $this->_helper->menu()->render($container);
 
-        $this->assertTrue(strpos($render, 'p2') !== false);
+        $this->assertContains('p2', $render);
     }
 
     public function testMultipleNavigations()

--- a/tests/ZendTest/View/Helper/Placeholder/ContainerTest.php
+++ b/tests/ZendTest/View/Helper/Placeholder/ContainerTest.php
@@ -427,7 +427,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $lis = substr_count($string, "\n        <li>");
         $this->assertEquals(3, $lis);
-        $this->assertTrue((bool) strstr($string, "    <ul>\n"), $string);
-        $this->assertTrue((bool) strstr($string, "\n    </ul>"));
+        $this->assertContains("    <ul>\n", $string, $string);
+        $this->assertContains("\n    </ul>", $string, $string);
     }
 }

--- a/tests/ZendTest/View/Helper/Placeholder/RegistryTest.php
+++ b/tests/ZendTest/View/Helper/Placeholder/RegistryTest.php
@@ -66,7 +66,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->registry->containerExists('foo'));
         $container = $this->registry->createContainer('foo');
-        $this->assertTrue($container instanceof Container);
+        $this->assertInstanceOf('Zend\View\Helper\Placeholder\Container', $container);
     }
 
     /**
@@ -76,7 +76,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->registry->containerExists('foo'));
         $container = $this->registry->getContainer('foo');
-        $this->assertTrue($container instanceof Container\AbstractContainer);
+        $this->assertInstanceOf('Zend\View\Helper\Placeholder\Container\AbstractContainer', $container);
         $this->assertTrue($this->registry->containerExists('foo'));
     }
 
@@ -135,7 +135,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->registry->setContainerClass('ZendTest\View\Helper\Placeholder\MockContainer');
         $container = $this->registry->createContainer('foo');
-        $this->assertTrue($container instanceof MockContainer);
+        $this->assertInstanceOf('ZendTest\View\Helper\Placeholder\MockContainer', $container);
     }
 
     /**

--- a/tests/ZendTest/View/Model/ViewModelTest.php
+++ b/tests/ZendTest/View/Model/ViewModelTest.php
@@ -232,7 +232,7 @@ class ViewModelTest extends TestCase
     {
         $model    = new ViewModel();
         $template = $model->getTemplate();
-        $this->assertTrue(empty($template));
+        $this->assertEmpty($template);
     }
 
     public function testTemplateIsMutable()

--- a/tests/ZendTest/View/PhpRendererTest.php
+++ b/tests/ZendTest/View/PhpRendererTest.php
@@ -173,7 +173,7 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
     {
         $vars = array('foo' => 'bar');
         $this->renderer->setVars($vars);
-        $this->assertTrue($this->renderer->vars() instanceof Variables);
+        $this->assertInstanceOf('Zend\View\Variables', $this->renderer->vars());
     }
 
     /**

--- a/tests/ZendTest/View/Strategy/FeedStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/FeedStrategyTest.php
@@ -83,7 +83,7 @@ class FeedStrategyTest extends TestCase
     {
         $content = $this->response->getContent();
         $headers = $this->response->getHeaders();
-        $this->assertTrue(empty($content));
+        $this->assertEmpty($content);
         $this->assertFalse($headers->has('content-type'));
     }
 

--- a/tests/ZendTest/View/Strategy/JsonStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/JsonStrategyTest.php
@@ -87,7 +87,7 @@ class JsonStrategyTest extends TestCase
     {
         $content = $this->response->getContent();
         $headers = $this->response->getHeaders();
-        $this->assertTrue(empty($content));
+        $this->assertEmpty($content);
         $this->assertFalse($headers->has('content-type'));
     }
 

--- a/tests/ZendTest/View/Strategy/PhpRendererStrategyTest.php
+++ b/tests/ZendTest/View/Strategy/PhpRendererStrategyTest.php
@@ -36,7 +36,7 @@ class PhpRendererStrategyTest extends TestCase
     {
         $content = $this->response->getContent();
         $headers = $this->response->getHeaders();
-        $this->assertTrue(empty($content));
+        $this->assertEmpty($content);
         $this->assertFalse($headers->has('content-type'));
     }
 

--- a/tests/ZendTest/XmlRpc/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/FaultTest.php
@@ -44,7 +44,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructor()
     {
-        $this->assertTrue($this->_fault instanceof XmlRpc\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Fault', $this->_fault);
         $this->assertEquals(404, $this->_fault->getCode());
         $this->assertEquals('Unknown Error', $this->_fault->getMessage());
     }

--- a/tests/ZendTest/XmlRpc/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/FaultTest.php
@@ -190,20 +190,20 @@ class FaultTest extends \PHPUnit_Framework_TestCase
     {
         $sx = new \SimpleXMLElement($xml);
 
-        $this->assertTrue((bool) $sx->fault, $xml);
-        $this->assertTrue((bool) $sx->fault->value, $xml);
-        $this->assertTrue((bool) $sx->fault->value->struct, $xml);
+        $this->assertNotFalse($sx->fault, $xml);
+        $this->assertNotFalse($sx->fault->value, $xml);
+        $this->assertNotFalse($sx->fault->value->struct, $xml);
         $count = 0;
         foreach ($sx->fault->value->struct->member as $member) {
             $count++;
-            $this->assertTrue((bool) $member->name, $xml);
-            $this->assertTrue((bool) $member->value, $xml);
+            $this->assertNotFalse($member->name, $xml);
+            $this->assertNotFalse($member->value, $xml);
             if ('faultCode' == (string) $member->name) {
-                $this->assertTrue((bool) $member->value->int, $xml);
+                $this->assertNotFalse($member->value->int, $xml);
                 $this->assertEquals(1000, (int) $member->value->int, $xml);
             }
             if ('faultString' == (string) $member->name) {
-                $this->assertTrue((bool) $member->value->string, $xml);
+                $this->assertNotFalse($member->value->string, $xml);
                 $this->assertEquals('Fault message', (string) $member->value->string, $xml);
             }
         }

--- a/tests/ZendTest/XmlRpc/RequestTest.php
+++ b/tests/ZendTest/XmlRpc/RequestTest.php
@@ -334,7 +334,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $payload = sprintf($payload, 'file://' . realpath(dirname(__FILE__) . '/_files/ZF12293-payload.txt'));
         $this->request->loadXml($payload);
         $method = $this->request->getMethod();
-        $this->assertTrue(empty($method));
+        $this->assertEmpty($method);
         if (is_string($method)) {
             $this->assertNotContains('Local file inclusion', $method);
         }

--- a/tests/ZendTest/XmlRpc/RequestTest.php
+++ b/tests/ZendTest/XmlRpc/RequestTest.php
@@ -249,7 +249,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($fault);
         $this->request->loadXml('foo');
         $fault = $this->request->getFault();
-        $this->assertTrue($fault instanceof \Zend\XmlRpc\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Fault', $fault);
     }
 
     /**

--- a/tests/ZendTest/XmlRpc/RequestTest.php
+++ b/tests/ZendTest/XmlRpc/RequestTest.php
@@ -246,7 +246,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testGetFault()
     {
         $fault = $this->request->getFault();
-        $this->assertTrue(null === $fault);
+        $this->assertNull($fault);
         $this->request->loadXml('foo');
         $fault = $this->request->getFault();
         $this->assertTrue($fault instanceof \Zend\XmlRpc\Fault);

--- a/tests/ZendTest/XmlRpc/ResponseTest.php
+++ b/tests/ZendTest/XmlRpc/ResponseTest.php
@@ -250,7 +250,7 @@ EOD;
         $payload = sprintf($payload, 'file://' . realpath(dirname(__FILE__) . '/_files/ZF12293-payload.txt'));
         $this->_response->loadXml($payload);
         $value = $this->_response->getReturnValue();
-        $this->assertTrue(empty($value));
+        $this->assertEmpty($value);
         if (is_string($value)) {
             $this->assertNotContains('Local file inclusion', $value);
         }

--- a/tests/ZendTest/XmlRpc/ResponseTest.php
+++ b/tests/ZendTest/XmlRpc/ResponseTest.php
@@ -49,7 +49,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
      */
     public function test__construct()
     {
-        $this->assertTrue($this->_response instanceof Response);
+        $this->assertInstanceOf('Zend\XmlRpc\Response', $this->_response);
     }
 
     /**

--- a/tests/ZendTest/XmlRpc/ResponseTest.php
+++ b/tests/ZendTest/XmlRpc/ResponseTest.php
@@ -166,10 +166,10 @@ EOD;
     {
         $sx = new \SimpleXMLElement($xml);
 
-        $this->assertTrue((bool) $sx->params);
-        $this->assertTrue((bool) $sx->params->param);
-        $this->assertTrue((bool) $sx->params->param->value);
-        $this->assertTrue((bool) $sx->params->param->value->string);
+        $this->assertNotFalse($sx->params);
+        $this->assertNotFalse($sx->params->param);
+        $this->assertNotFalse($sx->params->param->value);
+        $this->assertNotFalse($sx->params->param->value->string);
         $this->assertEquals('return value', (string) $sx->params->param->value->string);
     }
 

--- a/tests/ZendTest/XmlRpc/Server/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/Server/FaultTest.php
@@ -117,7 +117,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
         Observer::clearObserved();
         Server\Fault::detachObserver('ZendTest\\XmlRpc\\Server\\Observer');
 
-        $this->assertTrue(!empty($observed));
+        $this->assertNotEmpty($observed);
         $f = array_shift($observed);
         $this->assertTrue($f instanceof Server\Fault);
         $this->assertEquals('Checking observers', $f->getMessage());

--- a/tests/ZendTest/XmlRpc/Server/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/Server/FaultTest.php
@@ -140,7 +140,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
         $e = new Server\Exception\RuntimeException('Checking observers', 411);
         $fault = Server\Fault::getInstance($e);
         $observed = Observer::getObserved();
-        $this->assertTrue(empty($observed));
+        $this->assertEmpty($observed);
 
         $this->assertFalse(Server\Fault::detachObserver('foo'));
     }

--- a/tests/ZendTest/XmlRpc/Server/FaultTest.php
+++ b/tests/ZendTest/XmlRpc/Server/FaultTest.php
@@ -24,7 +24,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
         $e = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
 
-        $this->assertTrue($fault instanceof Server\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Server\Fault', $fault);
     }
 
     /**
@@ -119,7 +119,7 @@ class FaultTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($observed);
         $f = array_shift($observed);
-        $this->assertTrue($f instanceof Server\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Server\Fault', $f);
         $this->assertEquals('Checking observers', $f->getMessage());
         $this->assertEquals(411, $f->getCode());
 

--- a/tests/ZendTest/XmlRpc/ServerTest.php
+++ b/tests/ZendTest/XmlRpc/ServerTest.php
@@ -84,7 +84,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $methods = $this->_server->listMethods();
         $this->assertContains('zsr.ZendTest\\XmlRpc\\testFunction', $methods);
-        $this->assertFalse(in_array('zsr.ZendTest\\XmlRpc\\testFunction2', $methods), var_export($methods, 1));
+        $this->assertNotContains('zsr.ZendTest\\XmlRpc\\testFunction2', $methods, var_export($methods, 1));
     }
 
     public function testAddFunctionThrowsExceptionOnInvalidInput()
@@ -139,8 +139,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $methods = $this->_server->listMethods();
         $this->assertContains('test.test1', $methods);
         $this->assertContains('test.test2', $methods);
-        $this->assertFalse(in_array('test._test3', $methods));
-        $this->assertFalse(in_array('test.__construct', $methods));
+        $this->assertNotContains('test._test3', $methods);
+        $this->assertNotContains('test.__construct', $methods);
     }
 
     /**

--- a/tests/ZendTest/XmlRpc/ServerTest.php
+++ b/tests/ZendTest/XmlRpc/ServerTest.php
@@ -80,10 +80,10 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->_server->addFunction('ZendTest\\XmlRpc\\testFunction', 'zsr');
 
         $methods = $this->_server->listMethods();
-        $this->assertTrue(in_array('zsr.ZendTest\\XmlRpc\\testFunction', $methods), var_export($methods, 1));
+        $this->assertContains('zsr.ZendTest\\XmlRpc\\testFunction', $methods, var_export($methods, 1));
 
         $methods = $this->_server->listMethods();
-        $this->assertTrue(in_array('zsr.ZendTest\\XmlRpc\\testFunction', $methods));
+        $this->assertContains('zsr.ZendTest\\XmlRpc\\testFunction', $methods);
         $this->assertFalse(in_array('zsr.ZendTest\\XmlRpc\\testFunction2', $methods), var_export($methods, 1));
     }
 
@@ -137,8 +137,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->_server->setClass('ZendTest\\XmlRpc\\TestClass', 'test');
         $methods = $this->_server->listMethods();
-        $this->assertTrue(in_array('test.test1', $methods));
-        $this->assertTrue(in_array('test.test2', $methods));
+        $this->assertContains('test.test1', $methods);
+        $this->assertContains('test.test2', $methods);
         $this->assertFalse(in_array('test._test3', $methods));
         $this->assertFalse(in_array('test.__construct', $methods));
     }
@@ -211,7 +211,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($response->__toString(), $output);
         $return = $response->getReturnValue();
         $this->assertInternalType('array', $return);
-        $this->assertTrue(in_array('system.multicall', $return));
+        $this->assertContains('system.multicall', $return);
     }
 
     /**
@@ -233,7 +233,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response instanceof Response);
         $return = $response->getReturnValue();
         $this->assertInternalType('array', $return);
-        $this->assertTrue(in_array('system.multicall', $return));
+        $this->assertContains('system.multicall', $return);
     }
 
     /**
@@ -292,10 +292,10 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $methods = $this->_server->listMethods();
         $this->assertInternalType('array', $methods);
-        $this->assertTrue(in_array('system.listMethods', $methods));
-        $this->assertTrue(in_array('system.methodHelp', $methods));
-        $this->assertTrue(in_array('system.methodSignature', $methods));
-        $this->assertTrue(in_array('system.multicall', $methods));
+        $this->assertContains('system.listMethods', $methods);
+        $this->assertContains('system.methodHelp', $methods);
+        $this->assertContains('system.methodSignature', $methods);
+        $this->assertContains('system.multicall', $methods);
     }
 
     /**

--- a/tests/ZendTest/XmlRpc/ServerTest.php
+++ b/tests/ZendTest/XmlRpc/ServerTest.php
@@ -210,7 +210,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($response instanceof Response);
         $this->assertSame($response->__toString(), $output);
         $return = $response->getReturnValue();
-        $this->assertTrue(is_array($return));
+        $this->assertInternalType('array', $return);
         $this->assertTrue(in_array('system.multicall', $return));
     }
 
@@ -232,7 +232,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($response instanceof Response);
         $return = $response->getReturnValue();
-        $this->assertTrue(is_array($return));
+        $this->assertInternalType('array', $return);
         $this->assertTrue(in_array('system.multicall', $return));
     }
 
@@ -291,7 +291,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testListMethods()
     {
         $methods = $this->_server->listMethods();
-        $this->assertTrue(is_array($methods));
+        $this->assertInternalType('array', $methods);
         $this->assertTrue(in_array('system.listMethods', $methods));
         $this->assertTrue(in_array('system.methodHelp', $methods));
         $this->assertTrue(in_array('system.methodSignature', $methods));
@@ -330,7 +330,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testMethodSignature()
     {
         $sig = $this->_server->methodSignature('system.methodSignature');
-        $this->assertTrue(is_array($sig));
+        $this->assertInternalType('array', $sig);
         $this->assertEquals(1, count($sig), var_export($sig, 1));
 
         $this->setExpectedException('Zend\XmlRpc\Server\Exception\ExceptionInterface', 'Method "foo" does not exist');
@@ -366,10 +366,10 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($response instanceof Response, $response->__toString() . "\n\n" . $request->__toString());
         $returns = $response->getReturnValue();
-        $this->assertTrue(is_array($returns));
+        $this->assertInternalType('array', $returns);
         $this->assertEquals(2, count($returns), var_export($returns, 1));
-        $this->assertTrue(is_array($returns[0]), var_export($returns[0], 1));
-        $this->assertTrue(is_string($returns[1]), var_export($returns[1], 1));
+        $this->assertInternalType('array', $returns[0], var_export($returns[0], 1));
+        $this->assertInternalType('string', $returns[1], var_export($returns[1], 1));
     }
 
     /**
@@ -394,9 +394,9 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($response instanceof Response, $response->__toString() . "\n\n" . $request->__toString());
         $returns = $response->getReturnValue();
-        $this->assertTrue(is_array($returns));
+        $this->assertInternalType('array', $returns);
         $this->assertEquals(2, count($returns), var_export($returns, 1));
-        $this->assertTrue(is_array($returns[0]), var_export($returns[0], 1));
+        $this->assertInternalType('array', $returns[0], var_export($returns[0], 1));
         $this->assertSame(array(
             'faultCode' => 620, 'faultString' => 'Method "undefined" does not exist'),
             $returns[1], var_export($returns[1], 1));
@@ -568,31 +568,31 @@ class ServerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $returned = $this->_server->multicall($try);
-        $this->assertTrue(is_array($returned));
+        $this->assertInternalType('array', $returned);
         $this->assertEquals(5, count($returned));
 
         $response = $returned[0];
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertTrue(isset($response['faultCode']));
         $this->assertEquals(601, $response['faultCode']);
 
         $response = $returned[1];
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertTrue(isset($response['faultCode']));
         $this->assertEquals(602, $response['faultCode']);
 
         $response = $returned[2];
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertTrue(isset($response['faultCode']));
         $this->assertEquals(603, $response['faultCode']);
 
         $response = $returned[3];
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertTrue(isset($response['faultCode']));
         $this->assertEquals(604, $response['faultCode']);
 
         $response = $returned[4];
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertTrue(isset($response['faultCode']));
         $this->assertEquals(605, $response['faultCode']);
     }

--- a/tests/ZendTest/XmlRpc/ServerTest.php
+++ b/tests/ZendTest/XmlRpc/ServerTest.php
@@ -521,7 +521,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('test1');
         $request->addParam('value');
         $response = $this->_server->handle($request);
-        $this->assertFalse($response instanceof XmlRpc\Fault);
+        $this->assertNotInstanceOf('Zend\XmlRpc\Fault', $response);
         $this->assertEquals('String: value', $response->getReturnValue());
     }
 
@@ -532,7 +532,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('test2');
         $request->addParam(array('value1', 'value2'));
         $response = $this->_server->handle($request);
-        $this->assertFalse($response instanceof XmlRpc\Fault);
+        $this->assertNotInstanceOf('Zend\XmlRpc\Fault', $response);
         $this->assertEquals('value1; value2', $response->getReturnValue());
     }
 
@@ -543,7 +543,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('ZendTest\\XmlRpc\\testFunction');
         $request->setParams(array(array('value1'), 'key'));
         $response = $this->_server->handle($request);
-        $this->assertFalse($response instanceof Fault);
+        $this->assertNotInstanceOf('Zend\XmlRpc\Fault', $response);
         $this->assertEquals('key: value1', $response->getReturnValue());
     }
 
@@ -608,7 +608,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request = new Request('test.base64', array($param));
 
         $response = $this->_server->handle($request);
-        $this->assertFalse($response instanceof XmlRpc\Fault);
+        $this->assertNotInstanceOf('Zend\XmlRpc\Fault', $response);
         $this->assertEquals($data, $response->getReturnValue());
     }
 

--- a/tests/ZendTest/XmlRpc/ServerTest.php
+++ b/tests/ZendTest/XmlRpc/ServerTest.php
@@ -54,7 +54,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
      */
     public function test__construct()
     {
-        $this->assertTrue($this->_server instanceof Server);
+        $this->assertInstanceOf('Zend\XmlRpc\Server', $this->_server);
     }
 
     public function suppressNotFoundWarnings($errno, $errstr)
@@ -181,12 +181,12 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testFault()
     {
         $fault = $this->_server->fault('This is a fault', 411);
-        $this->assertTrue($fault instanceof Server\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Server\Fault', $fault);
         $this->assertEquals(411, $fault->getCode());
         $this->assertEquals('This is a fault', $fault->getMessage());
 
         $fault = $this->_server->fault(new Server\Exception\RuntimeException('Exception fault', 511));
-        $this->assertTrue($fault instanceof Server\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Server\Fault', $fault);
         $this->assertEquals(511, $fault->getCode());
         $this->assertEquals('Exception fault', $fault->getMessage());
     }
@@ -207,7 +207,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(isset($response));
         $response = $this->_server->getResponse();
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\XmlRpc\Response', $response);
         $this->assertSame($response->__toString(), $output);
         $return = $response->getReturnValue();
         $this->assertInternalType('array', $return);
@@ -230,7 +230,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('system.listMethods');
         $response = $this->_server->handle($request);
 
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf('Zend\XmlRpc\Response', $response);
         $return = $response->getReturnValue();
         $this->assertInternalType('array', $return);
         $this->assertContains('system.multicall', $return);
@@ -245,7 +245,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('system.methodHelp');
         $response = $this->_server->handle($request);
 
-        $this->assertTrue($response instanceof XmlRpc\Fault);
+        $this->assertInstanceOf('Zend\XmlRpc\Fault', $response);
         $this->assertEquals(623, $response->getCode());
     }
 
@@ -277,8 +277,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('system.listMethods');
         $response = $this->_server->handle($request);
 
-        $this->assertTrue($response instanceof Response);
-        $this->assertTrue($response instanceof TestResponse);
+        $this->assertInstanceOf('Zend\XmlRpc\Response', $response);
+        $this->assertInstanceOf('ZendTest\XmlRpc\TestResponse', $response);
     }
 
     /**
@@ -364,7 +364,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->addParam($struct);
         $response = $this->_server->handle($request);
 
-        $this->assertTrue($response instanceof Response, $response->__toString() . "\n\n" . $request->__toString());
+        $this->assertInstanceOf('Zend\XmlRpc\Response', $response, $response->__toString() . "\n\n" . $request->__toString());
         $returns = $response->getReturnValue();
         $this->assertInternalType('array', $returns);
         $this->assertEquals(2, count($returns), var_export($returns, 1));
@@ -392,7 +392,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $request->addParam($struct);
         $response = $this->_server->handle($request);
 
-        $this->assertTrue($response instanceof Response, $response->__toString() . "\n\n" . $request->__toString());
+        $this->assertInstanceOf('Zend\XmlRpc\Response', $response, $response->__toString() . "\n\n" . $request->__toString());
         $returns = $response->getReturnValue();
         $this->assertInternalType('array', $returns);
         $this->assertEquals(2, count($returns), var_export($returns, 1));
@@ -496,7 +496,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->_server->setRequest('ZendTest\\XmlRpc\\TestRequest');
         $req = $this->_server->getRequest();
-        $this->assertTrue($req instanceof TestRequest);
+        $this->assertInstanceOf('ZendTest\XmlRpc\TestRequest', $req);
     }
 
     /**


### PR DESCRIPTION
This PR aims to remove uses of `asserTrue` and `assertFalse`.

PHPUnit provides alternative assertions specific for certain cases and provides useful information about the nature of the failure.
