### PR TITLE
[memory] isLocked sometimes return integer instead bool

### DIFF
--- a/library/Zend/Memory/Container/Movable.php
+++ b/library/Zend/Memory/Container/Movable.php
@@ -102,7 +102,7 @@ class Movable extends AbstractContainer
      */
     public function isLocked()
     {
-        return $this->state & self::LOCKED;
+        return (bool) ($this->state & self::LOCKED);
     }
 
     /**

--- a/tests/ZendTest/Memory/AccessControllerTest.php
+++ b/tests/ZendTest/Memory/AccessControllerTest.php
@@ -79,9 +79,9 @@ class AccessControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse((bool) $memObject->isLocked());
 
         $memObject->lock();
-        $this->assertTrue((bool) $memObject->isLocked());
+        $this->assertTrue($memObject->isLocked());
 
         $memObject->unlock();
-        $this->assertFalse((bool) $memObject->isLocked());
+        $this->assertFalse($memObject->isLocked());
     }
 }

--- a/tests/ZendTest/Memory/LockedTest.php
+++ b/tests/ZendTest/Memory/LockedTest.php
@@ -58,14 +58,14 @@ class LockedTest extends \PHPUnit_Framework_TestCase
         $memObject = new Container\Locked('0123456789');
 
         // It's always locked
-        $this->assertTrue((bool) $memObject->isLocked());
+        $this->assertTrue($memObject->isLocked());
 
         $memObject->lock();
-        $this->assertTrue((bool) $memObject->isLocked());
+        $this->assertTrue($memObject->isLocked());
 
         $memObject->unlock();
         // It's always locked
-        $this->assertTrue((bool) $memObject->isLocked());
+        $this->assertTrue($memObject->isLocked());
     }
 
     /**

--- a/tests/ZendTest/Memory/MovableTest.php
+++ b/tests/ZendTest/Memory/MovableTest.php
@@ -62,13 +62,13 @@ class MovableTest extends \PHPUnit_Framework_TestCase
         $memoryManager = new DummyMemoryManager();
         $memObject = new Container\Movable($memoryManager, 10, '0123456789');
 
-        $this->assertFalse((bool) $memObject->isLocked());
+        $this->assertFalse($memObject->isLocked());
 
         $memObject->lock();
-        $this->assertTrue((bool) $memObject->isLocked());
+        $this->assertTrue($memObject->isLocked());
 
         $memObject->unlock();
-        $this->assertFalse((bool) $memObject->isLocked());
+        $this->assertFalse($memObject->isLocked());
     }
 
     /**


### PR DESCRIPTION
Method must return a bool type without need of cast
