### PR TITLE
[travis-ci] HHVM nightly is not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7
   - hhvm
-  - hhvm-nightly
 
 install:
   - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7' ]]; then phpenv config-rm xdebug.ini;  fi
@@ -41,4 +40,3 @@ matrix:
   allow_failures:
     - php: 7
     - php: hhvm
-    - php: hhvm-nightly


### PR DESCRIPTION
> HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220
