### PR TITLE
CS remove unused uses

### DIFF
--- a/tests/ZendTest/Code/Scanner/ClassScannerTest.php
+++ b/tests/ZendTest/Code/Scanner/ClassScannerTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Code\Scanner;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Code\Annotation;
 use Zend\Code\Scanner\FileScanner;
-use Zend\Code\Scanner\MethodScanner;
 use Zend\Stdlib\ErrorHandler;
 use ZendTest\Code\TestAsset\TraitWithSameMethods;
 use ZendTest\Code\TestAsset\TestClassWithTraitAliases;

--- a/tests/ZendTest/Console/ConsoleTest.php
+++ b/tests/ZendTest/Console/ConsoleTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Console;
 
 use Zend\Console\Console;
-use Zend\Console\Adapter;
 
 /**
  * @group      Zend_Console

--- a/tests/ZendTest/EventManager/EventManagerTest.php
+++ b/tests/ZendTest/EventManager/EventManagerTest.php
@@ -14,10 +14,8 @@ use stdClass;
 use Zend\EventManager\Event;
 use Zend\EventManager\EventInterface;
 use Zend\EventManager\EventManager;
-use Zend\EventManager\ResponseCollection;
 use Zend\EventManager\SharedEventManager;
 use Zend\EventManager\StaticEventManager;
-use Zend\Stdlib\CallbackHandler;
 
 /**
  * @group      Zend_EventManager

--- a/tests/ZendTest/EventManager/FilterChainTest.php
+++ b/tests/ZendTest/EventManager/FilterChainTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\EventManager;
 
 use Zend\EventManager\FilterChain;
-use Zend\Stdlib\CallbackHandler;
 
 /**
  * @group      Zend_Stdlib

--- a/tests/ZendTest/Feed/Reader/Entry/CommonTest.php
+++ b/tests/ZendTest/Feed/Reader/Entry/CommonTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Feed\Reader\Entry;
 
-use Zend\Feed\Reader\Extension;
 use Zend\Feed\Reader;
 
 /**

--- a/tests/ZendTest/File/Transfer/Adapter/HttpTest.php
+++ b/tests/ZendTest/File/Transfer/Adapter/HttpTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\File\Transfer\Adapter;
 
 use Zend\File\Transfer\Adapter;
 use Zend\File\Transfer\Exception\RuntimeException;
-use Zend\ProgressBar;
 use Zend\ProgressBar\Adapter as AdapterProgressBar;
 use Zend\Validator\File as FileValidator;
 

--- a/tests/ZendTest/Http/Client/StaticTest.php
+++ b/tests/ZendTest/Http/Client/StaticTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Http\Client;
 use Zend\Uri\Http as UriHttp;
 use Zend\Http\Client as HTTPClient;
 use Zend\Http;
-use Zend\Http\Header\SetCookie;
 use Zend\Http\Request;
 
 /**

--- a/tests/ZendTest/Log/Writer/ChromePhpTest.php
+++ b/tests/ZendTest/Log/Writer/ChromePhpTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Log\Writer;
 
 use ZendTest\Log\TestAsset\MockChromePhp;
 use Zend\Log\Writer\ChromePhp;
-use Zend\Log\Writer\ChromePhp\ChromePhpInterface;
 use Zend\Log\Logger;
 
 /**

--- a/tests/ZendTest/Math/BigInteger/BigIntegerTest.php
+++ b/tests/ZendTest/Math/BigInteger/BigIntegerTest.php
@@ -10,8 +10,6 @@
 namespace ZendTest\Math\BigInteger;
 
 use Zend\Math\BigInteger\BigInteger as BigInt;
-use Zend\Math\BigInteger\Adapter;
-use Zend\Math\BigInteger\Adapter\AdapterInterface;
 
 /**
  * @group      Zend_Math

--- a/tests/ZendTest/Memory/MemoryManagerTest.php
+++ b/tests/ZendTest/Memory/MemoryManagerTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Memory;
 use Zend\Cache\StorageFactory as CacheFactory;
 use Zend\Cache\Storage\Adapter\AdapterInterface as CacheAdapter;
 use Zend\Memory;
-use Zend\Memory\Container;
 
 
 /**

--- a/tests/ZendTest/Session/ContainerTest.php
+++ b/tests/ZendTest/Session/ContainerTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Session;
 use Zend\Session\Container;
 use Zend\Session\Config\StandardConfig;
 use Zend\Session\ManagerInterface as Manager;
-use Zend\Session;
 
 /**
  * @group      Zend_Session

--- a/tests/ZendTest/Session/SessionStorageTest.php
+++ b/tests/ZendTest/Session/SessionStorageTest.php
@@ -10,7 +10,6 @@
 namespace ZendTest\Session;
 
 use Zend\Session\Storage\SessionStorage;
-use Zend\Session\Storage\ArrayStorage;
 
 /**
  * @group      Zend_Session


### PR DESCRIPTION
Most of them are related with a0b87c091d2a35b6e52a90a07a8504a467264eff and 38d37f8aca9f00bcc2237efeeb34fcc044a25a3c
