### PR TITLE
[#7396] Functionality only works in PHP >= 5.6

### DIFF
--- a/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
+++ b/library/Zend/Db/Adapter/Driver/Pgsql/Connection.php
@@ -57,9 +57,16 @@ class Connection extends AbstractConnection
      */
     public function setType($type)
     {
-        if ($type !== PGSQL_CONNECT_FORCE_NEW && $type !== PGSQL_CONNECT_ASYNC) {
-            throw new Exception\InvalidArgumentException('Connection type is not valid. (See: http://php.net/manual/en/function.pg-connect.php)');
+        if (version_compare(PHP_VERSION, '5.6', 'lt')) {
+            throw new Exception\RuntimeException('Connection type cannot be set on versions < 5.6');
         }
+
+        if ($type !== PGSQL_CONNECT_FORCE_NEW && $type !== PGSQL_CONNECT_ASYNC) {
+            throw new Exception\InvalidArgumentException(
+                'Connection type is not valid. (See: http://php.net/manual/en/function.pg-connect.php)'
+            );
+        }
+
         $this->type = $type;
         return $this;
     }
@@ -97,7 +104,9 @@ class Connection extends AbstractConnection
         $connection = $this->getConnectionString();
         set_error_handler(function ($number, $string) {
             throw new Exception\RuntimeException(
-                __METHOD__ . ': Unable to connect to database', null, new Exception\ErrorException($string, $number)
+                __METHOD__ . ': Unable to connect to database',
+                null,
+                new Exception\ErrorException($string, $number)
             );
         });
         $this->resource = pg_connect($connection);
@@ -228,7 +237,10 @@ class Connection extends AbstractConnection
         if ($name === null) {
             return;
         }
-        $result = pg_query($this->resource, 'SELECT CURRVAL(\'' . str_replace('\'', '\\\'', $name) . '\') as "currval"');
+        $result = pg_query(
+            $this->resource,
+            'SELECT CURRVAL(\'' . str_replace('\'', '\\\'', $name) . '\') as "currval"'
+        );
 
         return pg_fetch_result($result, 0, 'currval');
     }

--- a/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/tests/ZendTest/Db/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -86,9 +86,14 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetConnectionTypeException()
     {
+        if (version_compare(PHP_VERSION, '5.6', 'lt')) {
+            $this->markTestSkipped('Functionality under test only works in 5.6 and above');
+        }
+
         if (! extension_loaded('pgsql')) {
             $this->markTestSkipped('pgsql extension not loaded');
         }
+
         $this->connection->setType(3);
     }
 
@@ -97,9 +102,14 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetConnectionType()
     {
+        if (version_compare(PHP_VERSION, '5.6', 'lt')) {
+            $this->markTestSkipped('Functionality under test only works in 5.6 and above');
+        }
+
         if (! extension_loaded('pgsql')) {
             $this->markTestSkipped('pgsql extension not loaded');
         }
+
         $type = PGSQL_CONNECT_FORCE_NEW;
         $this->connection->setType($type);
         $this->assertEquals($type, self::readAttribute($this->connection, 'type'));


### PR DESCRIPTION
PR #7396 introduced code that only works in 5.6; this patch does the following:
- Raises a RuntimeException when the new `setType()` method is invoked in
  versions less than 5.6.
- Skips unit tests of that method when the PHP version is less than 5.6.

This patch also fixes several long lines, flagged by phpcs when I was editing.
