### PR TITLE
[config][test] Fix assertContains should be assertArrayHasKey

### DIFF
--- a/tests/ZendTest/Config/ProcessorTest.php
+++ b/tests/ZendTest/Config/ProcessorTest.php
@@ -350,7 +350,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         $tokens = $processor->getTokens();
         $this->assertInternalType('array', $tokens);
-        $this->assertContains('SOME_USERLAND_CONSTANT', $tokens);
+        $this->assertArrayHasKey('SOME_USERLAND_CONSTANT', $tokens);
         $this->assertFalse($processor->getUserOnly());
 
         $this->assertEquals('some constant value', $config->simple);
@@ -371,7 +371,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $tokens = $processor->getTokens();
 
         $this->assertInternalType('array', $tokens);
-        $this->assertContains('SOME_USERLAND_CONSTANT', $tokens);
+        $this->assertArrayHasKey('SOME_USERLAND_CONSTANT', $tokens);
         $this->assertTrue($processor->getUserOnly());
 
         $this->assertEquals('some constant value', $config->simple);


### PR DESCRIPTION
This bug is NOT related with #7476 

Surprisingly `assertContains` as well `in_array('', $tokens, true)` does not fail when the string does not exists in the array value side.
