### PR TITLE
XMLRPC Incompatibility with HHVM

### DIFF
--- a/library/Zend/XmlRpc/AbstractValue.php
+++ b/library/Zend/XmlRpc/AbstractValue.php
@@ -438,7 +438,9 @@ abstract class AbstractValue
      */
     protected static function _extractTypeAndValue(\SimpleXMLElement $xml, &$type, &$value)
     {
-        list($type, $value) = each($xml);
+        // Casting is necessary to work with strict-typed systems
+        $xmlAsArray = (array) $xml;
+        list($type, $value) = each($xmlAsArray);
         if (!$type and $value === null) {
             $namespaces = array('ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions');
             foreach ($namespaces as $namespaceName => $namespaceUri) {


### PR DESCRIPTION
Hello!

I'm trying to use the zend-xmlrpc library with a composer package that I'am 
writing. I wanted to test it using a hhvm environment and received an error with the 
way hhvm handles the each() method.  

```
Fatal error: Uncaught exception 'ErrorException' with message 'Invalid operand type was used: expecting an array' in /srv/www/package/vendor/zendframework/zend-xmlrpc/AbstractValue.php:441
```

Looking at line 441  

```
439     protected static function _extractTypeAndValue(\SimpleXMLElement $xml, &$type, &$value)
440     {
441         list($type, $value) = each($xml);
442         if (!$type and $value === null) {
443             $namespaces = array('ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions');
444             foreach ($namespaces as $namespaceName => $namespaceUri) {
445                 $namespaceXml = $xml->children($namespaceUri);
446                 list($type, $value) = each($namespaceXml);
447                 if ($type !== null) {
448                     $type = $namespaceName . ':' . $type;
449                     break;
450                 }
451             }
452         }
```
