### PR TITLE
[stdlib][test] Fix Deprecated notice for Non-static method called static

### DIFF
--- a/tests/ZendTest/Stdlib/CallbackHandlerTest.php
+++ b/tests/ZendTest/Stdlib/CallbackHandlerTest.php
@@ -85,7 +85,7 @@ class CallbackHandlerTest extends \PHPUnit_Framework_TestCase
         $error   = false;
         set_error_handler(function ($errno, $errstr) use (&$error) {
             $error = true;
-        }, E_STRICT);
+        }, E_STRICT|E_DEPRECATED);
         $handler->call();
         restore_error_handler();
         $this->assertTrue($error);


### PR DESCRIPTION
Should handler E_DEPRECATED (PHP7 nightly change error level)

Close #7491
