### PR TITLE
[mail/mime] Fix content-type has invalid characters in field value. Fix #7503

### DIFF
--- a/library/Zend/Mail/Header/ContentType.php
+++ b/library/Zend/Mail/Header/ContentType.php
@@ -69,7 +69,7 @@ class ContentType implements HeaderInterface
             $values[] = sprintf('%s="%s"', $attribute, $value);
         }
 
-        return implode(';' . Headers::FOLDING, $values);
+        return implode(';', $values);
     }
 
     public function setEncoding($encoding)
@@ -165,7 +165,7 @@ class ContentType implements HeaderInterface
         if (isset($this->parameters[$name])) {
             return $this->parameters[$name];
         }
-        return;
+        return null;
     }
 
     /**

--- a/library/Zend/Mime/Part.php
+++ b/library/Zend/Mime/Part.php
@@ -439,8 +439,7 @@ class Part
         }
 
         if ($this->boundary) {
-            $contentType .= ';' . $EOL
-                          . " boundary=\"" . $this->boundary . '"';
+            $contentType .= '; boundary="' . $this->boundary . '"';
         }
 
         $headers[] = array('Content-Type', $contentType);

--- a/tests/ZendTest/Mail/Header/ContentTypeTest.php
+++ b/tests/ZendTest/Mail/Header/ContentTypeTest.php
@@ -63,7 +63,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $string = $header->toString();
 
         $this->assertContains("Content-Type: application/x-unit-test;", $string);
-        $this->assertContains(";\r\n charset=\"us-ascii\"", $string);
+        $this->assertContains(';charset="us-ascii"', $string);
     }
 
     public function testExtractsExtraInformationFromContentType()

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -538,7 +538,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($headers->has('content-type'));
         $header = $headers->get('content-type');
-        $this->assertEquals('text/html;' . "\r\n " . 'boundary="any_boundary"', $header->getFieldValue());
+        $this->assertEquals('text/html;boundary="any_boundary"', $header->getFieldValue());
     }
 
     public function testSettingUtf8MailBodyFromSinglePartMimeUtf8MessageSetsAppropriateHeaders()
@@ -556,7 +556,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setBody($body);
 
         $this->assertContains(
-            'Content-Type: text/plain;' . Headers::FOLDING . 'charset="utf-8"' . Headers::EOL
+            'Content-Type: text/plain;charset="utf-8"' . Headers::EOL
             . 'Content-Transfer-Encoding: quoted-printable' . Headers::EOL,
             $this->message->getHeaders()->toString()
         );
@@ -584,7 +584,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($headers->has('content-type'));
         $header = $headers->get('content-type');
-        $this->assertEquals("multipart/mixed;\r\n boundary=\"foo-bar\"", $header->getFieldValue());
+        $this->assertEquals('multipart/mixed;boundary="foo-bar"', $header->getFieldValue());
     }
 
     public function testRetrievingBodyTextFromMessageWithMultiPartMimeBodyReturnsMimeSerialization()

--- a/tests/ZendTest/Mail/MessageTest.php
+++ b/tests/ZendTest/Mail/MessageTest.php
@@ -523,6 +523,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $mime = new Mime('foo-bar');
         $part = new MimePart('<b>foo</b>');
         $part->type = 'text/html';
+        $part->boundary = 'any_boundary';
         $body = new MimeMessage();
         $body->setMime($mime);
         $body->addPart($part);
@@ -537,7 +538,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($headers->has('content-type'));
         $header = $headers->get('content-type');
-        $this->assertEquals('text/html', $header->getFieldValue());
+        $this->assertEquals('text/html;' . "\r\n " . 'boundary="any_boundary"', $header->getFieldValue());
     }
 
     public function testSettingUtf8MailBodyFromSinglePartMimeUtf8MessageSetsAppropriateHeaders()


### PR DESCRIPTION
This bug has been introduced in v2.4.1 due the security patch ZF2015-04 for to prevent CRLF injection.

Zend\Mime\Part line was originally introduced in ZF1@583 with the following commit message

> - Correctly handle multipart/alternative to close #59:
>   - If both text and html body present, create multipart/alternative part
>   - If text, html, and attachments are present, create multipart/alternative
>     part for text+html, but mark email as multipart/mixed
> - Note: Zend_Mime::LINEEND as \r\n is causing issues on multipart emails (too
>   many line breaks); switching to \n fixes the issue, but doesn't follow
>   standards. Need reviewers.

Zend_Mime::LINEEND was replaced by $EOL argument on ZF1@598 with the following commit message

> - Refactoring of Zend_Mail/Zend_Mime; mail message construction happens in
>   transport. Fixes #134 and #106.

RFC 2045 section 5.1 defines the syntax of Content-Type Header field as this (only relevant parts of the syntax posted):

> In the Augmented BNF notation of RFC 822, a Content-Type header field
> value is defined as follows:
> 
> ```
> content := "Content-Type" ":" type "/" subtype
>            *(";" parameter)
>            ; Matching of media type and subtype
>            ; is ALWAYS case-insensitive.
> 
> parameter := attribute "=" value
> 
> attribute := token
>              ; Matching of attributes
>              ; is ALWAYS case-insensitive.
> 
> value := token / quoted-string
> 
> token := 1*<any (US-ASCII) CHAR except SPACE, CTLs,
>          or tspecials>
> 
> tspecials :=  "(" / ")" / "<" / ">" / "@" /
>               "," / ";" / ":" / "\" / <">
>               "/" / "[" / "]" / "?" / "="
>               ; Must be in quoted-string,
>               ; to use within parameter values
> ```

Finally on ZF2 has been duplicated the same behavior on Zend\Mail\Header\ContentType

https://github.com/zendframework/zf2/commit/297ba86090fda8ef4cc5d343e49869b196e158aa#diff-78a765eeca5dcb0c4d8fa594675622f6R76
