### PR TITLE
[#7503] Pass the `\r\n` sequence to Part::getHeadersAsArray()

### DIFF
--- a/library/Zend/Mail/Message.php
+++ b/library/Zend/Mail/Message.php
@@ -403,7 +403,7 @@ class Message
         $parts = $this->body->getParts();
         if (!empty($parts)) {
             $part = array_shift($parts);
-            $headers->addHeaders($part->getHeadersArray());
+            $headers->addHeaders($part->getHeadersArray("\r\n"));
         }
         return $this;
     }


### PR DESCRIPTION
Per the [gist provided by @Qronicle](https://gist.github.com/Qronicle/dbd168d9cb9c84add6b1), I've created a unit test against `Zend\Mail\Message`, and a proposed fix.

`Zend\Mime\Part::getHeadersAsArray()` accepts an optional argument, the line separator sequence. This defaults to `\n`, but for mail messages, should be `\r\n`. The proposed patch passes that argument when retrieving MIME headers to include in the mail message.

This is an alternative to #7510. That patch removes all header folding. In most cases, that should be acceptable, but in cases where the MIME boundary is long, the header could potentially exceed 998 bytes. The attached patch preserves header folding, by ensuring the correct sequence is used when aggregating MIME headers for use in a Mail message.
