### PR TITLE
[ldap] fix case of Converter::toLdapBoolean calls

### DIFF
--- a/library/Zend/Ldap/Converter/Converter.php
+++ b/library/Zend/Ldap/Converter/Converter.php
@@ -83,7 +83,7 @@ class Converter
         try {
             switch ($type) {
                 case self::BOOLEAN:
-                    return static::toldapBoolean($value);
+                    return static::toLdapBoolean($value);
                 case self::GENERALIZED_TIME:
                     return static::toLdapDatetime($value);
                 default:
@@ -92,7 +92,7 @@ class Converter
                     } elseif (is_int($value) || is_float($value)) {
                         return (string) $value;
                     } elseif (is_bool($value)) {
-                        return static::toldapBoolean($value);
+                        return static::toLdapBoolean($value);
                     } elseif (is_object($value)) {
                         if ($value instanceof DateTime) {
                             return static::toLdapDatetime($value);

--- a/tests/ZendTest/Ldap/Converter/ConverterTest.php
+++ b/tests/ZendTest/Ldap/Converter/ConverterTest.php
@@ -81,7 +81,7 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
      */
     public function testToLdapBoolean($expect, $convert)
     {
-        $this->assertEquals($expect, Converter::toldapBoolean($convert));
+        $this->assertEquals($expect, Converter::toLdapBoolean($convert));
     }
 
     public function toLdapBooleanProvider()
@@ -147,7 +147,7 @@ class ConverterTest extends \PHPUnit_Framework_TestCase
                 'value'=> DateTime::createFromFormat(DateTime::ISO8601, '1970-01-01T00:00:00+0000'),
                 'type' => 0,
             )),
-            array(Converter::toldapBoolean(true), array(
+            array(Converter::toLdapBoolean(true), array(
                 'value' => (bool) true,
                 'type' => 0
             )),


### PR DESCRIPTION
PHP functions are not case sensitive but this looks better to me.

Is there a tool which can check for such things automatically?
