### PR TITLE
Fix for 7502

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -345,13 +345,14 @@ class SetCookie implements MultipleHeaderInterface
      * Set Max-Age
      *
      * @param int $maxAge
-     * @throws Exception\InvalidArgumentException
      * @return SetCookie
      */
     public function setMaxAge($maxAge)
     {
         if ($maxAge !== null && (!is_int($maxAge) || ($maxAge < 0))) {
-            throw new Exception\InvalidArgumentException('Invalid Max-Age number specified');
+            // Fix for 7502. RFC6265 compliance
+            $this->maxAge = null;
+            return $this;
         }
         $this->maxAge = $maxAge;
         return $this;

--- a/tests/ZendTest/Http/Header/SetCookieTest.php
+++ b/tests/ZendTest/Http/Header/SetCookieTest.php
@@ -395,6 +395,25 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($cookie->toString(), sprintf($formatUnquoted, $cookie->getFieldName(), $name, $value));
     }
 
+    /**
+     * Tests RFC6265 Compliance for Max-Age
+     * @group 7502
+     * @dataProvider invalidMaxAgeValues
+     */
+    public function testNegativeAndNonNumericMaxAgeDoesNotThrowException($val)
+    {
+        $cookie = new SetCookie();
+        $cookie->setMaxAge($val);
+        $this->assertNull($cookie->getMaxAge());
+    }
+
+    public function invalidMaxAgeValues() {
+        return array(
+            array(-1),
+            array('a')
+        );
+    }
+
     public function testSetJsonValue()
     {
         $cookieName ="fooCookie";


### PR DESCRIPTION
SetCookie Max-Age header is now RFC 6265 compliant and discards negative and non-numeric values.
