### PR TITLE
Travis: add language translations monitor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   # Run tests for the various components in parallel
   - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then ls -d tests/ZendTest/* | grep -v 'tests/ZendTest/_files' | grep -v 'tests/ZendTest/AllTests' | parallel --gnu -P 0 'echo "Running {} tests"; php ./vendor/bin/phpunit -c tests/phpunit.xml.dist --colors=always --coverage-php build/coverage/coverage-{/.}.cov {};' || exit 1; fi
   - if [[ $TRAVIS_PHP_VERSION != '5.6' ]]; then ls -d tests/ZendTest/* | grep -v 'tests/ZendTest/_files' | grep -v 'tests/ZendTest/AllTests' | parallel --gnu -P 0 'echo "Running {} tests"; php ./vendor/bin/phpunit -c tests/phpunit.xml.dist --colors=always {};' || exit 1; fi
+  - php ./vendor/bin/phpunit --verbose --color tests/ResourcesTest.php
 
   # Run coding standard checks in parallel
   - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then ls -d library/Zend/* tests/ZendTest/* bin | parallel --gnu -P 0 'echo "Running {} CS checks"; php ./vendor/bin/php-cs-fixer fix {} -v --diff --dry-run --config-file=.php_cs;' || exit 1; fi

--- a/tests/ResourcesTest.php
+++ b/tests/ResourcesTest.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
 
 class ResourcesTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/ResourcesTest.php
+++ b/tests/ResourcesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+class ResourcesTest extends PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->referenceKeys = $this->getTranslationKeys('en');
+    }
+
+    protected function getLanguagesDir()
+    {
+        return dirname(__DIR__) . '/resources/languages';
+    }
+
+    public function testEveryLanguageIsCompletelyCovered()
+    {
+        $output = array();
+        foreach ($this->getAvailableLanguages() as $language) {
+            $currentKeys = $this->getTranslationKeys($language);
+
+            $missing = 0;
+            foreach ($this->referenceKeys as $enKey => $value) {
+                if (! isset($currentKeys[$enKey])) {
+                    $missing++;
+                }
+            }
+
+            $surplus = 0;
+            foreach ($currentKeys as $currentKey => $value) {
+                if (! isset($this->referenceKeys[$currentKey])) {
+                    $surplus++;
+                }
+            }
+
+            if ($missing or $surplus) {
+                $output[] = sprintf('%-5s | %5s | %5s',
+                    $language,
+                    $missing ?: '-',
+                    $surplus ?: '-'
+                );
+            }
+        }
+
+        if (! empty($output)) {
+            array_unshift($output, 'LANG  | MISS  | PLUS ');
+            $this->markTestIncomplete(implode(PHP_EOL, $output));
+        }
+    }
+
+    public function getAvailableLanguages()
+    {
+        $languages = array();
+        foreach (glob($this->getLanguagesDir() . '/*') as $dir) {
+            $languages[] = basename($dir);
+        }
+
+        return $languages;
+    }
+
+    private function getTranslationKeys($language)
+    {
+        $glob = sprintf('%s/%s/*.php',
+            $this->getLanguagesDir(),
+            $language
+        );
+        $keys = array();
+        foreach (glob($glob) as $file) {
+            $keys = array_merge($keys, include $file);
+        }
+        ksort($keys);
+
+        return $keys;
+    }
+}


### PR DESCRIPTION
Keeping up-to-date the translations is tough.
But at least we have to try.

I've added a test executed only in Travis that outputs languages with differences from `en` one.

I've used `markTestIncomplete`: the test will **always** pass, so the build result is never affected.

I'm not sure the test placement in the folder tree is elegant, and likely it needs to be rethought for ZF3 and component splitting.
