### PR TITLE
Reestablish the connection to the SMTP server if a timeout occurred

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -299,8 +299,17 @@ class Smtp extends AbstractProtocol
     public function rset()
     {
         $this->_send('RSET');
-        // MS ESMTP doesn't follow RFC, see [ZF-1377]
-        $this->_expect(array(250, 220));
+
+        try {
+            // MS ESMTP doesn't follow RFC, see [ZF-1377]
+            $this->_expect(array(250, 220));
+        } catch (Exception\RuntimeException $e) {
+            if (strpos($e->getMessage(), 'timeout exceeded') !== false) {
+                $this->auth = false;
+                $this->_stopSession();
+            }
+            throw $e;
+        }
 
         $this->mail = false;
         $this->rcpt = false;

--- a/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
+++ b/tests/ZendTest/Mail/TestAsset/SmtpProtocolSpy.php
@@ -20,11 +20,12 @@ class SmtpProtocolSpy extends Smtp
     protected $connect = false;
     protected $mail;
     protected $rcptTest = array();
+    protected $serverTimeout = false;
 
     public function connect()
     {
         $this->connect = true;
-
+        $this->serverTimeout = false;
         return true;
     }
 
@@ -71,6 +72,14 @@ class SmtpProtocolSpy extends Smtp
 
     protected function _expect($code, $timeout = null)
     {
+        if ($this->serverTimeout) {
+            if ($this->connect) {
+                $this->connect = false;
+                throw new \Zend\Mail\Protocol\Exception\RuntimeException('4.4.2 host Error: timeout exceeded');
+            } else {
+                throw new \Zend\Mail\Protocol\Exception\RuntimeException('Could not read from host');
+            }
+        }
         return '';
     }
 
@@ -148,5 +157,27 @@ class SmtpProtocolSpy extends Smtp
         $this->sess = (bool) $status;
 
         return $this;
+    }
+
+    /**
+     * Set Server Timeout
+     *
+     * @param  bool $timeout
+     * @return self
+     */
+    public function getServerTimeout()
+    {
+        return $this->serverTimeout;
+    }
+
+    /**
+     * Set Server Timeout
+     *
+     * @param  bool $timeout
+     * @return self
+     */
+    public function setServerTimeout($timeout)
+    {
+        $this->serverTimeout = $timeout;
     }
 }

--- a/tests/ZendTest/Mail/Transport/SmtpTest.php
+++ b/tests/ZendTest/Mail/Transport/SmtpTest.php
@@ -233,4 +233,12 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->transport->send($this->getMessage());
         $this->assertTrue($this->connection->hasSession());
     }
+
+    public function testReconnectsOnServerTimeout()
+    {
+        $this->transport->send($this->getMessage());
+        $this->connection->setServerTimeout(true);
+        $this->transport->send($this->getMessage());
+        $this->assertFalse($this->connection->getServerTimeout());
+    }
 }


### PR DESCRIPTION
Holding a SMTP connection for a long time without activity  (>= 5 min) causes a server-side timeout (https://tools.ietf.org/html/rfc1123#page-61). This pull request improves the Zend Mailer to automatically reconnect to the server if a timeout occurred. I added a unit test that verifies the new functionality. I also wrote a test application that connects to a real SMTP server and triggers the server-side timeout by  sleeping a few minutes between sending mails. You can find this test application here: https://github.com/andrewisplinghoff/zend-timeout-test
