### PR TITLE
Return all the messages loaded in the Translator

### DIFF
--- a/library/Zend/I18n/Translator/Translator.php
+++ b/library/Zend/I18n/Translator/Translator.php
@@ -710,6 +710,25 @@ class Translator implements TranslatorInterface
     }
 
     /**
+     * Return all the messages.
+     *
+     * @param string $textDomain
+     * @param null   $locale
+     *
+     * @return mixed
+     */
+    public function getAllMessages($textDomain = 'default', $locale = null)
+    {
+        $locale = $locale ?: $this->getLocale();
+
+        if (!isset($this->messages[$textDomain][$locale])) {
+            $this->loadMessages($textDomain, $locale);
+        }
+
+        return $this->messages[$textDomain][$locale];
+    }
+
+    /**
      * Get the event manager.
      *
      * @return EventManagerInterface|null


### PR DESCRIPTION
Added public method to the I18n\Translator that return all the messages loaded in the Translator: useful in case we want to manage all of them with some tools (refactoring, find&replace, po2json).
