### PR TITLE
'type' in Input config may be plugin name

### DIFF
--- a/library/Zend/InputFilter/Factory.php
+++ b/library/Zend/InputFilter/Factory.php
@@ -171,19 +171,20 @@ class Factory
 
         if (isset($inputSpecification['type'])) {
             $class = $inputSpecification['type'];
-
-            if ($this->getInputFilterManager()->has($class)) {
-                return $this->createInputFilter($inputSpecification);
-            }
-
-            if (!class_exists($class)) {
-                throw new Exception\RuntimeException(sprintf(
-                    'Input factory expects the "type" to be a valid class; received "%s"',
-                    $class
-                ));
-            }
         }
-        $input = new $class();
+
+        $managerInstance = null;
+        if ($this->getInputFilterManager()->has($class)) {
+            $managerInstance = $this->getInputFilterManager()->get($class);
+        }
+        if (!$managerInstance && !class_exists($class)) {
+            throw new Exception\RuntimeException(sprintf(
+                'Input factory expects the "type" to be a valid class or a plugin name; received "%s"',
+                $class
+            ));
+        }
+
+        $input = $managerInstance ?: new $class();
 
         if ($input instanceof InputFilterInterface) {
             return $this->createInputFilter($inputSpecification);

--- a/tests/ZendTest/InputFilter/FactoryTest.php
+++ b/tests/ZendTest/InputFilter/FactoryTest.php
@@ -647,4 +647,39 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('Zend\InputFilter\InputFilterInterface', $inputFilter);
     }
+
+    public function testSuggestedTypeMayBePluginNameInInputFilterPluginManager()
+    {
+        $factory = new Factory();
+        $pluginManager = new InputFilterPluginManager();
+        $pluginManager->setService('bar', new Input('bar'));
+        $factory->setInputFilterManager($pluginManager);
+
+        $input = $factory->createInput(array(
+            'type' => 'bar'
+        ));
+        $this->assertSame('bar', $input->getName());
+
+        $this->setExpectedException('Zend\Filter\Exception\RuntimeException');
+        $factory->createInput(array(
+            'type' => 'foo'
+        ));
+    }
+
+    public function testInputFromPluginManagerMayBeFurtherConfiguredWithSpec()
+    {
+        $factory = new Factory();
+        $pluginManager = new InputFilterPluginManager();
+        $pluginManager->setService('bar', $barInput = new Input('bar'));
+        $this->assertTrue($barInput->isRequired());
+        $factory->setInputFilterManager($pluginManager);
+
+        $input = $factory->createInput(array(
+            'type' => 'bar',
+            'required' => false
+        ));
+
+        $this->assertFalse($input->isRequired());
+        $this->assertSame('bar', $input->getName());
+    }
 }


### PR DESCRIPTION
Support for input plugin name in `'type'` input configuration key for `Zend\InputFilter\Factory::createInput()`.
