### PR TITLE
Expire header fix

### DIFF
--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -349,7 +349,7 @@ class SetCookie implements MultipleHeaderInterface
      */
     public function setExpires($expires)
     {
-        if ($expires === null) {
+        if ($expires === null || $expires === '') {
             $this->expires = null;
             return $this;
         }


### PR DESCRIPTION
Expire header can be an empty string, without this fix exception will be throw later on `Invalid expires time specified` 
