### PR TITLE
Make zend-ldap optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "zendframework/zend-i18n-resources": "~2.5.0",
         "zendframework/zend-inputfilter": "~2.5.0",
         "zendframework/zend-json": "~2.5.0",
-        "zendframework/zend-ldap": "~2.5.0",
         "zendframework/zend-loader": "~2.5.0",
         "zendframework/zend-log": "~2.5.0",
         "zendframework/zend-mail": "~2.5.0",
@@ -62,6 +61,9 @@
         "zendframework/zend-view": "~2.5.0",
         "zendframework/zend-xmlrpc": "~2.5.0",
         "zendframework/zendxml": "~1.0"
+    },
+    "suggest": {
+        "zendframework/zend-ldap": "zend-ldap component ~2.5.0, if you need LDAP features"
     },
     "bin": [
         "bin/classmap_generator.php",


### PR DESCRIPTION
Per zendframework/zend-ldap#1, ZF2 cannot be installed at version 2.5.0 if you do not have ext/ldap installed, due to the hard requirement on that extension in zendframework/zend-ldap. This patch makes zendframework/zend-ldap an optional component.

After this is merged, users updating ZF2 that need zend-ldap will need to perform the following to grab the zend-ldap requirement:

``` console
$ composer require zendframework/zend-ldap
```
