### PR TITLE
Added zend-ldap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "zendframework/zend-i18n-resources": "~2.5.0",
         "zendframework/zend-inputfilter": "~2.5.0",
         "zendframework/zend-json": "~2.5.0",
+        "zendframework/zend-ldap": "~2.5.0",
         "zendframework/zend-loader": "~2.5.0",
         "zendframework/zend-log": "~2.5.0",
         "zendframework/zend-mail": "~2.5.0",


### PR DESCRIPTION
Somehow the zend-ldap component was missing. 

If that was not done intentionally this PR fixes that issue. If it _was_ intentionally, a hint in the README.md would be nice to know that it is missing :wink: 
