### PR TITLE
Add quoteIdentifierInFragment funciton to IBMDB2 platform

### DIFF
--- a/library/Zend/Db/Adapter/Platform/IbmDb2.php
+++ b/library/Zend/Db/Adapter/Platform/IbmDb2.php
@@ -44,6 +44,35 @@ class IbmDb2 extends AbstractPlatform
     /**
      * {@inheritDoc}
      */
+    public function quoteIdentifierInFragment($identifier, array $safeWords = array())
+    {
+        if (! $this->quoteIdentifiers) {
+            return $identifier;
+        }
+        $safeWordsInt = array('*' => true, ' ' => true, '.' => true, 'as' => true);
+        foreach ($safeWords as $sWord) {
+            $safeWordsInt[strtolower($sWord)] = true;
+        }
+        $parts = preg_split(
+            '/([^0-9,a-z,A-Z$#_:])/i',
+            $identifier,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+        );
+        $identifier = '';
+        foreach ($parts as $part) {
+            $identifier .= isset($safeWordsInt[strtolower($part)])
+                ? $part
+                : $this->quoteIdentifier[0]
+                . str_replace($this->quoteIdentifier[0], $this->quoteIdentifierTo, $part)
+                . $this->quoteIdentifier[1];
+        }
+        return $identifier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function quoteIdentifierChain($identifierChain)
     {
         if ($this->quoteIdentifiers === false) {


### PR DESCRIPTION
The quoteIdentifierInFragment function in the AbstractPlatform doesn't handle the hashtag symbol # in a field.  IBM i DB2 tables can have # in the database field name.  The only change to the function is the regex.  I've added # 

'/([^0-9,a-z,A-Z$#_:])/i',

For example the field name WE_WEQSEQ# becomes WE_WEQSEQ"#" after running

```
$resultSet = $this->tableGateway->select(function (Select $select) use ($data) {
$select->where($data);
$select->order("WE_WEQSEQ# DESC");
});
```

And the database gives the error "Column or global variable WE_WEQSEQ"# not found. SQLCODE=-206"
## References to AbstractPlatform:

quoteIdentifierInFragment function
https://github.com/zendframework/zf2/blob/release-2.4/library/Zend/Db/Adapter/Platform/AbstractPlatform.php#L32

regex used in quoteIdentifierInFragment that picks the # to be quoted
https://github.com/zendframework/zf2/blob/release-2.4/library/Zend/Db/Adapter/Platform/AbstractPlatform.php#L45
## Regex verified by testing here

Live Test my regex '/([^0-9,a-z,A-Z$#_:])/i',:
https://regex101.com/r/oV2wL1/2
