### PR TITLE
Exclude PHP 7.0.5 from allowed PHP versions (#7699)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.23",
+        "php": ">=5.3.23, !=7.0.5",
         "zendframework/zendxml": "~1.0-dev"
     },
     "require-dev": {


### PR DESCRIPTION
This fixes issue #7699 same fix as applied in https://github.com/zendframework/zend-code/issues/49
