### PR TITLE
Fix bug #7746

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -578,9 +578,7 @@ class Client implements Stdlib\DispatchableInterface
     {
         if (is_array($cookies)) {
             $this->clearCookies();
-            foreach ($cookies as $name => $value) {
-                $this->addCookie($name, $value);
-            }
+            $this->addCookie($cookies);
         } else {
             throw new Exception\InvalidArgumentException('Invalid cookies passed as parameter, it must be an array');
         }


### PR DESCRIPTION
*Fixing bug: Zend_Http_Client::setCookies fails with array argument*

This bugfix makes it pass the entire array to `addCookie`.